### PR TITLE
Restrict the online event sign up to events with a web_feed_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.7", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", "1.0.8", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 1b6a54e8379fd4d593a43e4df4c347935cb10654
+  revision: 933973b9e34a3340cebe3a42ad035246576e8d90
   specs:
-    get_into_teaching_api_client (1.0.7)
+    get_into_teaching_api_client (1.0.8)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -331,7 +331,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.7)!
+  get_into_teaching_api_client (= 1.0.8)!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -56,13 +56,21 @@
         <br />
         <% end %>
 
-        <h1 class="strapline-article">How to attend</h1>
-        <p>
-            To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
-        </p>
+        <% if @event.web_feed_id %>
+          <h1 class="strapline-article">How to attend</h1>
+          <p>
+              To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
+          </p>
 
-        <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
-            Sign up for this <span>event</span>
+          <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
+              Sign up for this <span>event</span>
+          <% end %>
+        <% elsif @event.provider_website_url %>
+          <h1 class="strapline-article">How to attend</h1>
+          <p>To attend this event, please <%= link_to(@event.provider_website_url, "visit this website", { target: "blank" }) %><i class="icon icon-external"></i>.<p>
+        <% elsif @event.provider_contact_email %>
+          <h1 class="strapline-article">How to attend</h1>
+          <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>
         <% end %>
-    </div>
+      </div>
 </section>

--- a/app/webpacker/styles/components/eventboxshort.scss
+++ b/app/webpacker/styles/components/eventboxshort.scss
@@ -6,7 +6,7 @@
     border: 2px solid $black;
     height: auto;
     width: 100%;
-    max-width: 290px;
+    max-width: 300px;
     overflow: hidden;
     margin: 18px;
     text-align: left;

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     sequence(:readable_id, &:to_s)
     type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    web_feed_id { "123" }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "Become a Teacher #{i} event description" }
     message { "An important message" }

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -70,18 +70,38 @@ describe EventsController do
 
       it { is_expected.to have_http_status :success }
 
-      context "event information" do
+      context "within the response body" do
         subject { response.body }
 
-        it { is_expected.to include(event.name) }
-        it { is_expected.to include(event.description) }
-        it { is_expected.to include(event.message) }
-        it { is_expected.to include(event.building.venue) }
-        it { is_expected.to match(/iframe.+src="#{event.video_url}"/) }
-        it { is_expected.to include(event.provider_website_url) }
-        it { is_expected.to include(event.provider_target_audience) }
-        it { is_expected.to include(event.provider_organiser) }
-        it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }
+        context "event information" do
+          it { is_expected.to include(event.name) }
+          it { is_expected.to include(event.description) }
+          it { is_expected.to include(event.message) }
+          it { is_expected.to include(event.building.venue) }
+          it { is_expected.to match(/iframe.+src="#{event.video_url}"/) }
+          it { is_expected.to include(event.provider_website_url) }
+          it { is_expected.to include(event.provider_target_audience) }
+          it { is_expected.to include(event.provider_organiser) }
+          it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }
+        end
+
+        context "when the event can be registered for online" do
+          let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id) }
+
+          it { is_expected.to match(/Sign up for this <span>event<\/span>/) }
+        end
+
+        context "when the event can be registered for by email" do
+          let(:event) { build(:event_api, web_feed_id: nil, provider_contact_email: "test@email.com", readable_id: event_readable_id) }
+
+          it { is_expected.to match(/To attend this event, please <a.*mailto.*email us.*a>/) }
+        end
+
+        context "when the event can be registered for via an external website" do
+          let(:event) { build(:event_api, web_feed_id: nil, provider_website_url: "http://event.com", readable_id: event_readable_id) }
+
+          it { is_expected.to match(/To attend this event, please <a.*visit this website.*a>/) }
+        end
       end
     end
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-580](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-580)

### Context

Only events with a `web_feed_id` can be signed up for using our online form; the other events must be linked out to a 3rd party provider. If the provider has a website, we will link out to that - if they have an email address we will prompt the user to email in.

### Changes proposed in this pull request

- Update API client to include TeachingEvent WebFeedId

- Show correct sign up method for event type

If the event has a `web_feed_id` present, we can offer the online registration
form.

If the event does not have a `web_feed_id` then it should have either a `provider_website_url`, in which case we can link out to the website, or a `provider_contact_email` that we can use to prompt the user to email for attendance.

### Guidance to review

