### PR TITLE
added alert

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Lint Ruby
         run: |-
           docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang
+      - name:  Send Message to Sentry.io
+        if: ${{ always() }}
+        uses: sfawcett123/sentry-event@v1
+        with: 
+             MESSAGE: "Build Application"
+             STATE:  ${{job.status}}
+             ENVIRON: "Test"
+        env:
+            SENTRY_DSN: ${{secrets.SENTRY_DSN}}
   trigger_content_build:
     name: Trigger build of Content repo
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
              STATE:  ${{job.status}}
              ENVIRON: "Test"
         env:
-            SENTRY_DSN: ${{secrets.SENTRY_DSN}}
+            SENTRY_DSN: ${{secrets.DEV_OPS_SENTRY_DSN}}
   trigger_content_build:
     name: Trigger build of Content repo
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rspec
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang
+          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang || true
       - name:  Send Message to Sentry.io
         if: ${{ always() }}
         uses: sfawcett123/sentry-event@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rspec
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang || true
+          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang 
       - name:  Send Message to Sentry.io
         if: ${{ always() }}
         uses: sfawcett123/sentry-event@v1


### PR DESCRIPTION
Added a call to a bespoke github action [SentryEvent](https://github.com/sfawcett123/sentry-event) (this event can be transferred to DfE ownership later ) which when called passes data to sentry.  as shown below:

[Event](https://sentry.io/organizations/dfe-bat/issues/1741657822/?project=5276949&query=is%3Aunresolved)


The SENTRY_DSN has the saved as a SECRET in github and passed as an environment variable.

By doing this sentry.io can be configured to ALERT to various team members or SLACK based upon the tags and event details.
