### PR TITLE
Default to prompt select option

### DIFF
--- a/app/models/mailing_list/steps/degree_stage.rb
+++ b/app/models/mailing_list/steps/degree_stage.rb
@@ -4,14 +4,14 @@ module MailingList
       attribute :degree_status_id, :integer
       validates :degree_status_id,
                 presence: true,
-                inclusion: { in: :degree_status_option_ids, allow_nil: true }
+                inclusion: { in: :degree_status_option_ids }
 
       def skipped?
         @store["describe_yourself_option_id"] != GetIntoTeachingApi::Constants::DESCRIBE_YOURSELF_OPTIONS["Student"]
       end
 
       def degree_status_options
-        @degree_status_options ||= query_degree_status
+        @degree_status_options ||= [OpenStruct.new(id: nil, value: "Please select")] + query_degree_status
       end
 
       def degree_status_option_ids

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -13,7 +13,7 @@ module MailingList
       validates :last_name, presence: true
       validates :describe_yourself_option_id,
                 presence: true,
-                inclusion: { in: :describe_yourself_option_ids, allow_nil: true }
+                inclusion: { in: :describe_yourself_option_ids }
 
       before_validation if: :email do
         self.email = email.to_s.strip
@@ -28,7 +28,7 @@ module MailingList
       end
 
       def describe_yourself_options
-        @describe_yourself_options ||= query_decribe_yourself_options
+        @describe_yourself_options ||= [OpenStruct.new(id: nil, value: "Please select")] + query_decribe_yourself_options
       end
 
       def describe_yourself_option_ids

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -4,10 +4,10 @@ module MailingList
       attribute :preferred_teaching_subject_id
       validates :preferred_teaching_subject_id,
                 presence: true,
-                inclusion: { in: :teaching_subject_ids, allow_nil: true }
+                inclusion: { in: :teaching_subject_ids }
 
       def teaching_subjects
-        @teaching_subjects ||= query_teaching_subjects
+        @teaching_subjects ||= [OpenStruct.new(id: nil, value: "Please select")] + query_teaching_subjects
       end
 
       def teaching_subject_ids

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -4,10 +4,10 @@ module MailingList
       attribute :consideration_journey_stage_id, :integer
       validates :consideration_journey_stage_id,
                 presence: true,
-                inclusion: { in: :consideration_journey_stage_ids, allow_nil: true }
+                inclusion: { in: :consideration_journey_stage_ids }
 
       def consideration_journey_stages
-        @consideration_journey_stages ||= query_consideration_journey_stages
+        @consideration_journey_stages ||= [OpenStruct.new(id: nil, value: "Please select")] + query_consideration_journey_stages
       end
 
       def consideration_journey_stage_ids

--- a/spec/models/mailing_list/steps/degree_stage_spec.rb
+++ b/spec/models/mailing_list/steps/degree_stage_spec.rb
@@ -23,7 +23,7 @@ describe MailingList::Steps::DegreeStage do
     it { is_expected.to allow_value(options.last).for :degree_status_id }
     it { is_expected.not_to allow_value(nil).for :degree_status_id }
     it { is_expected.not_to allow_value("").for :degree_status_id }
-    it { is_expected.not_to allow_value("random").for :degree_status_id }
+    it { is_expected.not_to allow_value(12_345).for :degree_status_id }
   end
 
   context "skipped?" do

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -40,7 +40,7 @@ describe MailingList::Steps::Name do
     it { is_expected.to allow_value(options.last).for :describe_yourself_option_id }
     it { is_expected.not_to allow_value(nil).for :describe_yourself_option_id }
     it { is_expected.not_to allow_value("").for :describe_yourself_option_id }
-    it { is_expected.not_to allow_value("random").for :describe_yourself_option_id }
+    it { is_expected.not_to allow_value(12_345).for :describe_yourself_option_id }
   end
 
   context "when the step is valid" do

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -23,6 +23,6 @@ describe MailingList::Steps::TeacherTraining do
     it { is_expected.to allow_value(options.last).for :consideration_journey_stage_id }
     it { is_expected.not_to allow_value(nil).for :consideration_journey_stage_id }
     it { is_expected.not_to allow_value("").for :consideration_journey_stage_id }
-    it { is_expected.not_to allow_value("random").for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value(12_345).for :consideration_journey_stage_id }
   end
 end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-284](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-284)

### Context

The drop downs in the mailing list journey are mandatory, but we currently default to the first option in the list which will encourage people to just click next. Instead, we want to add a default 'Please select' option that forces the user to manually choose from the list.

### Changes proposed in this pull request

- Default to prompt select option

We want the select fields in the mailing list sign up journey to be mandatory but not default to any of the valid options. This commit adds a default 'Please select' option that forces the user to manually choose a value before continuing.

### Guidance to review

