### PR TITLE
GITPB-612 Extra event step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "govuk_design_system_formbuilder"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client", "1.0.8", github: "DFE-Digital/get-into-teaching-api-ruby-client"
+gem "get_into_teaching_api_client", github: "DFE-Digital/get-into-teaching-api-ruby-client"
 gem "redis"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 933973b9e34a3340cebe3a42ad035246576e8d90
+  revision: ad6c74dd2d3bf88e90819f3e9f9f166a3f1c85c1
   specs:
-    get_into_teaching_api_client (1.0.8)
+    get_into_teaching_api_client (1.1.1)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -332,7 +332,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   front_matter_parser!
-  get_into_teaching_api_client (= 1.0.8)!
+  get_into_teaching_api_client!
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -51,8 +51,12 @@ private
     elsif (invalid_step = @wizard.first_invalid_step)
       step_path invalid_step
     else # all steps valid so completed
-      step_path :completed
+      completed_step_path
     end
+  end
+
+  def completed_step_path
+    step_path :completed
   end
 
   def step_params

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -6,10 +6,18 @@ class EventStepsController < ApplicationController
 
 private
 
-  def step_path(step = params[:id])
-    event_step_path params[:event_id], step
+  def step_path(step = params[:id], urlparams = {})
+    event_step_path params[:event_id], step, urlparams
   end
   helper_method :step_path
+
+  def completed_step_path
+    if wizard_store["subscribe_to_mailing_list"]
+      step_path :completed, subscribed: 1
+    else
+      step_path :completed
+    end
+  end
 
   def wizard_store
     Wizard::Store.new session_store

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -1,8 +1,6 @@
 module Events
   module Steps
     class FurtherDetails < ::Wizard::Step
-      SUBSCRIBE_OPTIONS = [["Yes", true], ["No", false]].freeze
-
       attribute :event_id
       attribute :privacy_policy, :boolean
       attribute :subscribe_to_mailing_list, :boolean
@@ -14,10 +12,6 @@ module Events
 
       def latest_privacy_policy
         @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
-      end
-
-      def subscribe_options
-        SUBSCRIBE_OPTIONS
       end
 
       def already_subscribed_to_mailing_list?

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -5,23 +5,17 @@ module Events
 
       attribute :event_id
       attribute :privacy_policy, :boolean
-      attribute :future_events, :boolean
       attribute :mailing_list, :boolean
       attribute :address_postcode
       attribute :accepted_policy_id
 
       validates :event_id, presence: true
       validates :privacy_policy, presence: true, acceptance: true
-      validates :future_events, inclusion: [true, false]
       validates :mailing_list, inclusion: [true, false]
       validates :address_postcode, postcode: { allow_blank: true }
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.presence
-      end
-
-      before_validation if: :already_subscribed_to_events? do
-        self.future_events = true
       end
 
       before_validation if: :already_subscribed_to_mailing_list? do
@@ -30,7 +24,6 @@ module Events
 
       def save
         if valid?
-          @store["subscribe_to_events"] = future_events == true
           @store["subscribe_to_mailing_list"] = mailing_list == true
         end
 
@@ -47,10 +40,6 @@ module Events
 
       def already_subscribed_to_mailing_list?
         @store["already_subscribed_to_mailing_list"]
-      end
-
-      def already_subscribed_to_events?
-        @store["already_subscribed_to_events"]
       end
     end
   end

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -6,17 +6,11 @@ module Events
       attribute :event_id
       attribute :privacy_policy, :boolean
       attribute :mailing_list, :boolean
-      attribute :address_postcode
       attribute :accepted_policy_id
 
       validates :event_id, presence: true
       validates :privacy_policy, presence: true, acceptance: true
       validates :mailing_list, inclusion: [true, false]
-      validates :address_postcode, postcode: { allow_blank: true }
-
-      before_validation if: :address_postcode do
-        self.address_postcode = address_postcode.to_s.strip.presence
-      end
 
       before_validation if: :already_subscribed_to_mailing_list? do
         self.mailing_list = true

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -5,24 +5,12 @@ module Events
 
       attribute :event_id
       attribute :privacy_policy, :boolean
-      attribute :mailing_list, :boolean
+      attribute :subscribe_to_mailing_list, :boolean
       attribute :accepted_policy_id
 
       validates :event_id, presence: true
       validates :privacy_policy, presence: true, acceptance: true
-      validates :mailing_list, inclusion: [true, false]
-
-      before_validation if: :already_subscribed_to_mailing_list? do
-        self.mailing_list = true
-      end
-
-      def save
-        if valid?
-          @store["subscribe_to_mailing_list"] = mailing_list == true
-        end
-
-        super
-      end
+      validates :subscribe_to_mailing_list, inclusion: { in: :mailing_list_values }
 
       def latest_privacy_policy
         @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
@@ -34,6 +22,12 @@ module Events
 
       def already_subscribed_to_mailing_list?
         @store["already_subscribed_to_mailing_list"]
