### PR TITLE
Use redis for cache store in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,6 +47,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
### JIRA ticket number

GITPB-571

### Context

Use Redis for the cache in production

### Changes proposed in this pull request

1. Configure the `:redis_cache_store` in production

### Guidance to review

1. `production.rb` is inherited by the `rolling` and `preprod` environments so this will also affect those by design.
2. I've not set it for development because this would make redis a new dependency in development environment, complicating on boarding for frontend developers/designers and potentially the content designers.
