### PR TITLE
GITPB-567 GTM per page events

### DIFF
--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -17,9 +17,15 @@ export default class extends Controller {
     }
   }
 
+  get isEnabled() {
+    return (this.serviceId && this.data.has('action') && this.data.has('event')) ;
+  }
+
   triggerEvent() {
-    if (!this.serviceId || !this.data.has('action') || !this.data.has('event'))
-      return
+    if (document.documentElement.hasAttribute("data-turbolinks-preview"))
+      return ;
+
+    if (!this.isEnabled) return ;
 
     if (!this.serviceFunction)
       this.initService() ;

--- a/app/webpacker/controllers/gtm_controller.js
+++ b/app/webpacker/controllers/gtm_controller.js
@@ -11,16 +11,17 @@ export default class extends AnalyticsBaseController {
   }
 
   initService() {
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function (){dataLayer.push(arguments);}
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer',this.serviceId);
 
-    var e="https://www.googletagmanager.com/gtag/js?id=" + this.serviceId ;
-    var t=document.createElement("script");t.async=true,t.src=e;var
-    r=document.getElementsByTagName("script")[0];
-    r.parentNode.insertBefore(t,r) ;
-
-    window.gtag('js', new Date());
-    window.gtag('config', this.serviceId);
+    /* this is added for simplicity but is not compatible with multiple GTM containers */
+    /* We dont support that anyway so its not an issue here */
+    window.gtag = function() {
+      window.dataLayer.push(arguments);
+    }
   }
 
   get isEnabled() {

--- a/app/webpacker/controllers/gtm_controller.js
+++ b/app/webpacker/controllers/gtm_controller.js
@@ -23,5 +23,19 @@ export default class extends AnalyticsBaseController {
     window.gtag('config', this.serviceId);
   }
 
+  get isEnabled() {
+    return !!this.serviceId ;
+  }
+
+  sendEvent() {
+    window.gtag({
+      'event':'virtualPageView',
+      'page':{
+        'title': document.title,
+        'url': window.location.href
+      }
+    }) ;
+  }
+
 }
 


### PR DESCRIPTION
### JIRA ticket number

GITPB-567

### Context

The GTM code was only firing on first page load. The general analytics triggers were also firing for turbolinks page previews

### Changes proposed in this pull request

1. Only fire the events if the page is not a preview at the point the controller is connected.
2. Updated to the latest GTM code
3. Don't require an event on the page to initialize the GTM integration
4. Send a virtualPageView event to GTM everytime a page is visited



