### PR TITLE
Use Kramdown instead of govspeak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "foreman"
 gem "canonical-rails"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
-gem "govspeak"
+gem "kramdown"
 gem "rinku"
 
 gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,8 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    kramdown (1.5.0)
+    kramdown (2.2.1)
+      rexml
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,13 +100,7 @@ GEM
     foreman (0.87.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (3.5.0)
-      htmlentities (~> 4)
-      kramdown (~> 1.5.0)
-      nokogiri (~> 1.5)
-      sanitize (~> 2.1.0)
     hashdiff (1.0.1)
-    htmlentities (4.3.4)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -223,8 +217,6 @@ GEM
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
-    sanitize (2.1.1)
-      nokogiri (>= 1.4.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -292,7 +284,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  govspeak
+  kramdown
   listen (>= 3.0.5, < 3.3)
   pry-byebug
   puma (~> 4.3)

--- a/lib/markdown_pages/template_handler.rb
+++ b/lib/markdown_pages/template_handler.rb
@@ -23,7 +23,7 @@ module MarkdownPages
   private
 
     def render_markdown
-      Govspeak::Document.new(markdown).to_html
+      Kramdown::Document.new(markdown).to_html
     end
 
     def autolink_html(content)

--- a/spec/lib/markdown_pages/template_handler_spec.rb
+++ b/spec/lib/markdown_pages/template_handler_spec.rb
@@ -38,7 +38,7 @@ describe MarkdownPages::TemplateHandler, type: :view do
       <<~MARKDOWN
         # Heading
 
-        Lorem <strong>ipsum</strong>
+        Lorem <strong class="testclass">ipsum</strong>
       MARKDOWN
     end
 
@@ -49,7 +49,7 @@ describe MarkdownPages::TemplateHandler, type: :view do
 
     it { is_expected.to have_css("p", text: /Lorem/) }
     it { is_expected.to have_css("h1", text: "Heading") }
-    it { is_expected.to have_css("p strong", text: "ipsum") }
+    it { is_expected.to have_css("p strong.testclass", text: "ipsum") }
   end
 
   context "with front matter" do

--- a/spec/lib/markdown_pages/template_handler_spec.rb
+++ b/spec/lib/markdown_pages/template_handler_spec.rb
@@ -33,6 +33,25 @@ describe MarkdownPages::TemplateHandler, type: :view do
     end
   end
 
+  context "with html" do
+    let(:markdown) do
+      <<~MARKDOWN
+        # Heading
+
+        Lorem <strong>ipsum</strong>
+      MARKDOWN
+    end
+
+    before do
+      stub_template "test.md" => markdown
+      render template: "test.md"
+    end
+
+    it { is_expected.to have_css("p", text: /Lorem/) }
+    it { is_expected.to have_css("h1", text: "Heading") }
+    it { is_expected.to have_css("p strong", text: "ipsum") }
+  end
+
   context "with front matter" do
     let :markdown do
       <<~MARKDOWN


### PR DESCRIPTION
### Context

We are currently using an old copy of Govspeak, and with it old Kramdown. Upgrading to the newer version pulls in a _lot_ of additional dependencies. We are not actually using any of the extended syntax provided.

### Changes proposed in this pull request

1. Swap to plain Kramdown instead of GovSpeak
2. Upgrade the Kramdown version
3. Added a test to check HTML can be passed through correctly

### Guidance to review