+      end
+
+    private
+
+      def mailing_list_values
+        already_subscribed_to_mailing_list? ? [true, false, nil] : [true, false]
       end
     end
   end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -8,6 +8,10 @@ module Events
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.presence
       end
+
+      def skipped?
+        !@store["subscribe_to_mailing_list"]
+      end
     end
   end
 end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -1,0 +1,13 @@
+module Events
+  module Steps
+    class PersonalisedUpdates < ::Wizard::Step
+      attribute :address_postcode
+
+      validates :address_postcode, postcode: { allow_blank: true }
+
+      before_validation if: :address_postcode do
+        self.address_postcode = address_postcode.to_s.strip.presence
+      end
+    end
+  end
+end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -20,27 +20,30 @@ module Events
       end
 
       def degree_status_options
-        [[1, "Undergraduate"]]
+        @degree_status_options ||=
+          GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
       end
 
       def degree_status_option_ids
-        degree_status_options.map(&:first)
+        degree_status_options.map(&:id).map(&:to_i)
       end
 
       def journey_stage_options
-        [[1, "Stage 1"]]
+        @journey_stage_options ||=
+          GetIntoTeachingApiClient::TypesApi.new.get_candidate_journey_stages
       end
 
       def journey_stage_option_ids
-        journey_stage_options.map(&:first)
+        journey_stage_options.map(&:id).map(&:to_i)
       end
 
       def teaching_subject_options
-        [["fd11dc24-54ee-41b7-bf46-5f7e4d8926e5", "Maths"]]
+        @teaching_subject_options ||=
+          GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
       end
 
       def teaching_subject_option_ids
-        teaching_subject_options.map(&:first)
+        teaching_subject_options.map(&:id)
       end
     end
   end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -1,9 +1,15 @@
 module Events
   module Steps
     class PersonalisedUpdates < ::Wizard::Step
+      attribute :degree_status_id, :integer
+      attribute :consideration_journey_stage_id, :integer
       attribute :address_postcode
+      attribute :preferred_teaching_subject_id
 
+      validates :degree_status_id, inclusion: { in: :degree_status_option_ids }
+      validates :consideration_journey_stage_id, inclusion: { in: :journey_stage_option_ids }
       validates :address_postcode, postcode: { allow_blank: true }
+      validates :preferred_teaching_subject_id, inclusion: { in: :teaching_subject_option_ids }
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.presence
@@ -11,6 +17,30 @@ module Events
 
       def skipped?
         !@store["subscribe_to_mailing_list"]
+      end
+
+      def degree_status_options
+        [[1, "Undergraduate"]]
+      end
+
+      def degree_status_option_ids
+        degree_status_options.map(&:first)
+      end
+
+      def journey_stage_options
+        [[1, "Stage 1"]]
+      end
+
+      def journey_stage_option_ids
+        journey_stage_options.map(&:first)
+      end
+
+      def teaching_subject_options
+        [["fd11dc24-54ee-41b7-bf46-5f7e4d8926e5", "Maths"]]
+      end
+
+      def teaching_subject_option_ids
+        teaching_subject_options.map(&:first)
       end
     end
   end

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -7,6 +7,7 @@ module Events
       Steps::Authenticate,
       Steps::ContactDetails,
       Steps::FurtherDetails,
+      Steps::PersonalisedUpdates,
     ].freeze
 
     def complete!

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -17,7 +17,5 @@
       inline: true %>
 <% end %>
 
-<%= f.govuk_text_field :address_postcode %>
-
 <%= f.hidden_field :event_id, value: @event.id %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -12,9 +12,16 @@
 <% end %>
 
 <% unless f.object.already_subscribed_to_mailing_list? %>
-<%= f.govuk_collection_radio_buttons :subscribe_to_mailing_list,
-      f.object.subscribe_options, :last, :first,
-      inline: true %>
+  <div data-controller="last-step" data-last-step-complete="Complete sign up" data-last-step-continue="Next Step">
+    <div data-action="click->last-step#updateSubmit">
+      <%= f.govuk_radio_buttons_fieldset :subscribe_to_mailing_list, inline: true do %>
+        <%= f.govuk_radio_button :subscribe_to_mailing_list, true, label: { text: "Yes" } %>
+        <div data-target="last-step.complete">
+        <%= f.govuk_radio_button :subscribe_to_mailing_list, false, label: { text: "No" } %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 <% end %>
 
 <%= f.hidden_field :event_id, value: @event.id %>

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -11,12 +11,6 @@
         label: { text: "Yes" } %>
 <% end %>
 
-<% unless f.object.already_subscribed_to_events? %>
-<%= f.govuk_collection_radio_buttons :future_events,
-      f.object.subscribe_options, :last, :first,
-      inline: true %>
-<% end %>
-
 <% unless f.object.already_subscribed_to_mailing_list? %>
 <%= f.govuk_collection_radio_buttons :mailing_list,
       f.object.subscribe_options, :last, :first,

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% unless f.object.already_subscribed_to_mailing_list? %>
-<%= f.govuk_collection_radio_buttons :mailing_list,
+<%= f.govuk_collection_radio_buttons :subscribe_to_mailing_list,
       f.object.subscribe_options, :last, :first,
       inline: true %>
 <% end %>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -1,19 +1,19 @@
 <%= f.govuk_collection_select :degree_status_id,
       f.object.degree_status_options,
