### PR TITLE
Connect re-send verification link to API

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -3,7 +3,7 @@ module WizardSteps
 
   included do
     class_attribute :wizard_class
-    before_action :load_wizard, :load_current_step, except: %i[index completed]
+    before_action :load_wizard, :load_current_step, except: %i[index completed resend_verification]
   end
 
   def index
@@ -27,6 +27,12 @@ module WizardSteps
 
   def completed
     # current_step is loaded via before_action
+  end
+
+  def resend_verification
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(wizard_store.to_hash)
+    GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+    redirect_to params[:redirect_path]
   end
 
 private

--- a/app/views/event_steps/_authenticate.html.erb
+++ b/app/views/event_steps/_authenticate.html.erb
@@ -1,5 +1,13 @@
+<%
+  hint_text = t("helpers.hint.events_steps_authenticate.timed_one_time_password.text", 
+    link: link_to(t("helpers.hint.events_steps_authenticate.timed_one_time_password.link"), 
+    resend_verification_event_steps_path(
+      redirect_path: event_step_path(@event.id, Events::Steps::Authenticate.key, 
+      verification_resent: true
+    ))))
+  hint_text += "<br /><b>#{t("helpers.hint.events_steps_authenticate.timed_one_time_password.resent")}</b>" if params[:verification_resent]
+%>
+
 <%= f.govuk_text_field :timed_one_time_password, 
 label: { text: t('helpers.label.events_steps_authenticate.timed_one_time_password', email: event_session["email"]) }, 
-hint_text: t("helpers.hint.events_steps_authenticate.timed_one_time_password.text", 
-link: link_to(t("helpers.hint.events_steps_authenticate.timed_one_time_password.link"), root_path)).html_safe %>
-
+hint_text: hint_text.html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
       events_steps_authenticate:
         timed_one_time_password:
           text: Check your junk mail folder or %{link}.
+          resent: We've sent you another email.
           link: resend verification
       events_steps_further_details:
         address_postcode: |-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,10 @@ Rails.application.routes.draw do
               path: "/apply",
               controller: "event_steps",
               only: %i[index show update] do
-      collection { get :completed }
+      collection do
+        get :completed
+        get :resend_verification
+      end
     end
   end
 

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -75,4 +75,12 @@ describe EventStepsController do
     end
     it { is_expected.to have_http_status :success }
   end
+
+  describe "#resend_verification" do
+    subject do
+      get resend_verification_event_steps_path(event_id, redirect_path: "redirect/path")
+      response
+    end
+    it { is_expected.to redirect_to("redirect/path") }
+  end
 end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-265](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=20451%2C18255&selectedIssue=GITPB-265)

### Context

If the user does not receive the verification email (or if they are too slow to input it and the code expires) they need a mechanism to be able to re-send the code.

### Changes proposed in this pull request

When a user clicks the resend verification link on the `Authenticate` step of event sign up, we issue another request to the API to generate a TOTP and email it to the user.

To make the mechanism work without Javascript we issue a GET request and retrieve the existing candidate details from the wizard store. This way no PII is retained in query string parameters and the request can be made without Javascript (which wouldn't be the case if it was a POST).

As part of the request a redirect path is sent to ensure the user returns to the `Authenticate` step, with an additional message visible:

> We've sent you another email.

### Guidance to review

