### PR TITLE
Show newlines in privacy policy content

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -1,0 +1,8 @@
+module TextFormattingHelper
+  extend ActiveSupport::Concern
+  include ActionView::Helpers::TextHelper
+
+  def safe_format(content)
+    simple_format strip_tags content
+  end
+end

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -2,7 +2,7 @@
   <div class="content__left">
     <h2>Privacy Policy</h2>
     <h3>Legal information</h3>
-    <%= @privacy_policy.text.html_safe %>
+    <%= safe_format @privacy_policy.text %>
   </div>
   <div class="content_right"></div>
 </section>

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe TextFormattingHelper, type: :helper do
+  describe "#safe_format" do
+    subject { safe_format content }
+
+    context "with new lines" do
+      let(:content) { "hello\r\n\r\nworld" }
+      it { is_expected.to eql "<p>hello</p>\n\n<p>world</p>" }
+    end
+
+    context "with html content" do
+      let(:content) { "<strong>hello</strong> <em>world</em>" }
+      it { is_expected.to eql "<p>hello world</p>" }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently the privacy policy content is shown as a single block and it is assumed to be safe HTML content

### Changes proposed in this pull request

1. Escape unexpected HTML content
2. Use Rails' simple_format helper to process new lines into breaks, and double new lines into paragraphs



