### PR TITLE
Hide opt-in to personalised information if subscribed to TTA

### DIFF
--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -14,14 +14,22 @@ module Events
         @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
       end
 
-      def already_subscribed_to_mailing_list?
-        @store["already_subscribed_to_mailing_list"]
+      def can_subscribe_to_mailing_list?
+        !already_subscribed_to_mailing_list? && !already_subscribed_to_teacher_training_adviser?
       end
 
     private
 
       def mailing_list_values
-        already_subscribed_to_mailing_list? ? [true, false, nil] : [true, false]
+        can_subscribe_to_mailing_list? ? [true, false] : [true, false, nil]
+      end
+
+      def already_subscribed_to_mailing_list?
+        @store["already_subscribed_to_mailing_list"]
+      end
+
+      def already_subscribed_to_teacher_training_adviser?
+        @store["already_subscribed_to_teacher_training_adviser"]
       end
     end
   end

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -11,7 +11,7 @@
         label: { text: "Yes" } %>
 <% end %>
 
-<% unless f.object.already_subscribed_to_mailing_list? %>
+<% if f.object.can_subscribe_to_mailing_list? %>
   <div data-controller="last-step" data-last-step-complete="Complete sign up" data-last-step-continue="Next Step">
     <div data-action="click->last-step#updateSubmit">
       <%= f.govuk_radio_buttons_fieldset :subscribe_to_mailing_list, inline: true do %>

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -24,8 +24,15 @@ describe Events::Steps::FurtherDetails do
     it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
     it { is_expected.not_to allow_value("").for :subscribe_to_mailing_list }
 
-    context "already_subscribed" do
+    context "already_subscribed_to_mailing_list" do
       let(:backingstore) { { "already_subscribed_to_mailing_list" => true } }
+      it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
+      it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
+      it { is_expected.to allow_value("").for :subscribe_to_mailing_list }
+    end
+
+    context "already_subscribed_to_teacher_training_adviser" do
+      let(:backingstore) { { "already_subscribed_to_teacher_training_adviser" => true } }
       it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("").for :subscribe_to_mailing_list }


### PR DESCRIPTION
### JIRA ticket number

[GITPB-702](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-702)

### Context

If a candidate has subscribed to the TTA service already, then the mailing list is not going to be of value to them and we should not show the option to opt-in.

### Changes proposed in this pull request

- Hide opt-in to personalised information if subscribed to TTA service

### Guidance to review

