### PR TITLE
Added additional hero images for mobile if alternatives are set.

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,8 +1,9 @@
 <%= render "sections/hero",  
-    :header => "Find an event near you", 
-    :image => "media/images/hero-events.png" ,
-    :deep => false,
-    :mailinglist => false
+      header: "Find an event near you",
+      image: "media/images/hero-events.png",
+      deep: false,
+      mailinglist: false,
+      mobileimage: false
 %>
 <section role="main" id="main-content">
     <div class="types-of-event content container-1000">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,8 +1,9 @@
-<%= render "sections/hero",  
-    :header => @event.name, 
-    :image => "media/images/hero-events.png",
-    :deep => false,
-    :mailinglist => false 
+<%= render "sections/hero",
+      header: @event.name,
+      image: "media/images/hero-events.png",
+      deep: false,
+      mailinglist: false,
+      mobileimage: false
 %>
 
 <section class="event-info content container-1000">

--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -1,8 +1,9 @@
-<%= render "sections/hero",  
-  header: "Train to teach events", 
-  image: "media/images/hero-events.png",
-  deep: false,
-  mailinglist: false 
+<%= render "sections/hero",
+      header: "Train to teach events",
+      image: "media/images/hero-events.png",
+      deep: false,
+      mailinglist: false,
+      mobileimage: false
 %>
 
 <% category_name = name_of_event_type(@type.id) %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -10,11 +10,15 @@
         <div class="container">
             <%= render "sections/header" %>
             <%= render "sections/hero", 
-                :header => @front_matter["title"], :image => @front_matter["image"], 
-                :deep => @front_matter["deepheader"], :subtitle =>  @front_matter["subtitle"], 
-                :mailinglist => @front_matter["mailinglist"] 
+                  header: @front_matter["title"],
+                  image: @front_matter["image"],
+                  deep: @front_matter["deepheader"],
+                  subtitle: @front_matter["subtitle"],
+                  mobileimage: @front_matter["mobileimage"],
+                  mailinglist: @front_matter["mailinglist"]
             %>
-            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %> role="main" id="main-content"> 
+
+            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %> role="main" id="main-content">
                 <%= yield %>
             </section>
             <%= render "sections/footer" %>     

--- a/app/views/sections/_hero.html.erb
+++ b/app/views/sections/_hero.html.erb
@@ -1,8 +1,8 @@
 <% if image === false %>
     <div class="no-hero" role="complementary"></div>
 <% else %>
-    <% if deep %> 
-        <div class="hero hero--deep" style="background-image: url('<%= hero_image_path image %>')" role="complementary">
+    <% if deep %>
+        <div class="hero hero--deep<%= " hero--desktop" if mobileimage.present? %>" style="background-image: url('<%= hero_image_path image %>')" role="complementary">
             <div class="hero__banner">
                 <div class="hero__banner__text">
                     <h1><%= header %></h1>
@@ -10,21 +10,46 @@
                 </div>
             </div>
         </div>
+
+        <%- if mobileimage.present? -%>
+        <div class="hero hero--deep hero--mobile" style="background-image: url('<%= hero_image_path mobileimage %>')" role="complementary">
+            <div class="hero__banner">
+                <div class="hero__banner__text">
+                    <h1><%= header %></h1>
+                    <p><%= subtitle %></p>
+                </div>
+            </div>
+        </div>
+        <%- end -%>
     <% else %>
-        <div class="hero" style="background-image: url('<%= hero_image_path image %>')" role="complementary">
+        <div class="hero<%= " hero--desktop" if mobileimage.present? %>" style="background-image: url('<%= hero_image_path image %>')" role="complementary">
             <div class="hero__banner">
                 <div class="hero__banner__text">
                     <h1><%= header %></h1>
                 </div>
             </div>
         </div>
+
+        <%- if mobileimage.present? %>
+        <div class="hero hero--mobile" style="background-image: url('<%= hero_image_path mobileimage %>')" role="complementary">
+            <div class="hero__banner">
+                <div class="hero__banner__text">
+                    <h1><%= header %></h1>
+                </div>
+            </div>
+        </div>
+        <%- end -%>
     <% end %>
     <% if mailinglist %>
         <div class="hero__mailing-strip">
             <div class="hero__mailing-strip__text">
-                <p>Alternatively, you can sign up to receive information via email that could help you make your decision to get into teaching.</p>  
+                <p>
+                  Alternatively, you can sign up to receive information via
+                  email that could help you make your decision to get into
+                  teaching.
+                </p>
             </div>
-            <%= link_to(mailing_list_steps_path, class: "hero__mailing-strip__button") do %>
+            <%= link_to mailing_list_steps_path, class: "hero__mailing-strip__button" do %>
                 <span>Sign up here</span>
             <% end %>
         </div>

--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -244,3 +244,17 @@
         }
     }
 }
+
+.hero.hero--mobile {
+  display: none
+}
+
+@media (max-width:550px) {
+  .hero.hero--mobile {
+    display: block;
+  }
+
+  .hero.hero--desktop {
+    display: none
+  }
+}


### PR DESCRIPTION
### JIRA ticket number

555

### Context

When on mobile devices we wish to show different hero images with different aspect ratios

### Changes proposed in this pull request

1. Added additional hero sections for mobile
2. These show when narrower than 550px, and the desktop versions are hidden
3. If no mobile versions are set then the desktop versions show always

### Guidance to review

Test various screens and check it looks right - frontmatter attribute is `mobileimage` - works the same as the normal `image` attribute

