### PR TITLE
Populate mailing list sign up select options from API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.1", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", "1.0.2", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 4269bc7f5b0ab4fb5069c76fc8eb789348a9ce82
+  revision: f55f85e9260c17421040377578a639b63a83ca73
   specs:
-    get_into_teaching_api_client (1.0.1)
+    get_into_teaching_api_client (1.0.2)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -325,7 +325,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.1)!
+  get_into_teaching_api_client (= 1.0.2)!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -30,7 +30,7 @@ module WizardSteps
   end
 
   def resend_verification
-    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(wizard_store.to_hash)
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(wizard_store.to_camelized_hash)
     GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
     redirect_to params[:redirect_path]
   end

--- a/app/models/events/steps/authenticate.rb
+++ b/app/models/events/steps/authenticate.rb
@@ -36,7 +36,7 @@ module Events
       end
 
       def timed_one_time_password_is_correct
-        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(@store.to_hash)
+        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(@store.to_camelized_hash)
         @api ||= GetIntoTeachingApiClient::TeachingEventsApi.new
         @totp_response ||= @api.get_pre_filled_teaching_event_add_attendee(timed_one_time_password, request)
       rescue GetIntoTeachingApiClient::ApiError

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -17,7 +17,7 @@ module Events
     end
 
     def add_attendee_to_event
-      request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(@store.to_hash)
+      request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(@store.to_camelized_hash)
       api = GetIntoTeachingApiClient::TeachingEventsApi.new
       api.add_teaching_event_attendee(request)
     end

--- a/app/models/mailing_list/steps/degree_stage.rb
+++ b/app/models/mailing_list/steps/degree_stage.rb
@@ -20,7 +20,7 @@ module MailingList
       end
 
       def skipped?
-        @store["current_status"] != "Student"
+        @store["describe_yourself_option_id"] != GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Student"]
       end
     end
   end

--- a/app/models/mailing_list/steps/degree_stage.rb
+++ b/app/models/mailing_list/steps/degree_stage.rb
@@ -1,26 +1,27 @@
 module MailingList
   module Steps
     class DegreeStage < ::Wizard::Step
-      STAGES = [
-        "Graduate or postgraduate",
-        "First year at university",
-        "Second year at university",
-        "Final year at university",
-      ].freeze
-
-      attribute :degree_stage
-      validates :degree_stage,
+      attribute :degree_status_id
+      validates :degree_status_id,
                 presence: true,
-                inclusion: { in: STAGES, allow_nil: true }
-
-      class << self
-        def stages
-          STAGES
-        end
-      end
+                inclusion: { in: :degree_status_option_ids, allow_nil: true }
 
       def skipped?
         @store["describe_yourself_option_id"] != GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Student"]
+      end
+
+      def degree_status_options
+        @degree_status_options ||= query_degree_status
+      end
+
+      def degree_status_option_ids
+        degree_status_options.map(&:id)
+      end
+
+    private
+
+      def query_degree_status
+        GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
       end
     end
   end

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -1,24 +1,17 @@
 module MailingList
   module Steps
     class Name < ::Wizard::Step
-      CURRENT_STATUSES = [
-        "Student",
-        "Exploring my career options",
-        "Looking to change career",
-        "Not studying and no plans to",
-      ].freeze
-
       attribute :first_name
       attribute :last_name
       attribute :email
-      attribute :current_status
+      attribute :describe_yourself_option_id
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true
       validates :last_name, presence: true
-      validates :current_status,
+      validates :describe_yourself_option_id,
                 presence: true,
-                inclusion: { in: CURRENT_STATUSES, allow_nil: true }
+                inclusion: { in: :describe_yourself_option_ids, allow_nil: true }
 
       before_validation if: :email do
         self.email = email.to_s.strip
@@ -32,10 +25,18 @@ module MailingList
         self.last_name = last_name.to_s.strip
       end
 
