### PR TITLE
Add support for on-campus mailing list sign ups

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -4,5 +4,6 @@ SNAPCHAT_ID=c7147501-f387-420a-b498-7134ee247bbd
 FACEBOOK_ID=241400573208008
 TWITTER_ID=o0wo4
 GOOGLE_TAG_MANAGER_ID=GTM-K7TK4WM
+BAM_ID=1
 TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
 SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a29813939539467a89d2d92062a6c7a0"

--- a/.env.production
+++ b/.env.production
@@ -3,5 +3,6 @@
 # SNAPCHAT_ID=c7147501-f387-420a-b498-7134ee247bbd
 # FACEBOOK_ID=241400573208008
 # GOOGLE_TAG_MANAGER_ID=UA-159214613-2
+BAM_ID=1
 TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
 SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=613c386327c3467383c35924148435e5"

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,3 +1,4 @@
 # Add public environment variables here for the Rolling environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a3b324c98fe94a858c87267a656768e8"
+BAM_ID=1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: e6903ee25cd33f549d35d625f7029f97d717fd15
+  revision: 06cfd0441cb87f4d5697ec6aa0eca65d434f3fee
   specs:
     get_into_teaching_api_client (1.1.2)
       json (~> 2.1, >= 2.1.0)

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -7,7 +7,8 @@ module WizardSteps
   end
 
   def index
-    redirect_to step_path(wizard_class.first_key)
+    query_params = request.query_parameters
+    redirect_to step_path(wizard_class.first_key, query_params)
   end
 
   def show

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -7,8 +7,8 @@ module MailingList
 
   private
 
-    def step_path(step = params[:id])
-      mailing_list_step_path step
+    def step_path(step = params[:id], urlparams = {})
+      mailing_list_step_path step, urlparams
     end
     helper_method :step_path
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,7 @@ module ApplicationHelper
       "analytics-facebook-id" => ENV["FACEBOOK_ID"],
       "analytics-hotjar-id" => ENV["HOTJAR_ID"],
       "analytics-twitter-id" => ENV["TWITTER_ID"],
+      "analytics-bam-id" => ENV["BAM_ID"],
       "pinterest-action" => "page",
       "snapchat-action" => "track",
       "snapchat-event" => "PAGE_VIEW",

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -7,6 +7,7 @@ module MailingList
       attribute :last_name
       attribute :email
       attribute :degree_status_id, :integer
+      attribute :channel_id, :integer
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true, length: { maximum: 256 }
@@ -14,6 +15,7 @@ module MailingList
       validates :degree_status_id,
                 presence: true,
                 inclusion: { in: :degree_status_option_ids }
+      validates :channel_id, inclusion: { in: :channel_ids, allow_nil: true }
 
       before_validation if: :email do
         self.email = email.to_s.strip
@@ -35,10 +37,18 @@ module MailingList
         degree_status_options.map { |option| option.id.to_i }
       end
 
+      def channel_ids
+        query_channels.map { |channel| channel.id.to_i }
+      end
+
     private
 
       def query_degree_status
         GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
+      end
+
+      def query_channels
+        @query_channels ||= GetIntoTeachingApiClient::TypesApi.new.get_candidate_mailing_list_subscription_channels
       end
     end
   end

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -16,6 +16,7 @@
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
 <%= f.govuk_email_field :email %>
+<%= f.hidden_field :channel_id, value: params[:channel] %>
 
 <%= f.govuk_collection_select :degree_status_id,
       f.object.degree_status_options,

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -24,6 +24,8 @@
             <span data-controller="facebook"
                 data-facebook-action="trackCustom"
                 data-facebook-event="Newsletter_Subscribers"></span>
+
+            <span data-controller="bam" data-bam-action="track"></span>
         </div>
         <div class="content__right">
 

