### PR TITLE
Added correct error messages for Event Search form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,19 @@ en:
   activemodel:
     errors:
       models:
+        events/search:
+          attributes:
+            type:
+              blank: Select the type of event
+              inclusion: Select the event type from the list
+            month:
+              blank: Select the month
+              invalid: Select the month from the list
+            distance:
+              inclusion: Select a distance from the list
+            postcode:
+              blank: Enter your postcode
+              invalid: Enter a valid postcode
         events/steps/personal_details:
           attributes:
             first_name:


### PR DESCRIPTION
### JIRA ticket number

GITPB-291

### Context

We should show GDS compliant error messages if the user completes the Event Search for incorrectly

### Changes proposed in this pull request

1. Update the translations file with appropriate error messages

### Guidance to review

Can be tested at `/apievents`

