### PR TITLE
GITPB-245 Base classes for event wizard

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -6,6 +6,7 @@ module WizardSteps
     before_action :load_current_step
   end
 
+  # current_step loaded via before_action
   def show; end
 
   def update

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -19,15 +19,15 @@ module WizardSteps
 private
 
   def wizard
-    wizard_class.new(wizard_store)
+    wizard_class.new(wizard_store, params[:id])
   end
 
   def load_current_step
-    @current_step = wizard.find(params[:id])
+    @current_step = wizard.find_current_step
   end
 
   def next_step_path
-    next_step = wizard.next_step(params[:id])
+    next_step = wizard.next_step
     next_step ? event_step_path(next_step) : root_path
   end
 

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -1,0 +1,41 @@
+module WizardSteps
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :wizard_class
+    before_action :load_current_step
+  end
+
+  def show; end
+
+  def update
+    @current_step.assign_attributes step_params
+
+    if @current_step.save
+      redirect_to next_step_path
+    end
+  end
+
+private
+
+  def wizard
+    wizard_class.new(wizard_store)
+  end
+
+  def load_current_step
+    @current_step = wizard.find(params[:id])
+  end
+
+  def next_step_path
+    next_step = wizard.next_step(params[:id])
+    next_step ? event_step_path(next_step) : root_path
+  end
+
+  def step_params
+    params.require(step_param_key).permit @current_step.attributes.keys
+  end
+
+  def step_param_key
+    @current_step.class.model_name.param_key
+  end
+end

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -1,0 +1,15 @@
+class EventStepsController < ApplicationController
+  include WizardSteps
+  self.wizard_class = Events::Wizard
+
+private
+
+  def wizard_store
+    Wizard::Store.new session_store
+  end
+
+  def session_store
+    session[:events] ||= {}
+    session[:events][params[:event_id]] ||= {}
+  end
+end

--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -1,0 +1,13 @@
+module Events
+  module Steps
+    class PersonalDetails < ::Wizard::Step
+      attribute :first_name
+      attribute :last_name
+      attribute :email_address
+
+      validates :first_name, presence: true
+      validates :last_name, presence: true
+      validates :email_address, presence: true
+    end
+  end
+end

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -1,0 +1,5 @@
+module Events
+  class Wizard < ::Wizard::Base
+    self.steps = [Steps::PersonalDetails].freeze
+  end
+end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -1,0 +1,40 @@
+module Wizard
+  class Base
+    class_attribute :steps
+
+    class << self
+      def indexed_steps
+        @indexed_steps ||= steps.index_by(&:key)
+      end
+
+      def step(key)
+        indexed_steps[key] || raise(UnknownStep)
+      end
+
+      def step_index(key)
+        steps.index step(key)
+      end
+    end
+
+    delegate :steps, :step, :step_index, :indexed_steps, to: :class
+
+    def initialize(store)
+      @store = store
+    end
+
+    def find(key)
+      step(key).new @store
+    end
+
+    def previous_step(key)
+      index = step_index(key)
+      index.positive? ? steps[index - 1]&.key : nil
+    end
+
+    def next_step(key)
+      steps[step_index(key) + 1]&.key
+    end
+
+    class UnknownStep < RuntimeError; end
+  end
+end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -1,4 +1,6 @@
 module Wizard
+  class UnknownStep < RuntimeError; end
+
   class Base
     class_attribute :steps
 
@@ -47,7 +49,5 @@ module Wizard
     def next_step(key = current_step)
       steps[step_index(key) + 1]&.key
     end
-
-    class UnknownStep < RuntimeError; end
   end
 end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -14,24 +14,37 @@ module Wizard
       def step_index(key)
         steps.index step(key)
       end
+
+      def step_keys
+        indexed_steps.keys
+      end
     end
 
-    delegate :steps, :step, :step_index, :indexed_steps, to: :class
+    delegate :steps, :step, :step_index, :indexed_steps, :step_keys, to: :class
+    attr_reader :current_step
 
-    def initialize(store)
+    def initialize(store, current_step)
       @store = store
+
+      raise(UnknownStep) unless step_keys.include?(current_step)
+
+      @current_step = current_step
     end
 
     def find(key)
       step(key).new @store
     end
 
-    def previous_step(key)
+    def find_current_step
+      find current_step
+    end
+
+    def previous_step(key = current_step)
       index = step_index(key)
       index.positive? ? steps[index - 1]&.key : nil
     end
 
