### PR TITLE
Switch to using readable_id of TeachingEvent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.3", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", "1.0.6", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 2b41a6a32f2b403fcff96855b96f1f4a932107cc
+  revision: e11a952f43f34645df2aca8912d5d396f520ecf5
   specs:
-    get_into_teaching_api_client (1.0.3)
+    get_into_teaching_api_client (1.0.6)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -325,7 +325,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.3)!
+  get_into_teaching_api_client (= 1.0.6)!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   def index
-    @events = GetIntoTeachingApiClient::TeachingEventsApi.new.get_upcoming_teaching_events
+    api = GetIntoTeachingApiClient::TeachingEventsApi.new
+    @events = api.get_upcoming_teaching_events
     @event_search = Events::Search.new
     @show_categorised_events = true
   end

--- a/app/views/event_steps/_authenticate.html.erb
+++ b/app/views/event_steps/_authenticate.html.erb
@@ -1,4 +1,4 @@
 <%= render "wizard/steps/authenticate", f: f, email: event_session["email"], resend_verification_path: resend_verification_event_steps_path(
-  redirect_path: event_step_path(@event.id, Events::Steps::Authenticate.key, 
+  redirect_path: event_step_path(@event.readable_id, Events::Steps::Authenticate.key, 
   verification_resent: true
 )) %>

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -19,4 +19,4 @@
 
 <%= f.govuk_text_field :address_postcode %>
 
-<%= f.hidden_field :event_id, value: params[:event_id] %>
+<%= f.hidden_field :event_id, value: @event.id %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,4 +1,4 @@
-<%= link_to event_path(event.id), class: "event-link" do %>
+<%= link_to event_path(id: event.readable_id), class: "event-link" do %>
     <%= render "components/eventbox",
         :title => event.name,
         :datetime => format_event_date(event),

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -28,7 +28,7 @@
             To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
         </p>
 
-        <%= link_to event_steps_path(@event.id), class: "call-to-action-button" do %>
+        <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
             Sign up for this <span>event</span>
         <% end %>
     </div>

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :event_api, class: GetIntoTeachingApiClient::TeachingEvent do
     id { SecureRandom.uuid }
+    sequence(:readable_id, &:to_s)
     type_id { 222_750_001 }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "Become a Teacher #{i} event description" }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.feature "Event wizard", type: :feature do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
-  let(:event_id) { "21849bfb-0cba-ea11-a812-000d3a44afcc" }
+  let(:event_readable_id) { "123" }
   let(:event_name) { "Event Name" }
   let(:latest_privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
-  let(:event) { build(:event_api, id: event_id, name: event_name) }
+  let(:event) { build(:event_api, readable_id: event_readable_id, name: event_name) }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_teaching_event).with(event_id).and_return(event)
+      receive(:get_teaching_event).with(event_readable_id).and_return(event)
     allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
       receive(:get_latest_privacy_policy).and_return(latest_privacy_policy)
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -20,7 +20,7 @@ RSpec.feature "Event wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
-    visit event_steps_path(event_id: event_id)
+    visit event_steps_path(event_id: event_readable_id)
 
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
@@ -50,14 +50,14 @@ RSpec.feature "Event wizard", type: :feature do
       receive(:create_candidate_access_token)
 
     response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
-      eventId: event_id,
+      eventId: "abc-123",
       addressPostcode: "TE57 1NG",
       telephone: "1234567890",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
-    visit event_steps_path(event_id: event_id)
+    visit event_steps_path(event_id: event_readable_id)
 
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
@@ -95,7 +95,7 @@ RSpec.feature "Event wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
-    visit event_steps_path(event_id: event_id)
+    visit event_steps_path(event_id: event_readable_id)
 
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
@@ -122,14 +122,14 @@ RSpec.feature "Event wizard", type: :feature do
       receive(:create_candidate_access_token)
 
     response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
