### PR TITLE
Return 404 when accessing an unknown page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,5 +29,18 @@ class PagesController < ApplicationController
     else
       render template: "content/#{params[:page]}", layout: "layouts/content"
     end
+  rescue ActionView::MissingTemplate
+    respond_to do |format|
+      format.html do
+        render \
+          template: "errors/not_found",
+          layout: "plain",
+          status: :not_found
+      end
+
+      format.all do
+        render status: :not_found, body: nil
+      end
+    end
   end
 end

--- a/app/views/layouts/plain.html.erb
+++ b/app/views/layouts/plain.html.erb
@@ -20,7 +20,7 @@
         <%= render "layouts/header" %>
 
         <div class="container-plain">
-            <section class='content container-1000'>
+            <section class="content container-1000">
                 <p>
                     <%= yield %>
                 </p>


### PR DESCRIPTION
### JIRA ticket number

GITPB-339

### Context

As part of the sentry work, it was found missing pages were triggering 500 errors.

### Changes proposed in this pull request

1. Rescue the errors from missing templates and render the appropriate 404 page



