### PR TITLE
Removed old GTag integration code

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -1,14 +1,4 @@
 <head>
-  <% if Rails.env.production? %>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-159214613-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-159214613-2');
-    </script>
-  <% end %>
   <meta charset="utf-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
### Context

GTM is now handled within the Stimulus controller, so the existing GTM which was unused can be removed.

### Changes proposed in this pull request

1. Remove unused GTag code



