### PR TITLE
Events empty view

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -26,7 +26,7 @@
 
     <%= render partial: "event_category", collection: @events_by_type %>
 
-    <% if @display_all_events_section %>
+    <% if @display_all_events_section && !@events.empty? %>
     <section class="search-for-events-results content container-1000">
         <div class="content__left">
             <h2 class="types-of-event__header types-of-event__header--ttt">All events</h2>
@@ -36,5 +36,15 @@
 
         <%= render partial: "event", collection: @events %>
     </section>
+    <% end %>
+
+    <% if @events.empty? %>
+      <section class="content container-1000">
+        <div class="content__left">
+          <div class="search-for-events-no-results">
+            There are no events that match your search criteria. Try widening your search and updating your results.
+          </div>
+        </div>
+      </section>
     <% end %>
 </section>

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -250,6 +250,14 @@
     }
 }
 
+.search-for-events-no-results {
+  background: $purple;
+  color: $white;
+  padding: 20px;
+  font-weight: bold;
+  margin-bottom: 80px;
+}
+
 @media only screen and (max-width: 800px) {
     
     .types-of-event {

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe "Find an event near you" do
   include_context "stub types api"
 
+  NO_EVENTS_REGEX = /no events that match your search criteria/.freeze
+
   let(:events) do
     5.times.collect do |index|
       start_at = Time.zone.today.at_beginning_of_month + index.days
@@ -28,6 +30,14 @@ describe "Find an event near you" do
     it "displays >3 events only under 'all events'" do
       expect(response.body.scan(/Event [4-5]/).count).to eq(2)
     end
+
+    context "when there are no results" do
+      let(:events) { [] }
+
+      it "displays the no results message" do
+        expect(response.body).to match(NO_EVENTS_REGEX)
+      end
+    end
   end
 
   context "when searching for an event by type" do
@@ -36,6 +46,14 @@ describe "Find an event near you" do
 
     it "displays all events of that type" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)
+    end
+
+    context "when there are no results" do
+      let(:events) { [] }
+
+      it "displays the no results message" do
+        expect(response.body).to match(NO_EVENTS_REGEX)
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-520](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451&selectedIssue=GITPB-520)

### Context

Currently if there are no matching events the results box is empty, or just shows the 'All events' heading. Instead, we want to display a message to the user to let them know that their search criteria does not match any events.

### Changes proposed in this pull request

- Display message when there are no matching events

<img width="838" alt="Screenshot 2020-08-06 at 15 40 45" src="https://user-images.githubusercontent.com/29867726/89545395-338f1680-d7fb-11ea-96a5-df4813ae8e11.png">

### Guidance to review

