### PR TITLE
Updated the export of data to the API only include valid data

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -3,7 +3,7 @@ module WizardSteps
 
   included do
     class_attribute :wizard_class
-    before_action :load_wizard, :load_current_step, except: %i[index completed resend_verification]
+    before_action :load_wizard, :load_current_step, only: %i[show update]
   end
 
   def index
@@ -30,7 +30,7 @@ module WizardSteps
   end
 
   def resend_verification
-    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(wizard_store.to_camelized_hash)
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
     GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
     redirect_to params[:redirect_path]
   end
@@ -61,5 +61,10 @@ private
 
   def step_param_key
     @current_step.class.model_name.param_key
+  end
+
+  def camelized_identity_data
+    Wizard::Steps::Authenticate.new(nil, wizard_store)
+      .candidate_identity_data
   end
 end

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -1,5 +1,7 @@
 module Events
   class Wizard < ::Wizard::Base
+    include ::Wizard::ApiClientSupport
+
     self.steps = [
       Steps::PersonalDetails,
       Steps::Authenticate,
@@ -16,8 +18,10 @@ module Events
       end
     end
 
+  private
+
     def add_attendee_to_event
-      request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(@store.to_camelized_hash)
+      request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::TeachingEventsApi.new
       api.add_teaching_event_attendee(request)
     end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -1,5 +1,7 @@
 module MailingList
   class Wizard < ::Wizard::Base
+    include ::Wizard::ApiClientSupport
+
     self.steps = [
       Steps::Name,
       Steps::Authenticate,
@@ -19,8 +21,10 @@ module MailingList
       end
     end
 
+  private
+
     def add_member_to_mailing_list
-      request = GetIntoTeachingApiClient::MailingListAddMember.new(@store.to_camelized_hash)
+      request = GetIntoTeachingApiClient::MailingListAddMember.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::MailingListApi.new
       api.add_mailing_list_member(request)
     end

--- a/app/models/wizard/api_client_support.rb
+++ b/app/models/wizard/api_client_support.rb
@@ -1,0 +1,13 @@
+module Wizard
+  module ApiClientSupport
+    def export_camelized_hash
+      camelize_hash export_data
+    end
+
+  private
+
+    def camelize_hash(hash)
+      hash.transform_keys { |k| k.camelize(:lower).to_sym }
+    end
+  end
+end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -93,6 +93,10 @@ module Wizard
       steps[0..(index - 1)].map(&:key)
     end
 
+    def export_data
+      all_steps.map(&:export).reduce({}, :merge)
+    end
+
   private
 
     def all_steps

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -39,6 +39,12 @@ module Wizard
       false
     end
 
+    def export
+      return {} if skipped?
+
+      Hash[attributes.keys.zip([])].merge attributes_from_store
+    end
+
   private
 
     def attributes_from_store

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -1,7 +1,7 @@
 module Wizard
   class Store
     attr_reader :data
-    delegate :keys, to: :data
+    delegate :keys, :to_h, :to_hash, to: :data
 
     def initialize(data)
       raise InvalidBackingStore unless data.respond_to?(:[]=)
@@ -29,10 +29,6 @@ module Wizard
 
     def purge!
       data.clear
-    end
-
-    def to_camelized_hash
-      data.transform_keys { |k| k.camelize(:lower).to_sym }
     end
 
     class InvalidBackingStore < RuntimeError; end

--- a/spec/models/wizard/api_client_support_spec.rb
+++ b/spec/models/wizard/api_client_support_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe Wizard::ApiClientSupport do
+  class ApiClientTestWizard
+    include ::Wizard::ApiClientSupport
+
+    def export_data
+      { "first_name" => "Joe", "last_name" => "Bloggs" }
+    end
+  end
+
+  let(:instance) { ApiClientTestWizard.new }
+  subject { instance }
+
+  describe "#export_camelized_hash" do
+    subject { instance.export_camelized_hash }
+    it { is_expected.to include firstName: "Joe" }
+    it { is_expected.to include lastName: "Bloggs" }
+  end
+end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -209,4 +209,23 @@ describe Wizard::Base do
       it { is_expected.to eql %w[postcode] }
     end
   end
+
+  describe "#export_data" do
+    subject { wizard.export_data }
+
+    it { is_expected.to include "name" => "Joe" }
+    it { is_expected.to include "age" => 35 }
+    it { is_expected.to include "postcode" => nil }
+
+    context "with skipped step" do
+      before do
+        allow_any_instance_of(TestWizard::Age).to \
+          receive(:skipped?).and_return true
+      end
+
+      it { is_expected.to include "name" => "Joe" }
+      it { is_expected.not_to include "age" }
+      it { is_expected.to include "postcode" => nil }
+    end
+  end
 end

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -51,4 +51,12 @@ describe Wizard::Step do
       it { is_expected.to have_attributes errors: hash_including(:name) }
     end
   end
+
+  describe "#export" do
+    let(:backingstore) { { "name" => "Joe" } }
+    let(:instance) { FirstStep.new nil, wizardstore, age: 35 }
+    subject { instance.export }
+    it { is_expected.to include "name" => "Joe" }
+    it { is_expected.to include "age" => nil } # should only export persisted data
+  end
 end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -67,11 +67,4 @@ describe Wizard::Store do
       is_expected.to have_attributes empty?: true
     end
   end
-
-  describe "#to_camelized_hash" do
-    subject { instance.to_camelized_hash }
-    it "returns returns a hash with camelCase keys" do
-      is_expected.to eq(firstName: "Joe", age: 20, region: "Manchester")
-    end
-  end
 end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -51,6 +51,9 @@ describe EventStepsController do
 
           allow_any_instance_of(Events::Steps::ContactDetails).to \
             receive(:valid?).and_return true
+
+          allow_any_instance_of(Events::Wizard).to \
+            receive(:add_attendee_to_event).and_return true
         end
         let(:model) { Events::Steps::FurtherDetails }
         let(:details_params) { attributes_for(:events_further_details) }

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -41,6 +41,9 @@ describe MailingList::StepsController do
       context "when all valid" do
         before do
           steps.each do |step|
+            allow_any_instance_of(MailingList::Wizard).to \
+              receive(:add_member_to_mailing_list).and_return true
+
             allow_any_instance_of(step).to receive(:valid?).and_return true
           end
         end


### PR DESCRIPTION
### JIRA ticket number

GITPB-517

### Context

We should allow wizard steps to decide how to export their data instead of shipping the entirety of the Wizard store. This will allow 1. Separating the data sent to the API from the UI design of the steps
2. Not sending data for steps which have been skipped

### Changes proposed in this pull request

1. Allow steps to export their own data - default in base class is to exclude their data if the step is skipped
2. Only export appropriate fields for authenticate step