--- a/app/webpacker/controllers/bam_controller.js
+++ b/app/webpacker/controllers/bam_controller.js
@@ -1,0 +1,38 @@
+import AnalyticsBaseController from "./analytics_base_controller"
+
+export default class extends AnalyticsBaseController {
+  static ids = [
+    '3g6cKlN4VmA4FAL/1SlB2',
+    'nis3acYUOeaVpuG/RPOzc',
+    'cfZRDrq9SRKrBVU/FpASD',
+    'V8R6qhowRkziLjG/Eg0N9',
+    'X4KBgSPXbMgXXon/CRJA9',
+    'MP8YKC867PjN6Rl/BTYf2',
+    '5DRPPG8Sakm5o8i/4yVXp',
+    'fSSR83JdeURiiQ3/YNZ99',
+    'nwQx6WBpT23FfAn/1hnVZ',
+    '3BSBg0IMtWQmpkb/wFCtJ',
+    '1MbhNg55GhAVDkd/3VrFR',
+  ];
+
+  get serviceId() {
+    return this.getServiceId('bam-id') ;
+  }
+
+  get serviceFunction() {
+    return window.bam;
+  }
+
+  get cookieCategory() {
+    return 'non-functional';
+  }
+
+  initService() {
+    // Empty as this is an image tracking pixel.
+    window.bam = () => {};
+  }
+
+  sendEvent() {
+    this.constructor.ids.forEach((id) => fetch(`https://linkbam.uk/m/${id}.png`, { mode: 'no-cors'}));
+  }
+}

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -15,7 +15,7 @@ SecureHeaders::Configuration.default do |config|
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self' *.youtube.com ct.pinterest.com tr.snapchat.com *.hotjar.com],
-    connect_src: %W['self' #{tta_service_uri.host} #{google_analytcs} ct.pinterest.com *.hotjar.com],
+    connect_src: %W['self' linkbam.uk #{tta_service_uri.host} #{google_analytcs} ct.pinterest.com *.hotjar.com],
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com],
     frame_ancestors: %w['none'],

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -15,6 +15,13 @@ module GetIntoTeachingApiClient
         "Closed" => 222_750_001,
       }.freeze
 
