### PR TITLE
Re-introduce break in footer links

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,8 +4,12 @@
     <div class="footer-top">
         <div class="footer-top__links-container">
             <a href="/">Home</a>
-            <% navigation_resources(@sitemap).each do |resource| %>
-              <span> | </span>
+            <% navigation_resources(@sitemap).each_with_index do |resource, index| %>
+              <% if index == 2 %>
+                <span><br /><br /></span>
+              <% else %>
+                <span> | </span>
+              <% end %>
               <a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a>
             <% end %>
             <span> | </span>


### PR DESCRIPTION
Prior to auto-generating the footer links from the content there was a hardcoded `<span><br /><br /></span>` that caused a line break after the third link; this re-introduces it.
