### PR TITLE
Fix exception when event type can't be found

### DIFF
--- a/app/views/components/_eventbox.html.erb
+++ b/app/views/components/_eventbox.html.erb
@@ -1,5 +1,5 @@
 <%
-  type_text = GetIntoTeachingApi::Constants::EVENT_TYPES.key(type)
+  type_text = GetIntoTeachingApi::Constants::EVENT_TYPES.key(type) || ""
 %>
 <div class="event-resultbox">
     <div class="event-resultbox__header">

--- a/app/views/components/_eventboxshort.html.erb
+++ b/app/views/components/_eventboxshort.html.erb
@@ -1,5 +1,5 @@
 <%
-  type_text = GetIntoTeachingApi::Constants::EVENT_TYPES.key(type)
+  type_text = GetIntoTeachingApi::Constants::EVENT_TYPES.key(type) || ""
 %>
 
 <div class="event-resultboxshort">


### PR DESCRIPTION
We have hard coded some event types that don't yet exist (Online events), so when we lookup their name `nil` is returned - we are then trying to `parameterize` the `nil` object, which causes an exception.

Defaulting to an empty string fixes this for now; going forward the events will be connected to the API so this problem will go away.