### PR TITLE
Show all events, categorised

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,6 @@
 class EventsController < ApplicationController
   before_action :load_events, only: %i[index search]
-  before_action :categorise_events, only: %i[index]
-
-  EVENTS_PER_CATEGORY = 3
+  before_action :categorise_events, only: %i[index search]
 
   def index
     @page_title = "Find an event near you"
@@ -47,8 +45,6 @@ private
 
       hash[category_name] ||= {}
       hash[category_name][type_name] ||= []
-
-      next if hash[category_name][type_name].count == EVENTS_PER_CATEGORY
 
       hash[category_name][type_name] << event
     end

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -15,9 +15,11 @@
         <div class="events-featured__text">
           <p><%= t("find_an_event.types.#{type_name.parameterize(separator: "_")}") %></p>
         </div>
-        <div class="events-featured__items">
-        <%= render partial: "events/event", collection: events %>
-        </div>
+        <% events.in_groups_of(3, false) do |events_on_row| %>
+          <div class="events-featured__items">
+          <%= render partial: "events/event", collection: events_on_row %>
+          </div>
+        <% end %>
         <%= link_to(event_category_events_path(type_name.parameterize)) do %>
             <div class="call-to-action-button">See all <%= type_name.pluralize %> <i class="fas fa-chevron-right"></i></div>
         <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -26,18 +26,6 @@
 
     <%= render partial: "event_category", collection: @events_by_category %>
 
-    <section class="search-for-events-results content container-1000">
-        <div class="content__left">
-        <% if @events_by_category.present? %>
-          <h2 class="types-of-event__header types-of-event__header--ttt">All events</h2>
-        <% end %>
-        </div>
-        <div class="content__right">
-        </div>
-
-        <%= render partial: "event", collection: @events %>
-    </section>
-
     <% if @events.empty? %>
       <section class="content container-1000">
         <div class="content__left">

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "Finding an event", type: :feature do
 
     expect(page).to have_text "Search for events"
     expect(page).to have_css "h2", text: "Organised by Get into Teaching"
-    expect(page).to have_css "h2", text: "All events"
 
     click_on(event.name)
 
@@ -40,7 +39,6 @@ RSpec.feature "Finding an event", type: :feature do
     click_on "Update results"
 
     expect(page).not_to have_css "h2", text: "Organized by Get into Teaching"
-    expect(page).not_to have_css "h2", text: "All events"
 
     click_on(event.name)
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -23,12 +23,8 @@ describe "Find an event near you" do
 
     it { is_expected.to have_http_status :success }
 
-    it "displays the first 3 events categorised and under 'all events'" do
-      expect(response.body.scan(/Event [1-3]/).count).to eq(6)
-    end
-
-    it "displays >3 events only under 'all events'" do
-      expect(response.body.scan(/Event [4-5]/).count).to eq(2)
+    it "displays all events" do
+      expect(response.body.scan(/Event [1-5]/).count).to eq(5)
     end
 
     context "when there are no results" do
@@ -66,6 +62,15 @@ describe "Find an event near you" do
 
     it "displays all events of that type" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)
+    end
+
+    it "categorises the results" do
+      headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+      expected_headings = [
+        "Train to Teach Events",
+      ]
+
+      expect(headings & expected_headings).to eq(expected_headings)
     end
 
     context "when there are no results" do


### PR DESCRIPTION
### JIRA ticket number

[GITPB-622](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-622)
[GITPB-623](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-623)

### Context

Previously, the events landing page displayed the first 3 events from each category (of the current month) and all the events in the current month at the bottom. When you performed a search you were always presented with the results, uncategorised.

Instead, we want to remove the 'all events' section and displays all the event results, categorised. 

### Changes proposed in this pull request

- Show all events, categorised

### Guidance to review

This is 2x Jira tickets, but it makes sense to do it in one PR to avoid writing tests that would immediately have to change when the second ticket is picked up.