### PR TITLE
Issue verification code on mailing list sign up

### DIFF
--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -1,10 +1,11 @@
 module Events
   module Steps
     class PersonalDetails < ::Wizard::Step
+      include ::Wizard::IssueVerificationCode
+
       attribute :email
       attribute :first_name
       attribute :last_name
-      attribute :authenticate
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true
@@ -20,27 +21,6 @@ module Events
 
       before_validation if: :last_name do
         self.last_name = last_name.to_s.strip
-      end
-
-      def save
-        if valid?
-          begin
-            request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
-            GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
-            self.authenticate = true
-          rescue GetIntoTeachingApiClient::ApiError
-            # Existing candidate not found or CRM is currently unavailable.
-            self.authenticate = false
-          end
-        end
-
-        super
-      end
-
-    private
-
-      def request_attributes
-        attributes.slice("email", "first_name", "last_name").transform_keys { |k| k.camelize(:lower).to_sym }
       end
     end
   end

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -1,6 +1,8 @@
 module MailingList
   module Steps
     class Name < ::Wizard::Step
+      include ::Wizard::IssueVerificationCode
+
       attribute :first_name
       attribute :last_name
       attribute :email

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -1,0 +1,26 @@
+module Wizard
+  module IssueVerificationCode
+    extend ActiveSupport::Concern
+
+    def save
+      if valid?
+        begin
+          request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
+          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+          @store["authenticate"] = true
+        rescue GetIntoTeachingApiClient::ApiError
+          # Existing candidate not found or CRM is currently unavailable.
+          @store["authenticate"] = false
+        end
+      end
+
+      super
+    end
+
+  private
+
+    def request_attributes
+      attributes.slice("email", "first_name", "last_name").transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+  end
+end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -26,6 +26,8 @@ RSpec.feature "View pages", type: :feature do
   end
 
   before do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_describe_yourself_options).and_return(describe_yourself_option_types)
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe Events::Steps::PersonalDetails do
   include_context "wizard step"
   it_behaves_like "a wizard step"
+  it_behaves_like "an issue verification code wizard step"
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
@@ -20,46 +21,5 @@ describe Events::Steps::PersonalDetails do
     it { is_expected.to allow_value("me@you.com").for :email }
     it { is_expected.to allow_value(" me@you.com ").for :email }
     it { is_expected.not_to allow_value("me@you").for :email }
-  end
-
-  describe "#save" do
-    before do
-      subject.email = "email@address.com"
-      subject.first_name = "first"
-      subject.last_name = "last"
-    end
-
-    let(:request) do
-      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
-        email: subject.email,
-        firstName: subject.first_name,
-        lastName: subject.last_name,
-      )
-    end
-
-    context "when invalid" do
-      it "does not call the API" do
-        subject.email = nil
-        subject.save
-        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to_not receive(:create_candidate_access_token)
-      end
-    end
-
-    context "when an existing candidate" do
-      it "sends verification code and sets authenticate to true" do
-        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
-        subject.save
-        expect(subject.authenticate).to be_truthy
-      end
-    end
-
-    context "when a new candidate or CRM is unavailable" do
-      it "will skip the authenticate step" do
-        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
-          .and_raise(GetIntoTeachingApiClient::ApiError)
-        subject.save
-        expect(subject.authenticate).to be_falsy
-      end
-    end
   end
 end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -42,4 +42,14 @@ describe MailingList::Steps::Name do
     it { is_expected.not_to allow_value("").for :describe_yourself_option_id }
     it { is_expected.not_to allow_value("random").for :describe_yourself_option_id }
   end
+
+  context "when the step is valid" do
+    subject do
+      instance.tap do |step|
+        step.describe_yourself_option_id = describe_yourself_option_types.first.id
+      end
+    end
+
+    it_behaves_like "an issue verification code wizard step"
+  end
 end

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe MailingList::StepsController do
   include_context "stub types api"
+  include_context "stub candidate create access token api"
 
   let(:model) { MailingList::Steps::Name }
   let(:step_path) { mailing_list_step_path model.key }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-284](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-284)

### Context

If an existing user comes to the mailing list sign up form we want to issue them a verification code so we can retrieve their details.

### Changes proposed in this pull request

- Issue verification code on mailing list sign up

Extract the logic to issue a verification code into a concern that can be reused in both the event and mailing list sign up.

### Guidance to review