-    def next_step(key)
+    def next_step(key = current_step)
       steps[step_index(key) + 1]&.key
     end
 

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -1,0 +1,35 @@
+module Wizard
+  class Step
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    class << self
+      def key
+        name.split("::").last.underscore
+      end
+    end
+
+    def initialize(store, attributes = {}, *args)
+      @store = store
+      super(*args)
+      assign_attributes attributes_from_store
+      assign_attributes attributes
+    end
+
+    def save
+      return false unless valid?
+
+      persist_to_store
+    end
+
+  private
+
+    def attributes_from_store
+      @store.fetch attributes.keys.map(&:to_sym)
+    end
+
+    def persist_to_store
+      @store.persist attributes
+    end
+  end
+end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -1,0 +1,18 @@
+module Wizard
+  class Store
+    attr_reader :data
+    delegate :[], :[]=, to: :data
+
+    def initialize(data)
+      raise InvalidBackingStore unless data.respond_to?(:[]=)
+
+      @data = data
+    end
+
+    def fetch(*keys)
+      data.slice(*Array.wrap(keys))
+    end
+
+    class InvalidBackingStore < RuntimeError; end
+  end
+end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -10,7 +10,13 @@ module Wizard
     end
 
     def fetch(*keys)
-      data.slice(*Array.wrap(keys))
+      data.slice(*Array.wrap(keys).flatten)
+    end
+
+    def persist(attributes)
+      data.merge! attributes.symbolize_keys
+
+      true
     end
 
     class InvalidBackingStore < RuntimeError; end

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -1,0 +1,1 @@
+<h1>FIXME: TBD</h1>

--- a/app/views/event_steps/show.html.erb
+++ b/app/views/event_steps/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', current_step: @current_step %>

--- a/app/views/event_steps/update.html.erb
+++ b/app/views/event_steps/update.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', current_step: @current_step %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   resources "events", path: "/apievents", only: %i[index show search] do
     collection { get "search" }
+    resources "steps", path: "/apply", controller: "event_steps", only: %i[show update]
   end
 
   get "*page", to: "pages#show", as: :page

--- a/spec/controllers/event_steps_controller_spec.rb
+++ b/spec/controllers/event_steps_controller_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe EventStepsController, type: :request do
+  let(:event_id) { SecureRandom.uuid }
+  let(:step_path) { event_step_path event_id, "personal_details" }
+
+  describe "#show" do
+    before { get step_path }
+    subject { response }
+    it { is_expected.to have_http_status :success }
+  end
+
+  describe "#update" do
+    let(:key) { Events::Steps::PersonalDetails.model_name.param_key }
+    before { patch step_path, params: { key => contact_params } }
+    subject { response }
+
+    context "with valid data" do
+      let(:contact_params) { attributes_for(:events_personal_details) }
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context "with invalid data" do
+      let(:contact_params) { { "first_name" => "test" } }
+      it { is_expected.to have_http_status :success }
+    end
+  end
+end

--- a/spec/factories/events/personal_details_factory.rb
+++ b/spec/factories/events/personal_details_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :events_personal_details, class: Events::Steps::PersonalDetails do
+    first_name { "Test" }
+    sequence(:last_name) { |n| "User #{n}" }
+    sequence(:email_address) { |n| "testuser#{n}@testing.education.gov.uk" }
+  end
+end

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Events::Steps::PersonalDetails do
+  include_context "wizard store"
+
+  let(:instance) { described_class.new wizardstore }
+  subject { instance }
+
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to respond_to :first_name }
+  it { is_expected.to respond_to :last_name }
+  it { is_expected.to respond_to :email_address }
+
+  context "validations" do
+    before { instance.valid? }
+    subject { instance.errors.messages }
+    it { is_expected.to include(:first_name) }
+    it { is_expected.to include(:last_name) }
+    it { is_expected.to include(:email_address) }
+  end
+end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -20,7 +20,7 @@ describe Wizard::Base do
   end
 
   let(:wizardclass) { TestWizard }
-  let(:wizard) { wizardclass.new wizardstore }
+  let(:wizard) { wizardclass.new wizardstore, "age" }
 
   describe ".indexed_steps" do
     subject { wizardclass.indexed_steps }
@@ -49,10 +49,36 @@ describe Wizard::Base do
     end
   end
 
+  describe ".step_keys" do
+    subject { wizardclass.step_keys }
+    it { is_expected.to eql %w[name age postcode] }
+  end
+
+  describe ".new" do
+    it "should return instance for known step" do
+      expect(wizardclass.new(wizardstore, "name")).to be_instance_of wizardclass
+    end
+
+    it "should raise exception for unknown step" do
+      expect { wizardclass.new wizardstore, "unknown" }.to \
+        raise_exception Wizard::Base::UnknownStep
+    end
+  end
+
+  describe "#current_step" do
+    subject { wizardclass.new(wizardstore, "name").current_step }
+    it { is_expected.to eql "name" }
+  end
+
   describe "#find" do
     subject { wizard.find("age") }
     it { is_expected.to be_instance_of Age }
     it { is_expected.to have_attributes age: 35 }