-      :first,
-      :last,
+      :id,
+      :value,
       options: { prompt: true } %>
 
 <%= f.govuk_collection_select :consideration_journey_stage_id,
       f.object.journey_stage_options,
-      :first,
-      :last,
+      :id,
+      :value,
       options: { prompt: true } %>
 
 <%= f.govuk_text_field :address_postcode %>
 
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
     f.object.teaching_subject_options,
-    :first,
-    :last,
+    :id,
+    :value,
     options: { prompt: true } %>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -1,0 +1,2 @@
+<%= f.govuk_text_field :address_postcode %>
+

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -1,2 +1,19 @@
+<%= f.govuk_collection_select :degree_status_id,
+      f.object.degree_status_options,
+      :first,
+      :last,
+      options: { prompt: true } %>
+
+<%= f.govuk_collection_select :consideration_journey_stage_id,
+      f.object.journey_stage_options,
+      :first,
+      :last,
+      options: { prompt: true } %>
+
 <%= f.govuk_text_field :address_postcode %>
 
+<%= f.govuk_collection_select :preferred_teaching_subject_id,
+    f.object.teaching_subject_options,
+    :first,
+    :last,
+    options: { prompt: true } %>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -3,10 +3,18 @@
         <div class="content__left">
             <h1 class="strapline">Sign up complete</h1>
             <br/><br/>	
-            <p>You are signed up for the following event:</p>
+            <h3>You are signed up for the following event:</h3>
 
             <b><%= @event.name %></b>
             <p><%= format_event_date @event, stacked: false %></p>
+
+            <%- if params[:subscribed].to_s == "1" -%>
+            <h3>You've also signed up for personalised updates</h3>
+            <p>
+                You're ready to receive personalised updates to help you get
+                into teaching.
+            </p>
+            <%- end -%>
 
             <h2>What happens next?</h2>
             <p>

