### PR TITLE
add fullstops to end of page title.

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -33,6 +33,9 @@
                 font-size: 42px;
                 margin: 0;
                 padding: 0;
+                &:after {
+                    content: ".";
+                }
             }
 
             p {


### PR DESCRIPTION
use CSS to add fullstop to end of page header as per branding request. 

