### PR TITLE
Update validation on steps for parity with API

### DIFF
--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -8,8 +8,8 @@ module Events
       attribute :last_name
 
       validates :email, presence: true, email_format: true
-      validates :first_name, presence: true
-      validates :last_name, presence: true
+      validates :first_name, presence: true, length: { maximum: 256 }
+      validates :last_name, presence: true, length: { maximum: 256 }
 
       before_validation if: :email do
         self.email = email.to_s.strip

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -9,8 +9,8 @@ module MailingList
       attribute :degree_status_id, :integer
 
       validates :email, presence: true, email_format: true
-      validates :first_name, presence: true
-      validates :last_name, presence: true
+      validates :first_name, presence: true, length: { maximum: 256 }
+      validates :last_name, presence: true, length: { maximum: 256 }
       validates :degree_status_id,
                 presence: true,
                 inclusion: { in: :degree_status_option_ids }

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,8 +1,9 @@
 class EmailFormatValidator < ActiveModel::EachValidator
   EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^\.\s]+\.[^\s]+\z}.freeze
+  MAXIMUM_LENGTH = 100 # As specified by the CRM
 
   def validate_each(record, attribute, value)
-    unless value.present? && is_an_email_uri?(value) && is_fqdn?(value)
+    unless value.present? && is_an_email_uri?(value) && is_fqdn?(value) && !too_long?(value)
       record.errors.add(attribute, :invalid)
     end
   end
@@ -15,5 +16,9 @@ private
 
   def is_fqdn?(value)
     value.to_s.match?(EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME)
+  end
+
+  def too_long?(value)
+    value.to_s.length > MAXIMUM_LENGTH
   end
 end

--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,11 +1,12 @@
 class TelephoneValidator < ActiveModel::EachValidator
   TELEPHONE_FORMAT = %r{\A[0-9 ]+\z}.freeze
   MINIMUM_LENGTH = 6
+  MAXIMUM_LENGTH = 20
 
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    if invalid_format?(value) || too_short?(value)
+    if invalid_format?(value) || too_short?(value) || too_long?(value)
       record.errors.add(attribute, :invalid)
     end
   end
@@ -18,5 +19,9 @@ private
 
   def too_short?(telephone)
     telephone.to_s.length < MINIMUM_LENGTH
+  end
+
+  def too_long?(telephone)
+    telephone.to_s.length > MAXIMUM_LENGTH
   end
 end

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -17,6 +17,14 @@ describe Events::Steps::PersonalDetails do
     it { is_expected.to include(:email) }
   end
 
+  context "first_name" do
+    it { is_expected.to_not allow_value("a" * 257).for :first_name }
+  end
+
+  context "last_name" do
+    it { is_expected.to_not allow_value("a" * 257).for :last_name }
+  end
+
   context "email address" do
     it { is_expected.to allow_value("me@you.com").for :email }
     it { is_expected.to allow_value(" me@you.com ").for :email }

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -28,6 +28,14 @@ describe MailingList::Steps::Name do
     it { is_expected.to include(:degree_status_id) }
   end
 
+  context "first_name" do
+    it { is_expected.to_not allow_value("a" * 257).for :first_name }
+  end
+
+  context "last_name" do
+    it { is_expected.to_not allow_value("a" * 257).for :last_name }
+  end
+
   context "email address" do
     it { is_expected.to allow_value("me@you.com").for :email }
     it { is_expected.to allow_value(" me@you.com ").for :email }

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -18,6 +18,14 @@ describe EmailFormatValidator do
         is_expected.to include email: "is invalid"
       end
     end
+
+    context "when over 100 characters" do
+      let(:instance) { TestModel.new(email: "#{'a' * 100}@test.com") }
+
+      it "is not be valid" do
+        is_expected.to include email: "is invalid"
+      end
+    end
   end
 
   context "valid addresses" do

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -10,7 +10,7 @@ describe TelephoneValidator do
   before { instance.valid? }
   subject { instance.errors.to_h }
 
-  %w[1234 random].each do |number|
+  %w[1234 123456789123456789123 random].each do |number|
     context "checking '#{number}'" do
       let(:instance) { TelephoneTestModel.new(telephone: number) }
       it { is_expected.to include telephone: "is invalid" }


### PR DESCRIPTION
We have some additional validation in the API that aligns with the CRM we should replicate in the clients. This updates the first/last name and email/telephone field validation to match what the CRM expects.
