### PR TITLE
Remove hard coded links to content

### DIFF
--- a/app/helpers/sitemap_helper.rb
+++ b/app/helpers/sitemap_helper.rb
@@ -1,0 +1,8 @@
+module SitemapHelper
+  def navigation_resources(sitemap)
+    resources = sitemap[:resources].select do |resource|
+      resource.dig(:front_matter, "navigation")
+    end
+    resources.sort_by { |resource| resource.dig(:front_matter, "navigation") }
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,14 +4,10 @@
     <div class="footer-top">
         <div class="footer-top__links-container">
             <a href="/">Home</a>
-            <span> | </span>
-            <a href="/steps-to-become-a-teacher/index">Steps to become a teacher</a>
-            <span> | </span>
-            <a href="/funding-your-training/index">Funding your training</a>
-            <span><br/><br/></span>
-            <a href="/life-as-a-teacher/index">Teaching as a career</a>
-            <span> | </span>
-            <a href="/life-as-a-teacher/teachers-salaries-and-benefits/">Salaries and Benefits</a>
+            <% navigation_resources(@sitemap).each do |resource| %>
+              <span> | </span>
+              <a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a>
+            <% end %>
             <span> | </span>
             <%= link_to "Find an event near you", events_path %>
             <span> | </span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,10 +17,9 @@
         <div class="navbar__desktop">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/funding-your-training/index">Funding your training</a></li>
-                <li><a href="/steps-to-become-a-teacher/index">Steps to become a teacher</a></li>
-                <li><a href="/life-as-a-teacher/index">Teaching as a career</a></li>
-                <li><a href="/life-as-a-teacher/teachers-salaries-and-benefits">Salaries and Benefits</a></li>
+                <% navigation_resources(@sitemap).each do |resource| %>
+                  <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                <% end %>
                 <li><%= link_to "Find an event near you", events_path %></li>
             </ul>
         </div>
@@ -35,10 +34,9 @@
             <div data-target="navigation.links" id="navbar-mobile-links" class="navbar__mobile__links">
                 <ul>
                     <li><a href="/">Home</a></li>
-                    <li><a href="/steps-to-become-a-teacher/index">Steps to become a teacher</a></li>
-                    <li><a href="/funding-your-training/index">Funding your training</a></li>
-                    <li><a href="/life-as-a-teacher/index">Teaching as a career</a></li>
-                    <li><a href="/life-as-a-teacher/teachers-salaries-and-benefits">Salaries and Benefits</a></li>
+                    <% navigation_resources(@sitemap).each do |resource| %>
+                      <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                    <% end %>
                     <li><%= link_to "Find an event near you", events_path %></li>
                     <li><a href="/">Talk to us</a></li>
                 </ul>

--- a/config/initializers/markdown_pages.rb
+++ b/config/initializers/markdown_pages.rb
@@ -1,4 +1,0 @@
-require "markdown_pages/template_handler"
-
-ActionView::Template.register_template_handler :md, MarkdownPages::TemplateHandler
-ActionView::Template.register_template_handler :markdown, MarkdownPages::TemplateHandler

--- a/config/initializers/template_handlers.rb
+++ b/config/initializers/template_handlers.rb
@@ -1,0 +1,4 @@
+require "template_handlers/markdown"
+
+ActionView::Template.register_template_handler :md, TemplateHandlers::Markdown
+ActionView::Template.register_template_handler :markdown, TemplateHandlers::Markdown

--- a/config/initializers/template_handlers.rb
+++ b/config/initializers/template_handlers.rb
@@ -1,4 +1,6 @@
 require "template_handlers/markdown"
+require "template_handlers/erb"
 
+ActionView::Template.register_template_handler :erb, TemplateHandlers::ERB
 ActionView::Template.register_template_handler :md, TemplateHandlers::Markdown
 ActionView::Template.register_template_handler :markdown, TemplateHandlers::Markdown

