### PR TITLE
Namespace cache keys for Redis

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-  config.cache_store = :redis_cache_store
+  config.cache_store = :redis_cache_store, { namespace: "GIT" }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
### Context

We wish to share a single Redis instance between both apps. We should namespace the keys to ensure isolation.

### Changes proposed in this pull request

1. Namespace all keys written to/read from cache under the `GIT` namespace



