### PR TITLE
Send request to add attendee to event

### DIFF
--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -3,16 +3,29 @@ module Events
     class FurtherDetails < ::Wizard::Step
       FUTURE_EVENT_OPTIONS = [["Yes", true], ["No", false]].freeze
 
+      attribute :event_id
       attribute :privacy_policy, :boolean
       attribute :future_events, :boolean
       attribute :address_postcode
 
+      validates :event_id, presence: true
       validates :privacy_policy, presence: true, acceptance: true
       validates :future_events, inclusion: [true, false]
       validates :address_postcode, postcode: { allow_blank: true }
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip
+      end
+
+      def save
+        if valid?
+          # TODO: ensure this is the policy we display to the user
+          accepted_policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
+          @store["accepted_policy_id"] = accepted_policy.id
+          @store["subscribe_to_events"] = future_events == true
+        end
+
+        super
       end
 
       def future_event_options

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -9,8 +9,17 @@ module Events
 
     def complete!
       super.tap do |result|
-        result && @store.purge!
+        break unless result
+
+        add_attendee_to_event
+        @store.purge!
       end
+    end
+
+    def add_attendee_to_event
+      request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(@store.to_hash)
+      api = GetIntoTeachingApiClient::TeachingEventsApi.new
+      api.add_teaching_event_attendee(request)
     end
   end
 end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -31,6 +31,10 @@ module Wizard
       data.clear
     end
 
+    def to_hash
+      data.transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+
     class InvalidBackingStore < RuntimeError; end
   end
 end

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -10,3 +10,5 @@
       inline: true %>
 
 <%= f.govuk_text_field :address_postcode %>
+
+<%= f.hidden_field :event_id, value: params[:event_id] %>

--- a/spec/factories/events/further_details_factory.rb
+++ b/spec/factories/events/further_details_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :events_further_details, class: Events::Steps::FurtherDetails do
+    event_id { "abc123" }
     privacy_policy { true }
     future_events { true }
     address_postcode { "TE57 1NG" }

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -6,12 +6,16 @@ describe Events::Steps::FurtherDetails do
   it_behaves_like "a wizard step"
 
   context "attributes" do
+    it { is_expected.to respond_to :event_id }
     it { is_expected.to respond_to :privacy_policy }
     it { is_expected.to respond_to :future_events }
     it { is_expected.to respond_to :address_postcode }
   end
 
   context "validations" do
+    it { is_expected.to allow_value("abc123").for :event_id }
+    it { is_expected.not_to allow_value("").for :event_id }
+
     it { is_expected.to allow_value("1").for :privacy_policy }
     it { is_expected.not_to allow_value("0").for :privacy_policy }
     it { is_expected.not_to allow_value("").for :privacy_policy }
@@ -31,5 +35,42 @@ describe Events::Steps::FurtherDetails do
     let(:attributes) { { address_postcode: "  TE57 1NG " } }
     before { subject.valid? }
     it { is_expected.to have_attributes address_postcode: "TE57 1NG" }
+  end
+
+  describe "#save" do
+    context "when invalid" do
+      before do
+        subject.privacy_policy = nil
+        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to_not \
+          receive(:get_latest_privacy_policy)
+      end
+
+      it "does not update the store" do
+        expect(subject).to_not be_valid
+        subject.save
+        expect(wizardstore["accepted_policy_id"]).to be_nil
+        expect(wizardstore["subscribe_to_events"]).to be_nil
+      end
+    end
+
+    context "when valid" do
+      let(:response) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
+
+      before do
+        subject.event_id = "abc123"
+        subject.privacy_policy = true
+        subject.future_events = true
+
+        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+          receive(:get_latest_privacy_policy).and_return(response)
+      end
+
+      it "updates the store" do
+        expect(subject).to be_valid
+        subject.save
+        expect(wizardstore["accepted_policy_id"]).to be(response.id)
+        expect(wizardstore["subscribe_to_events"]).to be_truthy
+      end
+    end
   end
 end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -16,10 +16,28 @@ describe Events::Wizard do
 
   describe "#complete!" do
     let(:uuid) { SecureRandom.uuid }
