### PR TITLE
Pipeline should not push feature branches to docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,32 @@
 name: Build and Deploy
 on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
   push:
-    branches:
-      - master
+    branches: [ master ]
 env:
   APP_REPOSITORY: dfedigital/get-into-teaching-web
   CONTENT_REPOSITORY: DFE-Digital/get-into-teaching-content
 jobs:
-  build_and_test:
-    name: Build and push to DockerHub
+  test_docker:
+    name: Test Dockerfile 
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Lint Dockerfile
+        uses: brpaz/hadolint-action@master
+        with:
+             dockerfile: "Dockerfile"
+  build:
+    name: Build 
+    runs-on: ubuntu-latest
+    needs: test_docker
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
       - name: Build and push to Docker Hub
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -24,6 +37,22 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
           push: true
+      - name: Build Only 
+        if: github.ref != 'refs/heads/master'
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+          repository: ${{ env.APP_REPOSITORY }}
+          always_pull: true
+          add_git_labels: true
+          tag_with_ref: true
+          tag_with_sha: true
+  test_ruby:
+    name: Test Ruby 
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Set DOCKER_IMAGE environment variable
         run: |-
           echo ::set-env name=DOCKER_IMAGE::${{ env.APP_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
@@ -37,8 +66,7 @@ jobs:
     name: Trigger build of Content repo
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs:
-      - build_and_test
+    needs: test_ruby
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
 CMD ["rails", "server" ]
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache build-base git tzdata nodejs yarn
 
 # install NPM packages removign artifacts
@@ -25,6 +26,7 @@ RUN gem install bundler --version=2.1.4
 
 # Install Gems removing artifacts
 COPY .ruby-version Gemfile Gemfile.lock ./
+# hadolint ignore=SC2046
 RUN bundle install --without development --jobs=$(nproc --all) && \
     rm -rf /root/.bundle/cache && \
     rm -rf /usr/local/bundle/cache


### PR DESCRIPTION
Prevent feature branches from pushing to docker hub, but allow them to build images and test those images.
