### PR TITLE
Render PrivacyPolicy from the API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    ffi (1.12.2)
+    ffi (1.13.1)
     foreman (0.87.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -31,6 +31,18 @@ class PagesController < ApplicationController
     render template: "pages/mailinglist/registration/step#{params[:step_number]}"
   end
 
+  def privacy_policy
+    policy_id = params[:id]
+
+    @privacy_policy = if policy_id
+                        GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_privacy_policy(policy_id)
+                      else
+                        GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
+                      end
+
+    render template: "pages/privacy_policy"
+  end
+
   def show
     render template: "content/#{params[:page]}", layout: "layouts/content"
   rescue ActionView::MissingTemplate

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -8,6 +8,7 @@ module Events
       attribute :future_events, :boolean
       attribute :mailing_list, :boolean
       attribute :address_postcode
+      attribute :accepted_policy_id
 
       validates :event_id, presence: true
       validates :privacy_policy, presence: true, acceptance: true
@@ -29,14 +30,15 @@ module Events
 
       def save
         if valid?
-          # TODO: ensure this is the policy we display to the user
-          accepted_policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
-          @store["accepted_policy_id"] = accepted_policy.id
           @store["subscribe_to_events"] = future_events == true
           @store["subscribe_to_mailing_list"] = mailing_list == true
         end
 
         super
+      end
+
+      def latest_privacy_policy
+        @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
       end
 
       def subscribe_options

--- a/app/models/mailing_list/steps/contact.rb
+++ b/app/models/mailing_list/steps/contact.rb
@@ -3,6 +3,7 @@ module MailingList
     class Contact < ::Wizard::Step
       attribute :telephone
       attribute :accept_privacy_policy, :boolean
+      attribute :accepted_policy_id
 
       validates :telephone, telephone: true
       validates :accept_privacy_policy, acceptance: true, allow_nil: false
@@ -13,13 +14,14 @@ module MailingList
 
       def save
         if valid?
-          # TODO: ensure this is the policy we display to the user
-          accepted_policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
-          @store["accepted_policy_id"] = accepted_policy.id
           @store["subscribe_to_events"] = true
         end
 
         super
+      end
+
+      def latest_privacy_policy
+        @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
       end
     end
   end

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -1,4 +1,10 @@
-<%= f.govuk_check_boxes_fieldset :privacy_policy do %>
+<%
+  legend_text = t("helpers.legend.events_steps_further_details.privacy_policy.text", 
+    link: link_to(t("helpers.legend.events_steps_further_details.privacy_policy.link"), 
+    privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }))
+%>
+
+<%= f.govuk_check_boxes_fieldset :privacy_policy, legend: { text: legend_text.html_safe } do %>
   <%= f.hidden_field :privacy_policy, value: false %>
   <%= f.govuk_check_box :privacy_policy, true,
         multiple: false, link_errors: true,
@@ -20,3 +26,4 @@
 <%= f.govuk_text_field :address_postcode %>
 
 <%= f.hidden_field :event_id, value: @event.id %>
+<%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>

--- a/app/views/mailing_list/steps/_contact.html.erb
+++ b/app/views/mailing_list/steps/_contact.html.erb
@@ -9,9 +9,17 @@
 
 <%= f.govuk_text_field :telephone %>
 
-<%= f.govuk_check_boxes_fieldset :accept_privacy_policy do %>
+<%
+  legend_text = t("helpers.legend.mailing_list_steps_contact.accept_privacy_policy.text", 
+    link: link_to(t("helpers.legend.mailing_list_steps_contact.accept_privacy_policy.link"), 
+    privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }))
+%>
+
+<%= f.govuk_check_boxes_fieldset :accept_privacy_policy, legend: { text: legend_text.html_safe } do %>
   <%= f.hidden_field :accept_privacy_policy, value: 0 %>
   <%= f.govuk_check_box :accept_privacy_policy, 1,
         multiple: false, link_errors: true,
         label: { text: "Yes" } %>
 <% end %>
+
+  <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,8 @@
+<section class="event-info content container-1000" role="main">
+  <div class="content__left">
+    <h2>Privacy Policy</h2>
+    <h3>Legal information</h3>
+    <%= @privacy_policy.text.html_safe %>
+  </div>
+  <div class="content_right"></div>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,12 +148,14 @@ en:
 
     legend:
       events_steps_further_details:
