### PR TITLE
GITPB-633 Redirect for TTA service

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  rescue_from ActionView::MissingTemplate, with: :rescue_missing_template
+
   def scribble
     @page_title = "Scribble Test"
     render template: "pages/scribble"
@@ -19,39 +21,40 @@ class PagesController < ApplicationController
 
   def show
     render template: content_template(params[:page]), layout: "layouts/content"
-  rescue ActionView::MissingTemplate
-    respond_to do |format|
-      format.html do
-        render \
-          template: "errors/not_found",
-          status: :not_found
-      end
-
-      format.all do
-        render status: :not_found, body: nil
-      end
-    end
   end
 
   def showblank
     render template: "content/#{params[:page]}", layout: "layouts/blank"
-  rescue ActionView::MissingTemplate
-    respond_to do |format|
-      format.html do
-        render \
-          template: "errors/not_found",
-          status: :not_found
-      end
+  end
 
-      format.all do
-        render status: :not_found, body: nil
-      end
+  def tta_service
+    raise ActionView::MissingTemplate if ENV["TTA_SERVICE_URL"].blank?
+
+    url = ENV["TTA_SERVICE_URL"]
+    if Rails.application.config.x.utm_codes && session[:utm]
+      url += "?" + session[:utm].to_param
     end
+
+    redirect_to url
   end
 
 private
 
   def content_template(requested_page)
     "content/#{requested_page}"
+  end
+
+  def rescue_missing_template
+    respond_to do |format|
+      format.html do
+        render \
+          template: "errors/not_found",
+          status: :not_found
+      end
+
+      format.all do
+        render status: :not_found, body: nil
+      end
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,15 +69,4 @@ module ApplicationHelper
 
     link_to text, path, **options
   end
-
-  def tta_service_link(opts = nil, &block)
-    return nil if ENV["TTA_SERVICE_URL"].blank?
-
-    url = ENV["TTA_SERVICE_URL"]
-    if Rails.application.config.x.utm_codes && session[:utm]
-      url += "?" + session[:utm].to_param
-    end
-
-    link_to url, opts, &block
-  end
 end

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -29,9 +29,10 @@
                     <p>
                         If you’re returning to teaching and are qualified to teach maths, physics or languages, you can also get support by using this service.
                     </p>
-                    <%= tta_service_link class: "call-to-action-button" do %>
+
+                    <a href="/tta-service" class="call-to-action-button">
                         Sign up to talk to a teacher training <span>adviser</span>
-                    <% end %>
+                    </a>
                 </div>
                 
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
   get "/scribble", to: "pages#scribble", via: :all, as: nil
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
+  get "/tta-service", to: "pages#tta_service", as: :tta_service
+  get "/tta", to: "pages#tta_service", as: nil
 
   resources "events", path: "/events", only: %i[index show search] do
     collection do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -78,21 +78,4 @@ describe ApplicationHelper do
       it { is_expected.to have_css "body.homepage" }
     end
   end
-
-  describe "#tta_service_link" do
-    before { allow(ENV).to receive(:[]).with("TTA_SERVICE_URL") { tta_url } }
-    subject { tta_service_link(class: "test") { "Testing" } }
-
-    context "with link set" do
-      let(:tta_url) { "https://tta-service/" }
-      it { is_expected.to have_css "a[href=\"https://tta-service/\"]" }
-      it { is_expected.to have_css "a.test" }
-      it { is_expected.to have_css "a", text: "Testing" }
-    end
-
-    context "without link set" do
-      let(:tta_url) { nil }
-      it { is_expected.to be_nil }
-    end
-  end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 describe PagesController do
+  let(:template) { "testing/markdown_test" }
+
   before do
     allow_any_instance_of(described_class).to \
-      receive(:content_template).and_return "testing/markdown_test"
+      receive(:content_template).and_return template
   end
 
   context "#show" do
@@ -44,6 +46,14 @@ describe PagesController do
 
         expect(response).to have_http_status 304
       end
+    end
+
+    context "for unknown page" do
+      let(:template) { "testing/unknown" }
+      before { get "/test" }
+      subject { response }
+      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_attributes body: %r{Page not found} }
     end
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -56,4 +56,24 @@ describe PagesController do
       it { is_expected.to have_attributes body: %r{Page not found} }
     end
   end
+
+  describe "redirect to TTA site" do
+    include_context "stub env vars", "TTA_SERVICE_URL" => "https://tta-service/"
+    subject { response }
+
+    context "with /tta-service url" do
+      before { get "/tta-service" }
+      it { is_expected.to redirect_to "https://tta-service/" }
+    end
+
+    context "with /tta url" do
+      before { get "/tta" }
+      it { is_expected.to redirect_to "https://tta-service/" }
+    end
+
+    context "with utm params" do
+      before { get "/tta-service?utm_test=abc&test=def" }
+      it { is_expected.to redirect_to "https://tta-service/?utm_test=abc" }
+    end
+  end
 end

--- a/spec/support/env_var_support.rb
+++ b/spec/support/env_var_support.rb
@@ -1,0 +1,9 @@
+shared_context "stub env vars" do |envvars|
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+
+    envvars.each do |key, value|
+      allow(ENV).to receive(:[]).with(key).and_return(value)
+    end
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

GITPB-633

### Context

We need to link from the GiT site to the TTA service. The link needs to be different in different environments. The static markdown pages in the content repo cannot have condiitonal logic within them. 

### Changes proposed in this pull request

1. Add redirecting path across to the TTA service - this provides a consistent internal link, which will redirect across to the appropriate TTA service for the environment the GiT site is running within. This includes any UTM codes in the users session.
2. Replaced the earlier solution to this problem of a rails helper to dynamicly generate the url



