### PR TITLE
Remove unused subscribe_to_events attribute

### DIFF
--- a/app/models/mailing_list/steps/contact.rb
+++ b/app/models/mailing_list/steps/contact.rb
@@ -12,14 +12,6 @@ module MailingList
         self.telephone = telephone.to_s.strip.presence
       end
 
-      def save
-        if valid?
-          @store["subscribe_to_events"] = true
-        end
-
-        super
-      end
-
       def latest_privacy_policy
         @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
       end

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -35,37 +35,4 @@ describe MailingList::Steps::Contact do
   context "accept_privacy_policy" do
     it { is_expected.to validate_acceptance_of :accept_privacy_policy }
   end
-
-  describe "#save" do
-    context "when invalid" do
-      before do
-        subject.accept_privacy_policy = nil
-        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to_not \
-          receive(:get_latest_privacy_policy)
-      end
-
-      it "does not update the store" do
-        expect(subject).to_not be_valid
-        subject.save
-        expect(wizardstore["subscribe_to_events"]).to be_nil
-      end
-    end
-
-    context "when valid" do
-      let(:response) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
-
-      before do
-        subject.accept_privacy_policy = true
-
-        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-          receive(:get_latest_privacy_policy).and_return(response)
-      end
-
-      it "updates the store" do
-        expect(subject).to be_valid
-        subject.save
-        expect(wizardstore["subscribe_to_events"]).to be_truthy
-      end
-    end
-  end
 end


### PR DESCRIPTION
The API no longer accepts this attribute from the client (we infer if they should get an events subscription based on if they provided a postcode).
