### PR TITLE
Remove sign up/how to attend from closed events

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -1,10 +1,17 @@
 class EventStepsController < ApplicationController
   before_action :load_event
+  before_action :redirect_closed_events, only: %i[show update] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   include WizardSteps
   self.wizard_class = Events::Wizard
 
 private
+
+  def redirect_closed_events
+    return unless @event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]
+
+    redirect_to event_path(id: @event.readable_id)
+  end
 
   def step_path(step = params[:id], urlparams = {})
     event_step_path params[:event_id], step, urlparams

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -17,6 +17,14 @@ module EventsHelper
     end
   end
 
+  def event_status_open?(event)
+    event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
+  end
+
+  def can_sign_up_online?(event)
+    event.web_feed_id && event_status_open?(event)
+  end
+
   def embed_event_video_url(video_url)
     video_url&.sub("watch?v=", "embed/")
   end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -15,7 +15,7 @@
             location: event_address(@event)
         %>
 
-        <% if @event.web_feed_id %>
+        <% if can_sign_up_online?(@event) %>
           <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button sidebar-button" do %>
               Sign up for this <span>event</span>
           <% end %>
@@ -62,21 +62,23 @@
         <br />
         <% end %>
 
-        <% if @event.web_feed_id %>
-          <h2 class="strapline-article">How to attend</h2>
-          <p>
-              To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
-          </p>
+        <% if event_status_open?(@event) %>
+          <% if can_sign_up_online?(@event) %>
+            <h2 class="strapline-article">How to attend</h2>
+            <p>
+                To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
+            </p>
 
-          <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
-              Sign up for this <span>event</span>
+            <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
+                Sign up for this <span>event</span>
+            <% end %>
+          <% elsif @event.provider_website_url %>
+            <h2 class="strapline-article">How to attend</h2>
+            <p>To attend this event, please <%= link_to(@event.provider_website_url, "visit this website", { target: "blank" }) %><i class="icon icon-external"></i>.<p>
+          <% elsif @event.provider_contact_email %>
+            <h2 class="strapline-article">How to attend</h2>
+            <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>
           <% end %>
-        <% elsif @event.provider_website_url %>
-          <h2 class="strapline-article">How to attend</h2>
-          <p>To attend this event, please <%= link_to(@event.provider_website_url, "visit this website", { target: "blank" }) %><i class="icon icon-external"></i>.<p>
-        <% elsif @event.provider_contact_email %>
-          <h2 class="strapline-article">How to attend</h2>
-          <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>
         <% end %>
       </div>
 </section>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,6 +22,10 @@
         <% end %>
     </div>
     <div class="content__left">
+        <% unless event_status_open?(@event) %>
+          <p class="content-alert">This event is now closed. Search <%= link_to("here", events_path) %> for our other events.</p>
+        <% end %>
+
         <% if @event.message %>
           <p class="content-alert"><%= @event.message %></p>
         <% end %>
@@ -41,7 +45,7 @@
         <% if event_has_provider_info?(@event) %>
           <h2 class="strapline-article">Provider information</h2>
           <% if @event.provider_website_url %>
-            <p><strong>Event website</strong><br /><%= link_to(@event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
+            <p><strong>Event website</strong><br /><%= link_to(@event.provider_website_url, @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
           <% end %>
           <% if @event.provider_target_audience %>
             <p><strong>Target audience</strong><br /><%= @event.provider_target_audience %></p>
@@ -74,7 +78,7 @@
             <% end %>
           <% elsif @event.provider_website_url %>
             <h2 class="strapline-article">How to attend</h2>
-            <p>To attend this event, please <%= link_to(@event.provider_website_url, "visit this website", { target: "blank" }) %><i class="icon icon-external"></i>.<p>
+            <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i>.<p>
           <% elsif @event.provider_contact_email %>
             <h2 class="strapline-article">How to attend</h2>
             <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>

--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -129,6 +129,10 @@
             display: block;
             margin-left: -20px;
             margin-right: -20px;
+
+            a {
+              color: $white;
+            }
         }
         
         div.content-video {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -23,6 +23,10 @@
             font-weight: bold;
             line-height: 1.5;
             display: inline-block;
+
+            a {
+              color: $white;
+            }
         }
 
     }

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -8,6 +8,13 @@ module GetIntoTeachingApiClient
         "School or University Event" => 222_750_009,
       }.freeze
 
