### PR TITLE
Re-enabled per-page caching

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  include StaticPages
+  around_action :cache_static_page, only: %i[show]
   rescue_from ActionView::MissingTemplate, with: :rescue_missing_template
 
   def scribble

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -39,6 +39,8 @@ describe PagesController do
         etag = response.headers["ETag"]
         lastmod = response.headers["Last-Modified"]
 
+        expect(lastmod).not_to be_nil
+
         get "/test", headers: {
           "If-None-Match" => etag,
           "If-Modified-Since" => lastmod,


### PR DESCRIPTION
### JIRA ticket number

GITPB-648

### Context

Caching got accidentally removed in a clean up. The test suite was insufficient and didn't pick up this was disabled.

### Changes proposed in this pull request

1. Enhance the test suite to fail when the caching is disabled
2. Re-enable the caching


