### PR TITLE
Add authentication step to event sign up

### DIFF
--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,0 +1,6 @@
+module SessionHelper
+  def event_session
+    session[:events] ||= {}
+    session[:events][params[:event_id]] ||= {}
+  end
+end

--- a/app/models/events/steps/authenticate.rb
+++ b/app/models/events/steps/authenticate.rb
@@ -1,0 +1,17 @@
+module Events
+  module Steps
+    class Authenticate < ::Wizard::Step
+      attribute :timed_one_time_password
+
+      validates :timed_one_time_password, presence: true, length: { is: 6 }, format: { with: /\A[0-9]*\z/, message: "can only contain numbers" }
+
+      before_validation if: :timed_one_time_password do
+        self.timed_one_time_password = timed_one_time_password.to_s.strip
+      end
+
+      def skipped?
+        @store["authenticate"] == false
+      end
+    end
+  end
+end

--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -1,16 +1,17 @@
 module Events
   module Steps
     class PersonalDetails < ::Wizard::Step
-      attribute :email_address
+      attribute :email
       attribute :first_name
       attribute :last_name
+      attribute :authenticate
 
-      validates :email_address, presence: true, email_format: true
+      validates :email, presence: true, email_format: true
       validates :first_name, presence: true
       validates :last_name, presence: true
 
-      before_validation if: :email_address do
-        self.email_address = email_address.to_s.strip
+      before_validation if: :email do
+        self.email = email.to_s.strip
       end
 
       before_validation if: :first_name do
@@ -19,6 +20,29 @@ module Events
 
       before_validation if: :last_name do
         self.last_name = last_name.to_s.strip
+      end
+
+      def save
+        if valid?
+          begin
+            request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
+            GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+            self.authenticate = true
+          rescue GetIntoTeachingApiClient::ApiError
+            # Existing candidate not found or CRM is currently unavailable.
+            self.authenticate = false
+          end
+        end
+
+        super
+      end
+
+    private
+
+      def request_attributes
+        attributes.slice("email", "first_name", "last_name").transform_keys do |k|
+          GetIntoTeachingApiClient::ExistingCandidateRequest.attribute_map[k.to_sym]
+        end
       end
     end
   end

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -2,6 +2,7 @@ module Events
   class Wizard < ::Wizard::Base
     self.steps = [
       Steps::PersonalDetails,
+      Steps::Authenticate,
       Steps::ContactDetails,
       Steps::FurtherDetails,
     ].freeze

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -10,18 +10,18 @@ module MailingList
 
       attribute :first_name
       attribute :last_name
-      attribute :email_address
+      attribute :email
       attribute :current_status
 
-      validates :email_address, presence: true, email_format: true
+      validates :email, presence: true, email_format: true
       validates :first_name, presence: true
       validates :last_name, presence: true
       validates :current_status,
                 presence: true,
                 inclusion: { in: CURRENT_STATUSES, allow_nil: true }
 
-      before_validation if: :email_address do
-        self.email_address = email_address.to_s.strip
+      before_validation if: :email do
+        self.email = email.to_s.strip
       end
 
       before_validation if: :first_name do

--- a/app/views/event_steps/_authenticate.html.erb
+++ b/app/views/event_steps/_authenticate.html.erb
@@ -1,0 +1,5 @@
+<%= f.govuk_text_field :timed_one_time_password, 
+label: { text: t('helpers.label.events_steps_authenticate.timed_one_time_password', email: event_session["email"]) }, 
+hint_text: t("helpers.hint.events_steps_authenticate.timed_one_time_password.text", 
+link: link_to(t("helpers.hint.events_steps_authenticate.timed_one_time_password.link"), root_path)).html_safe %>
+

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_email_field :email_address %>
+<%= f.govuk_email_field :email %>
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
 

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -15,7 +15,7 @@
 
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
-<%= f.govuk_email_field :email_address %>
+<%= f.govuk_email_field :email %>
 
 <%= f.govuk_collection_select :current_status,
       f.object.class.current_statuses,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
               blank: Enter your first name
             last_name:
               blank: Enter your last name
-            email_address:
+            email:
               blank: Enter your full email address
               invalid: Enter a valid email address
         events/steps/contact_details:
@@ -74,7 +74,7 @@ en:
               blank: Enter your first name
             last_name:
               blank: Enter your last name
-            email_address:
+            email:
               blank: Enter your full email address
               invalid: Enter a valid email address
             current_status:
@@ -116,15 +116,17 @@ en:
       events_steps_personal_details:
         first_name: First name
         last_name: Last name
-        email_address: Email address
+        email: Email address
       events_steps_contact_details:
         phone_number: Phone number (optional)
+      events_steps_authenticate:
+        timed_one_time_password: Enter the verification code sent to %{email}
       events_steps_further_details:
         postcode: Postcode (optional)
       mailing_list_steps_name:
         first_name: First name
         last_name: Last name
