### PR TITLE
Allow any non-letter in telephone number

### DIFF
--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,5 +1,5 @@
 class TelephoneValidator < ActiveModel::EachValidator
-  TELEPHONE_FORMAT = %r{\A[0-9 ]+\z}.freeze
+  TELEPHONE_FORMAT = %r{\A[^a-zA-Z]+\z}.freeze
   MINIMUM_LENGTH = 6
   MAXIMUM_LENGTH = 20
 

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -10,14 +10,14 @@ describe TelephoneValidator do
   before { instance.valid? }
   subject { instance.errors.to_h }
 
-  %w[1234 123456789123456789123 random].each do |number|
+  %w[1234 123456789123456789123 1feg313153gewg1 random].each do |number|
     context "checking '#{number}'" do
       let(:instance) { TelephoneTestModel.new(telephone: number) }
       it { is_expected.to include telephone: "is invalid" }
     end
   end
 
-  %w[01234567890 07123456789].each do |number|
+  %w[01234567890 07123456789 +448574837584 555.3442.3516 (5835)533-6326-3525].each do |number|
     context "checking '#{number}'" do
       let(:instance) { TelephoneTestModel.new(telephone: number) }
       it { is_expected.not_to include :telephone }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-511](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-511)

### Context

We need to accommodate international candidates in the sign up forms and telephone numbers can vary a lot between countries. This commit relaxes the validation so that a telephone number is valid as long as it doesn't contain letters:

```
+44 857 48935 252
(02554) 148 328
123.145356.1532
```

### Changes proposed in this pull request

- Allow any non-letter in telephone number

### Guidance to review

