### PR TITLE
Provide cache headers with static pages to lower load and speed up response

### DIFF
--- a/app/controllers/concerns/static_pages.rb
+++ b/app/controllers/concerns/static_pages.rb
@@ -1,0 +1,18 @@
+module StaticPages
+  extend ActiveSupport::Concern
+
+  def cache_static_page
+    config = Rails.application.config.x.static_pages
+
+    if config.etag && Rails.application.config.action_controller.perform_caching
+      @cacheable_static_page = true
+      expires_in config.expires_in, public: true
+
+      if stale?(etag: config.etag, last_modified: config.last_modified, public: true)
+        yield
+      end
+    else
+      yield
+    end
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
+  include StaticPages
+  around_action :cache_static_page, only: %i[show]
+
   def home
     render template: "pages/home"
   end
@@ -24,7 +27,7 @@ class PagesController < ApplicationController
   end
 
   def show
-    render template: "content/#{params[:page]}", layout: "layouts/content"
+    render template: "content/#{params[:page]}", layout: "layouts/application"
   rescue ActionView::MissingTemplate
     respond_to do |format|
       format.html do

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,7 +27,7 @@ class PagesController < ApplicationController
   end
 
   def show
-    render template: "content/#{params[:page]}", layout: "layouts/application"
+    render template: content_template(params[:page]), layout: "layouts/application"
   rescue ActionView::MissingTemplate
     respond_to do |format|
       format.html do
@@ -56,5 +56,11 @@ class PagesController < ApplicationController
         render status: :not_found, body: nil
       end
     end
+  end
+
+private
+
+  def content_template(requested_page)
+    "content/#{requested_page}"
   end
 end

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
-  <%= csrf_meta_tags %>
+  <%= csrf_meta_tags unless @cacheable_static_page %>
   <%= csp_meta_tag %>
   <%= canonical_tag %>
   <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' %>

--- a/config/initializers/static_pages.rb
+++ b/config/initializers/static_pages.rb
@@ -1,0 +1,16 @@
+Rails.application.config.x.static_pages.tap do |config|
+  if File.exist?("/etc/get-into-teaching-content-sha")
+    config.etag = [
+      File.read("/etc/get-into-teaching-app-sha"),
+      File.read("/etc/get-into-teaching-content-sha"),
+    ]
+
+    config.last_modified =
+      Time.parse(File.read("/etc/get-into-teaching-content-build-time")).utc
+    config.expires_in = 1.minute
+  else
+    config.etag = nil
+    config.last_modified = nil
+    config.expires_in = nil
+  end
+end

--- a/spec/controllers/concerns/static_pages_spec.rb
+++ b/spec/controllers/concerns/static_pages_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe StaticPages do
+  class StaticPageTester
+    include StaticPages
+    attr_reader :cacheable_static_page
+
+    def render
+      cache_static_page { fetch_content }
+    end
+
+    def fetch_content
+      true
+    end
+
+    def stale?(*_args)
+      true
+    end
+
+    def expires_in(*_args)
+      true
+    end
+  end
+
+  let(:tester) { StaticPageTester.new }
+
+  let(:config) { Rails.application.config.x.static_pages }
+  let(:etag) { "12345" }
+  let(:last_modified) { 2.minutes.ago }
+  let(:expires_in) { 2.minutes }
+
+  before do
+    allow(config).to receive(:etag).and_return(etag)
+    allow(config).to receive(:last_modified).and_return(last_modified)
+    allow(config).to receive(:expires_in).and_return(expires_in)
+
+    allow(tester).to receive(:stale?).and_call_original
+    allow(tester).to receive(:expires_in).and_call_original
+    allow(tester).to receive(:fetch_content).and_call_original
+  end
+
+  subject { tester.tap(&:render) }
+
+  context "with caching disabled" do
+    it { is_expected.to have_received :fetch_content }
+    it { is_expected.not_to have_received :stale? }
+    it { is_expected.not_to have_received :expires_in }
+    it { is_expected.to have_attributes cacheable_static_page: nil }
+  end
+
+  context "with caching enabled" do
+    before do
+      allow(Rails.application.config.action_controller).to \
+        receive(:perform_caching).and_return true
+    end
+
+    it { is_expected.to have_received(:fetch_content) }
+    it { is_expected.to have_attributes cacheable_static_page: true }
+
+    it do
+      is_expected.to have_received(:stale?).with \
+        etag: etag, last_modified: last_modified, public: true
+    end
+
+    it do
+      is_expected.to have_received(:expires_in).with expires_in, public: true
+    end
+  end
+end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe PagesController do
+  before do
+    allow_any_instance_of(described_class).to \
+      receive(:content_template).and_return "errors/not_found"
+  end
+
+  context "#show" do
+    context "without caching enabled" do
+      it "Should not have cache headers" do
+        get "/test"
+
+        expect(response).to have_http_status 200
+        expect(response.headers).not_to include "Last-Modified"
+        expect(response.headers["Cache-control"]).to match %r{max-age=0}
+        expect(response.headers["Cache-control"]).to match %r{private}
+        expect(response.headers["Cache-control"]).to match %r{must-revalidate}
+      end
+    end
+
+    context "with caching" do
+      let(:cache_config) { Rails.application.config.x.static_pages }
+
+      before do
+        allow(Rails.application.config.action_controller).to \
+          receive(:perform_caching).and_return true
+
+        allow(cache_config).to receive(:etag).and_return "12345"
+        allow(cache_config).to receive(:last_modified).and_return 2.minutes.ago
+      end
+
+      it "should utilise cached version" do
+        get "/test"
+        expect(response).to have_http_status 200
+
+        etag = response.headers["ETag"]
+        lastmod = response.headers["Last-Modified"]
+
+        get "/test", headers: {
+          "If-None-Match" => etag,
+          "If-Modified-Since" => lastmod,
+        }
+
+        expect(response).to have_http_status 304
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

GITPB-519

### Context

We want to avoid having a slow Rails app continually re-render the same markdown templates if a fast CDN can instead deliver the same static pages.

We also want page updates to be delivered in as timely a manner after release as possible whilst not introducing unnecessary load on the system.

### Changes proposed in this pull request

1. An around filter has been added to handle caching static pages
    1. Static pages are delivered with an ETag that is reflective of both git sha's - from the content and app repo's
    2. Static pages are delivered with a last modified time of whenever the container image was built
    3. The above 2 mean multiple server instances all deliver the same etag and last modified times for with pages designated static and cacheable
2. The `_head` partial has been modified to not include csrf meta tags for static pages

### Expected behaviour

Any static page should be cached for at least 1 minute, after that point a page may need to be fetched again but should include the etag and last modified times. These are derived from the built docker image, so should result in a 304 until a new release is rolled out.

This will add a 1 minute delay to deploying page updates but should significantly improve performance under heavy load

### Guidance to review

For manual testing within the browser, you can set the cache headers manually in the initialiser (eg where they are nil, set them to the values you wish to test). I'd suggest initially leaving expires_in to nil.

You'll also need to create a `tmp/caching-dev.txt` file to enable caching in development.

Things to be aware of

1. Refreshing a page ignores the cache in modern browsers, but opening a url a second time in a new tab honours the cache settings.
2. Thanks to turbolinks you can watch the response code as you navigate between different pages
3. If `expires_in` has been set, you'll only see a 304 response after the expires_in time has passed, prior to that you'll see a 200 response but the browser will show as having retrieved the page from cache.
4. On static pages, the csrf meta tags should be missing from the HEAD section (since these shouldn't end up in a public cache)
5. Navigating to the event search page (or any none static page) should set the csrf meta tags in the <head> section
