### PR TITLE
GITPB-683 Updated completion logging in wizards for Snapchat and Facebook

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,7 @@ module ApplicationHelper
       "analytics-snapchat-id" => ENV["SNAPCHAT_ID"],
       "analytics-facebook-id" => ENV["FACEBOOK_ID"],
       "analytics-hotjar-id" => ENV["HOTJAR_ID"],
+      "pinterest-action" => "page",
       "snapchat-action" => "track",
       "snapchat-event" => "PAGE_VIEW",
       "facebook-action" => "track",

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -25,11 +25,11 @@
                 data-pinterest-action="track"
                 data-pinterest-event="custom"></span>
 
-            <span data-controller="pinterest"
+            <span data-controller="snapchat"
                 data-pinterest-action="track"
                 data-pinterest-event="INVITE"></span>
 
-            <span data-controller="pinterest"
+            <span data-controller="facebook"
                 data-pinterest-action="track"
                 data-pinterest-event="Event_Registrations"></span>
         </div>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -17,13 +17,13 @@
                 data-pinterest-event="lead"
                 data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
 
-            <span data-controller="pinterest"
-                data-pinterest-action="track"
-                data-pinterest-event="SUBSCRIBE"></span>
+            <span data-controller="snapchat"
+                data-snapchat-action="track"
+                data-snapchat-event="SUBSCRIBE"></span>
 
-            <span data-controller="pinterest"
-                data-pinterest-action="trackCustom"
-                data-pinterest-event="Newsletter_Subscribers"></span>
+            <span data-controller="facebook"
+                data-facebook-action="trackCustom"
+                data-facebook-event="Newsletter_Subscribers"></span>
         </div>
         <div class="content__right">
 

--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
   }
 
   get isEnabled() {
-    return (this.serviceId && this.data.has('action') && this.data.has('event')) ;
+    return (this.serviceId && this.data.has('action')) ;
   }
 
   triggerEvent() {
@@ -47,21 +47,25 @@ export default class extends Controller {
   }
 
   get eventData() {
+    if (typeof(this.parsedEventData) != "undefined")
+      return this.parsedEventData ;
+
     let evData = this.data.get('event-data') ;
+    this.parsedEventData = null ;
 
     if (evData && evData != "")
-      return JSON.parse(evData) ;
-    else
-      return null ;
+      this.parsedEventData = JSON.parse(evData) ;
+
+    return this.parsedEventData ;
   }
 
   sendEvent() {
-    let evData = this.eventData ;
-
-    if (evData)
-      this.serviceFunction(this.serviceAction, this.eventName, evData) ;
-    else
+    if (this.eventData)
+      this.serviceFunction(this.serviceAction, this.eventName, this.eventData) ;
+    else if (this.eventName)
       this.serviceFunction(this.serviceAction, this.eventName) ;
+    else
+      this.serviceFunction(this.serviceAction) ;
   }
 
 }


### PR DESCRIPTION
### JIRA ticket number

GITPB-683

### Context

We should be logging all page views on the TTA service to our analytics platforms

### Changes proposed in this pull request

1. Change the sendEvent function to allow actions without events - needed for pinterest, per page views
2. Fire analytics events on all page views
3. Fire 'completed' events upon completion of the Mailing list and Sign up for an Event flows

### Guidance to review
1. Can be enabled by setting the appropriate env vars in `.env.local` - see here https://github.com/DFE-Digital/get-into-teaching-app/blob/master/.env.preprod - the env vars for pinterest, snapchat and facebook are the ones affected by this PR