--- a/app/webpacker/controllers/last_step_controller.js
+++ b/app/webpacker/controllers/last_step_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["complete"]
+
+  connect() {
+    this.updateSubmit() ;
+  }
+
+  updateSubmit() {
+    if (this.isLastStep()) {
+      this.setSubmitText(this.data.get('complete')) ;
+    } else {
+      this.setSubmitText(this.data.get('continue')) ;
+    }
+  }
+
+  isLastStep() {
+    return this.radioInput.checked ;
+  }
+
+  get radioInput() {
+    return this.completeTarget.querySelector('input[type=radio]') ;
+  }
+
+  get submitButton() {
+    return this.radioInput.form.querySelector('button[type=submit]') ;
+  }
+
+  setSubmitText(submitMsg) {
+    this.submitButton.innerText = submitMsg ;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,8 +130,15 @@ en:
             subscribe_to_mailing_list:
               inclusion: Choose yes or no
         events/steps/personalised_updates:
+          attributes:
             address_postcode:
               invalid: Enter a valid postcode, or leave blank
+            degree_status_id:
+              inclusion: Select the stage of your degree you are at
+            consideration_journey_stage_id:
+              inclusion: Select how close you are to applying for teacher training
+            preferred_teaching_subject_id:
+              inclusion: Select the subject do you want to teach
 
         mailing_list/steps/name:
           attributes:
@@ -170,16 +177,21 @@ en:
 
   helpers:
     label:
+      wizard_steps_authenticate:
+        timed_one_time_password: Enter the verification code sent to %{email}
+
       events_steps_personal_details:
         first_name: First name
         last_name: Surname
         email: Email address
       events_steps_contact_details:
         telephone: Phone number (optional)
-      wizard_steps_authenticate:
-        timed_one_time_password: Enter the verification code sent to %{email}
       events_steps_personalised_updates:
-        address_postcode: Postcode (optional)
+        address_postcode: What is your postcode? (optional)
+        degree_status_id: What stage are you at with your degree?
+        consideration_journey_stage_id: How close are you to applying for teacher training?
+        preferred_teaching_subject_id: What subject do you want to teach?
+
       mailing_list_steps_name:
         first_name: First name
         last_name: Surname

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,7 +127,7 @@ en:
           attributes:
             privacy_policy:
               blank: Accept the privacy policy to continue
-            mailing_list:
+            subscribe_to_mailing_list:
               inclusion: Choose yes or no
         events/steps/personalised_updates:
             address_postcode:
@@ -214,7 +214,7 @@ en:
         privacy_policy:
           text: Are you over 16 and do you agree to our %{link}?
           link: privacy policy
-        mailing_list: |-
+        subscribe_to_mailing_list: |-
           Would you like to receive personalised information to help you get into teaching?
       mailing_list_steps_contact:
         accept_privacy_policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,8 +127,6 @@ en:
           attributes:
             privacy_policy:
               blank: Accept the privacy policy to continue
-            future_events:
-              inclusion: Choose yes or no
             mailing_list:
               inclusion: Choose yes or no
             address_postcode:
@@ -215,8 +213,6 @@ en:
         privacy_policy:
           text: Are you over 16 and do you agree to our %{link}?
           link: privacy policy
-        future_events: |-
-          Would you like to receive information about future events in your area?
         mailing_list: |-
           Would you like to receive personalised information to help you get into teaching?
       mailing_list_steps_contact:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
               blank: Accept the privacy policy to continue
             mailing_list:
               inclusion: Choose yes or no
+        events/steps/personalised_updates:
             address_postcode:
               invalid: Enter a valid postcode, or leave blank
 
@@ -177,7 +178,7 @@ en:
         telephone: Phone number (optional)
       wizard_steps_authenticate:
         timed_one_time_password: Enter the verification code sent to %{email}
-      events_steps_further_details:
+      events_steps_personalised_updates:
         address_postcode: Postcode (optional)
       mailing_list_steps_name:
         first_name: First name
@@ -203,7 +204,7 @@ en:
           text: Check your junk mail folder or %{link}.
           resent: We've sent you another email.
           link: resend verification
-      events_steps_further_details:
+      events_steps_personalised_updates:
         address_postcode: |-
           Enter your postcode so that we can send you event information
           specificities to your area.

--- a/spec/factories/events/further_details_factory.rb
+++ b/spec/factories/events/further_details_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :events_further_details, class: Events::Steps::FurtherDetails do
     event_id { "abc123" }
     privacy_policy { true }
-    mailing_list { true }
+    subscribe_to_mailing_list { true }
   end
 end

--- a/spec/factories/events/further_details_factory.rb
+++ b/spec/factories/events/further_details_factory.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     event_id { "abc123" }
     privacy_policy { true }
     mailing_list { true }
-    address_postcode { "TE57 1NG" }
   end
 end

--- a/spec/factories/events/further_details_factory.rb
+++ b/spec/factories/events/further_details_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :events_further_details, class: Events::Steps::FurtherDetails do
     event_id { "abc123" }
     privacy_policy { true }
-    future_events { true }
     mailing_list { true }
     address_postcode { "TE57 1NG" }
   end

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -1,8 +1,20 @@
 FactoryBot.define do
   factory :events_personalised_updates, class: Events::Steps::PersonalisedUpdates do
-    degree_status_id { 1 }
-    consideration_journey_stage_id { 1 }
+    degree_status_id do
+      GetIntoTeachingApiClient::TypesApi.new
+        .get_qualification_degree_status.first.id
+    end
+
+    consideration_journey_stage_id do
+      GetIntoTeachingApiClient::TypesApi.new
+        .get_candidate_journey_stages.first.id
+    end
+
     address_postcode { "TE57 1NG" }
-    preferred_teaching_subject_id { "fd11dc24-54ee-41b7-bf46-5f7e4d8926e5" }
+
+    preferred_teaching_subject_id do
+      GetIntoTeachingApiClient::TypesApi.new
+        .get_teaching_subjects.first.id
+    end
   end
 end

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :events_personalised_updates, class: Events::Steps::PersonalisedUpdates do
+    address_postcode { "TE57 1NG" }
+  end
+end

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :events_personalised_updates, class: Events::Steps::PersonalisedUpdates do
+    degree_status_id { 1 }
+    consideration_journey_stage_id { 1 }
     address_postcode { "TE57 1NG" }
+    preferred_teaching_subject_id { "fd11dc24-54ee-41b7-bf46-5f7e4d8926e5" }
   end
 end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -32,14 +32,20 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in "Phone number (optional)", with: "01234567890"
     click_on "Next Step"
 
-    fill_in "Postcode (optional)", with: "TE57 1NG"
-    click_on "Complete sign up"
+    within_fieldset "Would you like to receive personalised information" do
+      choose "Yes"
+    end
+    click_on "Next Step"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
-    expect(page).to have_text "Choose yes or no"
-    check "Yes"
-    choose "events-steps-further-details-mailing-list-field"
+    within_fieldset "Are you over 16 and do you agree" do
+      check "Yes"
+    end
+
+    click_on "Next Step"
+
+    fill_in "Postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -71,14 +77,23 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_field("Phone number (optional)", with: response.telephone)
     click_on "Next Step"
 
-    expect(page).to have_field("Postcode (optional)", with: response.address_postcode)
-    click_on "Complete sign up"
+    expect(page).to have_text "Are you over 16 and do you agree"
+    click_on "Next Step"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
     expect(page).to have_text "Choose yes or no"
-    check "Yes"
+
+    within_fieldset "Are you over 16 and do you agree" do
+      check "Yes"
+    end
+    within_fieldset "Would you like to receive personalised information" do
+      choose "Yes"
+    end
     choose "events-steps-further-details-mailing-list-field-error"
+    click_on "Next Step"
+
+    expect(page).to have_field("Postcode (optional)", with: response.address_postcode)
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -142,15 +157,20 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text("Phone number (optional)")
     click_on "Next Step"
 
-    expect(page).to have_text("Postcode (optional)")
-    expect(page).to_not have_text("Would you like to receive information about future events")
+    expect(page).to have_text("Are you over 16 and do you agree")
     expect(page).to_not have_text("Would you like to receive personalised information")
-    click_on "Complete sign up"
+    click_on "Next Step"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
     expect(page).to_not have_text "Choose yes or no"
-    check "Yes"
+
+    within_fieldset "Are you over 16 and do you agree" do
+      check "Yes"
+    end
+    click_on "Next Step"
+
+    expect(page).to have_text("Postcode (optional)")
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -124,7 +124,6 @@ RSpec.feature "Event wizard", type: :feature do
     within_fieldset "Would you like to receive personalised information" do
       choose "Yes"
     end
-    choose "events-steps-further-details-subscribe-to-mailing-list-field-error"
     click_on "Complete sign up"
 
     fill_in_personalised_updates

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Event wizard", type: :feature do
+  include_context "stub types api"
+
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:event_readable_id) { "123" }
   let(:event_name) { "Event Name" }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Event wizard", type: :feature do
     within_fieldset "Would you like to receive personalised information" do
       choose "Yes"
     end
