### PR TITLE
Prevent mailing list sign up if already signed up for TTA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 8c2f175fcb86236d68c931be3fee1f2662568b85
+  revision: e6903ee25cd33f549d35d625f7029f97d717fd15
   specs:
-    get_into_teaching_api_client (1.1.1)
+    get_into_teaching_api_client (1.1.2)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.1)
+    get_into_teaching_api_client_faraday (0.1.2)
       activesupport
       faraday
       faraday-encoding
@@ -97,7 +97,7 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -133,7 +133,7 @@ GEM
       activesupport (>= 5.2)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
     kramdown (2.3.0)
@@ -152,7 +152,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     msgpack (1.3.3)
     multipart-post (2.1.1)
     nio4r (2.5.2)
@@ -321,7 +321,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/app/models/mailing_list/steps/already_subscribed.rb
+++ b/app/models/mailing_list/steps/already_subscribed.rb
@@ -2,11 +2,19 @@ module MailingList
   module Steps
     class AlreadySubscribed < ::Wizard::Step
       def skipped?
-        !@store["already_subscribed_to_mailing_list"]
+        !subscribed_to_mailing_list? && !subscribed_to_teacher_training_adviser?
       end
 
       def can_proceed?
         false
+      end
+
+      def subscribed_to_mailing_list?
+        @store["already_subscribed_to_mailing_list"]
+      end
+
+      def subscribed_to_teacher_training_adviser?
+        @store["already_subscribed_to_teacher_training_adviser"]
       end
     end
   end

--- a/app/views/mailing_list/steps/_already_subscribed.html.erb
+++ b/app/views/mailing_list/steps/_already_subscribed.html.erb
@@ -1,5 +1,13 @@
+<% if f.object.subscribed_to_teacher_training_adviser? %>
+<h1>You have already signed up to an adviser</h1>
+
+<p>The email address <%= mailing_list_session["email"] %> has already signed up to get an adviser.</p>
+<p>Our email updates are intended for users who have not yet signed up for our Get an adviser service.</p>
+<p>The level of support you receive from an adviser will be more in-depth and personal to you than the information we provide in our emails.</p>
+<% else %>
 <h1>You’ve already signed up</h1>
 
 <p>
 The email address <%= mailing_list_session["email"] %> has already signed up to receive emails.
 </p>
+<% end %>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "How close are you to applying"
   end
 
-  scenario "Full journey as an existing candidate that has already subscribed" do
+  scenario "Full journey as an existing candidate that has already subscribed to the mailing list" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token)
 
@@ -178,6 +178,30 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "You’ve already signed up"
+    expect(page).to_not have_button("Next Step")
+  end
+
+  scenario "Full journey as an existing candidate that has already subscribed to a teacher training adviser" do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+
+    response = GetIntoTeachingApiClient::MailingListAddMember.new(
+      alreadySubscribedToTeacherTrainingAdviser: true,
+    )
+    allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+
+    visit mailing_list_steps_path
+
+    expect(page).to have_text "Sign up for personalised updates"
+    fill_in_name_step(degree_status: "Final year")
+    click_on "Next Step"
+
+    expect(page).to have_text "Verify your email address"
+    fill_in "Enter the verification code sent to test@user.com", with: "123456"
+    click_on "Next Step"
+
+    expect(page).to have_text "You have already signed up to an adviser"
     expect(page).to_not have_button("Next Step")
   end
 

--- a/spec/models/mailing_list/steps/already_subscribed_spec.rb
+++ b/spec/models/mailing_list/steps/already_subscribed_spec.rb
@@ -15,8 +15,21 @@ describe MailingList::Steps::AlreadySubscribed do
       expect(subject).to be_skipped
     end
 
+    it "returns true if already_subscribed_to_teacher_training_adviser is false/nil/undefined" do
+      expect(subject).to be_skipped
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = nil
+      expect(subject).to be_skipped
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = false
+      expect(subject).to be_skipped
+    end
+
     it "returns false if already_subscribed_to_mailing_list is true" do
       wizardstore["already_subscribed_to_mailing_list"] = true
+      expect(subject).to_not be_skipped
+    end
+
+    it "returns false if already_subscribed_to_teacher_training_adviser is true" do
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = true
       expect(subject).to_not be_skipped
     end
   end


### PR DESCRIPTION
### JIRA ticket number

[GITPB-701](https://dfedigital.atlassian.net/browse/GITPB-701)

### Context

If a candidate has already signed up for a teacher training adviser, the mailing list content is not going to be applicable to them anymore.

### Changes proposed in this pull request

- Prevent mailing list sign up if already signed up for TTA

This adds a check to show the 'AlreadySubscribed' step if they have signed up for a TTA.

### Guidance to review

![Screenshot 2020-09-11 at 11 39 10](https://user-images.githubusercontent.com/29867726/92914580-a9525780-f423-11ea-99f5-91fa2367bd90.png)