### PR TITLE
Send CSP violations to Sentry

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -4,3 +4,4 @@
 # FACEBOOK_ID=241400573208008
 GOOGLE_TAG_MANAGER_ID=GTM-K7TK4WM
 TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a29813939539467a89d2d92062a6c7a0"

--- a/.env.production
+++ b/.env.production
@@ -4,3 +4,4 @@
 # FACEBOOK_ID=241400573208008
 # GOOGLE_TAG_MANAGER_ID=UA-159214613-2
 TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=613c386327c3467383c35924148435e5"

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,2 +1,3 @@
 # Add public environment variables here for the Rolling environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a3b324c98fe94a858c87267a656768e8"

--- a/.env.userresearch
+++ b/.env.userresearch
@@ -5,3 +5,4 @@
 GOOGLE_TAG_MANAGER_ID=GTM-TCZDM7V
 HOTJAR_ID=1871524
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-ur.london.cloudapps.digital/"
+SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=7c23120dec954783b05e503003546514"

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -22,6 +22,7 @@ SecureHeaders::Configuration.default do |config|
     style_src: %w['self' 'unsafe-inline'],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+    report_uri: [ENV["SENTRY_CSP_REPORT_URI"]],
   }
 end
 # rubocop:enable Lint/PercentStringArray


### PR DESCRIPTION
### JIRA ticket number

[GITPB-706](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-706)

### Context

If a CSP violation is triggered we want to report the violation to Sentry so that we will be notified/alerted.

### Changes proposed in this pull request

- Send CSP violations to Sentry
- Rename `initializers/csp` to `initializers/secure_headers` as this file does more than just the CSP.

### Guidance to review