+    # This is not a complete list.
+    EVENT_STATUS =
+      {
+        "Open" => 222_750_000,
+        "Closed" => 222_750_001,
+      }.freeze
+
     GET_INTO_TEACHING_EVENT_TYPES = EVENT_TYPES.select { |key|
       ["Train to Teach Event", "Online Event", "Application Workshop"].include?(key)
     }.freeze

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
     is_online { false }
     building { build :event_building_api }
 
+    trait :closed do
+      status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"] }
+    end
+
     trait :with_provider_info do
       provider_website_url { "https://event-provider.com" }
       provider_target_audience { "Anyone interested in teaching from Sept 2021" }

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:readable_id, &:to_s)
     type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     web_feed_id { "123" }
+    status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "Become a Teacher #{i} event description" }
     message { "An important message" }

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -38,6 +38,48 @@ describe EventsHelper, type: "helper" do
     end
   end
 
+  describe "#event_status_open?" do
+    it "returns true for events that have a status of open" do
+      event = GetIntoTeachingApiClient::TeachingEvent.new(
+        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
+      )
+      expect(event_status_open?(event)).to be_truthy
+    end
+
+    it "returns false for closed events" do
+      event = GetIntoTeachingApiClient::TeachingEvent.new(
+        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"],
+      )
+      expect(event_status_open?(event)).to be_falsy
+    end
+  end
+
+  describe "#can_sign_up_online?" do
+    it "returns true for events with a web_feed_id that are not closed" do
+      event = GetIntoTeachingApiClient::TeachingEvent.new(
+        webFeedId: "abc-123",
+        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
+      )
+      expect(can_sign_up_online?(event)).to be_truthy
+    end
+
+    it "returns false for events without a web_feed_id" do
+      event = GetIntoTeachingApiClient::TeachingEvent.new(
+        webFeedId: nil,
+        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
+      )
+      expect(can_sign_up_online?(event)).to be_falsy
+    end
+
+    it "returns false for closed events" do
+      event = GetIntoTeachingApiClient::TeachingEvent.new(
+        webFeedId: "abc-123",
+        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"],
+      )
+      expect(can_sign_up_online?(event)).to be_falsy
+    end
+  end
+
   describe "#event_type_color" do
     it "returns green for train to teach events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -21,6 +21,12 @@ describe EventStepsController do
     before { get step_path }
     subject { response }
     it { is_expected.to have_http_status :success }
+
+    context "when the event is closed" do
+      let(:event) { build :event_api, :closed, readable_id: readable_event_id }
+
+      it { is_expected.to redirect_to(event_path(id: event.readable_id)) }
+    end
   end
 
   describe "#update" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -107,9 +107,10 @@ describe EventsController do
         end
 
         context "when the event is closed" do
-          let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id, status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]) }
+          let(:event) { build(:event_api, :closed, web_feed_id: "123", readable_id: event_readable_id) }
 
           it { is_expected.to_not match(/How to attend/) }
+          it { is_expected.to match(/This event is now closed/) }
         end
 
         context "when the event is online" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -106,6 +106,12 @@ describe EventsController do
           it { is_expected.to match(/To attend this event, please <a.*visit this website.*a>/) }
         end
 
+        context "when the event is closed" do
+          let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id, status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]) }
+
+          it { is_expected.to_not match(/How to attend/) }
+        end
+
         context "when the event is online" do
           let(:event) { build(:event_api, is_online: true) }
 


### PR DESCRIPTION
### JIRA ticket number

[GITPB-578](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-578)

### Context

If an event has a status of 'Closed' then it should not be possible to sign up or enquire about attendance. Also, if someone attempts to access the sign up page for a closed event we should redirect them and inform them that they cannot sign up.

### Changes proposed in this pull request

- Remove sign up/how to attend from closed events

This commit hides the 'Sign up for this event' buttons from the event detail page if the event accepts online registration and also removes the 'How to attend' section if the event is closed.

- Prevent sign up to closed event

If an event is closed we don't want to let users proceed through the sign up journey. Instead, they will be redirected to the event page which has been updated to include a message when the event is closed for new attendees.

### Guidance to review

![Screenshot 2020-09-04 at 13 15 44](https://user-images.githubusercontent.com/29867726/92238265-c2518a80-eeb0-11ea-8e8a-036ff1f1e9f4.png)

