### PR TITLE
Clear Mailing List wizard data upon completion

### DIFF
--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -8,5 +8,11 @@ module MailingList
       Steps::Postcode,
       Steps::Contact,
     ].freeze
+
+    def complete!
+      super.tap do |result|
+        result && @store.purge!
+      end
+    end
   end
 end

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -15,4 +15,15 @@ describe MailingList::Wizard do
       ]
     end
   end
+
+  describe "#complete!" do
+    let(:store) { { "first_name" => "Joe", "last_name" => "Joeseph" } }
+    let(:wizardstore) { Wizard::Store.new store }
+    subject { described_class.new wizardstore, "contact" }
+    before { allow(subject).to receive(:valid?).and_return true }
+    before { subject.complete! }
+
+    it { is_expected.to have_received(:valid?) }
+    it { expect(store).to eql({}) }
+  end
 end


### PR DESCRIPTION
### Context

Currently the Mailing List wizard hangs onto data for the duration of the session cookie

### Changes proposed in this pull request

1. Clear the data upon successful completion of the wizard



