### PR TITLE
Send "is this page helpful?" responses to Prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "dotenv-rails"
 
 gem "govuk_design_system_formbuilder"
 
+gem "prometheus-client"
+
 gem "sentry-raven"
 
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -343,6 +344,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   kramdown
   listen (>= 3.0.5, < 3.3)
+  prometheus-client
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.2)

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,0 +1,21 @@
+class FeedbackController < ApplicationController
+  def page_helpful
+    prometheus = Prometheus::Client.registry
+    counter = prometheus.get(:page_helpful)
+    page_helpful = Feedback::PageHelpful.new(page_helpful_params)
+
+    head(:bad_request) && return if page_helpful.invalid?
+
+    labels = page_helpful.attributes
+      .slice("url", "answer")
+      .transform_keys(&:to_sym)
+    counter.increment(labels: labels)
+    head :ok
+  end
+
+private
+
+  def page_helpful_params
+    params.require(:page_helpful).permit(:url, :answer)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,5 @@
+class SessionsController < ApplicationController
+  def crsf_token
+    render json: { token: form_authenticity_token }
+  end
+end

--- a/app/models/feedback/page_helpful.rb
+++ b/app/models/feedback/page_helpful.rb
@@ -1,0 +1,12 @@
+module Feedback
+  class PageHelpful
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :url, :string
+    attribute :answer, :string
+
+    validates :url, presence: true, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
+    validates :answer, presence: true, inclusion: { in: %w[yes no] }
+  end
+end

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -8,5 +8,4 @@
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
-  <%= javascript_tag "window._token = '#{form_authenticity_token}'" %>
 </head>

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -8,4 +8,5 @@
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+  <%= javascript_tag "window._token = '#{form_authenticity_token}'" %>
 </head>

--- a/app/views/sections/_page-question.erb
+++ b/app/views/sections/_page-question.erb
@@ -1,11 +1,11 @@
-<div class="page-question-wrapper">
+<div class="page-question-wrapper" data-controller="page-helpful">
     <div class="page-question">
         <div class="page-question__left">
-            <strong>Is this page helpful?</strong>
+            <strong data-target="page-helpful.text">Is this page helpful?</strong>
         </div>
         <div class="page-question__right">
-            <a href="#" class="page-question__answer">Yes</a>
-            <a href="#" class="page-question__answer">No</a>
+            <a href="javascript:void(0)" class="page-question__answer" data-target="page-helpful.link" data-action="page-helpful#yes">Yes</a>
+            <a href="javascript:void(0)" class="page-question__answer" data-target="page-helpful.link" data-action="page-helpful#no">No</a>
         </div>
     </div>
 </div>

--- a/app/webpacker/controllers/page_helpful_controller.js
+++ b/app/webpacker/controllers/page_helpful_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
     this.submitAnswer('no')
   }
 
