### PR TITLE
Update events index to match designs

### DIFF
--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -1,24 +1,36 @@
 <% type_id, events = event_category %>
+<% category_name = name_of_event_type(type_id) %>
 
-<section class="search-for-events-results content container-1000">
-    <div class="content__left">
-        <h2 class="types-of-event__header types-of-event__header--ttt">
-            <%= name_of_event_type(type_id) %>
-        </h2>
-    </div>
-    <div class="content__right">
-    </div>
-
-    <% events.each do |event| %>
-      <%= link_to event_path(id: event.readable_id), class: "event-link" do %>
-        <%= render "components/eventbox",
-            title: event.name,
-            datetime: format_event_date(event),
-            description: event.description,
-            type: event.type_id,
-            online: event.building.nil?,
-            location: event.building&.address_city
-        %>
+<section class="types-of-event content container-1000">
+  <div class="content__left">
+      <h2>
+        <% if type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
+          <div class="types-of-event__header__icon icon-train-to-teach-event"></div>
+          Organised by Get into Teaching
+        <% else %>
+          Organised by <%= category_name %>
+        <% end %>
+      </h2>
+  </div>
+  <div class="events-featured">
+      <h3><%= name_of_event_type(type_id) %></h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non augue a mauris efficitur ullamcorper id sed nisi. Fusce maximus, magna vel volutpat sollicitudin, nisl lectus maximus nibh, ut aliquam nunc ipsum eu ante.</p>
+      <div class="events-featured__items">
+      <% events.each do |event| %>
+        <%= link_to event_path(id: event.readable_id), class: "event-link" do %>
+          <%= render "components/eventbox",
+              title: event.name,
+              datetime: format_event_date(event),
+              description: event.description,
+              type: event.type_id,
+              online: event.building.nil?,
+              location: event.building&.address_city
+          %>
+        <% end %>
       <% end %>
-    <% end %>
+      </div>
+      <%= link_to("#") do %>
+          <div class="call-to-action-button">See all <%= category_name %> <i class="fas fa-chevron-right"></i></div>
+      <% end %>
+  </div>
 </section>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -26,17 +26,17 @@
 
     <%= render partial: "event_category", collection: @events_by_type %>
 
-    <% if @display_all_events_section && !@events.empty? %>
     <section class="search-for-events-results content container-1000">
         <div class="content__left">
-            <h2 class="types-of-event__header types-of-event__header--ttt">All events</h2>
+        <% if @events_by_type.present? %>
+          <h2 class="types-of-event__header types-of-event__header--ttt">All events</h2>
+        <% end %>
         </div>
         <div class="content__right">
         </div>
 
         <%= render partial: "event", collection: @events %>
     </section>
-    <% end %>
 
     <% if @events.empty? %>
       <section class="content container-1000">

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -43,6 +43,10 @@
 
 }
 
+.types-of-event__header__icon {
+  margin-bottom: 5px;
+}
+
 .types-of-event-quote {
 
     &__left {

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.feature "Finding an event", type: :feature do
+  include_context "stub types api"
+
+  let(:events) do
+    5.times.collect do |index|
+      start_at = Time.zone.today.at_beginning_of_month + index.days
+      build(:event_api, name: "Event #{index + 1}", start_at: start_at)
+    end
+  end
+  let(:event) { events.last }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:search_teaching_events) { events }
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:get_teaching_event) { event }
+  end
+
+  scenario "Finding an event by the list of featured events" do
+    visit events_path
+
+    expect(page).to have_text "Search for events"
+    expect(page).to have_css "h2", text: "Organised by Get into Teaching"
+    expect(page).to have_css "h2", text: "All events"
+
+    click_on(event.name)
+
+    expect(page).to have_css "h1", text: event.name
+    click_on "Sign up for this event"
+  end
+
+  scenario "Finding an event by type" do
+    visit events_path
+
+    expect(page).to have_text "Search for events"
+
+    select "Train to Teach event"
+    click_on "Update results"
+
+    expect(page).not_to have_css "h2", text: "Organized by Get into Teaching"
+    expect(page).not_to have_css "h2", text: "All events"
+
+    click_on(event.name)
+
+    expect(page).to have_css "h1", text: event.name
+    click_on "Sign up for this event"
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-562](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451&selectedIssue=GITPB-562)

### Context

When a user views the events page initially, we want to show the first 3 events in each category in addition to all events (uncategorised) at the bottom of the page. When the user searches for events, we want all matching events to show in the results, uncategorised and without a heading.

### Changes proposed in this pull request

Categorises the events by type on the events index page, updating to show all matching events uncategorised when the user performs a search.

### Guidance to review

