### PR TITLE
Configure SonarCloud to align with SimpleCov output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,6 @@ jobs:
            -Dsonar.organization=dfe-digital
            -Dsonar.host.url=https://sonarcloud.io/
            -Dsonar.projectKey=DFE-Digital_get-into-teaching-app
-           -Dsonar.sources='app,lib,db,config' 
-           -Dsonar.tests='./spec' 
-           -Dsonar.exclusions='app/assets/**/*'
            -Dsonar.testExecutionReportPaths=out/test-report.xml
            -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
 

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,0 @@
-sonar.cpd.exclusions=app/views/pages/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.cpd.exclusions=app/views/pages/**/*
-sonar.sources=app,lib,db,config
+sonar.sources=app,lib,config
 sonar.tests=./spec
-sonar.exclusions=app/assets/**/*
+sonar.exclusions=app/assets/**/*,app/webpacker/**/*,**/fake_endpoints.rb
 sonar.ruby.coverage.framework=RSpec
+sonar.coverage.exclusions=config

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.cpd.exclusions=app/views/pages/**/*
+sonar.sources=app,lib,db,config
+sonar.tests=./spec
+sonar.exclusions=app/assets/**/*
+sonar.ruby.coverage.framework=RSpec


### PR DESCRIPTION
### JIRA ticket number

GITPB-400

### Context

Sonarcloud code coverage numbers are not accurate but need to be for developers to trust the results.

### Changes proposed in this pull request

1. Rename the sonarcloud config file to the sonar-scanner variant
2. Move the per app sonarscanner configuration to the sonar-scanner config file
3. Update the configuration to exclude certain folders from code coverage, eg `config/`,`db/` 