+  end
+
+  describe "#find_current_step" do
+    subject { wizard.find_current_step }
+    it { is_expected.to be_instance_of Age }
   end
 
   describe "#previous_step" do
@@ -65,6 +91,11 @@ describe Wizard::Base do
       subject { wizard.previous_step("name") }
       it { is_expected.to be_nil }
     end
+
+    context "when no step supplied" do
+      subject { wizard.previous_step }
+      it { is_expected.to eql "name" }
+    end
   end
 
   describe "#next_step" do
@@ -76,6 +107,11 @@ describe Wizard::Base do
     context "when there are no more steps" do
       subject { wizard.next_step("postcode") }
       it { is_expected.to be_nil }
+    end
+
+    context "when no step supplied" do
+      subject { wizard.next_step }
+      it { is_expected.to eql "postcode" }
     end
   end
 end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe Wizard::Base do
+  class Name < Wizard::Step
+    attribute :name
+  end
+
+  class Age < Wizard::Step
+    attribute :age, :integer
+  end
+
+  class Address < Wizard::Step
+    attribute :postcode
+  end
+
+  class TestWizard < Wizard::Base
+    self.steps = [Name, Age, Address].freeze
+  end
+
+  let(:wizardclass) { TestWizard }
+  let(:backingstore) { { name: "Joe", age: 35 } }
+  let(:store) { Wizard::Store.new backingstore }
+  let(:wizard) { wizardclass.new store }
+
+  describe ".indexed_steps" do
+    subject { wizardclass.indexed_steps }
+    it { is_expected.to eql("name" => Name, "age" => Age, "address" => Address) }
+  end
+
+  describe ".step" do
+    it "will return steps class for valid step" do
+      expect(wizardclass.step("age")).to eql Age
+    end
+
+    it "will raise exception for unknown step" do
+      expect { wizardclass.step("unknown") }.to \
+        raise_exception(Wizard::Base::UnknownStep)
+    end
+  end
+
+  describe ".step_index" do
+    it "will return index for known step" do
+      expect(wizardclass.step_index("age")).to eql 1
+    end
+
+    it "will raise exception for unknown step" do
+      expect { wizardclass.step_index("unknown") }.to \
+        raise_exception(Wizard::Base::UnknownStep)
+    end
+  end
+
+  describe "#find" do
+    subject { wizard.find("age") }
+    it { is_expected.to be_instance_of Age }
+    it { is_expected.to have_attributes age: 35 }
+  end
+
+  describe "#previous_step" do
+    context "when there are more steps" do
+      subject { wizard.previous_step("age") }
+      it { is_expected.to eql "name" }
+    end
+
+    context "when there are no more steps" do
+      subject { wizard.previous_step("name") }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#next_step" do
+    context "when there are more steps" do
+      subject { wizard.next_step("age") }
+      it { is_expected.to eql "address" }
+    end
+
+    context "when there are no more steps" do
+      subject { wizard.next_step("address") }
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -34,7 +34,7 @@ describe Wizard::Base do
 
     it "will raise exception for unknown step" do
       expect { wizardclass.step("unknown") }.to \
-        raise_exception(Wizard::Base::UnknownStep)
+        raise_exception(Wizard::UnknownStep)
     end
   end
 
@@ -45,7 +45,7 @@ describe Wizard::Base do
 
     it "will raise exception for unknown step" do
       expect { wizardclass.step_index("unknown") }.to \
-        raise_exception(Wizard::Base::UnknownStep)
+        raise_exception(Wizard::UnknownStep)
     end
   end
 
@@ -61,7 +61,7 @@ describe Wizard::Base do
 
     it "should raise exception for unknown step" do
       expect { wizardclass.new wizardstore, "unknown" }.to \
-        raise_exception Wizard::Base::UnknownStep
+        raise_exception Wizard::UnknownStep
     end
   end
 

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Wizard::Base do
+  include_context "wizard store"
+
   class Name < Wizard::Step
     attribute :name
   end
@@ -9,22 +11,20 @@ describe Wizard::Base do
     attribute :age, :integer
   end
 
-  class Address < Wizard::Step
+  class Postcode < Wizard::Step
     attribute :postcode
   end
 
   class TestWizard < Wizard::Base
