### PR TITLE
Use autogenerated api client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
+gem "get_into_teaching_api_client", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
+  revision: 9a2e7399c45eb635475aaffb6b60618e085c0470
+  specs:
+    get_into_teaching_api_client (1.0.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GIT
   remote: https://github.com/waiting-for-dev/front_matter_parser.git
   revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
   specs:
@@ -93,6 +101,8 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.2.0)
@@ -270,6 +280,8 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uk_postcode (2.1.5)
@@ -313,6 +325,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
+  get_into_teaching_api_client!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -66,7 +66,8 @@ module Events
     end
 
     def query_event_types
-      GetIntoTeachingApi::Client.event_types
+      # GetIntoTeachingApi::Client.event_types
+      GetIntoTeachingApiClient::TypesApi.new.get_teaching_event_types
     end
 
     def start_of_month

--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -1,0 +1,15 @@
+GetIntoTeachingApiClient.configure do |config|
+  config.api_key["Authorization"] = \
+    ENV["GIT_API_TOKEN"].presence || \
+    Rails.application.credentials.git_api_token.presence
+
+  endpoint = ENV["GIT_API_ENDPOINT"].presence || \
+    Rails.application.config.x.git_api_endpoint.presence
+
+  if endpoint
+    parsed = URI.parse(endpoint)
+
+    config.host = parsed.hostname
+    config.base_path = parsed.path.gsub(%r{\A/api}, "")
+  end
+end

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -1,9 +1,13 @@
 shared_context "stub types api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:event_types) { [{ "id" => 1, "value" => "First type" }] }
 
   before do
-    allow_any_instance_of(GetIntoTeachingApi::EventTypes).to \
-      receive(:data).and_return event_types
+    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_event/types")
+      .to_return \
+        status: 200,
+        headers: { "Content-type" => "application/json" },
+        body: event_types.to_json
   end
 end
 


### PR DESCRIPTION
### Context

We would like to swap to using the autogenerated swagger get-into-teaching-api ruby client

### Changes proposed in this pull request

1. Setup the API client on boot
2. Use the API client for the types listing in the search interface



