### PR TITLE
Add all events option to event type dropdown

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -12,7 +12,7 @@ module Events
     attribute :postcode, :string
     attribute :month, :string
 
-    validates :type, presence: true, inclusion: { in: :available_event_type_ids, allow_blank: true }
+    validates :type, presence: false, inclusion: { in: :available_event_type_ids, allow_nil: true }
     validates :distance, inclusion: { in: :available_distance_keys }, allow_nil: true
     validates :postcode, presence: true, postcode: { allow_blank: true }, if: :distance
     validates :month, presence: true, format: { with: MONTH_FORMAT, allow_blank: true }

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -8,7 +8,7 @@
 
     <div class="search-for-events__content__input">
         <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
-        <%= f.collection_select :type, f.object.available_event_types, :id, :value %>
+        <%= f.collection_select :type, f.object.available_event_types, :id, :value, { include_blank: "All events" } %>
     </div>
 
     <div class="search-for-events__content__input">

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -19,8 +19,9 @@ describe Events::Search do
     context "for event type" do
       it { is_expected.to allow_value(1).for :type }
       it { is_expected.to allow_value("1").for :type }
+      it { is_expected.to allow_value(nil).for :type }
+      it { is_expected.to allow_value("").for :type }
       it { is_expected.not_to allow_value("2").for :type }
-      it { is_expected.not_to allow_value("").for :type }
     end
 
     context "for distance" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-561](https://dfedigital.atlassian.net/browse/GITPB-561)

### Context

When a user lands on the events index page we are going to show all events (latest 3 by group, plus all in a separate section at the bottom) however we default to the first type in the dropdown, which is confusing.

### Changes proposed in this pull request

- Add all events option to event type dropdown

We want to default to showing users all events, however currently we select the first type in the list which is confusing from a user's perspective. This commit adds an `All events` option as the default/blank value of the type dropdown.

### Guidance to review

<img width="827" alt="Screenshot 2020-08-05 at 10 56 37" src="https://user-images.githubusercontent.com/29867726/89400333-ac16aa00-d70b-11ea-9dc1-1e3919c6d877.png">
