### PR TITLE
Clear store when previously authenticated

### DIFF
--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -3,6 +3,8 @@ module Wizard
     extend ActiveSupport::Concern
 
     def save
+      @store.purge! if previously_authenticated?
+
       if valid?
         begin
           request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
@@ -18,6 +20,10 @@ module Wizard
     end
 
   private
+
+    def previously_authenticated?
+      @store["authenticate"]
+    end
 
     def request_attributes
       attributes.slice("email", "first_name", "last_name").transform_keys { |k| k.camelize(:lower).to_sym }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-474](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-474)

### Context

We need to take into account the scenario when a candidate authenticates and then returns to the first screen and continues with a new email address.

### Changes proposed in this pull request

If a candidate authenticates successfully we pre-fill the store with their details. They could then back out and enter a new email, in which case we want to clear the details we hold in the store (so we don't pre-populate it incorrectly).

### Guidance to review