-      class << self
-        def current_statuses
-          CURRENT_STATUSES
-        end
+      def describe_yourself_options
+        @describe_yourself_options ||= query_decribe_yourself_options
+      end
+
+      def describe_yourself_option_ids
+        describe_yourself_options.map(&:id)
+      end
+
+    private
+
+      def query_decribe_yourself_options
+        GetIntoTeachingApiClient::TypesApi.new.get_candidate_describe_yourself_options
       end
     end
   end

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -1,49 +1,23 @@
 module MailingList
   module Steps
     class Subject < ::Wizard::Step
-      SUBJECTS = [
-        "Art and Design",
-        "Biology",
-        "Business Studies",
-        "Chemistry",
-        "Citizenship",
-        "Classics",
-        "Computing",
-        "Dance",
-        "Design",
-        "Economics",
-        "English",
-        "French",
-        "Geography",
-        "German",
-        "Health and social care",
-        "History",
-        "Languages (other)",
-        "Maths",
-        "Media studies",
-        "French",
-        "Music",
-        "Physical education",
-        "Physics",
-        "Physics with maths",
-        "Primary psycology",
-        "Religious education",
-        "Social sciences",
-        "Spanish",
-        "Vocational health",
-        "Primary",
-        "I don't know",
-      ].freeze
-
-      attribute :subject
-      validates :subject,
+      attribute :preferred_teaching_subject_id
+      validates :preferred_teaching_subject_id,
                 presence: true,
-                inclusion: { in: SUBJECTS, allow_nil: true }
+                inclusion: { in: :teaching_subject_ids, allow_nil: true }
 
-      class << self
-        def subjects
-          SUBJECTS
-        end
+      def teaching_subjects
+        @teaching_subjects ||= query_teaching_subjects
+      end
+
+      def teaching_subject_ids
+        teaching_subjects.map(&:id)
+      end
+
+    private
+
+      def query_teaching_subjects
+        GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
       end
     end
   end

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -1,22 +1,23 @@
 module MailingList
   module Steps
     class TeacherTraining < ::Wizard::Step
-      STATUSES = [
-        "It's just an idea",
-        "I'm not sure and finding out more",
-        "I'm fairly sure and exploring my options",
-        "I'm very sure and think I'll apply",
-      ].freeze
-
-      attribute :teacher_training
-      validates :teacher_training,
+      attribute :consideration_journey_stage_id
+      validates :consideration_journey_stage_id,
                 presence: true,
-                inclusion: { in: STATUSES, allow_nil: true }
+                inclusion: { in: :consideration_journey_stage_ids, allow_nil: true }
 
-      class << self
-        def statuses
-          STATUSES
-        end
+      def consideration_journey_stages
+        @consideration_journey_stages ||= query_consideration_journey_stages
+      end
+
+      def consideration_journey_stage_ids
+        consideration_journey_stages.map(&:id)
+      end
+
+    private
+
+      def query_consideration_journey_stages
+        GetIntoTeachingApiClient::TypesApi.new.get_candidate_journey_stages
       end
     end
   end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -31,7 +31,7 @@ module Wizard
       data.clear
     end
 
-    def to_hash
+    def to_camelized_hash
       data.transform_keys { |k| k.camelize(:lower).to_sym }
     end
 

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -9,13 +9,21 @@ module GetIntoTeachingApi
       }.freeze
 
     DEGREE_STATUS_OPTIONS =
-    {
-      "Graduate or postgraduate" => "222750000",
-      "Final year" => "222750001",
-      "Second year" => "222750002",
-      "First year" => "222750003",
-      "I don't have a degree and am not studying for one" => "222750004",
-      "Other" => "222750005",
-    }.freeze
+      {
+        "Graduate or postgraduate" => "222750000",
+        "Final year" => "222750001",
+        "Second year" => "222750002",
+        "First year" => "222750003",
+        "I don't have a degree and am not studying for one" => "222750004",
+        "Other" => "222750005",
+      }.freeze
+
+    CONSIDERATION_JOURNEY_STAGES =
+      {
+        "It’s just an idea" => "222750000",
+        "I’m not sure and finding out more" => "222750001",
+        "I’m fairly sure and exploring my options" => "222750002",
+        "I’m very sure and think I’ll apply" => "222750003",
+      }.freeze
   end
 end

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -25,5 +25,14 @@ module GetIntoTeachingApi
         "I’m fairly sure and exploring my options" => "222750002",
         "I’m very sure and think I’ll apply" => "222750003",
       }.freeze