-    click_on "Next Step"
+    click_on "Complete sign up"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
@@ -43,9 +43,38 @@ RSpec.feature "Event wizard", type: :feature do
       check "Yes"
     end
 
-    click_on "Next Step"
+    click_on "Complete sign up"
 
     fill_in "Postcode (optional)", with: "TE57 1NG"
+    click_on "Complete sign up"
+
+    expect(page).to have_text "What happens next"
+  end
+
+  scenario "Full journey as a new candidate declining the mailing list option" do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
+
+    visit event_steps_path(event_id: event_readable_id)
+
+    expect(page).to have_text "Sign up for this event"
+    expect(page).to have_text event_name
+    fill_in_personal_details_step
+    click_on "Next Step"
+
+    fill_in "Phone number (optional)", with: "01234567890"
+    click_on "Next Step"
+
+    within_fieldset "Would you like to receive personalised information" do
+      choose "No"
+    end
+    click_on "Complete sign up"
+
+    expect(page).to have_text "There is a problem"
+    expect(page).to have_text "Accept the privacy policy to continue"
+    within_fieldset "Are you over 16 and do you agree" do
+      check "Yes"
+    end
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -78,7 +107,8 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "Are you over 16 and do you agree"
-    click_on "Next Step"
+    expect(page).to have_text "Would you like to receive personalised information"
+    click_on "Complete sign up"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
@@ -90,10 +120,10 @@ RSpec.feature "Event wizard", type: :feature do
     within_fieldset "Would you like to receive personalised information" do
       choose "Yes"
     end
-    choose "events-steps-further-details-mailing-list-field-error"
-    click_on "Next Step"
+    choose "events-steps-further-details-subscribe-to-mailing-list-field-error"
+    click_on "Complete sign up"
 
-    expect(page).to have_field("Postcode (optional)", with: response.address_postcode)
+    fill_in "Postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -159,7 +189,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     expect(page).to have_text("Are you over 16 and do you agree")
     expect(page).to_not have_text("Would you like to receive personalised information")
-    click_on "Next Step"
+    click_on "Complete sign up"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
@@ -168,9 +198,6 @@ RSpec.feature "Event wizard", type: :feature do
     within_fieldset "Are you over 16 and do you agree" do
       check "Yes"
     end
-    click_on "Next Step"
-
-    expect(page).to have_text("Postcode (optional)")
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
+    expect(page).to have_text "signed up for personalised updates"
   end
 
   scenario "Full journey as a new candidate declining the mailing list option" do
@@ -80,6 +81,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
+    expect(page).not_to have_text "signed up for personalised updates"
   end
 
   scenario "Full journey as an existing candidate" do
@@ -129,6 +131,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
+    expect(page).to have_text "signed up for personalised updates"
   end
 
   scenario "Full journey as a returning candidate that resends the verification code" do
