### PR TITLE
Add mobile support to feedback prompt

### DIFF
--- a/app/webpacker/controllers/feedback_prompt_controller.js
+++ b/app/webpacker/controllers/feedback_prompt_controller.js
@@ -1,20 +1,51 @@
 import { Controller } from "stimulus"
+import isTouchDevice from 'is-touch-device';
 
 export default class extends Controller {
   static targets = ['dialog'];
-  sensitivity = 20;
+  topExitSensitivity = 20;
+  topScrollEndSensitivity = 300;
+  topScrollMinimumDistance = 700;
 
   connect() {
-    this.handleMouseLeave = this.showDialog.bind(this);
+    if (isTouchDevice()) {
+      this.setupTouchDevice();
+    } else {
+      this.setupDesktop();
+    }
+  }
+  
+  setupDesktop() {
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
     document.documentElement.addEventListener('mouseleave', this.handleMouseLeave);
   }
 
-  disconnect() {
-    document.documentElement.removeEventListener('mouseleave', this.handleMouseLeave);
+  setupTouchDevice() {
+    this.monitorScrollDistance((distance, _start, end) => {
+      const scrollUp = distance < 0;
+      const atTop = end < this.topScrollEndSensitivity;
+      const longScroll = Math.abs(distance) >= this.topScrollMinimumDistance;
+
+      if (!scrollUp || !atTop || !longScroll) { 
+        return;
+      }
+
+      this.showDialog();
+    });
   }
 
-  showDialog(e) {
-    if (this.disabled || e.clientY > this.sensitivity) {
+  disconnect() {
+    if (this.handleMouseLeave) {
+      document.documentElement.removeEventListener('mouseleave', this.handleMouseLeave);
+    }
+
+    if (this.handleScroll) {
+      window.removeEventListener('scroll', this.handleScroll);
+    }
+  }
+
+  showDialog() {
+    if (this.disabled) {
       return;
     }
 
@@ -32,6 +63,36 @@ export default class extends Controller {
     expiry.setFullYear(expiry.getFullYear() + 1);
     document.cookie = `${this.cookie}; expires=${expiry.toUTCString()}`
   }
+
+  handleMouseLeave(e) {
+    if (e.clientY <= this.topExitSensitivity) {
+      this.showDialog();
+    }
+  }
+
+  monitorScrollDistance(callback) {
+    var isScrolling, start, end, distance;
+
+    const onScroll = () => {
+      if (!start) {
+        start = window.pageYOffset;
+      }
+
+      window.clearTimeout(isScrolling);
+  
+      isScrolling = setTimeout(() => {
+        end = window.pageYOffset;
+        distance = end - start;
+  
+        callback(distance, start, end);
+  
+        start = end = distance = null;
+      }, 50);
+    };
+
+    this.handleScroll = onScroll.bind(this);
+    window.addEventListener('scroll', this.handleScroll, false);
+  };
 
   get cookiesAccepted() {
     return document.cookie.indexOf('GiTBetaCookie=Accepted') > -1;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@rails/webpacker": "^5.1.1",
     "@stimulus/polyfills": "^1.1.1",
     "govuk-frontend": "^3.6.0",
+    "is-touch-device": "^1.0.1",
     "rails-ujs": "^5.2.4",
     "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,6 +4774,11 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
+is-touch-device@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-touch-device/-/is-touch-device-1.0.1.tgz#9a2fd59f689e9a9bf6ae9a86924c4ba805a42eab"
+  integrity sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"


### PR DESCRIPTION
### JIRA ticket number

[GITPB-700](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-700)

### Context

When on mobile we want to show the feedback banner if a user suddenly scrolls to the top of the page (indicating they are going to leave the page). Specifically, we want to show the banner if:

- The user scrolls up
- They scroll up by at least 700px
- The end position of their scroll is within 300px of the top of the window

### Changes proposed in this pull request

- Add mobile support to feedback prompt

### Guidance to review

![Screenshot 2020-09-11 at 08 29 19](https://user-images.githubusercontent.com/29867726/92883595-eceb9800-f408-11ea-8a0b-863c02cd4e76.png)
