### PR TITLE
Restrict available event types

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -21,11 +21,13 @@ module Events
     before_validation(unless: :distance) { self.postcode = nil }
 
     def available_event_types
-      @available_event_types ||= query_event_types
+      @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
+        GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+      end
     end
 
     def available_event_type_ids
-      available_event_types.map(&:id).map(&:to_i)
+      available_event_types.map(&:id)
     end
 
     def available_distances
@@ -61,10 +63,6 @@ module Events
         start_after: start_of_month,
         start_before: end_of_month,
       )
-    end
-
-    def query_event_types
-      GetIntoTeachingApiClient::TypesApi.new.get_teaching_event_types
     end
 
     def start_of_month

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -5,6 +5,7 @@ module GetIntoTeachingApiClient
         "Train to Teach Event" => 222_750_001,
         "Online Event" => 222_750_008,
         "Application Workshop" => 222_750_000,
+        "School or University Event" => 222_750_009,
       }.freeze
 
     GET_INTO_TEACHING_EVENT_TYPES = EVENT_TYPES.select { |key|

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe Events::Search do
-  include_context "stub types api"
-
   context "attributes" do
     it { is_expected.to respond_to :type }
     it { is_expected.to respond_to :distance }
@@ -13,6 +11,11 @@ describe Events::Search do
   context "available_distance_keys" do
     subject { described_class.new.available_distance_keys }
     it { is_expected.to eql [nil, 30, 50, 100] }
+  end
+
+  context "available_event_type_ids" do
+    subject { described_class.new.available_event_type_ids }
+    it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.values }
   end
 
   context "validation" do


### PR DESCRIPTION
We only want to allow users to search for specific event types:

```
Train to Teach Event
Online Event
Application Workshop
School or University Event
```