@@ -203,6 +206,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
+    expect(page).not_to have_text "signed up for personalised updates"
   end
 
   def fill_in_personal_details_step(

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     click_on "Complete sign up"
 
-    fill_in "Postcode (optional)", with: "TE57 1NG"
+    fill_in_personalised_updates
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -123,7 +123,7 @@ RSpec.feature "Event wizard", type: :feature do
     choose "events-steps-further-details-subscribe-to-mailing-list-field-error"
     click_on "Complete sign up"
 
-    fill_in "Postcode (optional)", with: "TE57 1NG"
+    fill_in_personalised_updates
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
@@ -211,5 +211,26 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in "First name", with: first_name if first_name
     fill_in "Surname", with: last_name if last_name
     fill_in "Email address", with: email if email
+  end
+
+  def fill_in_personalised_updates(
+    degree_status: nil,
+    consideration_journey_stage: nil,
+    postcode: "TE57 1NG",
+    preferred_teaching_subject: nil
+  )
+    select_value_or_default "What stage are you at with your degree?", degree_status
+    select_value_or_default "How close are you to applying for teacher training?", consideration_journey_stage
+    fill_in "What is your postcode? (optional)", with: postcode
+    select_value_or_default "What subject do you want to teach?", preferred_teaching_subject
+  end
+
+  def select_value_or_default(label, value = nil)
+    if value
+      select(value, from: label)
+    else
+      # choosing second option because first is 'Please select'
+      find_field(label).find("option:nth-of-type(2)").select_option
+    end
   end
 end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -39,7 +39,6 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Accept the privacy policy to continue"
     expect(page).to have_text "Choose yes or no"
     check "Yes"
-    choose "events-steps-further-details-future-events-field-error"
     choose "events-steps-further-details-mailing-list-field"
     click_on "Complete sign up"
 
@@ -79,7 +78,6 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Accept the privacy policy to continue"
     expect(page).to have_text "Choose yes or no"
     check "Yes"
-    choose "events-steps-further-details-future-events-field"
     choose "events-steps-further-details-mailing-list-field-error"
     click_on "Complete sign up"
 

--- a/spec/javascript/controllers/last_step_controller_spec.js
+++ b/spec/javascript/controllers/last_step_controller_spec.js
@@ -1,0 +1,66 @@
+import { Application } from 'stimulus' ;
+import LastStepController from 'last_step_controller' ;
+
+describe('LastStepController', () => {
+  document.body.innerHTML = `
+    <form>
+      <div data-controller="last-step" data-last-step-continue="continue" data-last-step-complete="complete">
+        <div data-action="click->last-step#updateSubmit">
+          <fieldset>
+            <legend>Test option</legend>
+
+            <div>
+              <label>
+                <input type="radio" value="yes" id="yes-radio"> Yes
+              </label>
+            <div>
+
+            <div data-target="last-step.complete">
+              <div>
+                <label>
+                  <input type="radio" value="no" id="no-radio"> No
+                </label>
+              </div>
+            <div>
+        </div>
+      </div>
+
+      <button type="submit" id="button">undetermined</button>
+    </form>
+  ` ;
+
+  beforeEach(() => {
+    const application = Application.start() ;
+    application.register('last-step', LastStepController) ;
+  })
+
+  function buttonLabel() {
+    return document.getElementById("button").innerText
+  } ;
+
+  describe("When no button clicked", () => {
+    it("should have default message", () => {
+      expect(buttonLabel()).toEqual("continue") ;
+    }) ;
+  }) ;
+
+  describe("Clicking normal radio", () => {
+    beforeEach(() => {
+      document.getElementById("yes-radio").click() ;
+    }) ;
+
+    it("should set message to continue", () => {
+      expect(buttonLabel()).toEqual("continue")
+    }) ;
+  }) ;
+
+  describe("Clicking radio to end wizard", () => {
+    beforeEach(() => {
+      document.getElementById("no-radio").click() ;
+    }) ;
+
+    it("should set message to complete", () => {
+      expect(buttonLabel()).toEqual("complete")
+    }) ;
+  }) ;
+})

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -8,7 +8,6 @@ describe Events::Steps::FurtherDetails do
   context "attributes" do
     it { is_expected.to respond_to :event_id }
     it { is_expected.to respond_to :privacy_policy }
-    it { is_expected.to respond_to :future_events }
     it { is_expected.to respond_to :mailing_list }
     it { is_expected.to respond_to :address_postcode }
     it { is_expected.to respond_to :accepted_policy_id }
@@ -21,10 +20,6 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.to allow_value("1").for :privacy_policy }
     it { is_expected.not_to allow_value("0").for :privacy_policy }
     it { is_expected.not_to allow_value("").for :privacy_policy }
-
-    it { is_expected.to allow_value("1").for :future_events }
-    it { is_expected.to allow_value("0").for :future_events }
-    it { is_expected.not_to allow_value("").for :future_events }
 
     it { is_expected.to allow_value("1").for :mailing_list }
     it { is_expected.to allow_value("0").for :mailing_list }
@@ -51,12 +46,6 @@ describe Events::Steps::FurtherDetails do
       wizardstore["already_subscribed_to_mailing_list"] = true
       subject.valid?
       expect(subject.mailing_list).to be_truthy
-    end
-
-    it "defaults future_events if already subscribed" do
-      wizardstore["already_subscribed_to_events"] = true
-      subject.valid?
-      expect(subject.future_events).to be_truthy
     end
   end
 
@@ -87,20 +76,16 @@ describe Events::Steps::FurtherDetails do
       end
 
       it "updates the store if the candidate subscribes" do
-        subject.future_events = true
         subject.mailing_list = true
         expect(subject).to be_valid
         subject.save
