### PR TITLE
Styling and content updates for events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.6", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", "1.0.7", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: e11a952f43f34645df2aca8912d5d396f520ecf5
+  revision: 1b6a54e8379fd4d593a43e4df4c347935cb10654
   specs:
-    get_into_teaching_api_client (1.0.6)
+    get_into_teaching_api_client (1.0.7)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -331,7 +331,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.6)!
+  get_into_teaching_api_client (= 1.0.7)!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -17,6 +17,17 @@ module EventsHelper
     end
   end
 
+  def embed_event_video_url(video_url)
+    video_url&.sub("watch?v=", "embed/")
+  end
+
+  def event_has_provider_info?(event)
+    event.provider_website_url ||
+      event.provider_target_audience ||
+      event.provider_organiser ||
+      event.provider_contact_email
+  end
+
   def event_address(event)
     building = event.building
     return nil unless building
@@ -26,7 +37,7 @@ module EventsHelper
       building.address_line2,
       building.address_line3,
       building.address_city,
-      building.address_postcode
+      building.address_postcode,
     ].compact!.join(",\n")
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -24,6 +24,6 @@ module EventsHelper
   end
 
   def train_to_teach_event_type?(type_id)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] == type_id
+    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] == type_id
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -17,6 +17,19 @@ module EventsHelper
     end
   end
 
+  def event_address(event)
+    building = event.building
+    return nil unless building
+
+    [
+      building.address_line1,
+      building.address_line2,
+      building.address_line3,
+      building.address_city,
+      building.address_postcode
+    ].compact!.join(",\n")
+  end
+
   def name_of_event_type(type_id)
     api = GetIntoTeachingApiClient::TypesApi.new
     type = api.get_teaching_event_types.find { |t| t.id == type_id.to_s }

--- a/app/views/components/_eventbox.html.erb
+++ b/app/views/components/_eventbox.html.erb
@@ -8,15 +8,19 @@
     <div class="event-resultbox__datetime">
         <%= datetime %>
     </div>
-    <div class="<%= train_to_teach_event_type?(type) ? 'event-resultbox__greenstripe' : 'event-resultbox__bluestripe' %>"></div>
+    <div class="event-resultbox__divider event-resultbox__divider--<%= type_name.parameterize %>"></div>
     <div class="event-resultbox__content">
         <p><%= description %></p>
-        <% if type %>
-          <div><h3><div class="event-resultbox__content__icon icon-<%= type_name.parameterize %>" ></div>
-          <%= type_name %></h3></div>
+        <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] %>
+          <h5><div class="event-resultbox__content__icon icon-<%= type_name.parameterize %>" ></div>
+          <%= type_name %></h5>
         <% end %>
 
-        <div style="<%= 'display:none' unless online %>"><h3><div class='event-resultbox__content__icon icon-online'></div> Online Event</h3></div>
-        <div style="<%= 'display:none' unless defined?(location) && location.present? %>"><h3><div class='event-resultbox__content__icon icon-pin'></div> <%= location if defined?(location) %></h3></div>
+      <% if online %>
+        <h5><div class='event-resultbox__content__icon icon-online-event'></div> Online Event</h5>
+      <% end %>
+      <% if location %>
+        <h5 class="event-resultbox__content__location"><div class='event-resultbox__content__icon icon-pin'></div> <%= safe_format(location) %></h5>
+      <% end %>
     </div>
 </div>

--- a/app/views/components/_eventboxshort.html.erb
+++ b/app/views/components/_eventboxshort.html.erb
@@ -6,13 +6,18 @@
     <div class="event-resultboxshort__header">
         <h1><%= datetime %></h1>
     </div>
-    <div class="<%=  train_to_teach_event_type?(type) ? 'event-resultboxshort__greenstripe' : 'event-resultboxshort__bluestripe' %>"></div>
+    <div class="event-resultbox__divider event-resultbox__divider--<%= type_name.parameterize %>"></div>
     <div class="event-resultboxshort__content">
