### PR TITLE
Feature/284 send mailing list sign up request

### DIFF
--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -1,8 +1,6 @@
 module Events
   module Steps
     class FurtherDetails < ::Wizard::Step
-      FUTURE_EVENT_OPTIONS = [["Yes", true], ["No", false]].freeze
-
       attribute :event_id
       attribute :privacy_policy, :boolean
       attribute :future_events, :boolean
@@ -26,10 +24,6 @@ module Events
         end
 
         super
-      end
-
-      def future_event_options
-        FUTURE_EVENT_OPTIONS
       end
     end
   end

--- a/app/models/mailing_list/steps/contact.rb
+++ b/app/models/mailing_list/steps/contact.rb
@@ -17,6 +17,17 @@ module MailingList
       before_validation if: :callback_information do
         self.callback_information = callback_information.to_s.strip
       end
+
+      def save
+        if valid?
+          # TODO: ensure this is the policy we display to the user
+          accepted_policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
+          @store["accepted_policy_id"] = accepted_policy.id
+          @store["subscribe_to_mailing_list"] = true
+        end
+
+        super
+      end
     end
   end
 end

--- a/app/models/mailing_list/steps/contact.rb
+++ b/app/models/mailing_list/steps/contact.rb
@@ -2,20 +2,20 @@ module MailingList
   module Steps
     class Contact < ::Wizard::Step
       attribute :telephone
-      attribute :more_info
+      attribute :callback_information
       attribute :accept_privacy_policy, :boolean
 
       validates :telephone, telephone: true
-      validates :more_info, presence: true, if: -> { telephone.present? }
-      validates :more_info, number_of_words: { less_than: 200 }
+      validates :callback_information, presence: true, if: -> { telephone.present? }
+      validates :callback_information, number_of_words: { less_than: 200 }
       validates :accept_privacy_policy, acceptance: true, allow_nil: false
 
       before_validation if: :telephone do
         self.telephone = telephone.to_s.strip
       end
 
-      before_validation if: :more_info do
-        self.more_info = more_info.to_s.strip
+      before_validation if: :callback_information do
+        self.callback_information = callback_information.to_s.strip
       end
     end
   end

--- a/app/models/mailing_list/steps/degree_stage.rb
+++ b/app/models/mailing_list/steps/degree_stage.rb
@@ -1,7 +1,7 @@
 module MailingList
   module Steps
     class DegreeStage < ::Wizard::Step
-      attribute :degree_status_id
+      attribute :degree_status_id, :integer
       validates :degree_status_id,
                 presence: true,
                 inclusion: { in: :degree_status_option_ids, allow_nil: true }
@@ -15,7 +15,7 @@ module MailingList
       end
 
       def degree_status_option_ids
-        degree_status_options.map(&:id)
+        degree_status_options.map { |option| option.id.to_i }
       end
 
     private

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -6,7 +6,7 @@ module MailingList
       attribute :first_name
       attribute :last_name
       attribute :email
-      attribute :describe_yourself_option_id
+      attribute :describe_yourself_option_id, :integer
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true
@@ -32,7 +32,7 @@ module MailingList
       end
 
       def describe_yourself_option_ids
-        describe_yourself_options.map(&:id)
+        describe_yourself_options.map { |option| option.id.to_i }
       end
 
     private

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -1,7 +1,7 @@
 module MailingList
   module Steps
     class TeacherTraining < ::Wizard::Step
-      attribute :consideration_journey_stage_id
+      attribute :consideration_journey_stage_id, :integer
       validates :consideration_journey_stage_id,
                 presence: true,
                 inclusion: { in: :consideration_journey_stage_ids, allow_nil: true }
@@ -11,7 +11,7 @@ module MailingList
       end
 
       def consideration_journey_stage_ids
-        consideration_journey_stages.map(&:id)
+        consideration_journey_stages.map { |option| option.id.to_i }
       end
 
     private

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -12,8 +12,17 @@ module MailingList
 
     def complete!
       super.tap do |result|
-        result && @store.purge!
+        break unless result
+
+        add_member_to_mailing_list
+        @store.purge!
       end
+    end
+
+    def add_member_to_mailing_list
+      request = GetIntoTeachingApiClient::MailingListAddMember.new(@store.to_camelized_hash)
+      api = GetIntoTeachingApiClient::MailingListApi.new
+      api.add_mailing_list_member(request)
     end
   end
 end

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -50,7 +50,7 @@ module Wizard
 
       def prepopulate_store
         hash = @totp_response.to_hash.transform_keys { |k| k.to_s.underscore }
-        @store.persist(hash.except("email", "first_name", "last_name"))
+        @store.persist(hash.except(*@store.keys))
       end
     end
   end