-    let(:store) { { uuid => { "first_name" => "Joe", "last_name" => "Joeseph" } } }
+    let(:store) do
+      { uuid => {
+        "event_id" => "abc123",
+        "email" => "email@address.com",
+        "first_name" => "Joe",
+        "last_name" => "Joseph",
+      } }
+    end
     let(:wizardstore) { Wizard::Store.new store[uuid] }
+    let(:request) do
+      GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
+        { eventId: "abc123", email: "email@address.com", firstName: "Joe", lastName: "Joseph" },
+      )
+    end
+
     subject { described_class.new wizardstore, "further_details" }
+
     before { allow(subject).to receive(:valid?).and_return true }
+    before do
+      expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:add_teaching_event_attendee).with(request).once
+    end
     before { subject.complete! }
 
     it { is_expected.to have_received(:valid?) }

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Wizard::Store do
   let(:backingstore) do
-    { "name" => "Joe", "age" => 20, "region" => "Manchester" }
+    { "first_name" => "Joe", "age" => 20, "region" => "Manchester" }
   end
   let(:instance) { described_class.new backingstore }
   subject { instance }
@@ -25,8 +25,8 @@ describe Wizard::Store do
   end
 
   describe "#[]" do
-    context "name" do
-      subject { instance["name"] }
+    context "first_name" do
+      subject { instance["first_name"] }
       it { is_expected.to eql "Joe" }
     end
 
@@ -38,23 +38,23 @@ describe Wizard::Store do
 
   describe "#[]=" do
     it "will update stored value" do
-      expect { subject["name"] = "Jane" }.to \
-        change { subject["name"] }.from("Joe").to("Jane")
+      expect { subject["first_name"] = "Jane" }.to \
+        change { subject["first_name"] }.from("Joe").to("Jane")
     end
   end
 
   describe "#fetch" do
     context "with multiple keys" do
-      subject { instance.fetch :name, :region }
+      subject { instance.fetch :first_name, :region }
       it "will return hash of requested keys" do
-        is_expected.to eql({ "name" => "Joe", "region" => "Manchester" })
+        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
       end
     end
 
     context "with array of keys" do
-      subject { instance.fetch %w[name region] }
+      subject { instance.fetch %w[first_name region] }
       it "will return hash of requested keys" do
-        is_expected.to eql({ "name" => "Joe", "region" => "Manchester" })
+        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
       end
     end
   end
@@ -65,6 +65,13 @@ describe Wizard::Store do
 
     it "will remove all keys" do
       is_expected.to have_attributes empty?: true
+    end
+  end
+
+  describe "#to_hash" do
+    subject { instance.to_hash }
+    it "returns returns a hash with camelCase keys" do
+      is_expected.to eq(firstName: "Joe", age: 20, region: "Manchester")
     end
   end
 end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe EventStepsController do
   include_context "stub types api"
   include_context "stub candidate create access token api"
+  include_context "stub latest privacy policy api"
+  include_context "stub event add attendee api"
 
   let(:event_id) { SecureRandom.uuid }
   let(:model) { Events::Steps::PersonalDetails }

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -19,6 +19,23 @@ shared_context "stub candidate create access token api" do
   end
 end
 
+shared_context "stub latest privacy policy api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
+  let(:policy) { [{ "id" => "abc123" }] }
+
+  before do
+    stub_request(:get, "#{git_api_endpoint}/api/privacy_policies/latest").to_return(status: 200, body: policy.to_json, headers: {})
+  end
+end
+
+shared_context "stub event add attendee api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
+
+  before do
+    stub_request(:post, "#{git_api_endpoint}/api/teaching_events/attendees").to_return(status: 200, body: "", headers: {})
+  end
+end
+
 shared_examples "api support" do
   let(:token) { "test123" }
   let(:endpoint) { "http://my.api/api" }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-265](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=20451%2C18255&selectedIssue=GITPB-265)

### Context

When a candidate gets to the end of the event registration form we need to send a request to the API to actually register them for the event.

### Changes proposed in this pull request

- Update the wizard to send a request to the API to add the attendee to an event.

It is assumed that the latest privacy policy is being accepted, however this will need to be updated to match the actual policy we show to the candidate (we don't link to the policy yet).

If the request to the API fails a 500 error will currently be thrown; we may want to handle this more gracefully in the future.

### Guidance to review