--- a/lib/template_handlers/erb.rb
+++ b/lib/template_handlers/erb.rb
@@ -1,0 +1,46 @@
+module TemplateHandlers
+  class ERB < ActionView::Template::Handlers::ERB
+    CONTENT_DIR = Rails.root.join("app/views/content").freeze
+
+    def call(template, source = nil)
+      # inspect objects to Ruby strings which can be eval'd
+      %(@sitemap = #{self.class.sitemap.inspect}; #{super}.html_safe)
+    end
+
+    class << self
+      attr_writer :sitemap
+
+      def sitemap
+        @sitemap ||= build_sitemap
+      end
+
+      def build_sitemap
+        resources = Dir.glob(content_pattern).map do |file|
+          {
+            path: path(file),
+            front_matter: front_matter(file),
+          }
+        end
+
+        { resources: resources }
+      end
+
+      def path(file)
+        pathname = Pathname.new(file).sub_ext("")
+        "/#{pathname.relative_path_from(CONTENT_DIR)}"
+      end
+
+      def content_pattern
+        "#{CONTENT_DIR}/**/*.{md,markdown}"
+      end
+
+      def front_matter(file)
+        parse(file).front_matter
+      end
+
+      def parse(file)
+        FrontMatterParser::Parser.parse_file(file)
+      end
+    end
+  end
+end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -1,5 +1,5 @@
-module MarkdownPages
-  class TemplateHandler
+module TemplateHandlers
+  class Markdown
     attr_reader :template, :source, :options
 
     DEFAULTS = {}.freeze

--- a/spec/fixtures/files/content/page1.md
+++ b/spec/fixtures/files/content/page1.md
@@ -1,0 +1,5 @@
+---
+title: Hello World 1
+---
+
+Some content

--- a/spec/fixtures/files/content/subfolder/page2.md
+++ b/spec/fixtures/files/content/subfolder/page2.md
@@ -1,0 +1,5 @@
+---
+title: Hello World 2
+---
+
+Some content

--- a/spec/helpers/sitemap_helper_spec.rb
+++ b/spec/helpers/sitemap_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe SitemapHelper, type: :helper do
+  describe "#navigation_resources" do
+    let(:sitemap) do
+      {
+        resources: [
+          { title: "Page 1", front_matter: { "navigation" => 10 } },
+          { title: "Page 2", front_matter: { "navigation" => 30 } },
+          { title: "Page 3", front_matter: { "navigation" => 20 } },
+        ]
+      }
+    end
+
+    subject { helper.navigation_resources(sitemap) }
+
+    it { expect(subject.map { |r| r[:title] }).to eq(["Page 1", "Page 3", "Page 2"]) }
+  end
+end

--- a/spec/helpers/sitemap_helper_spec.rb
+++ b/spec/helpers/sitemap_helper_spec.rb
@@ -8,7 +8,7 @@ describe SitemapHelper, type: :helper do
           { title: "Page 1", front_matter: { "navigation" => 10 } },
           { title: "Page 2", front_matter: { "navigation" => 30 } },
           { title: "Page 3", front_matter: { "navigation" => 20 } },
-        ]
+        ],
       }
     end
 

--- a/spec/lib/template_handlers/erb_spec.rb
+++ b/spec/lib/template_handlers/erb_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe TemplateHandlers::ERB, type: :view do
+  subject { rendered }
+
+  context "generic ERB page accessing the @sitemap" do
+    let(:erb) do
+      <<~ERB
+        <%= pluralize(@sitemap[:resources].count, "resource") %>
+        <%= @sitemap[:resources].map { |r| r[:path] } %>
+        <%= @sitemap[:resources].map { |r| r[:front_matter] } %>
+      ERB
+    end
+
+    before do
+      TemplateHandlers::ERB.sitemap = nil # clear cache
+      stub_const("TemplateHandlers::ERB::CONTENT_DIR", "#{file_fixture_path}/content")
+      stub_template "test.erb" => erb
+      render template: "test.erb"
+    end
+
+    it { is_expected.to have_text("2 resources") }
+    it { is_expected.to match(/\/page1/) }
+    it { is_expected.to match(/\/subfolder\/page2/) }
+    it { is_expected.to match(/Hello World 1/) }
+    it { is_expected.to match(/Hello World 2/) }
+  end
+end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe MarkdownPages::TemplateHandler, type: :view do
+describe TemplateHandlers::Markdown, type: :view do
   subject { rendered }
 
   context "generic markdown page" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-523](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-523)

### Context

We want to be able to dynamically render the navigation links (and index pages for other content), avoiding the need to hardcode links to the content pages.

### Changes proposed in this pull request

- Move markdown_pages into template_handlers

We are going to add another template handler that will provide a sitemap to all ERB pages; shuffling the existing template handler into a namespace that can be used for both going forward.

- Add ERB template handler to inject sitemap

Subclass the ActionView ERB template handler to inject a `@sitemap` instance variable that contains the details and front matter of all the content pages. This will enable us to build lists of content, navigation menus, etc. Takes inspiration from the [Middleman Sitemap](https://middlemanapp.com/advanced/sitemap/).

- Build navigation menus from front matter

The content repo is being updated so that pages include a `navigation` front matter attribute containing the position of the page in the header/footer navigation menus. This commit adds a helper to find pages that should appear in the navigation and updates the static links to be built out dynamically.

### Guidance to review

