### PR TITLE
Allow searching without postcode

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -29,10 +29,7 @@ module Events
     end
 
     def available_distances
-      # [["Nationwide", nil]] + # Commented out for now because the API requires a postcode for now
-      DISTANCES.map do |d|
-        ["Within #{d} miles", d]
-      end
+      [["Nationwide", nil]] + DISTANCES.map { |d| ["Within #{d} miles", d] }
     end
 
     def available_distance_keys

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -56,7 +56,7 @@ module Events
     def query_events_api
       GetIntoTeachingApi::Client.search_events \
         type_id: type,
-        radius_in_km: distance,
+        radius: distance,
         postcode: postcode,
         start_after: start_of_month,
         start_before: end_of_month

--- a/app/services/get_into_teaching_api/search_events.rb
+++ b/app/services/get_into_teaching_api/search_events.rb
@@ -1,8 +1,8 @@
 module GetIntoTeachingApi
   class SearchEvents < Base
-    def initialize(type_id:, radius_in_km:, postcode:, start_before:, start_after:, **base_args)
+    def initialize(type_id:, radius:, postcode:, start_before:, start_after:, **base_args)
       @type_id = type_id
-      @radius_in_km = radius_in_km
+      @radius = radius
       @postcode = postcode
       @start_after = start_after
       @start_before = start_before
@@ -16,7 +16,7 @@ module GetIntoTeachingApi
     def params
       {
         "TypeId" => @type_id,
-        "RadiusInKm" => @radius_in_km,
+        "Radius" => @radius,
         "Postcode" => @postcode,
         "StartAfter" => @start_after.xmlschema,
         "StartBefore" => @start_before.xmlschema,

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -12,7 +12,7 @@ describe Events::Search do
 
   context "available_distance_keys" do
     subject { described_class.new.available_distance_keys }
-    it { is_expected.to eql [30, 50, 100] }
+    it { is_expected.to eql [nil, 30, 50, 100] }
   end
 
   context "validation" do

--- a/spec/services/get_into_teaching_api/search_events_spec.rb
+++ b/spec/services/get_into_teaching_api/search_events_spec.rb
@@ -10,7 +10,7 @@ describe GetIntoTeachingApi::SearchEvents do
   let(:search_params) do
     {
       "TypeId" => 222_750_001,
-      "RadiusInKm" => 30,
+      "Radius" => 30,
       "Postcode" => "TE571NG",
       "StartAfter" => /2020-07-01/,
       "StartBefore" => /2020-07-31/,
@@ -19,7 +19,7 @@ describe GetIntoTeachingApi::SearchEvents do
   let(:client) do
     described_class.new(**api_params.merge(
       type_id: 222_750_001,
-      radius_in_km: 30,
+      radius: 30,
       postcode: "TE571NG",
       start_after: DateTime.parse("2020-07-01T00:00:00"),
       start_before: DateTime.parse("2020-07-31T23:59:59"),


### PR DESCRIPTION
### JIRA ticket number

[GITPB-456](https://dfedigital.atlassian.net/browse/GITPB-456)

### Context

We want users to be able to search for events nationally (not centred around a specific postcode).

### Changes proposed in this pull request

- Re-introduce nationwide event search option

The API now supports searching nationwide (without a postcode).

- Use radius instead of radius_in_km

The API was incorrectly exposing a `radiusInKm` query string attribute as well as a `radius` attribute when searching for events. The former is a readonly computed attribute so setting it would have no effect. Updating to use the `radius` attribute instead will filter correctly.

We were also passing a distance collected in miles to `radiusInKm` which would not have returned accurate results. The `radius` attribute, however, does accept miles so this should now be fine.

### Guidance to review