+    # This is not a complete list.
+    CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS =
+      {
+        "GITIS - On Campus - Careers Services activity" => 222_750_037,
+        "GITIS - On Campus - Students Union Media" => 222_750_038,
+      }.freeze
+
     GET_INTO_TEACHING_EVENT_TYPES = EVENT_TYPES.select { |key|
       ["Train to Teach Event", "Online Event", "Application Workshop"].include?(key)
     }.freeze

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.2",
     "stimulus": "^1.1.1",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {
     "@stimulus/test": "^1.1.1",
     "jest": "^26.0.1",
+    "jest-fetch-mock": "^3.0.3",
     "webpack-dev-server": "^3.11.0"
   },
   "jest": {
@@ -27,6 +29,9 @@
       "node_modules",
       "app/webpacker/controllers",
       "app/webpacker/javascript"
+    ],
+    "setupFilesAfterEnv": [
+      "./spec/javascript/jest.setup.js"
     ]
   },
   "scripts": {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 describe ApplicationHelper do
   describe "#analytics_body_tag" do
-    let(:gtm_id) { "1234" }
-    let(:pinterest_id) { gtm_id }
-    let(:snapchat_id) { gtm_id }
-    let(:facebook_id) { gtm_id }
-    let(:twitter_id) { gtm_id }
+    let(:id) { "1234" }
+    let(:gtm_id) { id }
+    let(:bam_id) { id }
+    let(:pinterest_id) { id }
+    let(:snapchat_id) { id }
+    let(:facebook_id) { id }
+    let(:twitter_id) { id }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -15,6 +17,7 @@ describe ApplicationHelper do
       allow(ENV).to receive(:[]).with("SNAPCHAT_ID").and_return snapchat_id
       allow(ENV).to receive(:[]).with("FACEBOOK_ID").and_return facebook_id
       allow(ENV).to receive(:[]).with("TWITTER_ID").and_return twitter_id
+      allow(ENV).to receive(:[]).with("BAM_ID").and_return bam_id
     end
 
     subject { analytics_body_tag { "<h1>TEST</h1>".html_safe } }
@@ -35,24 +38,27 @@ describe ApplicationHelper do
       it { is_expected.to have_css "body[data-analytics-snapchat-id=1234]" }
       it { is_expected.to have_css "body[data-analytics-facebook-id=1234]" }
       it { is_expected.to have_css "body[data-analytics-twitter-id=1234]" }
+      it { is_expected.to have_css "body[data-analytics-bam-id=1234]" }
     end
 
     context "with blank service ids" do
-      let(:gtm_id) { "" }
+      let(:id) { "" }
       it { is_expected.to have_css "body[data-analytics-gtm-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-pinterest-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-snapchat-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-facebook-id=\"\"]" }
       it { is_expected.to have_css "body[data-analytics-twitter-id=\"\"]" }
+      it { is_expected.to have_css "body[data-analytics-bam-id=\"\"]" }
     end
 
     context "with no service ids" do
-      let(:gtm_id) { nil }
+      let(:id) { nil }
       it { is_expected.not_to have_css "body[data-analytics-gtm-id]" }
       it { is_expected.not_to have_css "body[data-analytics-pinterest-id]" }
       it { is_expected.not_to have_css "body[data-analytics-snapchat-id]" }
       it { is_expected.not_to have_css "body[data-analytics-facebook-id]" }
       it { is_expected.not_to have_css "body[data-analytics-twitter-id]" }
+      it { is_expected.not_to have_css "body[data-analytics-bam-id]" }
     end
 
     context "default events" do

--- a/spec/javascript/controllers/bam_controller_spec.js
+++ b/spec/javascript/controllers/bam_controller_spec.js
@@ -1,0 +1,47 @@
+const Cookies = require('js-cookie');
+import AnalyticsHelper from './analytics_spec_helper';
+import BamController from 'bam_controller';
+
+describe('BamController', () => {
+  document.head.innerHTML = `<script></script>`;
+  document.body.innerHTML = `
+  <div
+    data-controller="bam"
+    data-bam-action="test"
+    data-bam-event="test"
+  >
+  </div>
+  `;
+
+  // window appears to not be getting redefined between runs, so remove manually
+  afterEach(() => { delete window.bam })
+
+  AnalyticsHelper.describeWithCookieSet('bam', BamController, 'bam', 'non-functional')
+  AnalyticsHelper.describeWhenEventFires('bam', BamController, 'bam', 'non-functional')
+
+  describe("tracking pixels", () => {
+    beforeEach(() => { 
+      AnalyticsHelper.setAcceptedCookie();
+      AnalyticsHelper.initApp('bam', BamController, 'bam');
+      window.fetch.resetMocks();
+    })
+
+    it("makes a fetch request for each pixel", () => {
+      const urls = fetch.mock.calls.map((call) => call[0]);
+
+      expect(urls).toEqual([
+        'https://linkbam.uk/m/3g6cKlN4VmA4FAL/1SlB2.png',
+        'https://linkbam.uk/m/nis3acYUOeaVpuG/RPOzc.png',
+        'https://linkbam.uk/m/cfZRDrq9SRKrBVU/FpASD.png',
+        'https://linkbam.uk/m/V8R6qhowRkziLjG/Eg0N9.png',
+        'https://linkbam.uk/m/X4KBgSPXbMgXXon/CRJA9.png',
+        'https://linkbam.uk/m/MP8YKC867PjN6Rl/BTYf2.png',
+        'https://linkbam.uk/m/5DRPPG8Sakm5o8i/4yVXp.png',
+        'https://linkbam.uk/m/fSSR83JdeURiiQ3/YNZ99.png',
+        'https://linkbam.uk/m/nwQx6WBpT23FfAn/1hnVZ.png',
+        'https://linkbam.uk/m/3BSBg0IMtWQmpkb/wFCtJ.png',
+        'https://linkbam.uk/m/1MbhNg55GhAVDkd/3VrFR.png'
+      ])
+    })
+  })
+})

--- a/spec/javascript/jest.setup.js
+++ b/spec/javascript/jest.setup.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks();

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -10,9 +10,17 @@ describe MailingList::Steps::Name do
     end
   end
 
+  let(:channels) do
+    GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
   end
 
   it { is_expected.to respond_to :first_name }
@@ -49,6 +57,13 @@ describe MailingList::Steps::Name do
     it { is_expected.not_to allow_value(nil).for :degree_status_id }
     it { is_expected.not_to allow_value("").for :degree_status_id }
     it { is_expected.not_to allow_value(12_345).for :degree_status_id }
+  end
+
+  context "channel_id" do
+    let(:options) { channels.map(&:id) }
+    it { is_expected.to allow_values(options).for :channel_id }
+    it { is_expected.to allow_value(nil, "").for :channel_id }
+    it { is_expected.to_not allow_value(12_345).for :channel_id }
   end
 
   context "when the step is valid" do

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -17,6 +17,12 @@ describe EventStepsController do
       receive(:get_teaching_event).and_return event
   end
 
+  describe "#index" do
+    before { get event_steps_path("123", query: "param") }
+    subject { response }
+    it { is_expected.to redirect_to(event_step_path("123", { id: :personal_details, query: "param" })) }
+  end
+
   describe "#show" do
     before { get step_path }
     subject { response }

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -9,6 +9,12 @@ describe MailingList::StepsController do
   let(:model) { MailingList::Steps::Name }
   let(:step_path) { mailing_list_step_path model.key }
 
+  describe "#index" do
+    before { get mailing_list_steps_path(query: "param") }
+    subject { response }
+    it { is_expected.to redirect_to(mailing_list_step_path({ id: :name, query: "param" })) }
+  end
+
   describe "#show" do
     before { get step_path }
     subject { response }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,6 +2773,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.4:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4977,6 +4984,14 @@ jest-environment-node@^26.0.1:
     jest-mock "^26.0.1"
     jest-util "^26.0.1"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.0.0.tgz#381e986a718998dbfafcd5ec05934be538db4039"
@@ -5965,6 +5980,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -7359,6 +7379,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.3.2"
@@ -9333,6 +9358,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
### JIRA ticket number

[GITPB-611](https://dfedigital.atlassian.net/jira/software/projects/GITPB/boards/61?assignee=5e997e0e6b01320c41b6d21c&selectedIssue=GITPB-611)

### Context

We want to enable on-campus mailing list sign ups where the type of sign up is determined by the `ChannelId` sent to the CRM. The sign up URLs should be:

`/mailinglist/signup?channel=:channel_id`

We also need to display a tracking pixel on the sign up completion page, so that the sign up can be attributed to an agent at the event (via BAM).

### Changes proposed in this pull request

- Include query parameters in index redirect

When we land on the index page for a wizard we get redirected to the first step; this ensures that any query parameters present are also passed through.

We will need this to ensure the `channel_id` for on-campus events is available in the mailing list wizard: `/mailinglist/sign_up?channel_id=123

- Set channel_id on first step of mailing list sign up

If a `channel` is passed as part of the query string we want to persist this in the candidate's session so that when they come to submit their completed form it contains the `channel_id` as part of the payload.

This will be used to track on-campus mailing list sign ups via URLs:

`/mailinglist/signup?channel=<channel_id>`

- Update API client dependency

- Add BAM tracking pixel to mailing list completion page

Add a BAM tracking pixel to the mailing list completion page. The pixel is of the image variety (as opposed to JS) so we need to trigger it with a `fetch` from JS, ensuring it only fires when the various cookie preferences are set.

### Guidance to review