-        expect(wizardstore["subscribe_to_events"]).to be_truthy
         expect(wizardstore["subscribe_to_mailing_list"]).to be_truthy
       end
 
       it "updates the store if the candidate does not subscribe" do
-        subject.future_events = false
         subject.mailing_list = false
         expect(subject).to be_valid
         subject.save
-        expect(wizardstore["subscribe_to_events"]).to be_falsy
         expect(wizardstore["subscribe_to_mailing_list"]).to be_falsy
       end
     end

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -9,7 +9,6 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.to respond_to :event_id }
     it { is_expected.to respond_to :privacy_policy }
     it { is_expected.to respond_to :mailing_list }
-    it { is_expected.to respond_to :address_postcode }
     it { is_expected.to respond_to :accepted_policy_id }
   end
 
@@ -24,24 +23,9 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.to allow_value("1").for :mailing_list }
     it { is_expected.to allow_value("0").for :mailing_list }
     it { is_expected.not_to allow_value("").for :mailing_list }
-
-    it { is_expected.to allow_value("TE571NG").for :address_postcode }
-    it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
-    it { is_expected.to allow_value(" TE57 1NG ").for :address_postcode }
-    it { is_expected.to allow_value("").for :address_postcode }
-    it { is_expected.not_to allow_value("unknown").for :address_postcode }
   end
 
   context "data cleaning" do
-    it "cleans the postcode" do
-      subject.address_postcode = "  TE57 1NG "
-      subject.valid?
-      expect(subject.address_postcode).to eq("TE57 1NG")
-      subject.address_postcode = "  "
-      subject.valid?
-      expect(subject.address_postcode).to be_nil
-    end
-
     it "defaults mailing_list if already subscribed" do
       wizardstore["already_subscribed_to_mailing_list"] = true
       subject.valid?

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -8,7 +8,7 @@ describe Events::Steps::FurtherDetails do
   context "attributes" do
     it { is_expected.to respond_to :event_id }
     it { is_expected.to respond_to :privacy_policy }
-    it { is_expected.to respond_to :mailing_list }
+    it { is_expected.to respond_to :subscribe_to_mailing_list }
     it { is_expected.to respond_to :accepted_policy_id }
   end
 
@@ -20,16 +20,15 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.not_to allow_value("0").for :privacy_policy }
     it { is_expected.not_to allow_value("").for :privacy_policy }
 
-    it { is_expected.to allow_value("1").for :mailing_list }
-    it { is_expected.to allow_value("0").for :mailing_list }
-    it { is_expected.not_to allow_value("").for :mailing_list }
-  end
+    it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
+    it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
+    it { is_expected.not_to allow_value("").for :subscribe_to_mailing_list }
 
-  context "data cleaning" do
-    it "defaults mailing_list if already subscribed" do
-      wizardstore["already_subscribed_to_mailing_list"] = true
-      subject.valid?
-      expect(subject.mailing_list).to be_truthy
+    context "already_subscribed" do
+      let(:backingstore) { { "already_subscribed_to_mailing_list" => true } }
+      it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
+      it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
+      it { is_expected.to allow_value("").for :subscribe_to_mailing_list }
     end
   end
 
@@ -44,7 +43,7 @@ describe Events::Steps::FurtherDetails do
       it "does not update the store" do
         expect(subject).to_not be_valid
         subject.save
-        expect(wizardstore["subscribe_to_events"]).to be_nil
+        expect(wizardstore["subscribe_to_mailing_list"]).to be_nil
       end
     end
 
@@ -60,14 +59,14 @@ describe Events::Steps::FurtherDetails do
       end
 
       it "updates the store if the candidate subscribes" do
-        subject.mailing_list = true
+        subject.subscribe_to_mailing_list = true
         expect(subject).to be_valid
         subject.save
         expect(wizardstore["subscribe_to_mailing_list"]).to be_truthy
       end
 
       it "updates the store if the candidate does not subscribe" do
-        subject.mailing_list = false
+        subject.subscribe_to_mailing_list = false
         expect(subject).to be_valid
         subject.save
         expect(wizardstore["subscribe_to_mailing_list"]).to be_falsy

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -27,4 +27,23 @@ describe Events::Steps::PersonalisedUpdates do
       expect(subject.address_postcode).to be_nil
     end
   end
+
+  context "skipped?" do
+    let(:mailing_list) { nil }
+    let(:backingstore) { { "subscribe_to_mailing_list" => mailing_list } }
+
+    context "with mailing_list question not answered" do
+      it { is_expected.to be_skipped }
+    end
+
+    context "with mailing_list question answered as yes" do
+      let(:mailing_list) { true }
+      it { is_expected.not_to be_skipped }
+    end
+
+    context "with mailing_list question answered as no" do
+      let(:mailing_list) { false }
+      it { is_expected.to be_skipped }
+    end
+  end
 end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -7,6 +7,9 @@ describe Events::Steps::PersonalisedUpdates do
 
   context "attributes" do
     it { is_expected.to respond_to :address_postcode }
