### PR TITLE
add annotation for screen reader users

### DIFF
--- a/app/views/sections/_hero.html.erb
+++ b/app/views/sections/_hero.html.erb
@@ -25,7 +25,7 @@
                 <p>Alternatively, you can sign up to receive information via email that could help you make your decision to get into teaching.</p>  
             </div>
             <%= link_to(mailing_list_steps_path, class: "hero__mailing-strip__button") do %>
-                <span>Sign up here</span>
+                <span>Sign up here <i class="visually-hidden">to receive information via email</i></span>
             <% end %>
         </div>
     <% end %>


### PR DESCRIPTION
"Sign up here" makes no sense to screen reader users, and needs a more descriptive text.
This is achieved here with visually hidden additional text

https://trello.com/c/U6ZPny1d/284-sign-up-here-no-context-given-for-a-screen-reader