-        email_address: Email address
+        email: Email address
         current_status: How would you describe yourself?
       mailing_list_steps_degree_stage:
         degree_stage: What stage are you at with your degree?
@@ -143,6 +145,10 @@ en:
         phone_number: |-
           This helps us contact you with updates to this event and other
           important information.
+      events_steps_authenticate:
+        timed_one_time_password:
+          text: Check your junk mail folder or %{link}.
+          link: resend verification
       events_steps_further_details:
         postcode: |-
           Enter your postcode so that we can send you event information

--- a/spec/factories/events/authenticate_factory.rb
+++ b/spec/factories/events/authenticate_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :authenticate, class: Events::Steps::Authenticate do
+    timed_one_time_password { "012345" }
+  end
+end

--- a/spec/factories/events/personal_details_factory.rb
+++ b/spec/factories/events/personal_details_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :events_personal_details, class: Events::Steps::PersonalDetails do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
-    sequence(:email_address) { |n| "testuser#{n}@testing.education.gov.uk" }
+    sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }
   end
 end

--- a/spec/factories/mailing_list/name_factory.rb
+++ b/spec/factories/mailing_list/name_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :mailing_list_name, class: MailingList::Steps::Name do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
-    sequence(:email_address) { |n| "testuser#{n}@testing.education.gov.uk" }
+    sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }
     current_status { MailingList::Steps::Name.current_statuses.first }
   end
 end

--- a/spec/helpers/session_helper_spec.rb
+++ b/spec/helpers/session_helper_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe SessionHelper, type: :helper do
+  describe "#event_session" do
+    it "defaults to an empty hash" do
+      expect(event_session).to eq({})
+    end
+
+    it "returns the session event data associated with the event_id param" do
+      params[:event_id] = "123"
+      event_session_data = { email: "email@address.com" }
+      session[:events] = { "123" => event_session_data }
+      expect(event_session).to eq(event_session_data)
+    end
+  end
+end

--- a/spec/models/events/steps/authenticate_spec.rb
+++ b/spec/models/events/steps/authenticate_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe Events::Steps::Authenticate do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  it { is_expected.to respond_to :timed_one_time_password }
+
+  context "validations" do
+    before { instance.valid? }
+    subject { instance.errors.messages }
+    it { is_expected.to include(:timed_one_time_password) }
+  end
+
+  context "timed one time password" do
+    it { is_expected.to allow_value("000000").for :timed_one_time_password }
+    it { is_expected.to allow_value(" 123456").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("abc123").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("1234567").for :timed_one_time_password }
+    it { is_expected.not_to allow_value("12345").for :timed_one_time_password }
+  end
+
+  describe "skipped?" do
+    it "returns true if authenticate is false" do
+      wizardstore["authenticate"] = false
+      expect(subject).to be_skipped
+    end
+
+    it "returns false if authenticate is true" do
+      wizardstore["authenticate"] = true
+      expect(subject).to_not be_skipped
+    end
+  end
+end

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -6,19 +6,60 @@ describe Events::Steps::PersonalDetails do
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
-  it { is_expected.to respond_to :email_address }
+  it { is_expected.to respond_to :email }
 
   context "validations" do
     before { instance.valid? }
     subject { instance.errors.messages }
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
-    it { is_expected.to include(:email_address) }
+    it { is_expected.to include(:email) }
   end
 
   context "email address" do
-    it { is_expected.to allow_value("me@you.com").for :email_address }
-    it { is_expected.to allow_value(" me@you.com ").for :email_address }
-    it { is_expected.not_to allow_value("me@you").for :email_address }
+    it { is_expected.to allow_value("me@you.com").for :email }
+    it { is_expected.to allow_value(" me@you.com ").for :email }
+    it { is_expected.not_to allow_value("me@you").for :email }
+  end
+
+  describe "#save" do
+    before do
+      subject.email = "email@address.com"
+      subject.first_name = "first"
+      subject.last_name = "last"
+    end
+
+    let(:request) do
+      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+        email: subject.email,
+        firstName: subject.first_name,
+        lastName: subject.last_name,
+      )
+    end
+
+    context "when invalid" do
+      it "does not call the API" do
+        subject.email = nil
+        subject.save
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to_not receive(:create_candidate_access_token)
+      end
+    end
+
+    context "when an existing candidate" do
+      it "sends verification code and sets authenticate to true" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+        subject.save
+        expect(subject.authenticate).to be_truthy
+      end
+    end
+
+    context "when a new candidate or CRM is unavailable" do
+      it "will skip the authenticate step" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(GetIntoTeachingApiClient::ApiError)
+        subject.save
+        expect(subject.authenticate).to be_falsy
+      end
+    end
   end
 end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -7,6 +7,7 @@ describe Events::Wizard do
     it do
       is_expected.to eql [
         Events::Steps::PersonalDetails,
+        Events::Steps::Authenticate,
         Events::Steps::ContactDetails,
         Events::Steps::FurtherDetails,
       ]

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -6,21 +6,21 @@ describe MailingList::Steps::Name do
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
-  it { is_expected.to respond_to :email_address }
+  it { is_expected.to respond_to :email }
   it { is_expected.to respond_to :current_status }
 
   context "validations" do
     subject { instance.tap(&:valid?).errors.messages }
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
-    it { is_expected.to include(:email_address) }
+    it { is_expected.to include(:email) }
     it { is_expected.to include(:current_status) }
   end
 
   context "email address" do
