### PR TITLE
Added healthcheck endpoint

### DIFF
--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -1,0 +1,6 @@
+class HealthchecksController < ApplicationController
+  def show
+    @healthcheck = Healthcheck.new
+    render json: @healthcheck
+  end
+end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -1,0 +1,26 @@
+class Healthcheck
+  delegate :to_json, to: :to_h
+
+  def app_sha
+    read_file "/etc/get-into-teaching-app-sha"
+  end
+
+  def content_sha
+    read_file "/etc/get-into-teaching-content-sha"
+  end
+
+  def to_h
+    {
+      app_sha: app_sha,
+      content_sha: content_sha,
+    }
+  end
+
+private
+
+  def read_file(file)
+    File.read(file).strip
+  rescue Errno::ENOENT
+    nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     get "/assets/*missing", to: "errors#not_found", via: :all
   end
 
+  get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
+
   get "/events", to: "pages#events", via: :all, as: nil
   get "/eventschool", to: "pages#eventschool", via: :all
   get "/event", to: "pages#event", via: :all, as: nil

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe Healthcheck do
+  let(:gitsha) { "d64e925a5c70b05246e493de7b60af73e1dfa9dd" }
+
+  shared_examples "reading git shas" do |shamethod, shafile|
+    describe "##{shamethod}" do
+      subject { described_class.new.send(shamethod) }
+
+      context "when #{shafile} is set" do
+        before do
+          allow(File).to receive(:read).with(shafile).and_return("#{gitsha}\n")
+        end
+
+        it { is_expected.to eql gitsha }
+      end
+
+      context "when #{shafile} is missing" do
+        before do
+          allow(File).to receive(:read).with(shafile).and_raise Errno::ENOENT
+        end
+
+        it { is_expected.to eql nil }
+      end
+    end
+  end
+
+  include_examples "reading git shas", "app_sha", "/etc/get-into-teaching-app-sha"
+  include_examples "reading git shas", "content_sha", "/etc/get-into-teaching-content-sha"
+
+  describe "#to_h" do
+    subject { described_class.new.to_h }
+    it { is_expected.to include :app_sha }
+    it { is_expected.to include :content_sha }
+  end
+
+  describe "#to_json" do
+    subject { JSON.parse described_class.new.to_json }
+    it { is_expected.to include "app_sha" }
+    it { is_expected.to include "content_sha" }
+  end
+end

--- a/spec/requests/healthchecks_controller_spec.rb
+++ b/spec/requests/healthchecks_controller_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe HealthchecksController do
+  describe "#show" do
+    before { get healthcheck_path }
+    it { expect(response).to have_http_status(:success) }
+  end
+end


### PR DESCRIPTION
### Context

We need to be able to provide a health check endpoint for verifying the image is working correctly.

### Changes proposed in this pull request

1. Add an initial "/healthcheck.json" end point which just includes the relevant git shas



