### PR TITLE
Raise 404 when accessing missing assets

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
+  if Rails.env.rolling? || Rails.env.preprod? || Rails.env.production?
+    get "/assets/*missing", to: "errors#not_found", via: :all
+  end
+
   get "/events", to: "pages#events", via: :all, as: nil
   get "/eventschool", to: "pages#eventschool", via: :all
   get "/event", to: "pages#event", via: :all, as: nil


### PR DESCRIPTION
### JIRA ticket number

GITPB-339

### Context

As part of the Sentry changes it was found that missing assets produce 500 errors instead of 404s

### Changes proposed in this pull request

1, Use existing exceptions handler for missing assets