-    self.steps = [Name, Age, Address].freeze
+    self.steps = [Name, Age, Postcode].freeze
   end
 
   let(:wizardclass) { TestWizard }
-  let(:backingstore) { { name: "Joe", age: 35 } }
-  let(:store) { Wizard::Store.new backingstore }
-  let(:wizard) { wizardclass.new store }
+  let(:wizard) { wizardclass.new wizardstore }
 
   describe ".indexed_steps" do
     subject { wizardclass.indexed_steps }
-    it { is_expected.to eql("name" => Name, "age" => Age, "address" => Address) }
+    it { is_expected.to eql("name" => Name, "age" => Age, "postcode" => Postcode) }
   end
 
   describe ".step" do
@@ -70,11 +70,11 @@ describe Wizard::Base do
   describe "#next_step" do
     context "when there are more steps" do
       subject { wizard.next_step("age") }
-      it { is_expected.to eql "address" }
+      it { is_expected.to eql "postcode" }
     end
 
     context "when there are no more steps" do
-      subject { wizard.next_step("address") }
+      subject { wizard.next_step("postcode") }
       it { is_expected.to be_nil }
     end
   end

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Wizard::Step do
+  include_context "wizard store"
+
   class FirstStep < Wizard::Step
     attribute :name
     attribute :age, :integer
@@ -13,8 +15,7 @@ describe Wizard::Step do
   end
 
   describe ".new" do
-    let(:store) { Wizard::Store.new name: "Joe", age: 30 }
-    subject { FirstStep.new store, age: "20" }
+    subject { FirstStep.new wizardstore, age: "20" }
     it { is_expected.to be_instance_of FirstStep }
     it { is_expected.to have_attributes name: "Joe" }
     it { is_expected.to have_attributes age: 20 }
@@ -22,18 +23,17 @@ describe Wizard::Step do
 
   describe "#save" do
     let(:backingstore) { {} }
-    let(:store) { Wizard::Store.new backingstore }
 
     context "when valid" do
-      subject { FirstStep.new store, name: "Jane" }
+      subject { FirstStep.new wizardstore, name: "Jane" }
       let!(:result) { subject.save }
 
       it { expect(result).to be true }
-      it { expect(store[:name]).to eql "Jane" }
+      it { expect(wizardstore[:name]).to eql "Jane" }
     end
 
     context "when invalid" do
-      subject { FirstStep.new store, age: 30 }
+      subject { FirstStep.new wizardstore, age: 30 }
       let!(:result) { subject.save }
 
       it { expect(result).to be false }

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe Wizard::Step do
+  class FirstStep < Wizard::Step
+    attribute :name
+    attribute :age, :integer
+    validates :name, presence: true
+  end
+
+  describe ".key" do
+    it { expect(described_class.key).to eql "step" }
+    it { expect(FirstStep.key).to eql "first_step" }
+  end
+
+  describe ".new" do
+    let(:store) { Wizard::Store.new name: "Joe", age: 30 }
+    subject { FirstStep.new store, age: "20" }
+    it { is_expected.to be_instance_of FirstStep }
+    it { is_expected.to have_attributes name: "Joe" }
+    it { is_expected.to have_attributes age: 20 }
+  end
+
+  describe "#save" do
+    let(:backingstore) { {} }
+    let(:store) { Wizard::Store.new backingstore }
+
+    context "when valid" do
+      subject { FirstStep.new store, name: "Jane" }
+      let!(:result) { subject.save }
+
+      it { expect(result).to be true }
+      it { expect(store[:name]).to eql "Jane" }
+    end
+
+    context "when invalid" do
+      subject { FirstStep.new store, age: 30 }
+      let!(:result) { subject.save }
+
+      it { expect(result).to be false }
+      it { is_expected.to have_attributes errors: hash_including(:name) }
+    end
+  end
+end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -42,9 +42,18 @@ describe Wizard::Store do
   end
 
   describe "#fetch" do
-    subject { instance.fetch :name, :region }
-    it "will return hash of requested keys" do
-      is_expected.to eql({ name: "Joe", region: "North West" })
+    context "with multiple keys" do
+      subject { instance.fetch :name, :region }
+      it "will return hash of requested keys" do
+        is_expected.to eql({ name: "Joe", region: "North West" })
+      end
+    end
+
+    context "with array of keys" do
+      subject { instance.fetch %i[name region] }
+      it "will return hash of requested keys" do
+        is_expected.to eql({ name: "Joe", region: "North West" })
+      end
     end
   end
 end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe Wizard::Store do