+
+    # This is not a complete list.
+    TEACHING_SUBJECTS =
+      {
+        "Art and design" => "7e2655a1-2afa-e811-a981-000d3a276620",
+        "Maths" => "a42655a1-2afa-e811-a981-000d3a276620",
+        "Pyhsics" => "ac2655a1-2afa-e811-a981-000d3a276620",
+        "No preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
+      }.freeze
   end
 end

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -1,0 +1,11 @@
+module GetIntoTeachingApi
+  module Constants
+    DESCRIBE_YOURSELF_OPTIONS = 
+    {
+      "Student" => "222750000",
+      "Exploring my career options" => "222750001",
+      "Looking to change career" => "222750002",
+      "Not studying and no plans to" => "222750003",
+    }
+  end
+end

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -1,11 +1,11 @@
 module GetIntoTeachingApi
   module Constants
-    DESCRIBE_YOURSELF_OPTIONS = 
-    {
-      "Student" => "222750000",
-      "Exploring my career options" => "222750001",
-      "Looking to change career" => "222750002",
-      "Not studying and no plans to" => "222750003",
-    }
+    DESCRIBE_YOURSELF_OPTIONS =
+      {
+        "Student" => "222750000",
+        "Exploring my career options" => "222750001",
+        "Looking to change career" => "222750002",
+        "Not studying and no plans to" => "222750003",
+      }.freeze
   end
 end

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -7,5 +7,15 @@ module GetIntoTeachingApi
         "Looking to change career" => "222750002",
         "Not studying and no plans to" => "222750003",
       }.freeze
+
+    DEGREE_STATUS_OPTIONS =
+    {
+      "Graduate or postgraduate" => "222750000",
+      "Final year" => "222750001",
+      "Second year" => "222750002",
+      "First year" => "222750003",
+      "I don't have a degree and am not studying for one" => "222750004",
+      "Other" => "222750005",
+    }.freeze
   end
 end

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -1,4 +1,3 @@
-<%= f.govuk_email_field :email %>
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
-
+<%= f.govuk_email_field :email %>

--- a/app/views/mailing_list/steps/_degree_stage.html.erb
+++ b/app/views/mailing_list/steps/_degree_stage.html.erb
@@ -7,7 +7,7 @@
 
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_collection_select :degree_stage,
-      f.object.class.stages,
-      :to_s,
-      :to_s %>
+<%= f.govuk_collection_select :degree_status_id,
+      f.object.degree_status_options,
+      :id,
+      :value %>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -17,7 +17,7 @@
 <%= f.govuk_text_field :last_name %>
 <%= f.govuk_email_field :email %>
 
-<%= f.govuk_collection_select :current_status,
-      f.object.class.current_statuses,
-      :to_s,
-      :to_s %>
+<%= f.govuk_collection_select :describe_yourself_option_id,
+      f.object.describe_yourself_options,
+      :id,
+      :value %>

--- a/app/views/mailing_list/steps/_subject.html.erb
+++ b/app/views/mailing_list/steps/_subject.html.erb
@@ -7,7 +7,7 @@
 
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_collection_select :subject,
-      f.object.class.subjects,
-      :to_s,
-      :to_s %>
+<%= f.govuk_collection_select :preferred_teaching_subject_id,
+      f.object.teaching_subjects,
+      :id,
+      :value %>

--- a/app/views/mailing_list/steps/_teacher_training.html.erb
+++ b/app/views/mailing_list/steps/_teacher_training.html.erb
@@ -7,7 +7,7 @@
 
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_collection_select :teacher_training,
-      f.object.class.statuses,
-      :to_s,
-      :to_s %>
+<%= f.govuk_collection_select :consideration_journey_stage_id,
+      f.object.consideration_journey_stages,
+      :id,
+      :value %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
               inclusion: Select how you would describe yourself
         mailing_list/steps/degree_stage:
           attributes:
-            degree_stage:
+            degree_status_id:
               blank: Select your degree stage
               inclusion: Select your degree stage from the list
         mailing_list/steps/teacher_training:
@@ -129,7 +129,7 @@ en:
         email: Email address
         describe_yourself_option_id: How would you describe yourself?
       mailing_list_steps_degree_stage:
-        degree_stage: What stage are you at with your degree?
+        degree_status_id: What stage are you at with your degree?
       mailing_list_steps_teacher_training:
         teacher_training: How close are you to applying for teacher training?
       mailing_list_steps_subject:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
       mailing_list_steps_teacher_training:
         consideration_journey_stage_id: How close are you to applying for teacher training?
       mailing_list_steps_subject:
-        subject: Which subject do you want to teach?
+        preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
         address_postcode: What's your postcode?
       mailing_list_steps_contact:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
               inclusion: Select your degree stage from the list
         mailing_list/steps/teacher_training:
           attributes:
-            teacher_training:
+            consideration_journey_stage_id:
               blank: Choose an option from the list
               inclusion: Choose an option from the list
         mailing_list/steps/subject:
@@ -131,7 +131,7 @@ en:
       mailing_list_steps_degree_stage:
         degree_status_id: What stage are you at with your degree?
       mailing_list_steps_teacher_training:
-        teacher_training: How close are you to applying for teacher training?
+        consideration_journey_stage_id: How close are you to applying for teacher training?
       mailing_list_steps_subject:
         subject: Which subject do you want to teach?
       mailing_list_steps_postcode:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,7 +158,7 @@ en:
     legend:
       events_steps_further_details:
         privacy_policy: |-
-          Are you over 16 and have agreed to our privacy policy?
+          Are you over 16 and do you agree to our privacy policy?
         future_events: |-
           Sign up and receive information about future events (optional)
       mailing_list_steps_contact:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,7 @@ en:
     label:
       events_steps_personal_details:
         first_name: First name
-        last_name: Last name
+        last_name: Surname
         email: Email address
       events_steps_contact_details:
         telephone: Phone number (optional)
@@ -125,7 +125,7 @@ en:
         address_postcode: Postcode (optional)
       mailing_list_steps_name:
         first_name: First name
-        last_name: Last name
+        last_name: Surname
         email: Email address
         describe_yourself_option_id: How would you describe yourself?
       mailing_list_steps_degree_stage:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
             email:
               blank: Enter your full email address
               invalid: Enter a valid email address
-            current_status:
+            describe_yourself_option_id:
               blank: Select how you would describe yourself
               inclusion: Select how you would describe yourself
         mailing_list/steps/degree_stage:
@@ -127,7 +127,7 @@ en:
         first_name: First name
         last_name: Last name
         email: Email address
-        current_status: How would you describe yourself?
+        describe_yourself_option_id: How would you describe yourself?
       mailing_list_steps_degree_stage:
         degree_stage: What stage are you at with your degree?
       mailing_list_steps_teacher_training:

--- a/spec/factories/mailing_list/degree_stage_factory.rb
+++ b/spec/factories/mailing_list/degree_stage_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :mailing_list_degree_stage, class: MailingList::Steps::DegreeStage do
-    degree_stage { MailingList::Steps::DegreeStage.stages.first }
+    degree_status_id { GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS["First year"] }
   end
 end

--- a/spec/factories/mailing_list/name_factory.rb
+++ b/spec/factories/mailing_list/name_factory.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
     sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }
-    current_status { MailingList::Steps::Name.current_statuses.first }
+    describe_yourself_option_id { GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Student"] }
   end
 end

--- a/spec/factories/mailing_list/subject_factory.rb
+++ b/spec/factories/mailing_list/subject_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :mailing_list_subject, class: MailingList::Steps::Subject do
-    subject { MailingList::Steps::Subject.subjects.first }
+    preferred_teaching_subject_id { GetIntoTeachingApi::Constants::TEACHING_SUBJECTS["Physics"] }
   end
 end

--- a/spec/factories/mailing_list/teacher_training_factory.rb
+++ b/spec/factories/mailing_list/teacher_training_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :mailing_list_teacher_training, class: MailingList::Steps::TeacherTraining do
-    teacher_training { MailingList::Steps::TeacherTraining.statuses.first }
+    consideration_journey_stage_id { GetIntoTeachingApi::Constants::CONSIDERATION_JOURNEY_STAGES["It’s just an idea"] }
   end
 end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -19,6 +19,12 @@ RSpec.feature "View pages", type: :feature do
     end
   end
 
+  let(:teaching_subject_types) do
+    GetIntoTeachingApi::Constants::TEACHING_SUBJECTS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
@@ -26,6 +32,8 @@ RSpec.feature "View pages", type: :feature do
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_teaching_subjects).and_return(teaching_subject_types)
   end
 
   scenario "Full journey as Student" do

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "View pages", type: :feature do
 
     expect(page).to have_text "Sign up for personalised updates"
     fill_in "First name", with: "Test"
-    fill_in "Last name", with: "User"
+    fill_in "Surname", with: "User"
     fill_in "Email address", with: "test@testuser.com"
     select "Student"
     click_on "Next Step"
@@ -74,7 +74,7 @@ RSpec.feature "View pages", type: :feature do
 
     expect(page).to have_text "Sign up for personalised updates"
     fill_in "First name", with: "Test"
-    fill_in "Last name", with: "User"
+    fill_in "Surname", with: "User"
     fill_in "Email address", with: "test@testuser.com"
     select "Looking to change career"
     click_on "Next Step"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -13,11 +13,19 @@ RSpec.feature "View pages", type: :feature do
     end
   end
 
+  let(:consideration_journey_stage_types) do
+    GetIntoTeachingApi::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
   end
 
   scenario "Full journey as Student" do
@@ -35,7 +43,7 @@ RSpec.feature "View pages", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
-    select "I'm not sure and finding out more"
+    select "I’m not sure and finding out more"
     click_on "Next Step"
 
     expect(page).to have_text "Which subject do you want to teach"
@@ -72,7 +80,7 @@ RSpec.feature "View pages", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
-    select "I'm not sure and finding out more"
+    select "I’m not sure and finding out more"
     click_on "Next Step"
 
     expect(page).to have_text "Which subject do you want to teach"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -7,9 +7,17 @@ RSpec.feature "View pages", type: :feature do
     end
   end
 
+  let(:degree_status_option_types) do
+    GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
   end
 
   scenario "Full journey as Student" do

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.feature "View pages", type: :feature do
+  let(:describe_yourself_option_types) do
+    GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
+  end
+
   scenario "Full journey as Student" do
     visit mailing_list_steps_path
 

--- a/spec/models/mailing_list/steps/degree_stage_spec.rb
+++ b/spec/models/mailing_list/steps/degree_stage_spec.rb
@@ -4,15 +4,26 @@ describe MailingList::Steps::DegreeStage do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
-  it { is_expected.to respond_to :degree_stage }
+  let(:degree_status_option_types) do
+    GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
 
-  context "degree_stage" do
-    let(:stages) { described_class.stages }
-    it { is_expected.to allow_value(stages.first).for :degree_stage }
-    it { is_expected.to allow_value(stages.last).for :degree_stage }
-    it { is_expected.not_to allow_value(nil).for :degree_stage }
-    it { is_expected.not_to allow_value("").for :degree_stage }
-    it { is_expected.not_to allow_value("random").for :degree_stage }
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
+  end
+
+  it { is_expected.to respond_to :degree_status_id }
+
+  context "degree_status_id" do
+    let(:options) { degree_status_option_types.map(&:id) }
+    it { is_expected.to allow_value(options.first).for :degree_status_id }
+    it { is_expected.to allow_value(options.last).for :degree_status_id }
+    it { is_expected.not_to allow_value(nil).for :degree_status_id }
+    it { is_expected.not_to allow_value("").for :degree_status_id }
+    it { is_expected.not_to allow_value("random").for :degree_status_id }
   end
 
   context "skipped?" do

--- a/spec/models/mailing_list/steps/degree_stage_spec.rb
+++ b/spec/models/mailing_list/steps/degree_stage_spec.rb
@@ -18,17 +18,17 @@ describe MailingList::Steps::DegreeStage do
   context "skipped?" do
     subject { described_class.new nil, Wizard::Store.new(store), {} }
 
