### PR TITLE
Remove callback information from mailing list sign up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.2", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", "1.0.3", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: f55f85e9260c17421040377578a639b63a83ca73
+  revision: 2b41a6a32f2b403fcff96855b96f1f4a932107cc
   specs:
-    get_into_teaching_api_client (1.0.2)
+    get_into_teaching_api_client (1.0.3)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -325,7 +325,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.2)!
+  get_into_teaching_api_client (= 1.0.3)!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/models/mailing_list/steps/contact.rb
+++ b/app/models/mailing_list/steps/contact.rb
@@ -2,20 +2,13 @@ module MailingList
   module Steps
     class Contact < ::Wizard::Step
       attribute :telephone
-      attribute :callback_information
       attribute :accept_privacy_policy, :boolean
 
       validates :telephone, telephone: true
-      validates :callback_information, presence: true, if: -> { telephone.present? }
-      validates :callback_information, number_of_words: { less_than: 200 }
       validates :accept_privacy_policy, acceptance: true, allow_nil: false
 
       before_validation if: :telephone do
         self.telephone = telephone.to_s.strip.presence
-      end
-
-      before_validation if: :callback_information do
-        self.callback_information = callback_information.to_s.strip.presence
       end
 
       def save

--- a/app/views/mailing_list/steps/_contact.html.erb
+++ b/app/views/mailing_list/steps/_contact.html.erb
@@ -8,7 +8,6 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_text_field :telephone %>
-<%= f.govuk_text_area :callback_information, max_words: 200 %>
 
 <%= f.govuk_check_boxes_fieldset :accept_privacy_policy do %>
   <%= f.hidden_field :accept_privacy_policy, value: 0 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,9 +101,6 @@ en:
           attributes:
             telephone:
               invalid: Enter a valid phone number
-              callback_information:
-              blank: Enter the additional information you would like
-              use_fewer_words: Use 200 words or less
             accept_privacy_policy:
               blank: Accept the privacy policy to continue
               accepted: Accept the privacy policy to continue
@@ -133,7 +130,6 @@ en:
         address_postcode: What's your postcode?
       mailing_list_steps_contact:
         telephone: What's your phone number (optional)
-        callback_information: What would you like more information about when we call you?
 
     hint:
       events_steps_contact_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
 
   get "/scribble", to: "pages#scribble", via: :all, as: nil
 
-  get "/mailinglist/register/:step_number", to: "pages#mailingregistration", via: :all  
-    
+  get "/mailinglist/register/:step_number", to: "pages#mailingregistration", via: :all
+
   get "/eventschool", to: "pages#eventschool", via: :all
   get "/events_ttt", to: "pages#events_ttt", via: :all
   get "/events_online", to: "pages#events_online", via: :all

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -80,7 +80,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
       degreeStatusId: GetIntoTeachingApi::Constants::DEGREE_STATUS_OPTIONS["Final year"],
       addressPostcode: "TE57 1NG",
       telephone: "1234567890",
-      callbackInformation: "Please call me back!",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
       receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
@@ -115,10 +114,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "If you need more information"
     expect(page).to have_field("What's your phone number (optional)", with: response.telephone)
-    expect(page).to have_field(
-      "What would you like more information about when we call you?",
-      with: response.callback_information,
-    )
     click_on "Complete sign up"
 
     expect(page).to have_text "If you need more information"
@@ -199,10 +194,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
   end
 
   def fill_in_contact_step(
-    telephone: "01234567890",
-    callback_information: "Lorem ipsum"
+    telephone: "01234567890"
   )
     fill_in "What's your phone number", with: telephone
-    fill_in "What would you like more information about", with: callback_information
   end
 end

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -5,7 +5,6 @@ describe MailingList::Steps::Contact do
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }
-  it { is_expected.to respond_to :callback_information }
   it { is_expected.to respond_to :accept_privacy_policy }
 
   context "validations" do
@@ -21,24 +20,6 @@ describe MailingList::Steps::Contact do
     it { is_expected.not_to allow_value("1234").for :telephone }
   end
 
-  context "callback_information" do
-    it { is_expected.to allow_value(nil).for :callback_information }
-    it { is_expected.to allow_value("").for :callback_information }
-    it { is_expected.to allow_value("Lorem ipsum").for :callback_information }
-
-    context "with phone number present" do
-      let(:attributes) { { telephone: "0123456890" } }
-      it { is_expected.not_to allow_value(nil).for :callback_information }
-      it { is_expected.not_to allow_value("").for :callback_information }
-      it { is_expected.to allow_value("Lorem ipsum").for :callback_information }
-    end
-
-    context "with too many words" do
-      it { is_expected.to allow_value("word " * 200).for :callback_information }
-      it { is_expected.not_to allow_value("word " * 201).for :callback_information }
-    end
-  end
-
   context "data cleaning" do
     it "cleans the telephone" do
       subject.telephone = "  01234567890 "
@@ -47,15 +28,6 @@ describe MailingList::Steps::Contact do
       subject.telephone = "  "
       subject.valid?
       expect(subject.telephone).to be_nil
-    end
-
-    it "cleans the callback information" do
-      subject.callback_information = "  please call me back "
-      subject.valid?
-      expect(subject.callback_information).to eq("please call me back")
-      subject.callback_information = "  "
-      subject.valid?
-      expect(subject.callback_information).to be_nil
     end
   end
 


### PR DESCRIPTION
### JIRA ticket number

### Context

We no longer want to collect this information from the candidate.

### Changes proposed in this pull request

Remove callback information from the mailing list sign up.

Bump the Ruby API client to the latest version.

### Guidance to review