-        privacy_policy: |-
-          Are you over 16 and do you agree to our privacy policy?
+        privacy_policy:
+          text: Are you over 16 and do you agree to our %{link}?
+          link: privacy policy
         future_events: |-
           Would you like to receive information about future events in your area?
         mailing_list: |-
           Would you like to receive personalised information to help you get into teaching?
       mailing_list_steps_contact:
-        accept_privacy_policy: |-
-          Are you over 16 and do you agree to our privacy policy?
+        accept_privacy_policy:
+          text: Are you over 16 and do you agree to our %{link}?
+          link: privacy policy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "/events_school", to: "pages#events_school", via: :all
   get "/event", to: "pages#event", via: :all, as: nil
   get "/event/register/:step_number", to: "pages#eventregistration", via: :all
+  get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
 
   resources "events", path: "/events", only: %i[index show search] do
     collection { get "search" }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -30,7 +30,6 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in "Phone number (optional)", with: "01234567890"
     click_on "Next Step"
 
-    expect(page).to have_text "agree to our privacy policy?"
     fill_in "Postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -11,6 +11,7 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.to respond_to :future_events }
     it { is_expected.to respond_to :mailing_list }
     it { is_expected.to respond_to :address_postcode }
+    it { is_expected.to respond_to :accepted_policy_id }
   end
 
   context "validations" do
@@ -70,7 +71,6 @@ describe Events::Steps::FurtherDetails do
       it "does not update the store" do
         expect(subject).to_not be_valid
         subject.save
-        expect(wizardstore["accepted_policy_id"]).to be_nil
         expect(wizardstore["subscribe_to_events"]).to be_nil
       end
     end
@@ -91,7 +91,6 @@ describe Events::Steps::FurtherDetails do
         subject.mailing_list = true
         expect(subject).to be_valid
         subject.save
-        expect(wizardstore["accepted_policy_id"]).to be(response.id)
         expect(wizardstore["subscribe_to_events"]).to be_truthy
         expect(wizardstore["subscribe_to_mailing_list"]).to be_truthy
       end
@@ -101,7 +100,6 @@ describe Events::Steps::FurtherDetails do
         subject.mailing_list = false
         expect(subject).to be_valid
         subject.save
-        expect(wizardstore["accepted_policy_id"]).to be(response.id)
         expect(wizardstore["subscribe_to_events"]).to be_falsy
         expect(wizardstore["subscribe_to_mailing_list"]).to be_falsy
       end

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -6,6 +6,7 @@ describe MailingList::Steps::Contact do
 
   it { is_expected.to respond_to :telephone }
   it { is_expected.to respond_to :accept_privacy_policy }
+  it { is_expected.to respond_to :accepted_policy_id }
 
   context "validations" do
     subject { instance.tap(&:valid?).errors.messages }
@@ -46,7 +47,6 @@ describe MailingList::Steps::Contact do
       it "does not update the store" do
         expect(subject).to_not be_valid
         subject.save
-        expect(wizardstore["accepted_policy_id"]).to be_nil
         expect(wizardstore["subscribe_to_events"]).to be_nil
       end
     end
@@ -64,7 +64,6 @@ describe MailingList::Steps::Contact do
       it "updates the store" do
         expect(subject).to be_valid
         subject.save
-        expect(wizardstore["accepted_policy_id"]).to be(response.id)
         expect(wizardstore["subscribe_to_events"]).to be_truthy
       end
     end

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "GET /privacy-policy" do
+  let(:policy) { GetIntoTeachingApiClient::PrivacyPolicy.new(id: "123", text: "Latest privacy policy") }
+
+  context "when viewing the latest privacy policy" do
+    subject do
+      get(privacy_policy_path)
+      response
+    end
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+        receive(:get_latest_privacy_policy).and_return(policy)
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { expect(subject.body).to include(policy.text) }
+  end
+
+  context "when viewing the latest privacy policy" do
+    subject do
+      get(privacy_policy_path(id: policy.id))
+      response
+    end
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+        receive(:get_privacy_policy).with(policy.id).and_return(policy)
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { expect(subject.body).to include(policy.text) }
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-482](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451%2C19124&selectedIssue=GITPB-482)

### Context

When a user submits a form they accept a privacy policy; currently this is the latest at the time of submission, but it should be whatever policy we actually linked them to/they viewed.

### Changes proposed in this pull request

- Connect mailing list/event sign up to API privacy policy

We add a link to the privacy policy and include the id in the form submission to be sure we log the accepted policy as the one they were linked to.

- Bump API client for getting privacy policy by id

- Render privacy policy from the API

We render the latest privacy policy by default, but if there is an optional `id` in the query string we will render that specific version.

### Guidance to review

