### PR TITLE
Don't require the postcode in the Mailing list flow

### DIFF
--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -2,7 +2,7 @@ module MailingList
   module Steps
     class Postcode < ::Wizard::Step
       attribute :address_postcode
-      validates :address_postcode, presence: true, postcode: true
+      validates :address_postcode, postcode: true
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.presence

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,7 +191,7 @@ en:
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
-        address_postcode: What's your postcode?
+        address_postcode: What's your postcode? (optional)
       mailing_list_steps_contact:
         telephone: What's your phone number (optional)
 

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -9,8 +9,8 @@ describe MailingList::Steps::Postcode do
   context "address_postcode" do
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
     it { is_expected.to allow_value("  TE571NG  ").for :address_postcode }
-    it { is_expected.not_to allow_value(nil).for :address_postcode }
-    it { is_expected.not_to allow_value("").for :address_postcode }
+    it { is_expected.to allow_value(nil).for :address_postcode }
+    it { is_expected.to allow_value("").for :address_postcode }
     it { is_expected.not_to allow_value("random").for :address_postcode }
   end
 


### PR DESCRIPTION
### JIRA ticket number

GITPB-526

### Context

The postcode in the Mailing list wizard should be optional

### Changes proposed in this pull request

1. Changed the validation and specs
2. Updated the label on the field to show the question is optional