-  submitAnswer(answer) {
+  async submitAnswer(answer) {
     this.disableLinks();
     
     fetch('/feedback/page_helpful', { 
@@ -30,7 +30,7 @@ export default class extends Controller {
           url: window.location.href.split('?')[0], 
           answer 
         }, 
-        authenticity_token: window._token 
+        authenticity_token: await this.getToken() 
       })
     }) 
     .then(() => { 
@@ -42,6 +42,12 @@ export default class extends Controller {
     .finally(() => {
       this.hideLinks();
     });
+  }
+
+  async getToken() {
+    const response = await fetch('/sessions/crsf_token');
+    const json = await response.json();
+    return json.token;
   }
 
   disableLinks() {

--- a/app/webpacker/controllers/page_helpful_controller.js
+++ b/app/webpacker/controllers/page_helpful_controller.js
@@ -1,0 +1,63 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ['text', 'link']
+
+  connect() {
+    this.element.style.display = 'block';
+  }
+
+  yes(e) {
+    e.preventDefault();
+    this.submitAnswer('yes')
+  }
+
+  no(e) {
+    e.preventDefault();
+    this.submitAnswer('no')
+  }
+
+  submitAnswer(answer) {
+    this.disableLinks();
+    
+    fetch('/feedback/page_helpful', { 
+      method: 'POST', 
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ 
+        page_helpful: { 
+          url: window.location.href.split('?')[0], 
+          answer 
+        }, 
+        authenticity_token: window._token 
+      })
+    }) 
+    .then(() => { 
+      this.showThankYouText();
+    })
+    .catch(() => {
+      this.showErrorText();
+    })
+    .finally(() => {
+      this.hideLinks();
+    });
+  }
+
+  disableLinks() {
+    this.linkTargets.forEach((target) => target.disabled = true);
+  }
+
+  showThankYouText() {
+    this.textTarget.textContent = 'Thank you for your feedback';
+  }
+
+  showErrorText() {
+    this.textTarget.textContent = 'Sorry, the response did not send successfully. \
+    We really value your feedback, so please refresh the page or try again later';
+  }
+
+  hideLinks() {
+    this.linkTargets.forEach((target) => target.style.display = 'none');
+  }
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,6 +2,7 @@ require.context('../fonts', true) ;
 require.context('../images', true) ;
 
 import '@stimulus/polyfills'
+import 'whatwg-fetch'
 import '../styles/application.scss';
 import Rails from 'rails-ujs';
 import Turbolinks from 'turbolinks';

--- a/app/webpacker/styles/page-question.scss
+++ b/app/webpacker/styles/page-question.scss
@@ -4,6 +4,7 @@
     clear: both;
     padding: 20px 0 50px;
     box-sizing: border-box;
+    display: none;
 }
 
 .page-question {

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,11 @@
 
 require_relative 'config/environment'
 
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,9 +15,22 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+require "prometheus/client/data_stores/direct_file_store"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+PROMETHEUS_DIR = "/tmp/prometheus".freeze
+
+# Needs to clear before initializing.
+Dir["#{PROMETHEUS_DIR}/*.bin"].each do |file_path|
+  File.unlink(file_path)
+end
+
+# The DirectFileStore is the only way to aggregate metrics across processes.
+file_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_DIR)
+Prometheus::Client.config.data_store = file_store
 
 module GovukRailsBoilerplate
   class Application < Rails::Application

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,1 @@
+require "prometheus/metrics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   post "feedback/page_helpful", to: "feedback#page_helpful", as: :page_helpful_feedback
 
+  get "sessions/crsf_token", to: "sessions#crsf_token"
+
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get "/tta-service", to: "pages#tta_service", as: :tta_service
   get "/tta", to: "pages#tta_service", as: nil
 