+    it { is_expected.to respond_to :degree_status_id }
+    it { is_expected.to respond_to :consideration_journey_stage_id }
+    it { is_expected.to respond_to :preferred_teaching_subject_id }
   end
 
   context "validations" do
@@ -15,6 +18,21 @@ describe Events::Steps::PersonalisedUpdates do
     it { is_expected.to allow_value(" TE57 1NG ").for :address_postcode }
     it { is_expected.to allow_value("").for :address_postcode }
     it { is_expected.not_to allow_value("unknown").for :address_postcode }
+
+    it { is_expected.to allow_value(subject.degree_status_option_ids.first).for :degree_status_id }
+    it { is_expected.to allow_value(subject.degree_status_option_ids.last).for :degree_status_id }
+    it { is_expected.not_to allow_value(nil).for :degree_status_id }
+    it { is_expected.not_to allow_value("12345").for :degree_status_id }
+
+    it { is_expected.to allow_value(subject.journey_stage_option_ids.first).for :consideration_journey_stage_id }
+    it { is_expected.to allow_value(subject.journey_stage_option_ids.last).for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value(nil).for :consideration_journey_stage_id }
+    it { is_expected.not_to allow_value("12345").for :consideration_journey_stage_id }
+
+    it { is_expected.to allow_value(subject.teaching_subject_option_ids.first).for :preferred_teaching_subject_id }
+    it { is_expected.to allow_value(subject.teaching_subject_option_ids.last).for :preferred_teaching_subject_id }
+    it { is_expected.not_to allow_value(nil).for :preferred_teaching_subject_id }
+    it { is_expected.not_to allow_value("12345").for :preferred_teaching_subject_id }
   end
 
   context "data cleaning" do

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Events::Steps::PersonalisedUpdates do
   include_context "wizard step"
+  include_context "stub types api"
 
   it_behaves_like "a wizard step"
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe Events::Steps::PersonalisedUpdates do
+  include_context "wizard step"
+
+  it_behaves_like "a wizard step"
+
+  context "attributes" do
+    it { is_expected.to respond_to :address_postcode }
+  end
+
+  context "validations" do
+    it { is_expected.to allow_value("TE571NG").for :address_postcode }
+    it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
+    it { is_expected.to allow_value(" TE57 1NG ").for :address_postcode }
+    it { is_expected.to allow_value("").for :address_postcode }
+    it { is_expected.not_to allow_value("unknown").for :address_postcode }
+  end
+
+  context "data cleaning" do
+    it "cleans the postcode" do
+      subject.address_postcode = "  TE57 1NG "
+      subject.valid?
+      expect(subject.address_postcode).to eq("TE57 1NG")
+      subject.address_postcode = "  "
+      subject.valid?
+      expect(subject.address_postcode).to be_nil
+    end
+  end
+end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -10,6 +10,7 @@ describe Events::Wizard do
         Events::Steps::Authenticate,
         Events::Steps::ContactDetails,
         Events::Steps::FurtherDetails,
+        Events::Steps::PersonalisedUpdates,
       ]
     end
   end
@@ -31,7 +32,7 @@ describe Events::Wizard do
       )
     end
 
-    subject { described_class.new wizardstore, "further_details" }
+    subject { described_class.new wizardstore, "personalised_updates" }
 
     before { allow(subject).to receive(:valid?).and_return true }
     before do

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -52,17 +52,20 @@ describe EventStepsController do
           allow_any_instance_of(Events::Steps::ContactDetails).to \
             receive(:valid?).and_return true
 
+          allow_any_instance_of(Events::Steps::FurtherDetails).to \
+            receive(:valid?).and_return true
+
           allow_any_instance_of(Events::Wizard).to \
             receive(:add_attendee_to_event).and_return true
         end
-        let(:model) { Events::Steps::FurtherDetails }
-        let(:details_params) { attributes_for(:events_further_details) }
+        let(:model) { Events::Steps::PersonalisedUpdates }
+        let(:details_params) { attributes_for(:events_personalised_updates) }
         it { is_expected.to redirect_to completed_event_steps_path(readable_event_id) }
       end
 
       context "when invalid steps" do
-        let(:model) { Events::Steps::FurtherDetails }
-        let(:details_params) { attributes_for(:events_further_details) }
+        let(:model) { Events::Steps::PersonalisedUpdates }
+        let(:details_params) { attributes_for(:events_personalised_updates) }
         it do
           is_expected.to redirect_to \
             event_step_path(readable_event_id, "personal_details")


### PR DESCRIPTION
### JIRA ticket number

GITPB-612

### Context

We now give candidates the opportunity to subscribe to the newsletter as part of the signup process.

### Changes proposed in this pull request

1. Dropped the future events field
2. Moved the postcode field to a new screen
3. Added fields for Degree Status, Journey Stage and Preferred Teaching subject
4. Updated the API integration to submit the new fields
5. Updated the completion screen to confirm if the user has subscribed to the newsletter
6. Added a javascript controller to update the label on the submit button dependant on whether they are subscribing to the newsletter



