### PR TITLE
Pin event_search factory month

### DIFF
--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     type { Events::Search.new.available_event_types.first.id }
     distance { Events::Search.new.available_distances.first[0] }
     postcode { "TE57 1NG" }
-    month { Events::Search.new.available_months.first[0] }
+    month { "2020-07" }
   end
 end


### PR DESCRIPTION
A test started failing when we rolled over into August due to the `month` attribute of the `:events_search` factory being tied to the current month (and the assertion hardcoded to July).