### PR TITLE
Security headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "bootsnap", ">= 1.1.0", require: false
 # Manage multiple processes i.e. web server and webpack
 gem "foreman"
 
+gem "secure_headers"
+
 # Canonical meta tag
 gem "canonical-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     scss_lint-govuk (0.2.0)
       scss_lint
+    secure_headers (6.3.1)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -352,6 +353,7 @@ DEPENDENCIES
   rspec-sonarqube-formatter (~> 1.3)
   rubocop-govuk
   scss_lint-govuk
+  secure_headers
   sentry-raven
   shoulda-matchers
   simplecov (<= 0.17)

--- a/config/initializers/cookie_store.rb
+++ b/config/initializers/cookie_store.rb
@@ -1,3 +1,4 @@
 Rails.application.config.session_store :cookie_store,
                                        key: "_dfe_session",
-                                       same_site: :lax
+                                       same_site: :lax,
+                                       secure: Rails.env.production?

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,0 +1,27 @@
+# rubocop:disable Lint/PercentStringArray
+SecureHeaders::Configuration.default do |config|
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_download_options = "noopen"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
+  config.csp = {
+    default_src: %w['none'],
+    base_uri: %w['self'],
+    block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
+    child_src: %w['self' *.youtube.com *.scribblelive.com],
+    connect_src: %w['self'],
+    font_src: %w['self'],
+    form_action: %w['self'],
+    frame_ancestors: %w['none'],
+    img_src: %w['self'],
+    manifest_src: %w['self'],
+    media_src: %w['self'],
+    script_src: %w['self' 'unsafe-inline' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net *.scribblelive.com],
+    style_src: %w['self' 'unsafe-inline'],
+    worker_src: %w['self'],
+    upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+  }
+end
+# rubocop:enable Lint/PercentStringArray


### PR DESCRIPTION
### JIRA ticket number

[GITPB-678](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?selectedIssue=GITPB-678)

### Context

We want to make sure all cookies have the `secure` flag and an appropriate CSP is configured, along with other security headers flagged in the PEN test (x-content-type, x-xss-protection, x-frame-options).

### Changes proposed in this pull request

- Enable secure cookies in production

- Configure CSP headers

Adds `SecureHeaders` gem for easily configuring CSP headers (Rails has this built in but the gem will prevent unsupported headers being sent if the browser doesn't support them, avoiding potential errors in dev).

CSP is basically locked down to self with inline styles and JS allowed (we should aim to remove the inline JS in the future). Allows YouTube and Scribble as a src for iframes. Allows JS from tracking pixel domains and scribble.

### Guidance to review

We allow inline JS due to a couple of places still doing this, but we should aim to remove these and lock down that CSP option in the future.