-      eventId: event_id,
+      eventId: "abc-123",
       alreadySubscribedToMailingList: true,
       alreadySubscribedToEvents: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
-    visit event_steps_path(event_id: event_id)
+    visit event_steps_path(event_id: event_readable_id)
 
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -6,11 +6,11 @@ describe EventStepsController do
   include_context "stub latest privacy policy api"
   include_context "stub event add attendee api"
 
-  let(:event_id) { SecureRandom.uuid }
+  let(:readable_event_id) { "123" }
   let(:model) { Events::Steps::PersonalDetails }
-  let(:step_path) { event_step_path event_id, model.key }
-  let(:authenticate_path) { event_step_path(event_id, "authenticate") }
-  let(:event) { build :event_api, id: event_id }
+  let(:step_path) { event_step_path readable_event_id, model.key }
+  let(:authenticate_path) { event_step_path(readable_event_id, "authenticate") }
+  let(:event) { build :event_api, readable_id: readable_event_id }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -54,7 +54,7 @@ describe EventStepsController do
         end
         let(:model) { Events::Steps::FurtherDetails }
         let(:details_params) { attributes_for(:events_further_details) }
-        it { is_expected.to redirect_to completed_event_steps_path(event_id) }
+        it { is_expected.to redirect_to completed_event_steps_path(readable_event_id) }
       end
 
       context "when invalid steps" do
@@ -62,7 +62,7 @@ describe EventStepsController do
         let(:details_params) { attributes_for(:events_further_details) }
         it do
           is_expected.to redirect_to \
-            event_step_path(event_id, "personal_details")
+            event_step_path(readable_event_id, "personal_details")
         end
       end
     end
@@ -70,7 +70,7 @@ describe EventStepsController do
 
   describe "#completed" do
     subject do
-      get completed_event_steps_path(event_id)
+      get completed_event_steps_path(readable_event_id)
       response
     end
     it { is_expected.to have_http_status :success }
@@ -78,7 +78,7 @@ describe EventStepsController do
 
   describe "#resend_verification" do
     subject do
-      get resend_verification_event_steps_path(event_id, redirect_path: "redirect/path")
+      get resend_verification_event_steps_path(readable_event_id, redirect_path: "redirect/path")
       response
     end
     it { is_expected.to redirect_to("redirect/path") }

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -4,13 +4,13 @@ describe EventsController do
   include_context "stub types api"
 
   describe "#index" do
-    let(:first_id) { SecureRandom.uuid }
-    let(:second_id) { SecureRandom.uuid }
+    let(:first_readable_id) { "123" }
+    let(:second_readable_id) { "456" }
 
     let(:events) do
       [
-        build(:event_api, id: first_id, name: "First"),
-        build(:event_api, id: second_id, name: "Second"),
+        build(:event_api, readable_id: first_readable_id, name: "First"),
+        build(:event_api, readable_id: second_readable_id, name: "Second"),
       ]
     end
 
@@ -52,14 +52,14 @@ describe EventsController do
   end
 
   describe "#show" do
-    let(:event_id) { SecureRandom.uuid }
+    let(:event_readable_id) { "123" }
 
     let(:event) do
-      build(:event_api, id: event_id)
+      build(:event_api, readable_id: event_readable_id)
     end
 
     subject do
-      get(event_path(event_id))
+      get(event_path(id: event_readable_id))
       response
     end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-507](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-507)

### Context

The event id is a long Guid and we currently use it in the URLs for event pages; the API now exposes a readable id, which is a small int followed by the event name (slugified) and a timestamp; using this will be more user/SEO friendly.

### Changes proposed in this pull request

- Switch to using readable_id of TeachingEvent

We currently use the `id` attribute of the `TeachingEvent` in URLs - this is a long `Guid` that is not SEO friendly. Instead, the `TeachingEvent` object now exposes a `readable_id` that is a small integer, followed by the event name (slugified) and a timestamp.

This commit updates the routes to use the `readable_id` instead of the `id`.

### Guidance to review