-        <% if type %>
-          <div><h3><div class="event-resultbox__content__icon icon-<%= type_name.parameterize %>" ></div>
-          <%= type_name %></h3></div>
-        <% end %>
-        <div style="<%= 'display:none' unless online %>"><h3><div class='event-resultbox__content__icon icon-online'></div> Online Event</h3></div>
-        <div style="<%= 'display:none' unless defined?(location) && location.present? %>"><h3><div class='event-resultbox__content__icon icon-pin'></div> <%= location if defined?(location) %></h3></div>
+      <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] %>
+        <h5><div class="event-resultbox__content__icon icon-<%= type_name.parameterize %>" ></div>
+        <%= type_name %></h5>
+      <% end %>
+
+      <% if online %>
+        <h5><div class='event-resultbox__content__icon icon-online-event'></div> Online Event</h5>
+      <% end %>
+      <% if location %>
+        <h5 class="event-resultboxshort__content__location"><div class='event-resultbox__content__icon icon-pin'></div> <%= safe_format(location) %></h5>
+      <% end %>
     </div>
 </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,10 +1,10 @@
 <%= link_to event_path(id: event.readable_id), class: "event-link" do %>
     <%= render "components/eventbox",
-        :title => event.name,
-        :datetime => format_event_date(event),
-        :description => event.description,
-        :type => event.type_id,
-        :online => event.building.nil?,
-        :location => event.building&.address_city
+        title: event.name,
+        datetime: format_event_date(event, stacked: false),
+        description: event.summary,
+        type: event.type_id,
+        online: event.is_online,
+        location: event.building&.address_city
     %>
 <% end %>

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -4,7 +4,7 @@
 <section class="types-of-event content container-1000">
   <div class="content__left">
       <h2>
-        <% if type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
+        <% if type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] %>
           <div class="types-of-event__header__icon icon-train-to-teach-event"></div>
           Organised by Get into Teaching
         <% else %>
@@ -16,18 +16,7 @@
       <h3><%= name_of_event_type(type_id) %></h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non augue a mauris efficitur ullamcorper id sed nisi. Fusce maximus, magna vel volutpat sollicitudin, nisl lectus maximus nibh, ut aliquam nunc ipsum eu ante.</p>
       <div class="events-featured__items">
-      <% events.each do |event| %>
-        <%= link_to event_path(id: event.readable_id), class: "event-link" do %>
-          <%= render "components/eventbox",
-              title: event.name,
-              datetime: format_event_date(event),
-              description: event.description,
-              type: event.type_id,
-              online: event.building.nil?,
-              location: event.building&.address_city
-          %>
-        <% end %>
-      <% end %>
+      <%= render partial: "events/event", collection: events %>
       </div>
       <%= link_to("#") do %>
           <div class="call-to-action-button">See all <%= category_name %> <i class="fas fa-chevron-right"></i></div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,24 +8,25 @@
 <section class="event-info content container-1000">
     <div class="content__right">
         <%= render "components/eventboxshort",
-            :title => @event.name,
-            :datetime => format_event_date(@event),
-            :type => @event.type_id,
-            :online => @event.is_online,
-            :location => @event.building&.address_city
+            title: @event.name,
+            datetime: format_event_date(@event),
+            type: @event.type_id,
+            online: @event.is_online,
+            location: event_address(@event)
         %>
     </div>
     <div class="content__left">
         <h1 class="strapline-article">Event information</h1>
         <p>
-            Our local Train to Teach events have gone online and will now take the format of online question and answer sessions.
+            Our local Train to Teach events have gone online and will now take the format of online question and answer sessions.	
+        </p>	
+        <p>	
+            This event is specifically for those who are looking to train to teach in Coventry and will give you the opportunity to ask our teaching experts questions on eligibility, the application process and funding.	
+        </p>	
+        <p>	
+            When you sign up we will send you links to the Train to Teach presentations which give an overview of teacher training, the different options available, financial support and the application process.	
         </p>
