### PR TITLE
Give GOV.UK styles precedence/reset overrides

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
-@import "~govuk-frontend/govuk/all";
 @import './git.scss';
+@import "~govuk-frontend/govuk/all";
 
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts'; 
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -2,6 +2,7 @@
 
 @import './git.scss';
 @import "~govuk-frontend/govuk/all";
+@import './govuk-reset.scss';
 
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts'; 
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/webpacker/styles/govuk-reset.scss
+++ b/app/webpacker/styles/govuk-reset.scss
@@ -1,0 +1,21 @@
+/**
+ * As well as our own stylesheet, we also import the GOV.UK design system styles.
+ *
+ * There are a number of generic selectors used in our stylesheets (anchor
+ * tags, lists, etc) that end up adding attributes to some of the GOV.UK styles. 
+ * We need to undo these style changes when they occur, which is what this set of
+ * styles is for.
+ */
+
+.govuk-error-summary__list a:link, .govuk-error-summary__list a:visited, .govuk-error-summary__list a:hover, .govuk-error-summary__list a:active {
+  text-decoration: underline;
+}
+
+.govuk-error-summary__body ul.govuk-error-summary__list {
+  padding-left: 0;
+  list-style-type: none;
+}
+
+h2.govuk-error-summary__title {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
### JIRA ticket number

[GITPB-568](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5c3cab26ad984b521085ebed%2C5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-568)

### Context

As well as our own stylesheet, we also import the GOV.UK design system styles.

At the moment, our stylesheet takes precedence over the GOV.UK stylesheet; this should be the other way around, as our stylesheet has generic selectors whereas the GOV.UK styles are all componentised.

There are also a number of generic selectors used in our stylesheets (anchor tags, lists, etc) that end up adding attributes to some of the GOV.UK styles. We need to undo these style changes when they occur.

### Changes proposed in this pull request

- Ensure GOV.UK styles take precedence

The GOV.UK styles are very specific so shouldn't ever override/clash with our class names, but we have a few generic selectors to style anchor links etc in the website which _do_ override the GOV.UK styles.

Swapping them around will ensure the GOV.UK styles take precedence and are not changed by our local styles. That being said, if one of our local, generic selectors defines a style attribute not set by the GOV.UK classes it _will_ still cause it to change.

- Reset GOV.UK styles that are unintentionally modified

There are a number of generic selectors used in our stylesheets (anchor tags, lists, etc) that end up adding attributes to some of the GOV.UK styles.  We need to undo these style changes when they occur, which is what this set of styles is for.

### Guidance to review

