### PR TITLE
Correct icon colour for Train to Teach events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -48,6 +48,10 @@ module EventsHelper
   end
 
   def train_to_teach_event_type?(type_id)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] == type_id
+    train_to_teach_types = [
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"],
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"],
+    ]
+    train_to_teach_types.include?(type_id)
   end
 end

--- a/app/views/components/_eventbox.html.erb
+++ b/app/views/components/_eventbox.html.erb
@@ -17,10 +17,10 @@
         <% end %>
 
       <% if online %>
-        <h5><div class='event-resultbox__content__icon icon-online-event'></div> Online Event</h5>
+        <h5><div class='event-resultbox__content__icon icon-online-event <%= "icon-online-event--green" if train_to_teach_event_type?(type) %>'></div> Online Event</h5>
       <% end %>
       <% if location %>
-        <h5 class="event-resultbox__content__location"><div class='event-resultbox__content__icon icon-pin'></div> <%= safe_format(location) %></h5>
+        <h5 class="event-resultbox__content__location"><div class='event-resultbox__content__icon icon-pin <%= "icon-pin--green" if train_to_teach_event_type?(type) %>'></div> <%= safe_format(location) %></h5>
       <% end %>
     </div>
 </div>

--- a/app/views/components/_eventboxshort.html.erb
+++ b/app/views/components/_eventboxshort.html.erb
@@ -14,10 +14,10 @@
       <% end %>
 
       <% if online %>
-        <h5><div class='event-resultbox__content__icon icon-online-event'></div> Online Event</h5>
+        <h5><div class='event-resultbox__content__icon icon-online-event <%= "icon-online-event--green" if train_to_teach_event_type?(type) %>'></div> Online Event</h5>
       <% end %>
       <% if location %>
-        <h5 class="event-resultboxshort__content__location"><div class='event-resultbox__content__icon icon-pin'></div> <%= safe_format(location) %></h5>
+        <h5 class="event-resultboxshort__content__location"><div class='event-resultbox__content__icon icon-pin <%= "icon-pin--green" if train_to_teach_event_type?(type) %>'></div> <%= safe_format(location) %></h5>
       <% end %>
     </div>
 </div>

--- a/app/webpacker/styles/components/eventbox.scss
+++ b/app/webpacker/styles/components/eventbox.scss
@@ -59,7 +59,7 @@
       margin-bottom: 20px;
     }
 
-    &__divider--train-to-teach-event {
+    &__divider--train-to-teach-event, &__divider--online-event {
         height: 8px;
         background-color: $green;
         margin-top: 6px;

--- a/app/webpacker/styles/components/eventboxshort.scss
+++ b/app/webpacker/styles/components/eventboxshort.scss
@@ -29,18 +29,6 @@
         margin-top: 4px;
     }
 
-    &__greenstripe {
-        height: 8px;
-        background-color: $green;
-        margin-bottom: 20px;
-    }
-
-    &__bluestripe {
-        height: 8px;
-        background-color: $blue;
-        margin-bottom: 20px;
-    }
-
     &__content {
         
         &__icon {

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -33,6 +33,10 @@
     background-image: url('../images/icon-online-blue.svg');
     width: 38px;
     height: 25px;
+
+    &--green {
+      background-image: url('../images/icon-online-green.svg');
+    }
 }
 
 .icon-pin {
@@ -40,6 +44,10 @@
     background-image: url('../images/icon-pin-blue.svg');
     width: 23px;
     height: 36px;
+
+    &--green {
+      background-image: url('../images/icon-pin-green.svg');
+    }
 }
 
 .icon-pin-large {
@@ -56,7 +64,7 @@
     height: 24px;
 }
 
-.icon-school {
+.icon-school-or-university-event {
     @include icon;
     background-image: url('../images/icon-school-blue.svg');
     width: 33px;

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -46,6 +46,11 @@ describe EventsHelper, type: "helper" do
       expect(train_to_teach_event_type?(type_id)).to be_truthy
     end
 
+    it "returns true for online events" do
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]
+      expect(train_to_teach_event_type?(type_id)).to be_truthy
+    end
+
     it "returns false for other event types" do
       expect(train_to_teach_event_type?(-1)).to be_falsy
     end


### PR DESCRIPTION
The Train to Teach events (those with category `train to teach` or `online event`) should have green icons as well as a green divider.

We are waiting for icons for the remaining event types: 

```
Application workshop
Early year event
Other type of event
```