--- a/app/services/get_into_teaching_api/constants.rb
+++ b/app/services/get_into_teaching_api/constants.rb
@@ -2,28 +2,28 @@ module GetIntoTeachingApi
   module Constants
     DESCRIBE_YOURSELF_OPTIONS =
       {
-        "Student" => "222750000",
-        "Exploring my career options" => "222750001",
-        "Looking to change career" => "222750002",
-        "Not studying and no plans to" => "222750003",
+        "Student" => 222_750_000,
+        "Exploring my career options" => 222_750_001,
+        "Looking to change career" => 222_750_002,
+        "Not studying and no plans to" => 222_750_003,
       }.freeze
 
     DEGREE_STATUS_OPTIONS =
       {
-        "Graduate or postgraduate" => "222750000",
-        "Final year" => "222750001",
-        "Second year" => "222750002",
-        "First year" => "222750003",
-        "I don't have a degree and am not studying for one" => "222750004",
-        "Other" => "222750005",
+        "Graduate or postgraduate" => 222_750_000,
+        "Final year" => 222_750_001,
+        "Second year" => 222_750_002,
+        "First year" => 222_750_003,
+        "I don't have a degree and am not studying for one" => 222_750_004,
+        "Other" => 222_750_005,
       }.freeze
 
     CONSIDERATION_JOURNEY_STAGES =
       {
-        "It’s just an idea" => "222750000",
-        "I’m not sure and finding out more" => "222750001",
-        "I’m fairly sure and exploring my options" => "222750002",
-        "I’m very sure and think I’ll apply" => "222750003",
+        "It’s just an idea" => 222_750_000,
+        "I’m not sure and finding out more" => 222_750_001,
+        "I’m fairly sure and exploring my options" => 222_750_002,
+        "I’m very sure and think I’ll apply" => 222_750_003,
       }.freeze
 
     # This is not a complete list.

--- a/app/views/mailing_list/steps/_contact.html.erb
+++ b/app/views/mailing_list/steps/_contact.html.erb
@@ -8,7 +8,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_text_field :telephone %>
-<%= f.govuk_text_area :more_info, max_words: 200 %>
+<%= f.govuk_text_area :callback_information, max_words: 200 %>
 
 <%= f.govuk_check_boxes_fieldset :accept_privacy_policy do %>
   <%= f.hidden_field :accept_privacy_policy, value: 0 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
           attributes:
             telephone:
               invalid: Enter a valid phone number
-            more_info:
+              callback_information:
               blank: Enter the additional information you would like
               use_fewer_words: Use 200 words or less
             accept_privacy_policy:
@@ -138,7 +138,7 @@ en:
         address_postcode: What's your postcode?
       mailing_list_steps_contact:
         telephone: What's your phone number (optional)
-        more_info: What would you like more information about when we call you?
+        callback_information: What would you like more information about when we call you?
 
     hint:
       events_steps_contact_details:

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature "View pages", type: :feature do
     end
   end
 
+  let(:latest_privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
@@ -36,6 +38,10 @@ RSpec.feature "View pages", type: :feature do
       receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_teaching_subjects).and_return(teaching_subject_types)
+    allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_latest_privacy_policy).and_return(latest_privacy_policy)
+    allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+      receive(:add_mailing_list_member)
   end
 
   scenario "Full journey as Student" do

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -5,7 +5,7 @@ describe MailingList::Steps::Contact do
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }
-  it { is_expected.to respond_to :more_info }
+  it { is_expected.to respond_to :callback_information }
   it { is_expected.to respond_to :accept_privacy_policy }
 
   context "validations" do
@@ -21,21 +21,21 @@ describe MailingList::Steps::Contact do
     it { is_expected.not_to allow_value("1234").for :telephone }
   end
 
-  context "more_info" do
-    it { is_expected.to allow_value(nil).for :more_info }
-    it { is_expected.to allow_value("").for :more_info }
-    it { is_expected.to allow_value("Lorem ipsum").for :more_info }
+  context "callback_information" do
+    it { is_expected.to allow_value(nil).for :callback_information }
+    it { is_expected.to allow_value("").for :callback_information }
+    it { is_expected.to allow_value("Lorem ipsum").for :callback_information }
 
     context "with phone number present" do
       let(:attributes) { { telephone: "0123456890" } }
-      it { is_expected.not_to allow_value(nil).for :more_info }
-      it { is_expected.not_to allow_value("").for :more_info }
-      it { is_expected.to allow_value("Lorem ipsum").for :more_info }
+      it { is_expected.not_to allow_value(nil).for :callback_information }
+      it { is_expected.not_to allow_value("").for :callback_information }
+      it { is_expected.to allow_value("Lorem ipsum").for :callback_information }
     end
 
     context "with too many words" do
