### PR TITLE
Use GovSpeak instead of redcarpet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "foreman"
 gem "canonical-rails"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
-gem "redcarpet"
+gem "govspeak"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "canonical-rails"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
 gem "govspeak"
+gem "rinku"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
       ffi (~> 1.0)
     regexp_parser (1.7.0)
     rexml (3.2.4)
+    rinku (2.0.6)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -281,6 +282,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.2)
+  rinku
   rspec-rails (~> 4.0.0)
   rubocop-govuk
   scss_lint-govuk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,16 @@ GEM
     foreman (0.87.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govspeak (3.5.0)
+      htmlentities (~> 4)
+      kramdown (~> 1.5.0)
+      nokogiri (~> 1.5)
+      sanitize (~> 2.1.0)
+    htmlentities (4.3.4)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    kramdown (1.5.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -164,7 +171,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.4.0)
     regexp_parser (1.7.0)
     rexml (3.2.4)
     rspec-core (3.9.1)
@@ -207,6 +213,8 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
+    sanitize (2.1.1)
+      nokogiri (>= 1.4.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -268,11 +276,11 @@ DEPENDENCIES
   dotenv-rails
   foreman
   front_matter_parser!
+  govspeak
   listen (>= 3.0.5, < 3.3)
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.2)
-  redcarpet
   rspec-rails (~> 4.0.0)
   rubocop-govuk
   scss_lint-govuk

--- a/lib/markdown_pages/template_handler.rb
+++ b/lib/markdown_pages/template_handler.rb
@@ -2,6 +2,8 @@ module MarkdownPages
   class TemplateHandler
     attr_reader :template, :source, :options
 
+    DEFAULTS = {}.freeze
+
     def self.call(template, source = nil)
       new(template, source).call
     end
@@ -10,17 +12,7 @@ module MarkdownPages
       @template = template
       @source = source.to_s
 
-      @options = options.reverse_merge(
-        no_intra_emphasis:            true,
-        fenced_code_blocks:           true,
-        space_after_headers:          true,
-        smartypants:                  true,
-        disable_indented_code_blocks: true,
-        prettify:                     true,
-        tables:                       true,
-        with_toc_data:                true,
-        autolink:                     true,
-      )
+      @options = DEFAULTS.merge(options)
     end
 
     def call
@@ -30,12 +22,8 @@ module MarkdownPages
 
   private
 
-    def renderer
-      Redcarpet::Render::HTML.new(filter_html: false, hard_wrap: true)
-    end
-
     def render
-      Redcarpet::Markdown.new(renderer, options).render(markdown)
+      Govspeak::Document.new(markdown).to_html
     end
 
     def markdown

--- a/lib/markdown_pages/template_handler.rb
+++ b/lib/markdown_pages/template_handler.rb
@@ -22,8 +22,16 @@ module MarkdownPages
 
   private
 
-    def render
+    def render_markdown
       Govspeak::Document.new(markdown).to_html
+    end
+
+    def autolink_html(content)
+      Rinku.auto_link content
+    end
+
+    def render
+      autolink_html render_markdown
     end
 
     def markdown

--- a/spec/lib/markdown_pages/template_handler_spec.rb
+++ b/spec/lib/markdown_pages/template_handler_spec.rb
@@ -27,7 +27,6 @@ describe MarkdownPages::TemplateHandler, type: :view do
     it { is_expected.to have_css('a[href="https://www.gov.uk"]', text: "link") }
 
     it "will autolink urls" do
-    debugger
       is_expected.to have_css \
         'a[href="https://www.gov.uk/autolink"]',
         text: "https://www.gov.uk/autolink"

--- a/spec/lib/markdown_pages/template_handler_spec.rb
+++ b/spec/lib/markdown_pages/template_handler_spec.rb
@@ -27,6 +27,7 @@ describe MarkdownPages::TemplateHandler, type: :view do
     it { is_expected.to have_css('a[href="https://www.gov.uk"]', text: "link") }
 
     it "will autolink urls" do
+    debugger
       is_expected.to have_css \
         'a[href="https://www.gov.uk/autolink"]',
         text: "https://www.gov.uk/autolink"


### PR DESCRIPTION
### Context

Currently we use RedCarpet to render HTML output but our content designers are more familiar
with the GovSpeak dialect of Markdown.

### Changes proposed in this pull request

1. Change to use GovSpeak gem to render markdown
2. Added Rinku to Autolink URLs - looks like there's been some discussion in Kramdown on supporting autolinking but no actual PRs merged. This just adds support within our template renderer.

### Guidance to review
1. Does it still render pages correctly.
2. Does it parse the `section{` parts
