### PR TITLE
Fix broken password protection feature spec

### DIFF
--- a/spec/features/password_protection_spec.rb
+++ b/spec/features/password_protection_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Password protection", type: :feature do
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("HTTPAUTH_USERNAME") { username }
     allow(ENV).to receive(:[]).with("HTTPAUTH_PASSWORD") { password }
-    visit root_path
+    visit healthcheck_path
   end
 
   subject { page }


### PR DESCRIPTION
The spec was hitting the home page, which was moved to be content-driven in PR #214 (meaning it 404's locally instead).