-      it { is_expected.to allow_value("word " * 200).for :more_info }
-      it { is_expected.not_to allow_value("word " * 201).for :more_info }
+      it { is_expected.to allow_value("word " * 200).for :callback_information }
+      it { is_expected.not_to allow_value("word " * 201).for :callback_information }
     end
   end
 

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -42,4 +42,39 @@ describe MailingList::Steps::Contact do
   context "accept_privacy_policy" do
     it { is_expected.to validate_acceptance_of :accept_privacy_policy }
   end
+
+  describe "#save" do
+    context "when invalid" do
+      before do
+        subject.accept_privacy_policy = nil
+        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to_not \
+          receive(:get_latest_privacy_policy)
+      end
+
+      it "does not update the store" do
+        expect(subject).to_not be_valid
+        subject.save
+        expect(wizardstore["accepted_policy_id"]).to be_nil
+        expect(wizardstore["subscribe_to_mailing_list"]).to be_nil
+      end
+    end
+
+    context "when valid" do
+      let(:response) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
+
+      before do
+        subject.accept_privacy_policy = true
+
+        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+          receive(:get_latest_privacy_policy).and_return(response)
+      end
+
+      it "updates the store" do
+        expect(subject).to be_valid
+        subject.save
+        expect(wizardstore["accepted_policy_id"]).to be(response.id)
+        expect(wizardstore["subscribe_to_mailing_list"]).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -18,13 +18,31 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
-    let(:store) { { "first_name" => "Joe", "last_name" => "Joeseph" } }
-    let(:wizardstore) { Wizard::Store.new store }
+    let(:uuid) { SecureRandom.uuid }
+    let(:store) do
+      { uuid => {
+        "email" => "email@address.com",
+        "first_name" => "Joe",
+        "last_name" => "Joseph",
+      } }
+    end
+    let(:wizardstore) { Wizard::Store.new store[uuid] }
+    let(:request) do
+      GetIntoTeachingApiClient::MailingListAddMember.new(
+        { email: "email@address.com", firstName: "Joe", lastName: "Joseph" },
+      )
+    end
+
     subject { described_class.new wizardstore, "contact" }
+
     before { allow(subject).to receive(:valid?).and_return true }
+    before do
+      expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+        receive(:add_mailing_list_member).with(request).once
+    end
     before { subject.complete! }
 
     it { is_expected.to have_received(:valid?) }
-    it { expect(store).to eql({}) }
+    it { expect(store[uuid]).to eql({}) }
   end
 end

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -81,6 +81,14 @@ describe Wizard::Steps::Authenticate do
         subject.save
         expect(wizardstore["candidate_id"]).to eq(response.candidate_id)
       end
+
+      it "does not overwrite data already in the store" do
+        response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "abc123", firstName: "Jim")
+        expect(subject).to receive(:perform_existing_candidate_request).with(request) { response }
+        subject.save
+        expect(wizardstore["candidate_id"]).to eq(response.candidate_id)
+        expect(wizardstore["first_name"]).to eq("First")
+      end
     end
 
     context "when TOTP is incorrect" do

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe MailingList::StepsController do
   include_context "stub types api"
   include_context "stub candidate create access token api"
+  include_context "stub latest privacy policy api"
+  include_context "stub mailing list add member api"
 
   let(:model) { MailingList::Steps::Name }
   let(:step_path) { mailing_list_step_path model.key }
@@ -62,5 +64,13 @@ describe MailingList::StepsController do
       response
     end
     it { is_expected.to have_http_status :success }
+  end
+
+  describe "#resend_verification" do
+    subject do
+      get resend_verification_mailing_list_steps_path(redirect_path: "redirect/path")
+      response
+    end
+    it { is_expected.to redirect_to("redirect/path") }
   end
 end

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -60,6 +60,14 @@ shared_context "stub event add attendee api" do
   end
 end
 
+shared_context "stub mailing list add member api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
+
+  before do
+    stub_request(:post, "#{git_api_endpoint}/api/mailing_list/members").to_return(status: 200, body: "", headers: {})
+  end
+end
+
 shared_examples "api support" do
   let(:token) { "test123" }
   let(:endpoint) { "http://my.api/api" }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-284](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-284)

### Context

When a candidate completes the mailing list form we want to send the data to the API so the CRM can be updated.

### Changes proposed in this pull request

- Rename more_info to callback_information

Make the attribute name consistent with the API so that pre-filling the form works automatically.

- Send mailing list add member request

### Guidance to review

