### PR TITLE
Set the session cookie name

### DIFF
--- a/config/initializers/cookie_store.rb
+++ b/config/initializers/cookie_store.rb
@@ -1,0 +1,3 @@
+Rails.application.config.session_store :cookie_store,
+                                       key: "_dfe_session",
+                                       same_site: :lax


### PR DESCRIPTION
### JIRA ticket number

GITPB-575

### Context

Currently our session cookie is using an incorrect name

### Changes proposed in this pull request

1. Use a generic name for the cookie
2. Set the SameSite value to improve security