-    it { is_expected.to allow_value("me@you.com").for :email_address }
-    it { is_expected.to allow_value(" me@you.com ").for :email_address }
-    it { is_expected.not_to allow_value("me@you").for :email_address }
+    it { is_expected.to allow_value("me@you.com").for :email }
+    it { is_expected.to allow_value(" me@you.com ").for :email }
+    it { is_expected.not_to allow_value("me@you").for :email }
   end
 
   context "current_status" do

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -2,11 +2,12 @@ require "rails_helper"
 
 describe EventStepsController do
   include_context "stub types api"
+  include_context "stub candidate create access token api"
 
   let(:event_id) { SecureRandom.uuid }
   let(:model) { Events::Steps::PersonalDetails }
   let(:step_path) { event_step_path event_id, model.key }
-  let(:contact_details_path) { event_step_path(event_id, "contact_details") }
+  let(:authenticate_path) { event_step_path(event_id, "authenticate") }
   let(:event) { build :event_api, id: event_id }
 
   before do
@@ -29,7 +30,7 @@ describe EventStepsController do
 
     context "with valid data" do
       let(:details_params) { attributes_for(:events_personal_details) }
-      it { is_expected.to redirect_to contact_details_path }
+      it { is_expected.to redirect_to authenticate_path }
     end
 
     context "with invalid data" do
@@ -41,6 +42,9 @@ describe EventStepsController do
       context "when all valid" do
         before do
           allow_any_instance_of(Events::Steps::PersonalDetails).to \
+            receive(:valid?).and_return true
+
+          allow_any_instance_of(Events::Steps::Authenticate).to \
             receive(:valid?).and_return true
 
           allow_any_instance_of(Events::Steps::ContactDetails).to \

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -11,6 +11,14 @@ shared_context "stub types api" do
   end
 end
 
+shared_context "stub candidate create access token api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
+
+  before do
+    stub_request(:post, "#{git_api_endpoint}/api/candidates/access_tokens").to_return(status: 200, body: "", headers: {})
+  end
+end
+
 shared_examples "api support" do
   let(:token) { "test123" }
   let(:endpoint) { "http://my.api/api" }

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -3,30 +3,30 @@ require "rails_helper"
 describe EmailFormatValidator do
   class TestModel
     include ActiveModel::Model
-    attr_accessor :email_address
-    validates :email_address, email_format: true
+    attr_accessor :email
+    validates :email, email_format: true
   end
 
   before { instance.valid? }
   subject { instance.errors.to_h }
 
   context "invalid addresses" do
-    %w[test.com test@@test.com test@test test@test.].each do |email_address|
-      let(:instance) { TestModel.new(email_address: email_address) }
+    %w[test.com test@@test.com test@test test@test.].each do |email|
+      let(:instance) { TestModel.new(email: email) }
 
-      it "#{email_address} should not be valid" do
-        is_expected.to include email_address: "is invalid"
+      it "#{email} should not be valid" do
+        is_expected.to include email: "is invalid"
       end
     end
   end
 
   context "valid addresses" do
     %w[test@example.com testymctest@gmail.com test%.mctest@domain.co.uk]
-      .each do |email_address|
-      let(:instance) { TestModel.new(email_address: email_address) }
+      .each do |email|
+      let(:instance) { TestModel.new(email: email) }
 
-      it "#{email_address} should be valid" do
-        is_expected.not_to include :email_address
+      it "#{email} should be valid" do
+        is_expected.not_to include :email
       end
     end
   end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-265](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=20451%2C18255&selectedIssue=GITPB-265)

### Context

Returning candidates should be able to authenticate with the system so that we can pre-fill the form with the data we already have on record.

### Changes proposed in this pull request

If a user enters first/last/email that matches a candidate already in the CRM then they will be taken to a new `Authenticate` wizard step where they will be asked to enter the verification token that has been emailed to them.

In the event that the user cannot be found or if the CRM is not reachable (the API throws an exception) then the user will be treated as a new candidate and the `Authenticate` step will be skipped.

Renames `email_address` to `email` throughout for parity with the API (making request logic slightly easier).

### Guidance to review

