### PR TITLE
Fire pinterest events upon completion of wizards

### DIFF
--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -12,6 +12,18 @@
             <p>
                 You will receive a confirmation email with details of the event. If there is an issue with the event we will contact you via phone.
             </p>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="track"
+                data-pinterest-event="custom"></span>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="track"
+                data-pinterest-event="INVITE"></span>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="track"
+                data-pinterest-event="Event_Registrations"></span>
         </div>
         <div class="content__right">
 

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -11,6 +11,19 @@
               You can unsubscribe if you change your mind. To find out how we
               handle your personal data, you can read our privacy policy.
             </p>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="track"
+                data-pinterest-event="lead"
+                data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="track"
+                data-pinterest-event="SUBSCRIBE"></span>
+
+            <span data-controller="pinterest"
+                data-pinterest-action="trackCustom"
+                data-pinterest-event="Newsletter_Subscribers"></span>
         </div>
         <div class="content__right">
 

--- a/app/webpacker/controllers/pinterest_controller.js
+++ b/app/webpacker/controllers/pinterest_controller.js
@@ -18,7 +18,7 @@ export default class extends AnalyticsBaseController {
     r=document.getElementsByTagName("script")[0];
     r.parentNode.insertBefore(t,r)}}("https://s.pinimg.com/ct/core.js");
 
-    pintrk('load', this.pinterestId);
+    pintrk('load', this.serviceId);
   }
 
 }


### PR DESCRIPTION
### JIRA ticket number

GITPB-566

### Context

Pinterest events should be fired upon completion of the wizards so aid with targetting potential teachers.

### Changes proposed in this pull request

1. Trigger events upon completion of Mailing list wizard
2. Trigger events upon completion of Newsletter wizard
3. Fixed bug with incorrect variable used for reading pinterest id