-    context "when current_status equals 'Student'" do
-      let(:store) { { "current_status" => "Student" } }
+    context "when describe_yourself_option_id equals 'Student'" do
+      let(:store) { { "describe_yourself_option_id" => GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Student"] } }
       it { is_expected.to have_attributes skipped?: false }
     end
 
-    context "when current_status does not equal student" do
-      let(:store) { { "current_status" => "Looking to change career" } }
+    context "when describe_yourself_option_id does not equal student" do
+      let(:store) { { "describe_yourself_option_id" => GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Looking to change career"] } }
       it { is_expected.to have_attributes skipped?: true }
     end
 
-    context "when current_status is not set" do
+    context "when describe_yourself_option_id is not set" do
       let(:store) { {} }
       it { is_expected.to have_attributes skipped?: true }
     end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -4,17 +4,28 @@ describe MailingList::Steps::Name do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
+  let(:describe_yourself_option_types) do
+    GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
+  end
+
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
   it { is_expected.to respond_to :email }
-  it { is_expected.to respond_to :current_status }
+  it { is_expected.to respond_to :describe_yourself_option_id }
 
   context "validations" do
     subject { instance.tap(&:valid?).errors.messages }
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
     it { is_expected.to include(:email) }
-    it { is_expected.to include(:current_status) }
+    it { is_expected.to include(:describe_yourself_option_id) }
   end
 
   context "email address" do
@@ -23,12 +34,12 @@ describe MailingList::Steps::Name do
     it { is_expected.not_to allow_value("me@you").for :email }
   end
 
-  context "current_status" do
-    let(:statuses) { described_class.current_statuses }
-    it { is_expected.to allow_value(statuses.first).for :current_status }
-    it { is_expected.to allow_value(statuses.last).for :current_status }
-    it { is_expected.not_to allow_value(nil).for :current_status }
-    it { is_expected.not_to allow_value("").for :current_status }
-    it { is_expected.not_to allow_value("random").for :current_status }
+  context "describe_yourself_option_id" do
+    let(:options) { describe_yourself_option_types.map(&:id) }
+    it { is_expected.to allow_value(options.first).for :describe_yourself_option_id }
+    it { is_expected.to allow_value(options.last).for :describe_yourself_option_id }
+    it { is_expected.not_to allow_value(nil).for :describe_yourself_option_id }
+    it { is_expected.not_to allow_value("").for :describe_yourself_option_id }
+    it { is_expected.not_to allow_value("random").for :describe_yourself_option_id }
   end
 end

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -4,14 +4,25 @@ describe MailingList::Steps::Subject do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
-  it { is_expected.to respond_to :subject }
+  let(:teaching_subject_types) do
+    GetIntoTeachingApi::Constants::TEACHING_SUBJECTS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
 
-  context "subject" do
-    let(:subjects) { described_class.subjects }
-    it { is_expected.to allow_value(subjects.first).for :subject }
-    it { is_expected.to allow_value(subjects.last).for :subject }
-    it { is_expected.not_to allow_value(nil).for :subject }
-    it { is_expected.not_to allow_value("").for :subject }
-    it { is_expected.not_to allow_value("random").for :subject }
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_teaching_subjects).and_return(teaching_subject_types)
+  end
+
+  it { is_expected.to respond_to :preferred_teaching_subject_id }
+
+  context "preferred_teaching_subject_id" do
+    let(:options) { teaching_subject_types.map(&:id) }
+    it { is_expected.to allow_value(options.first).for :preferred_teaching_subject_id }
+    it { is_expected.to allow_value(options.last).for :preferred_teaching_subject_id }
+    it { is_expected.not_to allow_value(nil).for :preferred_teaching_subject_id }
+    it { is_expected.not_to allow_value("").for :preferred_teaching_subject_id }
+    it { is_expected.not_to allow_value("random").for :preferred_teaching_subject_id }
   end
 end

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -4,14 +4,25 @@ describe MailingList::Steps::TeacherTraining do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
-  it { is_expected.to respond_to :teacher_training }
+  let(:consideration_journey_stage_types) do
+    GetIntoTeachingApi::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
 
-  context "teacher_training" do
-    let(:statuses) { described_class.statuses }
-    it { is_expected.to allow_value(statuses.first).for :teacher_training }
-    it { is_expected.to allow_value(statuses.last).for :teacher_training }
-    it { is_expected.not_to allow_value(nil).for :teacher_training }
-    it { is_expected.not_to allow_value("").for :teacher_training }
-    it { is_expected.not_to allow_value("random").for :teacher_training }
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
+  end
+
+  it { is_expected.to respond_to :consideration_journey_stage_id }
+
+  context "consideration_journey_stage_id" do
+    let(:options) { consideration_journey_stage_types.map(&:id) }
+    it { is_expected.to allow_value(options.first).for :consideration_journey_stage_id }
+    it { is_expected.to allow_value(options.last).for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value(nil).for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value("").for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value("random").for :consideration_journey_stage_id }
   end
 end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -68,8 +68,8 @@ describe Wizard::Store do
     end
   end
 
-  describe "#to_hash" do
-    subject { instance.to_hash }
+  describe "#to_camelized_hash" do
+    subject { instance.to_camelized_hash }
     it "returns returns a hash with camelCase keys" do
       is_expected.to eq(firstName: "Joe", age: 20, region: "Manchester")
     end

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -20,6 +20,12 @@ shared_context "stub types api" do
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS.map { |k, v| { id: v, value: k } }.to_json
+
+    stub_request(:get, "#{git_api_endpoint}/api/types/candidate/consideration_journey_stages")
+      .to_return \
+        status: 200,
+        headers: { "Content-type" => "application/json" },
+        body: GetIntoTeachingApi::Constants::CONSIDERATION_JOURNEY_STAGES.map { |k, v| { id: v, value: k } }.to_json
   end
 end
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -13,7 +13,7 @@ shared_context "stub types api" do
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
-        body: GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map { |k, v| { id: v, value: k} }.to_json
+        body: GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map { |k, v| { id: v, value: k } }.to_json
   end
 end
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -1,13 +1,19 @@
 shared_context "stub types api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
-  let(:event_types) { [{ "id" => 1, "value" => "First type" }] }
+  let(:stub_types) { [{ "id" => 1, "value" => "First type" }] }
 
   before do
     stub_request(:get, "#{git_api_endpoint}/api/types/teaching_event/types")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
-        body: event_types.to_json
+        body: stub_types.to_json
+
+    stub_request(:get, "#{git_api_endpoint}/api/types/candidate/describe_yourself")
+      .to_return \
+        status: 200,
+        headers: { "Content-type" => "application/json" },
+        body: GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map { |k, v| { id: v, value: k} }.to_json
   end
 end
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -26,6 +26,12 @@ shared_context "stub types api" do
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApi::Constants::CONSIDERATION_JOURNEY_STAGES.map { |k, v| { id: v, value: k } }.to_json
+
+    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_subjects")
+      .to_return \
+        status: 200,
+        headers: { "Content-type" => "application/json" },
+        body: GetIntoTeachingApi::Constants::TEACHING_SUBJECTS.map { |k, v| { id: v, value: k } }.to_json
   end
 end
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -14,6 +14,12 @@ shared_context "stub types api" do
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS.map { |k, v| { id: v, value: k } }.to_json
+
+    stub_request(:get, "#{git_api_endpoint}/api/types/qualification/degree_status")
+      .to_return \
+        status: 200,
+        headers: { "Content-type" => "application/json" },
+        body: GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS.map { |k, v| { id: v, value: k } }.to_json
   end
 end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-284](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-284)

### Context

We want to populate the drop down options from the API so that they match valid data.

### Changes proposed in this pull request

- Populate describe yourself options from API
- Populate degree status options from API
- Populate candidate journey stage from API
- Populate teaching subjects from API
- Change order of personal detail fields to match adviser app
- Update privacy policy copy in event sign up to match mailing list
- Rename `to_hash` to `to_camelized_hash` for clarity

### Guidance to review