+  let(:backingstore) { { name: "Joe", age: 20, region: "North West" } }
+  let(:instance) { described_class.new backingstore }
+  subject { instance }
+
+  describe ".new" do
+    context "with valid source data" do
+      it { is_expected.to be_instance_of(Wizard::Store) }
+      it { is_expected.to have_attributes data: backingstore }
+      it { is_expected.to respond_to :[] }
+      it { is_expected.to respond_to :[]= }
+    end
+
+    context "with invalid source data" do
+      subject { described_class.new nil }
+
+      it "should raise an InvalidBackingStore" do
+        expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
+      end
+    end
+  end
+
+  describe "#[]" do
+    context "name" do
+      subject { instance[:name] }
+      it { is_expected.to eql "Joe" }
+    end
+
+    context "age" do
+      subject { instance[:age] }
+      it { is_expected.to eql 20 }
+    end
+  end
+
+  describe "#[]=" do
+    it "will update stored value" do
+      expect { subject[:name] = "Jane" }.to \
+        change { subject[:name] }.from("Joe").to("Jane")
+    end
+  end
+
+  describe "#fetch" do
+    subject { instance.fetch :name, :region }
+    it "will return hash of requested keys" do
+      is_expected.to eql({ name: "Joe", region: "North West" })
+    end
+  end
+end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Wizard::Store do
-  let(:backingstore) { { name: "Joe", age: 20, region: "North West" } }
+  let(:backingstore) { { name: "Joe", age: 20, region: "Manchester" } }
   let(:instance) { described_class.new backingstore }
   subject { instance }
 
@@ -45,14 +45,14 @@ describe Wizard::Store do
     context "with multiple keys" do
       subject { instance.fetch :name, :region }
       it "will return hash of requested keys" do
-        is_expected.to eql({ name: "Joe", region: "North West" })
+        is_expected.to eql({ name: "Joe", region: "Manchester" })
       end
     end
 
     context "with array of keys" do
       subject { instance.fetch %i[name region] }
       it "will return hash of requested keys" do
-        is_expected.to eql({ name: "Joe", region: "North West" })
+        is_expected.to eql({ name: "Joe", region: "Manchester" })
       end
     end
   end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -1,0 +1,9 @@
+shared_context "wizard store" do
+  let(:backingstore) { { name: "Joe", age: 35 } }
+  let(:wizardstore) { Wizard::Store.new backingstore }
+end
+
+shared_examples "a wizard step" do
+  it { expect(subject.class).to respond_to :key }
+  it { is_expected.to respond_to :save }
+end


### PR DESCRIPTION
### JIRA ticket number

GITPB-245

### Context

Within the Get into Teaching app we have a couple of wizard processes, Apply for an Event and the Join Newsletter.

These classes add a basic framework for implementing the wizard

### Changes proposed in this pull request

1. Added base classes for the data store, the wizard and the steps
2. Added an implementation for the first screen of the event application wizard
3. Added a common route and controller for the Event Application wizard

### Guidance to review

### Design notes

The `Store` class is abstracted out, even though it currently just wraps session to allow it to be replaced with alternatives in the future - eg use Redis as the backing store.

The `Step` 's implement each of the screens, are are effectively basic ActiveModels. 

The `Wizard` simply controls the flow between screens. 

A single controller is used to access a wizard with `params[:id]` being used to determine the step and load the appropriate form from the view.

Adding branching should not affect controllers because the flow logic is held within the `Step` and `Wizard` classes.

#### Future work

**Conditionals**

`Step`'s do not yet implement logic for whether they step should be being shown (ie conditional) but it is intended to add a `active?` method to `Step`, defaulting to `true`. 

This will allow implementing a Wizard as a linear flow but with steps that can be skipped. The actual logic for `active?` will have access to the full `Store` hash so can do things like 'this is active if the user said yes to a question 2 screens back`.

`#active?` will also allow determining whether to include the step in the serialization at the end when uploading data to the API.

Currently `Wizard`'s `#next_step`, `#previous_step` operate in a simple linear manner but the PR for the `#active?` method on the `Step` class will update `#next_step`/`#previous_step` to take `#active?` into account.

**API Integration**

This does not currently implement API integration support - the intention is to replace the current call to `#save` in the controller with separate `#valid?` and `#persist` calls, with an `Step#call_api` method or equivalent between those steps. This does mean the API call is held within the Step itself but does not tie it into the 'save` lifecycle as using callbacks would. It would also be a no-op for most steps apart from the identification ones at the start of the wizard.

**Users manually skipping steps**

Currently there is nothing to enforce that users follow the correct flow - whilst all steps are required this is only necessary at the end of the journey but will be implemented in the abstract `Wizard` class when conditionals are implemented. 