### PR TITLE
Pass correct step to re-authenticate

### DIFF
--- a/app/views/mailing_list/steps/_authenticate.html.erb
+++ b/app/views/mailing_list/steps/_authenticate.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <%= render "wizard/steps/authenticate", f: f, email: mailing_list_session["email"], resend_verification_path: resend_verification_mailing_list_steps_path(
-  redirect_path: mailing_list_step_path(Events::Steps::Authenticate.key, verification_resent: true)
+  redirect_path: mailing_list_step_path(MailingList::Steps::Authenticate.key, verification_resent: true)
 ) %>


### PR DESCRIPTION
This was probably a copy/paste error; the behaviour doesn't actually change as both steps have a key of `authenticate`, but this will protect against that potentially changing in the future and breaking the mailing list resend verification flow.