### PR TITLE
Send RSpec output to Sonarcloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,35 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
           build_args: SHA=${{ steps.sha.outputs.short}}
+
       - name: Set DOCKER_IMAGE environment variable
         run: |-
           echo ::set-env name=DOCKER_IMAGE::${{ env.APP_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
+
       - name: Run Specs
         run: |-
-          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rspec
+          docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test $DOCKER_IMAGE \
+            rspec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format documentation
+
+      - name: Fixup report file paths
+        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/.resultset.json
+
+      - name:  Keep Code Coverage Report
+        uses: actions/upload-artifact@v2
+        with:
+          name: Code_Coverage
+          path: ${{ github.workspace }}/coverage/*
+
+      - name:  Keep Unit Tests Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit_tests
+          path: ${{ github.workspace }}/out/*
+
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE bundle exec rubocop app config db lib spec Gemfile --format clang 
+          docker run -t --rm -e RAILS_ENV=test $DOCKER_IMAGE \
+            bundle exec rubocop app config db lib spec Gemfile --format clang
 
       - name: Run sonarqube
         env:
@@ -69,6 +89,8 @@ jobs:
            -Dsonar.sources='app,lib,db,config' 
            -Dsonar.tests='./spec' 
            -Dsonar.exclusions='app/assets/**/*'
+           -Dsonar.testExecutionReportPaths=out/test-report.xml
+           -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
 
       - name:  Send Message to Sentry.io
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 *.log
 app/views/content/**/*
 /config/credentials/*.key
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.31"
   gem "factory_bot_rails"
+  gem "rspec-sonarqube-formatter", "~> 1.3", require: false
+  gem "simplecov", "<= 0.17"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -110,8 +111,10 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    htmlentities (4.3.4)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    json (2.3.1)
     kramdown (2.2.1)
       rexml
     listen (3.2.1)
@@ -185,6 +188,10 @@ GEM
     regexp_parser (1.7.0)
     rexml (3.2.4)
     rinku (2.0.6)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -201,6 +208,9 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-sonarqube-formatter (1.3.0)
+      htmlentities (~> 4.3.3)
+      rspec (~> 3.0)
     rspec-support (3.9.3)
     rubocop (0.83.0)
       parallel (~> 1.10)
@@ -242,6 +252,11 @@ GEM
       faraday (>= 1.0)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
+    simplecov (0.17.0)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -306,10 +321,12 @@ DEPENDENCIES
   rails (~> 6.0.2)
   rinku
   rspec-rails (~> 4.0.0)
+  rspec-sonarqube-formatter (~> 1.3)
   rubocop-govuk
   scss_lint-govuk
   sentry-raven
   shoulda-matchers
+  simplecov (<= 0.17)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,14 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require "webmock/rspec"
 
+require "simplecov"
+SimpleCov.start "rails" do
+  add_filter "/app/services/get_into_teaching_api/fake_endpoints.rb"
+  add_filter "/bin/"
+  add_filter "/db/"
+  add_filter "/spec/"
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
### Context

Sonarcloud needs the output of test runs for it to pass PRs

### Changes proposed in this pull request

1. Added sonarqube output formatter for rspec
2. Export the formatter output to a folder on the host
3. Pass that folder of output to the sonarcloud step


