### PR TITLE
Show events by category

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,17 @@ class EventsController < ApplicationController
     render template: "errors/not_found", status: :not_found
   end
 
+  def show_category
+    @type = GetIntoTeachingApiClient::TypesApi.new.get_teaching_event_types.find do |type|
+      type.value.parameterize == params[:category]
+    end
+
+    render(template: "errors/not_found", status: :not_found) && return if @type.nil?
+
+    api = GetIntoTeachingApiClient::TeachingEventsApi.new
+    @events = api.search_teaching_events(type_id: @type.id)
+  end
+
 private
 
   def load_events

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -29,7 +29,7 @@
         <% end %>
       <% end %>
       </div>
-      <%= link_to("#") do %>
+      <%= link_to(event_category_events_path(category_name.parameterize)) do %>
           <div class="call-to-action-button">See all <%= category_name %> <i class="fas fa-chevron-right"></i></div>
       <% end %>
   </div>

--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -1,0 +1,39 @@
+<%= render "sections/hero",  
+  header: "Train to teach events", 
+  image: "media/images/hero-events.png",
+  deep: false,
+  mailinglist: false 
+%>
+
+<% category_name = name_of_event_type(@type.id) %>
+
+<section class="types-of-event content container-1000">
+
+    <div class="content__left">
+        <%= link_to "All events", events_path, class: "backlink" %>
+        <h3><%= category_name %></h3>
+        <br />
+        <p>
+            At our <%= category_name %>, you can meet experienced teaching professionals who can answer all of your questions. 
+        </p>
+        <h3>You’ll get the chance to:</h3>
+        <ul>
+            <li><span>Speak to experts about ways into teacher training and available funding</span></li>
+            <li><span>Talk one-to-one with experienced and newly qualified teachers to find out what Teaching is really like</span></li>
+            <li><span>Get advice on your teacher training application</span></li>
+            <li><span>Talk to schools and universities in your area to help you decide on the best place for you to train and how to apply</span></li>
+        </ul>
+        <p>
+            You can drop in at any time. Allow at least two hours to make the most of your visit. Train to Teach presentations run hourly throughout the event. 
+        </p>
+        <p>
+            Check event timetables to make sure you don’t miss anything.
+        </p>
+    </div>
+
+</section>
+
+<section class="search-for-events-results content container-1000">
+  <%= render partial: "event", collection: @events %>
+</section>
+

--- a/app/webpacker/styles/backlink.scss
+++ b/app/webpacker/styles/backlink.scss
@@ -1,5 +1,5 @@
 .backlink {
-    display: block;
+    display: inline-block;
     margin-bottom: 30px;
     color: #0b0c0c!important;
     position: relative;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
 
   resources "events", path: "/events", only: %i[index show search] do
-    collection { get "search" }
+    collection do
+      get "search"
+      get "category/:category", to: "events#show_category", as: :event_category
+    end
     resources "steps",
               path: "/apply",
               controller: "event_steps",

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "View events by category" do
+  include_context "stub types api"
+
+  let(:events) do
+    5.times.collect do |index|
+      start_at = Time.zone.today.at_beginning_of_month + index.days
+      build(:event_api, name: "Event #{index + 1}", start_at: start_at)
+    end
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:search_teaching_events) { events }
+  end
+
+  context "when viewing a category" do
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:search_teaching_events) { events }
+      get event_category_events_path("train-to-teach-event")
+    end
+
+    subject { response }
+
+    it { is_expected.to have_http_status :success }
+
+    it "displays all events in the category" do
+      expect(response.body.scan(/Event \d/).count).to eq(events.count)
+    end
+  end
+
+  context "when a category does not exist" do
+    before do
+      get event_category_events_path("non-existant")
+    end
+
+    subject { response }
+
+    it { is_expected.to have_http_status :not_found }
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-562](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?issueParent=18255%2C20451&selectedIssue=GITPB-562)

### Context

On the events index page we link through to the full category; we need to add this page and display all the events in the category. Currently, the API returns all events past and future, but as part of https://github.com/DFE-Digital/get-into-teaching-api/pull/188 the past events will be screened out at the API-layer, so won't display here.

### Changes proposed in this pull request

- Add event category page

### Guidance to review