-        <p>
-            This event is specifically for those who are looking to train to teach in Coventry and will give you the opportunity to ask our teaching experts questions on eligibility, the application process and funding.
-        </p>
-        <p>
-            When you sign up we will send you links to the Train to Teach presentations which give an overview of teacher training, the different options available, financial support and the application process.
-        </p>
+
         <h1 class="strapline-article">How to attend</h1>
         <p>
             To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,7 +11,7 @@
             :title => @event.name,
             :datetime => format_event_date(@event),
             :type => @event.type_id,
-            :online => @event.building.nil?,
+            :online => @event.is_online,
             :location => @event.building&.address_city
         %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,16 +16,45 @@
         %>
     </div>
     <div class="content__left">
+        <% if @event.message %>
+          <p class="content-alert"><%= @event.message %></p>
+        <% end %>
+
         <h1 class="strapline-article">Event information</h1>
-        <p>
-            Our local Train to Teach events have gone online and will now take the format of online question and answer sessions.	
-        </p>	
-        <p>	
-            This event is specifically for those who are looking to train to teach in Coventry and will give you the opportunity to ask our teaching experts questions on eligibility, the application process and funding.	
-        </p>	
-        <p>	
-            When you sign up we will send you links to the Train to Teach presentations which give an overview of teacher training, the different options available, financial support and the application process.	
-        </p>
+        <p><%= @event.description %></p>
+
+        <% if @event.building %>
+        <h1 class="strapline-article">Venue information</h1>
+        <p><%= @event.building.venue %>, <%= event_address(@event) %>.</p>
+        <% if @event.provider_website_url %>
+          <p><%= link_to("Visit venue website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
+        <%end %>
+        <div class="event-info__venue__map"></div>	        
+        <% end %>
+
+        <% if event_has_provider_info?(@event) %>
+          <h1 class="strapline-article">Provider information</h1>
+          <% if @event.provider_website_url %>
+            <p><strong>Event website</strong><br /><%= link_to(@event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
+          <% end %>
+          <% if @event.provider_target_audience %>
+            <p><strong>Target audience</strong><br /><%= @event.provider_target_audience %></p>
+          <% end %>
+          <% if @event.provider_organiser %>
+            <p><strong>Organiser</strong><br /><%= @event.provider_organiser %></p>
+          <% end %>
+          <% if @event.provider_contact_email %>
+            <p><strong>Contact email</strong><br /><%= mail_to(@event.provider_contact_email) %></p>
+          <% end %>
+        <% end %>
+
+        <% if @event.video_url %>
+        <h1 class="strapline-article">Video</h1>
+        <div class="responsive-video">
+          <iframe class="responsive-video__iframe" src="<%= embed_event_video_url(@event.video_url) %>"></iframe>
+        </div>
+        <br />
+        <% end %>
 
         <h1 class="strapline-article">How to attend</h1>
         <p>

--- a/app/webpacker/styles/components/eventbox.scss
+++ b/app/webpacker/styles/components/eventbox.scss
@@ -7,6 +7,11 @@
         box-shadow: none;
     }
 }
+
+.events-listing p {
+  font-size: 300px;
+}
+
 .event-resultbox {
     box-sizing: border-box;
     padding: 20px;
@@ -43,21 +48,20 @@
     }
 
     &__datetime {
-        height: 20px;
-        overflow: hidden;
         margin-bottom: 4px;
+        font-size: 0.8em;
     }
 
-    &__greenstripe {
+    &__divider {
+      height: 8px;
+      background-color: $blue;
+      margin-top: 6px;
+      margin-bottom: 20px;
+    }
+
+    &__divider--train-to-teach-event {
         height: 8px;
         background-color: $green;
-        margin-top: 6px;
-        margin-bottom: 20px;
-    }
-
-    &__bluestripe {
-        height: 8px;
-        background-color: $blue;
         margin-top: 6px;
         margin-bottom: 20px;
     }
@@ -70,15 +74,29 @@
             width: 40px;
         }
 
-        h3 {
-            margin: 0;
-            margin-top: 12px;
-
-            
+        &__location {
+          display: flex;
+        
+          p {
+            margin: 7px 0 0 0;
+          }
         }
+
+        h5 {
+          margin: 15px 0 0 0;
+        }
+
         p {
             margin: 0;
             font-size: 17px;
         }
-    } 
+
+        &__location {
+          display: flex;
+
+          p {
+            margin: 7px 0 0 0;
+          }
+        }
+    }
 }