+  post "feedback/page_helpful", to: "feedback#page_helpful", as: :page_helpful_feedback
+
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -1,0 +1,11 @@
+module Prometheus
+  module Metrics
+    prometheus = Prometheus::Client.registry
+
+    prometheus.counter(
+      :page_helpful,
+      docstring: "A counter of 'is this page helpful' responses",
+      labels: %i[url answer],
+    )
+  end
+end

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.2",
     "stimulus": "^1.1.1",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {
     "@stimulus/test": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@stimulus/test": "^1.1.1",
     "jest": "^26.0.1",
     "jest-fetch-mock": "^3.0.3",
+    "wait-for-expect": "^3.0.2",
     "webpack-dev-server": "^3.11.0"
   },
   "jest": {
@@ -23,7 +24,9 @@
     "roots": [
       "spec/javascript"
     ],
-    "setupFilesAfterEnv": ["./spec/javascript/jest.setup.js"],
+    "setupFilesAfterEnv": [
+      "./spec/javascript/jest.setup.js"
+    ],
     "moduleDirectories": [
       "node_modules",
       "app/webpacker/controllers"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@stimulus/test": "^1.1.1",
     "jest": "^26.0.1",
+    "jest-fetch-mock": "^3.0.3",
     "webpack-dev-server": "^3.11.0"
   },
   "jest": {
@@ -22,6 +23,7 @@
     "roots": [
       "spec/javascript"
     ],
+    "setupFilesAfterEnv": ["./spec/javascript/jest.setup.js"],
     "moduleDirectories": [
       "node_modules",
       "app/webpacker/controllers"

--- a/spec/javascript/controllers/page_helpful_controller_spec.js
+++ b/spec/javascript/controllers/page_helpful_controller_spec.js
@@ -1,0 +1,99 @@
+import { Application } from 'stimulus' ;
+import PageHelpfulController from 'page_helpful_controller';
+
+describe('PageHelpfulController', () => {
+  document.body.innerHTML = `
+  <div id="pageHelpful" data-controller="page-helpful">
+    <p id="text" data-target="page-helpful.text">Is this page helpful?</p>
+    <a href="javascript:void(0)" id="yesButton" data-target="page-helpful.link" data-action="page-helpful#yes">Yes</a>
+    <a href="javascript:void(0)" id="noButton" data-target="page-helpful.link" data-action="page-helpful#no">No</a>
+  </div>
+  ` ;
+
+  const application = Application.start();
+  application.register('page-helpful', PageHelpfulController);
+  const yesButton = document.getElementById("yesButton");
+  const noButton = document.getElementById("noButton");
+
+  const expectCall = (answer, url = window.location.href) => {
+    expect(fetch.mock.calls.length).toEqual(1);
+
+    const call = fetch.mock.calls[0];
+    const path = call[0];
+    const request = call[1];
+
+    expect(path).toEqual("/feedback/page_helpful");
+    expect(request.method).toEqual("POST");
+    expect(request.headers).toEqual({ "Content-Type": "application/json" });
+    expect(request.body).toEqual(JSON.stringify({ page_helpful: { url, answer: answer }}));
+  }
+
+  beforeEach(() => {
+    window.fetch.resetMocks();
+  });
+
+  describe("on connect", () => {
+    it("displays the page helpful HTML", () => {
+      const pageHelpful = document.getElementById("pageHelpful");
+      expect(pageHelpful.style.display).toContain('block');
+    });
+  });
+
+  describe("submitting an answer", () => {
+    it("sends a 'yes' answer", () => {
+      yesButton.click();
+      expectCall("yes");
+    });
+
+    it("sends a 'no' answer", () => {
+      noButton.click();
+      expectCall("no");
+    });
+
+    it("does not send query parameters as part of the url attribute", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost/test?param=ignore"
+        }
+      });
+      yesButton.click();
+      expectCall("yes", "http://localhost/test");
+    });
+
+    it("disables the links when clicked", () => {
+      yesButton.click();
+      expect(yesButton.disabled).toBeTruthy();
+      expect(noButton.disabled).toBeTruthy();
+    });
+
+    describe("when successfully submitted", () => {
+      beforeEach(() => fetch.mockResponseOnce());
+
+      it("hides the links", () => {
+        yesButton.click();
+        expect(yesButton.style.display).toContain('none');
+        expect(noButton.style.display).toContain('none');
+      });
+  
+      it("displays a thank you message", () => {
+        yesButton.click();
+        expect(text.textContent).toEqual('Thank you for your feedback');
+      });
+    });
+
+    describe("when an error occurs", () => {
+      beforeEach(() => fetch.mockRejectOnce());
+
+      it("hides the links", () => {
+        yesButton.click();
+        expect(yesButton.style.display).toContain('none');
+        expect(noButton.style.display).toContain('none');
+      });
+  
+      it("displays an error message", () => {
+        yesButton.click();
+        expect(text.textContent).toContain('Sorry, the response did not send successfully.');
+      });
+    });
+  });
+});

