### PR TITLE
Update SHA generated in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY . .
 RUN bundle exec rake assets:precompile
 
 ARG SHA
-RUN echo "${SHA}" > /etc/get-into-teaching-app-sha
+RUN echo "sha-${SHA}" > /etc/get-into-teaching-app-sha


### PR DESCRIPTION
### Changes proposed in this pull request
By default github adds sha- prefix to the docker image tag so we need to add it in the file
