### PR TITLE
[Spike] Design System

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "canonical-rails"
 
 gem 'redcarpet'
 gem 'emd'
+gem 'haml'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
     foreman (0.87.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    haml (5.1.2)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -228,8 +231,10 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    temple (0.8.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -265,6 +270,7 @@ DEPENDENCIES
   dotenv-rails
   emd
   foreman
+  haml
   listen (>= 3.0.5, < 3.3)
   pry-byebug
   puma (~> 4.3)

--- a/app/controllers/design_system_controller.rb
+++ b/app/controllers/design_system_controller.rb
@@ -1,0 +1,15 @@
+class DesignSystemController < ApplicationController
+  def index
+  end
+  
+  def components_index
+    files = Dir[Rails.root.join("lib/design_system/**/README.html.md")]
+    @components = files.map { |file| file.split("/").last(2).first }
+  end
+
+  def components_show
+    component = params[:id]
+    readme = Dir[Rails.root.join("lib/design_system/**/#{component}/README.html.md")].first
+    render file: readme.chomp('.html.md')
+  end
+end

--- a/app/views/design_system/components_index.html.erb
+++ b/app/views/design_system/components_index.html.erb
@@ -1,0 +1,7 @@
+<h1>Components</h1>
+
+<ul>
+<% @components.each do |component| %>
+  <li><%= link_to(component, component_path(component)) %></li>
+<% end %>
+</ul>

--- a/app/views/design_system/index.html.erb
+++ b/app/views/design_system/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Design System</h1>
+
+<ul>
+<li><%= link_to("Components", components_path) %></li>
+</ul>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GiT Design System</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= stylesheet_pack_tag 'design_system', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'design_system', 'data-turbolinks-track': 'reload', defer: true %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/webpacker/packs/design_system.js
+++ b/app/webpacker/packs/design_system.js
@@ -1,0 +1,12 @@
+import { Application } from "stimulus";
+import { definitionsFromContext } from "stimulus/webpack-helpers";
+
+import hljs from "highlightjs";
+import "highlightjs/styles/github.css";
+hljs.initHighlightingOnLoad();
+
+import "../../../lib/design_system/style.scss";
+
+const application = Application.start();
+const context = require.context("../../../lib/design_system", true, /\.js$/);
+application.load(definitionsFromContext(context));

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module GovukRailsBoilerplate
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.eager_load_paths << Rails.root.join("lib")
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/markdown_template_handler.rb
+++ b/config/initializers/markdown_template_handler.rb
@@ -1,0 +1,23 @@
+module MarkdownTemplateHandler
+  def self.call(template, source = nil)
+
+    compiled_source = if source
+      erb.call(template, source)
+    else
+      erb.call(template)
+    end
+    
+    %(Redcarpet::Markdown.new(DesignSystem::MarkdownRenderer.new,
+                            no_intra_emphasis:            true,
+                            fenced_code_blocks:           true,
+                            space_after_headers:          true,
+                            smartypants:                  true,
+                            disable_indented_code_blocks: true,
+                            prettify:                     true,
+                            tables:                       true,
+                            with_toc_data:                true,
+                            autolink:                     true
+                          ).render(begin;#{compiled_source};end).html_safe)
+                          
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   get "/pages/:page", to: "pages#show"
 
+  get "/design_system", to: "design_system#index"
+  get "/design_system/components/:id", to: "design_system#components_show", as: :component
+  get "/design_system/components", to: "design_system#components_index", as: :components
+
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all

--- a/lib/design_system/components/button/README.html.md
+++ b/lib/design_system/components/button/README.html.md
@@ -1,0 +1,27 @@
+# Button
+
+This is a button...
+
+## Example Usage
+
+<% example = DesignSystem::Components::Button::Helper.button_tag("Save", style: "primary", disabled: false, disable_with: "Please wait...") %>
+
+<%= example %>
+
+### HTML
+
+```html
+<%= example %>
+```
+
+### Helper
+
+```ruby
+DesignSystem::Components::Button::Helper.button_tag("Save", style: "primary", disabled: false, disable_with: "Please wait...")
+```
+
+### Markdown
+
+```markdown
+[button Save]
+```

--- a/lib/design_system/components/button/_style.scss
+++ b/lib/design_system/components/button/_style.scss
@@ -1,0 +1,20 @@
+.git-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  color: white;
+  padding: 0.5rem 1rem;
+
+  &.git-button--primary {
+    background: green;
+  }
+
+  &.git-button--secondary {
+    background: blue;
+  }
+
+  &:disabled {
+    background: gray;
+  }
+}

--- a/lib/design_system/components/button/button_controller.js
+++ b/lib/design_system/components/button/button_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static get targets() {
+    return ["button"];
+  }
+
+  handleClick() {
+    if (this.disableWith) {
+      this.buttonTarget.disabled = true;
+      this.buttonTarget.textContent = this.disableWith;
+    }
+  }
+
+  get disableWith() {
+    return this.data.get("disable-with");
+  }
+}

--- a/lib/design_system/components/button/helper.rb
+++ b/lib/design_system/components/button/helper.rb
@@ -1,0 +1,11 @@
+module DesignSystem::Components::Button::Helper
+  def self.button_tag(text, style: "primary", disabled: false, disable_with: nil)
+    DesignSystem::ViewRenderer.render(__FILE__, {
+      text: text,
+      klass: "git-button git-button--#{style}", 
+      disabled: disabled, 
+      disable_with: disable_with,
+      controller: "components--button--button",
+    })
+  end
+end

--- a/lib/design_system/components/button/template.haml
+++ b/lib/design_system/components/button/template.haml
@@ -1,0 +1,2 @@
+%span{ data: { controller: controller, "#{controller}-disable-with": disable_with } }
+  %button{ class: klass, disabled: disabled, data: { target: "#{controller}.button", action: "click->#{controller}#handleClick" } } #{text}

--- a/lib/design_system/markdown_renderer.rb
+++ b/lib/design_system/markdown_renderer.rb
@@ -1,0 +1,19 @@
+class DesignSystem::MarkdownRenderer < Redcarpet::Render::HTML
+  def block_code(code, language)
+    "<pre><code class=\"#{language}\">#{CGI::escapeHTML(code)}</code></pre>"
+  end
+  
+  def paragraph(text)
+    process_custom_tags("<p>#{text.strip}</p>\n")
+  end
+
+  private 
+
+  def process_custom_tags(text)
+    if matches = text.match(/(\[button )(.+)(\])/)
+      return DesignSystem::Components::Button::Helper.button_tag(matches[2])
+    end
+
+    text
+  end
+end

--- a/lib/design_system/style.scss
+++ b/lib/design_system/style.scss
@@ -1,0 +1,1 @@
+@import "./components/button/style";

--- a/lib/design_system/view_renderer.rb
+++ b/lib/design_system/view_renderer.rb
@@ -1,0 +1,8 @@
+module DesignSystem::ViewRenderer
+  def self.render(file, locals = {})
+    path = File.expand_path(File.dirname(file))
+    engine = Haml::Engine.new(File.read("#{path}/template.haml"))
+    engine.render(Object.new, locals) 
+  end
+end
+

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "dependencies": {
     "@rails/webpacker": "^5.1.1",
     "govuk-frontend": "^3.6.0",
+    "highlightjs": "^9.16.2",
     "rails-ujs": "^5.2.4",
     "serialize-javascript": "^3.0.0",
     "set-value": "^3.0.2",
+    "stimulus": "^1.1.1",
     "turbolinks": "^5.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,30 @@
     webpack-cli "^3.3.11"
     webpack-sources "^1.4.3"
 
+"@stimulus/core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-1.1.1.tgz#42b0cfe5b73ca492f41de64b77a03980bae92c82"
+  integrity sha512-PVJv7IpuQx0MVPCBblXc6O2zbCmU8dlxXNH4bC9KK6LsvGaE+PCXXrXQfXUwAsse1/CmRu/iQG7Ov58himjiGg==
+  dependencies:
+    "@stimulus/mutation-observers" "^1.1.1"
+
+"@stimulus/multimap@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-1.1.1.tgz#b95e3fd607345ab36e5d5b55486ee1a12d56b331"
+  integrity sha512-26R1fI3a8uUj0WlMmta4qcfIQGlagegdP4PTz6lz852q/dXlG6r+uPS/bx+H8GtfyS+OOXVr3SkZ0Zg0iRqRfQ==
+
+"@stimulus/mutation-observers@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-1.1.1.tgz#0f6c6f081308427fed2a26360dda0c173b79cfc0"
+  integrity sha512-/zCnnw1KJlWO2mrx0yxYaRFZWMGnDMdOgSnI4hxDLxdWVuL2HMROU8FpHWVBLjKY3T9A+lGkcrmPGDHF3pfS9w==
+  dependencies:
+    "@stimulus/multimap" "^1.1.1"
+
+"@stimulus/webpack-helpers@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-1.1.1.tgz#eff60cd4e58b921d1a2764dc5215f5141510f2c2"
+  integrity sha512-XOkqSw53N9072FLHvpLM25PIwy+ndkSSbnTtjKuyzsv8K5yfkFB2rv68jU1pzqYa9FZLcvZWP4yazC0V38dx9A==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3330,6 +3354,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highlightjs@^9.16.2:
+  version "9.16.2"
+  resolved "https://registry.yarnpkg.com/highlightjs/-/highlightjs-9.16.2.tgz#07ea6cc7c93340fc440734fb7abf28558f1f0fe1"
+  integrity sha512-FK1vmMj8BbEipEy8DLIvp71t5UsC7n2D6En/UfM/91PCwmOpj6f2iu0Y0coRC62KSRHHC+dquM2xMULV/X7NFg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6827,6 +6856,14 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
+
+stimulus@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-1.1.1.tgz#53c2fded6849e7b85eed3ed8dd76e33abd74bec5"
+  integrity sha512-R0mBqKp48YnRDZOxZ8hiOH4Ilph3Yj78CIFTBkCwyHs4iGCpe7xlEdQ7cjIxb+7qVCSxFKgxO+mAQbsNgt/5XQ==
+  dependencies:
+    "@stimulus/core" "^1.1.1"
+    "@stimulus/webpack-helpers" "^1.1.1"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
<img width="817" alt="Screenshot 2020-04-22 at 15 04 02" src="https://user-images.githubusercontent.com/29867726/79995418-1aae5f80-84af-11ea-898e-50987d06c8c0.png">

### Context

The Get into Learning website will be a different design to the main GOV UK website, therefore we will not be leveraging the GOV UK design system. Instead, we are opting to create a new design system for the website that will give clarity and ease of use to the content designers when publishing content.

Initially, we have opted to keep the whole website inside this single Rails app, however we can envisage a time further down the line where it may make sense to split the design system out into it's own repository/application (and with it moving the majority of website pages to a static website generator). For that reason, the design system should not be tightly coupled to the Rails ecosystem.

The content designers will be working exclusively in Markdown; where it makes sense they should be able to leverage view components using custom Markdown formatting (similar to [GovSpeak](https://github.com/alphagov/govspeak) and ideally using the exact same Markdown syntax where possible).

### Changes proposed in this pull request

Adds a design system living under `/lib/design_system`. The view components are made up of:

- _style.scss - styling, using class names consistent with the GOV UK design system
- template.haml - a partial containing the button Haml (HTML)
- button_controller.js - StimulusJS controller for handling dynamic interactions (can be omitted if not necessary)
- helper.rb - ruby helpers to render the component partial (providing a clean interface for the component and a way to render the component in place of it's Markdown tag)
- README.html.md - description of the component, usage examples, code snippets, etc

Haml is chosen over HTML simply because it's more concise when you start to apply conditional logic to HTML tags (such as disabling, class names, data attributes etc). The helper provides a way of defining the interface for a component, and something to call when we are mapping a bit of Markdown to a certain component. 

The component README contains examples, descriptions, use cases, etc and is designed to be pulled into a larger 'design system website' for browsing. The default Markdown renderer has been extended to support syntax highlighting with highlight.js (the GOV UK design system appears to use this). At the minute I'm pulling in all the READMEs and serving the design system 'website' as part of Rails - it's a lightweight controller/views and we could them to a Sinatra app or something if the design system was to be pulled out of Rails later on.

### Guidance to review

- Extending Markdown with custom tags is going to be quite time consuming (I've done a very simple button extension in this PR, but others are going to be complex). I wonder if we should try and get all the GovSpeak ones for free by mimicking their CSS class names and just using their Markdown extension directly? (we could also wrap it and transform the class names to continue using our own `git-` prefix). If we are writing custom Markdown extensions I would also opt to move the parsing logic into the individual component directory as well to be consistent.
- I haven't added tests for the design system components, but I would expect to use RSpec (or similar) for the helpers and Jest for the Stimulus controllers. We could also look at snapshot testing, though I don't know what the support for this is like in the Ruby world.