--- a/spec/javascript/jest.setup.js
+++ b/spec/javascript/jest.setup.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks();

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Prometheus::Metrics do
+  let(:registry) { Prometheus::Client.registry }
+
+  describe "page_helpful" do
+    subject { registry.get(:page_helpful) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of 'is this page helpful' responses") }
+    it { expect { subject.get(labels: %i[url answer]) }.to_not raise_error }
+  end
+end

--- a/spec/models/feedback/page_helpful_spec.rb
+++ b/spec/models/feedback/page_helpful_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Feedback::PageHelpful do
+  it { is_expected.to respond_to :url }
+  it { is_expected.to respond_to :answer }
+
+  context "url" do
+    it {
+      is_expected.to allow_values(
+        "http://test.com/test",
+        "https://test.com/test",
+        "http://www.test.com/test",
+        "https://www.test.com/test",
+      ).for :url
+    }
+    it { is_expected.to_not allow_values(nil, "", " ", "not-a-url").for :url }
+  end
+
+  context "answer" do
+    it { is_expected.to allow_values("yes", "no").for :answer }
+    it { is_expected.to_not allow_values(nil, "", true, false, "maybe").for :answer }
+  end
+end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "POST /feedback/page_helpful" do
+  let(:registry) { Prometheus::Client.registry }
+  let(:metric) { registry.get(:page_helpful) }
+
+  it "increments the :page_helpful metric" do
+    params = { url: "http://test.com/test", answer: "yes" }
+    expect(metric).to receive(:increment).with(labels: params).once
+    post page_helpful_feedback_path, params: { page_helpful: params }
+    expect(response).to have_http_status(:success)
+  end
+
+  it "returns 400 bad request if answer is not yes/no" do
+    params = { url: "http://test.com/test", answer: "maybe" }
+    expect(metric).to_not receive(:increment)
+    post page_helpful_feedback_path, params: { page_helpful: params }
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "returns 400 bad request if url is invalid" do
+    params = { url: "not-a-url", answer: "yes" }
+    expect(metric).to_not receive(:increment)
+    post page_helpful_feedback_path, params: { page_helpful: params }
+    expect(response).to have_http_status(:bad_request)
+  end
+end

--- a/spec/requests/javascript_form_authenticity_token_spec.rb
+++ b/spec/requests/javascript_form_authenticity_token_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+describe "Javascript form authenticity token" do
+  before { get root_path }
+  subject { response.body }
+  it { is_expected.to match(/window\._token = '.{88}'/) }
+end

--- a/spec/requests/javascript_form_authenticity_token_spec.rb
+++ b/spec/requests/javascript_form_authenticity_token_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-describe "Javascript form authenticity token" do
-  before { get root_path }
-  subject { response.body }
-  it { is_expected.to match(/window\._token = '.{88}'/) }
-end

--- a/spec/requests/session_spec.rb
+++ b/spec/requests/session_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe "GET /sessions/form_authenticity_token" do
+  before { get sessions_crsf_token_path }
+  subject { response }
+
+  it { is_expected.to have_http_status(:success) }
+
+  context "within the response body" do
+    subject { response.body }
+
+    it { is_expected.to match(/{"token":".{88}"}/) }
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,6 +2773,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  dependencies:
+    node-fetch "2.6.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4972,6 +4979,14 @@ jest-environment-node@^26.0.1:
     jest-mock "^26.0.1"
     jest-util "^26.0.1"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.0.0.tgz#381e986a718998dbfafcd5ec05934be538db4039"
@@ -5955,6 +5970,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -7349,6 +7369,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9324,6 +9324,11 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
+
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9163,6 +9163,11 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
### JIRA ticket number

[GITPB-574](https://dfedigital.atlassian.net/browse/GITPB-547)

### Context

We currently as the user on various content pages 'is this page helpful?' but the links for yes/no are not connected to any storage mechanism. 

- We want to send these responses through to Prometheus so we can display them in a Grafana dashboard. 
- When a user has sent a response we want to display the text "Thank you for your feedback" and hide the yes/no buttons. 
- If there is a problem when sending the response we should show an error message to the user, prompting them to try again.
- If the user has Javascript disabled the feedback box should not display at all. 

### Changes proposed in this pull request

- Add Prometheus::Client

Add the `Prometheus::Client` for aggregating and exporting metrics on the `/metrics` endpoint.

Configured to use `DirectFileStore` as this supports Puma forking additional processes (by default metrics will be summed together; if we use a gauge metric this may not be desirable).

- Add FeedbackController to increment :page_helpful metric

Introduces the `FeedbackController` which will increment a `:page_helpful` counter metric, tagging it with labels for the URL and the 'answer' (yes or no).

This will be called when a user hits the yes/no links in response to the question 'Is this page useful?'

- Expose form authenticity token to Javascript

We will need to make a POST ajax request from a Stimulus controller in order to submit the feedback 'page helpful' answer. This exposes the form authenticity token to JS so that we can use it when making the request.

- Add fetch polyfill

So that we can support `fetch` in IE.

- Add PageHelpfulController for sending responses

Adds a Stimulus controller to send feedback responses to the application when the user clicks yes/no. We display a thank you message to the user when their submission has been sent. If there was an error we inform the user that their submission was not successful.

### Guidance to review

Best reviewed by-commit.