### PR TITLE
Drop unsafe-inline from the script CSP

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,11 +3,6 @@ class PagesController < ApplicationController
   around_action :cache_static_page, only: %i[show]
   rescue_from ActionView::MissingTemplate, with: :rescue_missing_template
 
-  def scribble
-    @page_title = "Scribble Test"
-    render template: "pages/scribble"
-  end
-
   def privacy_policy
     @page_title = "Privacy Policy"
     policy_id = params[:id]

--- a/app/views/pages/scribble.html.erb
+++ b/app/views/pages/scribble.html.erb
@@ -1,6 +1,0 @@
-<div role="main" id="main-content">
-    <br/><br/>
-    <div class="scrbbl-embed" data-src="/event/2931242/38942"></div>
-    <script>(function(d, s, id) {var js,ijs=d.getElementsByTagName(s)[0];if(d.getElementById(id))return;js=d.createElement(s);js.id=id;js.src="//embed.scribblelive.com/widgets/embed.js";ijs.parentNode.insertBefore(js, ijs);}(document, 'script', 'scrbbl-js'));</script>
-    <br/><br/>
-</div>

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -40,26 +40,3 @@
 
     </div>
 </nav>
-
-<script>
-
-    //polyfill for ie8
-    if (!Element.prototype.matches) {
-        Element.prototype.matches = Element.prototype.msMatchesSelector || 
-        Element.prototype.webkitMatchesSelector;
-    }
-
-    if (!Element.prototype.closest) {
-        Element.prototype.closest = function(s) {
-        var el = this;
-
-        do {
-            if (Element.prototype.matches.call(el, s)) return el;
-            el = el.parentElement || el.parentNode;
-        } while (el !== null && el.nodeType === 1);
-        return null;
-    };
-    
-}
-
-</script>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,6 +3,7 @@ require.context('../images', true) ;
 
 import '@stimulus/polyfills'
 import '../styles/application.scss';
+import 'polyfills/ie8.js';
 import Rails from 'rails-ujs';
 import Turbolinks from 'turbolinks';
 

--- a/app/webpacker/polyfills/ie8.js
+++ b/app/webpacker/polyfills/ie8.js
@@ -1,0 +1,14 @@
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this;
+    do {
+      if (Element.prototype.matches.call(el, s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -10,7 +10,7 @@ SecureHeaders::Configuration.default do |config|
     default_src: %w['none'],
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
-    child_src: %w['self' *.youtube.com *.scribblelive.com],
+    child_src: %w['self' *.youtube.com],
     connect_src: %w['self'],
     font_src: %w['self'],
     form_action: %w['self'],
@@ -18,7 +18,7 @@ SecureHeaders::Configuration.default do |config|
     img_src: %w['self'],
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %w['self' 'unsafe-inline' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net *.scribblelive.com],
+    script_src: %w['self' 'unsafe-inline' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
     style_src: %w['self' 'unsafe-inline'],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -18,7 +18,7 @@ SecureHeaders::Configuration.default do |config|
     img_src: %w['self'],
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %w['self' 'unsafe-inline' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
+    script_src: %w['self' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
     style_src: %w['self' 'unsafe-inline'],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
   end
 
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
-  get "/scribble", to: "pages#scribble", via: :all, as: nil
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/tta-service", to: "pages#tta_service", as: :tta_service
   get "/tta", to: "pages#tta_service", as: nil


### PR DESCRIPTION
### JIRA ticket number

[GITPB-707](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-707)

### Context

We currently allow `unsafe-inline` Javascript to execute in the application; this is due to it being used for some IE8 polyfills and the Scribble JS snippet. Instead, we should move these to be packaged in the main JS bundle and then we can drop the `unsafe-inline` from the script CSP.

### Changes proposed in this pull request

- Move IE8 JS polyfills into pack

- Remove test Scribble code

We will be implementing this properly in the future, but removing it for now will allow us to drop the `unsafe-inline` style CSP.

- Remove unsafe-inline from script CSP

### Guidance to review