--- a/app/webpacker/styles/components/eventboxshort.scss
+++ b/app/webpacker/styles/components/eventboxshort.scss
@@ -48,10 +48,8 @@
             margin-right: 2px;
         }
 
-        h1 {
-            font-size: 19px;
-            margin: 0;
-            margin-top: 12px;
+        h5 {
+          margin: 15px 0 0 0;
         }
         
         p {
@@ -59,7 +57,15 @@
             margin-top: 20px;
             font-size: 17px;
         }
-    } 
+
+        &__location {
+          display: flex;
+    
+          p {
+            margin: 7px 0 0 0;
+          }
+        } 
+    }
 }
 
 @media only screen and (max-width: 800px) {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -235,10 +235,6 @@
         line-height: 1.25;
     }
 
-    p {
-        margin: 0 0 30px;
-    }
-
     &__items {
         display: flex;
         margin-left: -10px;

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -20,7 +20,7 @@
     height: 20px;
 }
 
-.icon-online {
+.icon-online-event {
     @include icon;
     background-image: url('../images/icon-online-blue.svg');
     width: 38px;

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -14,10 +14,18 @@
 }
 
 .icon-hamburger {
-    @include icon;
-    background-image: url('../images/icon-hamburger.svg');
-    width: 30px;
-    height: 20px;
+  @include icon;
+  background-image: url('../images/icon-hamburger.svg');
+  width: 30px;
+  height: 20px;
+}
+
+.icon-external {
+  @include icon;
+  background-image: url('../images/icon-external.svg');
+  width: 20px;
+  height: 15px;
+  margin: 0 0 5px 5px;
 }
 
 .icon-online-event {

--- a/app/webpacker/styles/video.scss
+++ b/app/webpacker/styles/video.scss
@@ -1,3 +1,21 @@
+.responsive-video {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
+
+  &__iframe {
+    position: absolute;
+    border: 0;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
 .video-overlay {
     display: none;
     position: fixed;

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -2,7 +2,8 @@ module GetIntoTeachingApiClient
   module Constants
     EVENT_TYPES =
       {
-        "Train to Teach event" => 222_750_001,
+        "Train to Teach Event" => 222_750_001,
+        "Online Event" => 222_750_008,
       }.freeze
 
     DEGREE_STATUS_OPTIONS =

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -5,8 +5,17 @@ FactoryBot.define do
     type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "Become a Teacher #{i} event description" }
+    message { "An important message" }
+    video_url { "https://video.com" }
     sequence(:start_at) { |i| i.weeks.from_now }
     end_at { start_at }
     building { build :event_building_api }
+
+    trait :with_provider_info do
+      provider_website_url { "https://event-provider.com" }
+      provider_target_audience { "Anyone interested in teaching from Sept 2021" }
+      provider_organiser { "United Teaching" }
+      provider_contact_email { "jim@smith.com" }
+    end
   end
 end

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :event_api, class: GetIntoTeachingApiClient::TeachingEvent do
     id { SecureRandom.uuid }
     sequence(:readable_id, &:to_s)
-    type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "Become a Teacher #{i} event description" }
     sequence(:start_at) { |i| i.weeks.from_now }

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :event_building_api, class: GetIntoTeachingApiClient::TeachingEventBuilding do
     id { SecureRandom.uuid }
+    venue { "Albert Hall" }
     address_line1 { "Line 1" }
     address_line2 { "Line 2" }
     address_line3 { nil }

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     address_line2 { "Line 2" }
     address_line3 { nil }
     address_city { "Manchestr" }
-    address_state { "Greater Manchester" }
     address_postcode { "MA1 1AM" }
   end
 end

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     address_line1 { "Line 1" }
     address_line2 { "Line 2" }
     address_line3 { nil }
-    address_city { "Manchestr" }
+    address_city { "Manchester" }
     address_postcode { "MA1 1AM" }
   end
 end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Finding an event", type: :feature do
 
     expect(page).to have_text "Search for events"
 
-    select "Train to Teach event"
+    select "Train to Teach Event"
     click_on "Update results"
 
     expect(page).not_to have_css "h2", text: "Organized by Get into Teaching"

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -50,4 +50,16 @@ describe EventsHelper, type: "helper" do
       expect(train_to_teach_event_type?(-1)).to be_falsy
     end
   end
+
+  describe "#event_address" do
+    it "returns nil if the event has no building" do
+      event.building = nil
+      expect(event_address(event)).to be_nil
+    end
+
+    it "returns the address, comma separated with line breaks between parts" do
+      expect(event.building).to_not be_nil
+      expect(event_address(event)).to eq("Line 1,\nLine 2,\nManchester,\nMA1 1AM")
+    end
+  end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -62,4 +62,33 @@ describe EventsHelper, type: "helper" do
       expect(event_address(event)).to eq("Line 1,\nLine 2,\nManchester,\nMA1 1AM")
     end
   end
+
+  describe "#event_has_provider_info?" do
+    it "returns true if the event has provider information" do
+      event = build(:event_api, :with_provider_info)
+      expect(event_has_provider_info?(event)).to be_truthy
+    end
+
+    it "returns false if the event has no provider information" do
+      event = build(:event_api)
+      expect(event_has_provider_info?(event)).to be_falsy
+    end
+  end
+
+  describe "#embed_event_video_url" do
+    it "returns nil if the event video is nil" do
+      expect(embed_event_video_url(nil)).to be_nil
+    end
+
+    it "returns an embedded url when given an embedded url" do
+      standard_url = "https://www.youtube.com/watch?v=BelJ2AjtHoQ"
+      embed_url = "https://www.youtube.com/embed/BelJ2AjtHoQ"
+      expect(embed_event_video_url(standard_url)).to eq(embed_url)
+    end
+
+    it "returns an embedded url when given a standard url" do
+      embed_url = "https://www.youtube.com/embed/BelJ2AjtHoQ"
+      expect(embed_event_video_url(embed_url)).to eq(embed_url)
+    end
+  end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -29,8 +29,8 @@ describe EventsHelper, type: "helper" do
     include_context "stub types api"
 
     it "returns the name of the given event type id" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-      expect(name_of_event_type(type_id)).to eq("Train to Teach event")
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
+      expect(name_of_event_type(type_id)).to eq("Train to Teach Event")
     end
 
     it "returns an empty string if the event type cannot be found" do
@@ -42,7 +42,7 @@ describe EventsHelper, type: "helper" do
     include_context "stub types api"
 
     it "returns true for train to teach events" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
       expect(train_to_teach_event_type?(type_id)).to be_truthy
     end
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -41,7 +41,7 @@ describe "Find an event near you" do
   end
 
   context "when searching for an event by type" do
-    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
     it "displays all events of that type" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-580](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-580)

### Context

The eventbox/short partials don't quite match the design and are currently not fully connected to the data returned from the API.

The event page is mainly static information, but we now have the data in the API so we can populate this more fully.

### Changes proposed in this pull request

**Bump API client to 1.0.7**

Update the API client to include the latest schema changes, reflecting those changes in the views/tests/factories.

**Update eventbox/short partials**

Do not display the type of event if it is an `Online Event`, as this will already be shown due to the `is_online` attribute being `true`.

**Update event page with additional information**

Adds additional event information now pulled through from the API:

- Message from organisers
- Description
- Venue information (static map at the moment).
- Provider information
- Video

Once we have Google API credentials we can swap the static map image for an interactive Google map.

### Guidance to review

![screencapture-localhost-3000-events-2020-08-13-11_26_55](https://user-images.githubusercontent.com/29867726/90124340-22dd2400-dd58-11ea-8b53-b14f41d2cd93.png)
![screencapture-localhost-3000-events-1203-TTT-London4-Summer-2020-Test4286932461-2020-08-13-11_26_31](https://user-images.githubusercontent.com/29867726/90124419-4011f280-dd58-11ea-8f48-ce3d64e3499d.png)
