### PR TITLE
Include the cookie acceptance partials in all layouts

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -20,6 +20,7 @@
             <%= render "sections/footer" %>     
         </div>
         <%= render "components/videoplayer" %>
+        <%= render "sections/cookie-acceptance" %>
     <% end %>
 </html>
 

--- a/app/views/layouts/stories.html.erb
+++ b/app/views/layouts/stories.html.erb
@@ -10,6 +10,7 @@
             <%= render "sections/footer" %>     
         </div>
         <%= render "components/videoplayer" %>
+        <%= render "sections/cookie-acceptance" %>
     <% end %>
 </html>
 


### PR DESCRIPTION
### Context

The cookie acceptance page is no longer showing on the home page. It should be showing on all pages within the site until the user has accepted the cookie

### Changes proposed in this pull request

1. Include the cookie acceptance partials in all layouts



