### PR TITLE
Display featured events in the correct order

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -37,7 +37,7 @@ private
   end
 
   def categorise_events
-    @events_by_category = @events.each_with_object({}) do |event, hash|
+    @events_by_category = events_sorted_by_type.each_with_object({}) do |event, hash|
       type_id = event.type_id
       category_name = event_category_name(type_id)
       type_name = event_type_name(type_id)
@@ -48,6 +48,12 @@ private
       next if hash[category_name][type_name].count == EVENTS_PER_CATEGORY
 
       hash[category_name][type_name] << event
+    end
+  end
+
+  def events_sorted_by_type
+    @events.sort_by do |event|
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.index(event.type_id)
     end
   end
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -38,6 +38,26 @@ describe "Find an event near you" do
         expect(response.body).to match(NO_EVENTS_REGEX)
       end
     end
+
+    context "when there are events of different types" do
+      let(:events) do
+        GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.map do |type_id|
+          build(:event_api, start_at: DateTime.now, type_id: type_id)
+        end
+      end
+
+      it "presents the types in the correct order" do
+        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        expected_headings = [
+          "Train to Teach Events",
+          "Online Events",
+          "Application Workshops",
+          "School or University Events",
+        ]
+
+        expect(headings & expected_headings).to eq(expected_headings)
+      end
+    end
   end
 
   context "when searching for an event by type" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-601](https://dfedigital.atlassian.net/browse/GITPB-601)

### Context

Currently the events will be displayed in the order that they are returned from the API, which is relative to their start date. This means the order of the featured boxes will change over time. Instead, they should be explicitly ordered as:

```
Train to Teach Events
Online Events
Application Workshops
Schools or University Events
```

### Changes proposed in this pull request

Display featured events in the correct order

### Guidance to review

