### PR TITLE
Do not display the full address of online events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -31,6 +31,7 @@ module EventsHelper
   def event_address(event)
     building = event.building
     return nil unless building
+    return building.address_city if event.is_online
 
     [
       building.address_line1,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,7 +23,7 @@
         <h2 class="strapline-article">Event information</h2>
         <p><%= @event.description %></p>
 
-        <% if @event.building %>
+        <% if @event.building && !@event.is_online %>
         <h2 class="strapline-article">Venue information</h2>
         <p><%= @event.building.venue %>, <%= event_address(@event) %>.</p>
         <% if @event.provider_website_url %>

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     video_url { "https://video.com" }
     sequence(:start_at) { |i| i.weeks.from_now }
     end_at { start_at }
+    is_online { false }
     building { build :event_building_api }
 
     trait :with_provider_info do

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -66,6 +66,11 @@ describe EventsHelper, type: "helper" do
       expect(event_address(event)).to be_nil
     end
 
+    it "returns only the address_city if the event is online" do
+      event.is_online = true
+      expect(event_address(event)).to be(event.building.address_city)
+    end
+
     it "returns the address, comma separated with line breaks between parts" do
       expect(event.building).to_not be_nil
       expect(event_address(event)).to eq("Line 1,\nLine 2,\nManchester,\nMA1 1AM")

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -78,6 +78,9 @@ describe EventsController do
           it { is_expected.to include(event.description) }
           it { is_expected.to include(event.message) }
           it { is_expected.to include(event.building.venue) }
+          it { is_expected.to match(/#{event.building.address_line1}/) }
+          it { is_expected.to match(/#{event.building.address_line2}/) }
+          it { is_expected.to match(/#{event.building.address_postcode}/) }
           it { is_expected.to match(/iframe.+src="#{event.video_url}"/) }
           it { is_expected.to include(event.provider_website_url) }
           it { is_expected.to include(event.provider_target_audience) }
@@ -101,6 +104,15 @@ describe EventsController do
           let(:event) { build(:event_api, web_feed_id: nil, provider_website_url: "http://event.com", readable_id: event_readable_id) }
 
           it { is_expected.to match(/To attend this event, please <a.*visit this website.*a>/) }
+        end
+
+        context "when the event is online" do
+          let(:event) { build(:event_api, is_online: true) }
+
+          it { is_expected.to_not match(/#{event.building.venue}/) }
+          it { is_expected.to_not match(/#{event.building.address_line1}/) }
+          it { is_expected.to_not match(/#{event.building.address_line2}/) }
+          it { is_expected.to_not match(/#{event.building.address_postcode}/) }
         end
       end
     end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-626](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5c3cab26ad984b521085ebed%2C5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-626)

### Context

If an event is online it will still have an associated `building`. We should not display the full address/venue information to users in case they try and turn up for the online event in person.

Instead, the city will be displayed for online events in eventbox/short partials and the venue section will not be displayed as part of the view event page.

### Changes proposed in this pull request

- Do not display the full address of online events

### Guidance to review

