### PR TITLE
GITPB-694 Cookie preferences

### DIFF
--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -1,0 +1,3 @@
+class CookiePreferencesController < ApplicationController
+  def show; end
+end

--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -1,3 +1,5 @@
 class CookiePreferencesController < ApplicationController
-  def show; end
+  def show
+    # default render
+  end
 end

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,0 +1,32 @@
+<section class="event-info content container-1000" role="main" id="main-content">
+  <div class="content__left">
+    <%= back_link %>
+
+    <h1>Edit your cookie settings</h1>
+
+    <p class="govuk-body">
+      Cookies are files saved on your phone, tablet or computer when
+      you visit a website.
+    </p>
+
+    <p>
+      We use cookies to store information about how you use the Get into
+      Teaching website, such as the pages you visit.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Cookie settings
+    </h2>
+
+    <p>
+      We use 3 types of cookie. You can choose which cookies you're happy
+      for us to use.
+    </p>
+
+    <div id="cookie-preferences-form">
+      TBD
+    </div>
+  </div>
+
+  <div class="content__right"></div>
+</div>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -26,9 +26,13 @@
     </p>
 
     <div id="cookie-preferences-form">
-      <form id="cookie-preferences-from" novalidate>
+      <form id="cookie-preferences-from" novalidate data-controller="cookie-preferences">
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" aria-describedby="cookies-non-functional-hint">
+          <fieldset class="govuk-fieldset"
+            aria-describedby="cookies-non-functional-hint"
+            data-target="cookie-preferences.category"
+            data-category="non-functional">
+
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h3 class="govuk-fieldset__heading">
                 Cookies that measure website use
@@ -71,13 +75,13 @@
             </div>
             <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input id="cookies-non-functional-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-non-functional" />
+                <input id="cookies-non-functional-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
                 <label for="cookies-non-functional-yes" class="govuk-label govuk-radios__label">
                   Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" />
+                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional"  data-action="cookie-preferences#toggle" />
                 <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
                   No
                 </label>
@@ -87,7 +91,11 @@
 
           <hr />
 
-          <fieldset class="govuk-fieldset" aria-describedby="cookies-marketing-hint">
+          <fieldset class="govuk-fieldset"
+            aria-describedby="cookies-marketing-hint"
+            data-target="cookie-preferences.category"
+            data-category="marketing">
+
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h3 class="govuk-fieldset__heading">
                 Cookies that help with our communication and marketing
@@ -109,13 +117,13 @@
             </div>
             <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input id="cookies-marketing-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-marketing" />
+                <input id="cookies-marketing-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-marketing" data-action="cookie-preferences#toggle" />
                 <label for="cookies-marketing-yes" class="govuk-label govuk-radios__label">
                   Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="cookies-marketing-no" class="govuk-radios__input" type="radio" value="0" name="cookies-marketing" />
+                <input id="cookies-marketing-no" class="govuk-radios__input" type="radio" value="0" name="cookies-marketing" data-action="cookie-preferences#toggle" />
                 <label for="cookies-marketing-no" class="govuk-label govuk-radios__label">
                   No
                 </label>
@@ -125,7 +133,11 @@
 
           <hr />
 
-          <fieldset class="govuk-fieldset" aria-describedby="cookies-functional-hint">
+          <fieldset class="govuk-fieldset"
+            aria-describedby="cookies-functional-hint"
+            data-target="cookie-preferences.category"
+            data-category="functional">
+
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h3 class="govuk-fieldset__heading">
                 Strictly necessary cookies

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -40,7 +40,7 @@
             </legend>
             <div class="govuk-hint" id="cookies-non-functional-hint">
               <p>
-                We use Google Analytics to measure how you use the webservice so
+                We use Google Analytics to measure how you use the website so
                 we can improve it based on user needs. We do not allow Google
                 to use or share the data about how you use this service.
               </p>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -2,16 +2,18 @@
   <div class="content__left">
     <%= back_link %>
 
-    <h1>Edit your cookie settings</h1>
+    <h1>Cookies on Get into Teaching</h1>
 
     <p class="govuk-body">
-      Cookies are files saved on your phone, tablet or computer when
-      you visit a website.
+      <strong>
+        Cookies are files saved on your phone, tablet or computer when
+        you visit a website.
+      </strong>
     </p>
 
     <p>
-      We use cookies to store information about how you use the Get into
-      Teaching website, such as the pages you visit.
+      We use cookies to store information about how you use the website, such
+      as the pages you visit.
     </p>
 
     <h2 class="govuk-heading-m">
@@ -24,9 +26,146 @@
     </p>
 
     <div id="cookie-preferences-form">
-      TBD
+      <form id="cookie-preferences-from" novalidate>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="cookies-non-functional-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h3 class="govuk-fieldset__heading">
+                Cookies that measure website use
+              </h3>
+            </legend>
+            <div class="govuk-hint" id="cookies-non-functional-hint">
+              <p>
+                We use Google Analytics to measure how you use the webservice so
+                we can improve it based on user needs. We do not allow Google
+                to use or share the data about how you use this service.
+              </p>
+
+              <p>
+                Google Analytics sets cookies that store anonymised
+                information about:
+              </p>
+
+              <ul>
+                <li>how you got to the service</li>
+                <li>
+                  the pages you visit on <a href="https://www.gov.uk">GOV.UK</a>
+                  and government digital services, and how long you spend on
+                  each page
+                </li>
+                <li>what you click on while you're visiting the service</li>
+              </ul>
+
+              <p>
+                Cookies may be set by other third-party services to do things
+                like measure how you view YouTube videos that are on the
+                service.
+              </p>
+
+              <p>
+                If you have an account with other services provided by the
+                Education and Skills Funding Agency, the information collected
+                using analytics cookies will be linked to your account. This
+                will help us make the service work better for you.
+              </p>
+            </div>
+            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input id="cookies-non-functional-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-non-functional" />
+                <label for="cookies-non-functional-yes" class="govuk-label govuk-radios__label">
+                  Yes
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" />
+                <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
+                  No
+                </label>
+              </div>
+            </div>
+          </fieldset>
+
+          <hr />
+
+          <fieldset class="govuk-fieldset" aria-describedby="cookies-marketing-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h3 class="govuk-fieldset__heading">
+                Cookies that help with our communication and marketing
+              </h3>
+            </legend>
+            <div class="govuk-hint" id="cookies-marketing-hint">
+              <p>
+                These cookies help us to improve the relevency of advertising
+                campaigns you receive from us.
+              </p>
+
+              <p>
+                We also share information about your use of this service with
+                our social media, advertising and analytics partner. They
+                combine it with other information that they've collected from
+                your use of our services to guide the advertising that you
+                receive.
+              </p>
+            </div>
+            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input id="cookies-marketing-yes" class="govuk-radios__input" type="radio" value="1" name="cookies-marketing" />
+                <label for="cookies-marketing-yes" class="govuk-label govuk-radios__label">
+                  Yes
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input id="cookies-marketing-no" class="govuk-radios__input" type="radio" value="0" name="cookies-marketing" />
+                <label for="cookies-marketing-no" class="govuk-label govuk-radios__label">
+                  No
+                </label>
+              </div>
+            </div>
+          </fieldset>
+
+          <hr />
+
+          <fieldset class="govuk-fieldset" aria-describedby="cookies-functional-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h3 class="govuk-fieldset__heading">
+                Strictly necessary cookies
+              </h3>
+            </legend>
+            <div class="govuk-hint" id="cookies-functional-hint">
+              <p>
+                These essential cookies do things like:
+              </p>
+
+              <ul>
+                <li>
+                  your progress through a form (for example a licence
+                  application)
+                </li>
+                <li>
+                  the notifications you've seen so we do not show them to you
+                  again
+                </li>
+              </ul>
+
+              <p>They always need to be on.</p>
+
+              <p>
+                <a href="/cookie-policy">Find out more</a>
+                about cookies on this service
+              </p>
+            </div>
+          </fieldset>
+        </div>
+      </form>
+
+      <p>
+        You can find more about who we are, how you can contact us
+        and how we process personal data in our
+        <a href="/privacy-policy">privacy notice</a>
+      </p>
     </div>
   </div>
 
   <div class="content__right"></div>
-</div>
+</section>
+

--- a/app/views/sections/_cookie-acceptance.html.erb
+++ b/app/views/sections/_cookie-acceptance.html.erb
@@ -19,10 +19,10 @@
                 website for all of our users.
             </p>
             <a href="#" class="call-to-action-button" data-action="click->cookie-acceptance#accept" data-target="cookie-acceptance.agree" id="cookies-agree">
-                Yes, I agree. Continue to the new <span>website</span>
+                Accept all cookies <i class="fas fa-chevron-right"></i>
             </a>
-            <a class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-target="cookie-acceptance.disagree" id="cookies-disagree">
-                No, I want to go to the current website <i class="fas fa-chevron-right"></i>
+            <a class="secondary-link" href="/cookie_preference" data-target="cookie-acceptance.disagree" id="cookies-disagree">
+                Set cookie preferences <i class="fas fa-chevron-right"></i>
             </a>
         </div>
     </div>

--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -41,7 +41,7 @@ export default class extends Controller {
   }
 
   cookiesAcceptedChecker(event) {
-    if (event.detail && event.detail.cookies && event.detail.cookies.includes(this.cookieCategory))
+    if (event.detail?.cookies?.includes(this.cookieCategory))
       this.triggerEvent() ;
   }
 

--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -1,20 +1,27 @@
+import CookiePreferences from "../javascript/cookie_preferences"
 import { Controller } from "stimulus"
 
 export default class extends Controller {
 
   connect() {
-    if(document.cookie.indexOf('GiTBetaCookie=Accepted') > -1) {
+    const cookiePrefs = new CookiePreferences() ;
+
+    if(cookiePrefs.allowed(this.cookieCategory)) {
       this.triggerEvent() ;
     } else {
-      this.triggerEventHandler = this.triggerEvent.bind(this)
-      document.addEventListener("cookies:accepted", this.triggerEventHandler) ;
+      this.cookiesAcceptedHandler = this.cookiesAcceptedChecker.bind(this) ;
+      document.addEventListener("cookies:accepted", this.cookiesAcceptedHandler) ;
     }
   }
 
   disconnect() {
     if (this.analyticsAcceptedHandler) {
-      document.removeEventListener("cookies:accepted", this.triggerEventHandler) ;
+      document.removeEventListener("cookies:accepted", this.cookiesAcceptedHandler) ;
     }
+  }
+
+  get cookieCategory() {
+    return 'marketing' ;
   }
 
   get isEnabled() {
@@ -31,6 +38,11 @@ export default class extends Controller {
       this.initService() ;
 
     this.sendEvent() ;
+  }
+
+  cookiesAcceptedChecker(event) {
+    if (event.detail && event.detail.cookies && event.detail.cookies.includes(this.cookieCategory))
+      this.triggerEvent() ;
   }
 
   getServiceId(attribute) {

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -1,3 +1,4 @@
+import CookiePreferences from "../javascript/cookie_preferences"
 import { Controller } from "stimulus"
 
 export default class extends Controller {
@@ -9,20 +10,19 @@ export default class extends Controller {
     }
 
     checkforCookie() {
-        var cookie = document.cookie;
-        if(cookie.indexOf('GiTBetaCookie=Accepted') > -1) {
-            return;
-        }
+        const cookiePrefs = new CookiePreferences() ;
+        if (cookiePrefs.cookieSet)
+          return ;
+
         this.showDialog();
     }
 
     accept(event) {
         event.preventDefault();
         this.overlayTarget.style.display = "none";
-        document.cookie = "GiTBetaCookie=Accepted; expires=Fri, 31 Dec 2021 12:00:00 UTC";
 
-        let acceptedCookies = new Event("cookies:accepted") ;
-        document.dispatchEvent(acceptedCookies) ;
+        const cookiePrefs = new CookiePreferences() ;
+        cookiePrefs.allowAll() ;
     }
 
     showDialog() {
@@ -39,5 +39,4 @@ export default class extends Controller {
             document.getElementById('cookies-disagree').focus();
         });
     }
-
 }

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -6,7 +6,9 @@ export default class extends Controller {
     static targets = ["modal","overlay","agree","disagree"];
 
     connect() {
-        this.checkforCookie();
+        if (!this.isPreferencesPage()) {
+          this.checkforCookie();
+        }
     }
 
     checkforCookie() {
@@ -38,5 +40,10 @@ export default class extends Controller {
             e.preventDefault();
             document.getElementById('cookies-disagree').focus();
         });
+    }
+
+    isPreferencesPage() {
+      const path = window.location.href.replace(/^https?:\/\/[^/]+/, '')
+      return (path == "/cookie_preference") ;
     }
 }

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
 
   connect() {
     this.cookiePreferences = new CookiePreferences ;
+    this.cookiePreferences.writeCookie(this.cookiePreferences.all) ;
     this.assignRadios() ;
   }
 

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -1,0 +1,30 @@
+import CookiePreferences from "../javascript/cookie_preferences"
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ 'category' ]
+
+  connect() {
+    this.cookiePreferences = new CookiePreferences ;
+    this.assignRadios() ;
+  }
+
+  assignRadios() {
+    for(const category of this.categoryTargets) {
+      const categoryName = category.getAttribute("data-category") ;
+      const allowed = this.cookiePreferences.allowed(categoryName) ;
+      const value = allowed ? '1' : '0' ;
+      const radio = category.querySelector('input[type="radio"][value="' + value + '"]') ;
+
+      if (radio)
+        radio.checked = true ;
+    }
+  }
+
+  toggle(event) {
+    const category = event.target.name.toString().replace(/^cookies-/, '')
+    const value = event.target.value ;
+
+    this.cookiePreferences.setCategory(category, value) ;
+  }
+}

--- a/app/webpacker/controllers/gtm_controller.js
+++ b/app/webpacker/controllers/gtm_controller.js
@@ -10,6 +10,10 @@ export default class extends AnalyticsBaseController {
     return window.gtag ;
   }
 
+  get cookieCategory() {
+    return 'non-functional' ;
+  }
+
   initService() {
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/app/webpacker/controllers/hotjar_controller.js
+++ b/app/webpacker/controllers/hotjar_controller.js
@@ -10,6 +10,10 @@ export default class extends AnalyticsBaseController {
     return window.hj ;
   }
 
+  get cookieCategory() {
+    return 'non-functional' ;
+  }
+
   initService() {
     // IMPORTANT: see line marked below
     // the 'a' variable was originally used in the function call

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -46,4 +46,13 @@ export default class CookiePreferences {
 
     this.settings = this.parseSettings() ;
   }
+
+  setCategory(category, value) {
+    const strValue = value.toString() ;
+
+    this.settings[category] =
+      (strValue == "1" || strValue == "true" || strValue == "yes") ;
+
+    this.all = this.settings ;
+  }
 }

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -1,0 +1,49 @@
+const Cookies = require('js-cookie') ;
+
+export default class CookiePreferences {
+  static cookieBaseName = "git-cookie-preferences" ;
+  static cookieVersion = 1 ;
+  static cookieLifetimeInDays = 90 ;
+
+  settings = null ;
+
+  constructor() {
+    this.settings = this.parseSettings() ;
+  }
+
+  static get cookieName() {
+    return CookiePreferences.cookieBaseName + "-v" + CookiePreferences.cookieVersion ;
+  }
+
+  parseSettings() {
+    const cookie = Cookies.get(CookiePreferences.cookieName);
+    if (typeof(cookie) == 'undefined' || !cookie)
+      return {} ;
+
+    return JSON.parse(cookie) ;
+  }
+
+  get all() {
+    return this.settings ;
+  }
+
+  allowed(category) {
+    return this.settings[category] || false ;
+  }
+
+  get categories() {
+    if (this.settings)
+      return Object.keys(this.settings) ;
+    else
+      return new Array ;
+  }
+
+  set all(categories) {
+    const serialized = JSON.stringify(categories)
+    Cookies.set(CookiePreferences.cookieName, serialized, {
+      expires: CookiePreferences.cookieLifetimeInDays
+    }) ;
+
+    this.settings = this.parseSettings() ;
+  }
+}

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -4,6 +4,7 @@ export default class CookiePreferences {
   static cookieBaseName = "git-cookie-preferences" ;
   static cookieVersion = 1 ;
   static cookieLifetimeInDays = 90 ;
+  static alwaysOnCategory = 'functional' ;
   static allCategories = {
     'functional' : true,
     'non-functional' : true,
@@ -29,9 +30,12 @@ export default class CookiePreferences {
       this.settings = JSON.parse(cookie) ;
       this.cookieSet = true ;
     }
+
+    this.settings[CookiePreferences.alwaysOnCategory] = true ;
   }
 
   writeCookie(categories) {
+    categories[CookiePreferences.alwaysOnCategory] = true ;
     const serialized = JSON.stringify(categories)
     Cookies.set(CookiePreferences.cookieName, serialized, {
       expires: CookiePreferences.cookieLifetimeInDays

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -11,6 +11,7 @@ export default class CookiePreferences {
   } ;
 
   settings = null ;
+  cookieSet = false ;
 
   constructor() {
     this.readCookie() ;
@@ -22,10 +23,12 @@ export default class CookiePreferences {
 
   readCookie() {
     const cookie = Cookies.get(CookiePreferences.cookieName);
-    if (typeof(cookie) == 'undefined' || !cookie)
+    if (typeof(cookie) == 'undefined' || !cookie) {
       this.settings = {} ;
-    else
+    } else {
       this.settings = JSON.parse(cookie) ;
+      this.cookieSet = true ;
+    }
   }
 
   writeCookie(categories) {
@@ -33,6 +36,8 @@ export default class CookiePreferences {
     Cookies.set(CookiePreferences.cookieName, serialized, {
       expires: CookiePreferences.cookieLifetimeInDays
     }) ;
+
+    this.cookieSet = true ;
   }
 
   get all() {

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -4,6 +4,11 @@ export default class CookiePreferences {
   static cookieBaseName = "git-cookie-preferences" ;
   static cookieVersion = 1 ;
   static cookieLifetimeInDays = 90 ;
+  static allCategories = {
+    'functional' : true,
+    'non-functional' : true,
+    'marketing' : true
+  } ;
 
   settings = null ;
 
@@ -77,5 +82,9 @@ export default class CookiePreferences {
     }) ;
 
     document.dispatchEvent(acceptedCookies) ;
+  }
+
+  allowAll() {
+    this.all = CookiePreferences.allCategories ;
   }
 }

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,3 +11,4 @@ Rails.start();
 Turbolinks.start();
 
 import "controllers";
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
   get "/tta-service", to: "pages#tta_service", as: :tta_service
   get "/tta", to: "pages#tta_service", as: nil
 
+  resource "cookie_preference", only: %i[show]
+  get "/cookie-policy", to: "pages#show", page: "cookie-policy"
+
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@stimulus/polyfills": "^1.1.1",
     "govuk-frontend": "^3.6.0",
     "is-touch-device": "^1.0.1",
+    "js-cookie": "^2.2.1",
     "rails-ujs": "^5.2.4",
     "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.2",
@@ -24,7 +25,8 @@
     ],
     "moduleDirectories": [
       "node_modules",
-      "app/webpacker/controllers"
+      "app/webpacker/controllers",
+      "app/webpacker/javascript"
     ]
   },
   "scripts": {

--- a/spec/javascript/controllers/analytics_spec_helper.js
+++ b/spec/javascript/controllers/analytics_spec_helper.js
@@ -1,16 +1,14 @@
+const Cookies = require('js-cookie') ;
+import CookiePreferences from "cookie_preferences" ;
 import { Application } from 'stimulus' ;
 
 export default class {
   static setCookie(cookieContent) {
-    Object.defineProperty(window.document, 'cookie', {
-      writable: true,
-      value: cookieContent
-    })
+    Cookies.set(CookiePreferences.cookieName, cookieContent) ;
   }
 
   static setAcceptedCookie() {
-    const nextYear = (new Date).getFullYear() + 1 ;
-    this.setCookie('GiTBetaCookie=Accepted; expires=Fri, 31 Dec ' + nextYear + ' 12:00:00 UTC') ;
+    (new CookiePreferences).allowAll() ;
   }
 
   static setBlankCookie() {
@@ -23,7 +21,9 @@ export default class {
     application.register(name, controller) ;
   }
 
-  static describeWithCookieSet(name, controller, serviceFunctionName) {
+  static describeWithCookieSet(name, controller, serviceFunctionName, cookieCategory) {
+    beforeEach(() => { Cookies.remove(CookiePreferences.cookieName) })
+
     describe("with cookie already set", () => {
       beforeEach(() => { this.setAcceptedCookie() })
 
@@ -45,7 +45,9 @@ export default class {
     })
   }
 
-  static describeWhenEventFires(name, controller, serviceFunctionName) {
+  static describeWhenEventFires(name, controller, serviceFunctionName, cookieCategory) {
+    beforeEach(() => { Cookies.remove(CookiePreferences.cookieName) })
+
     describe("without cookie set yet", () => {
       beforeEach(() => {
         this.setBlankCookie() ;
@@ -57,7 +59,7 @@ export default class {
       }) ;
 
       it("Should register service when event is emitted", () => {
-        document.dispatchEvent(new Event("cookies:accepted")) ;
+        (new CookiePreferences).setCategory(cookieCategory, true) ;
         expect(typeof(window[serviceFunctionName])).toBe("function") ;
       }) ;
     }) ;

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -17,8 +17,11 @@ describe('CookieAcceptanceController', () => {
                     Header
                 </div>
                 BODY
-                <a href="#" id="accept-cookie" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
+                <a href="#" id="cookies-agree" data-target="cookie-acceptance.agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
                     Yes, I agree. Continue to the new <span>website</span>
+                </a>
+                <a class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-target="cookie-acceptance.disagree" id="cookies-disagree">
+                  No, I want to go to the current website <i class="fas fa-chevron-right"></i>
                 </a>
             </div>
         </div>
@@ -45,7 +48,7 @@ describe('CookieAcceptanceController', () => {
 
     describe("clicking the accept button", () => {
         it('sets the cookie', () => {
-            let acceptanceButton = document.getElementById("accept-cookie");
+            let acceptanceButton = document.getElementById("cookies-agree");
             acceptanceButton.click();
             expect(document.cookie.indexOf('GiTBetaCookie=Accepted') === -1).toBe(false);
         })
@@ -55,7 +58,7 @@ describe('CookieAcceptanceController', () => {
         it('hides the dialog', () => {
             window.document.cookie = "";
             application.register('cookie-acceptance', CookieAcceptanceController);
-            let acceptanceButton = document.getElementById("accept-cookie");
+            let acceptanceButton = document.getElementById("cookies-agree");
             acceptanceButton.click();
             let overlay = document.getElementById('overlay');
             expect(overlay.style.display).toBe("none");

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -1,12 +1,9 @@
+const Cookies = require('js-cookie') ;
 import { Application } from 'stimulus' ;
 import CookieAcceptanceController from 'cookie-acceptance_controller.js' ;
 
 describe('CookieAcceptanceController', () => {
-
-    Object.defineProperty(window.document, 'cookie', {
-        writable: true,
-        value: 'GiTBetaCookie=Accepted; expires=Fri, 31 Dec 2021 12:00:00 UTC'
-    });
+  let cookieName = "git-cookie-preferences-v1" ;
 
     document.body.innerHTML = 
     `<div data-controller="cookie-acceptance">
@@ -27,10 +24,23 @@ describe('CookieAcceptanceController', () => {
         </div>
     </div>`;
 
-    const application = Application.start() ;
-    application.register('cookie-acceptance', CookieAcceptanceController);
+    function initApp() {
+      const application = Application.start() ;
+      application.register('cookie-acceptance', CookieAcceptanceController);
+    }
+
+    beforeEach(() => {
+      Cookies.remove("git-cookie-preferences-v1") ;
+    }) ;
 
     describe("when the cookie is set", () => {
+        beforeEach(() => {
+          const data = JSON.stringify({functional: true}) ;
+          Cookies.set("git-cookie-preferences-v1", data) ;
+
+          initApp() ;
+        }) ;
+
         it('does not show the cookie acceptance dialog', () => {
             let overlay = document.getElementById('overlay');
             expect(overlay.style.display).toBe("");
@@ -38,28 +48,27 @@ describe('CookieAcceptanceController', () => {
     });
 
     describe("when the cookie is not set", () => {
+        beforeEach(() => { initApp() }) ;
+
         it('shows the cookie acceptance dialog', () => {
-            window.document.cookie = "";
-            application.register('cookie-acceptance', CookieAcceptanceController);
             let overlay = document.getElementById('overlay');
             expect(overlay.style.display).toBe("flex");
         })
     });
 
     describe("clicking the accept button", () => {
-        it('sets the cookie', () => {
-            let acceptanceButton = document.getElementById("cookies-agree");
-            acceptanceButton.click();
-            expect(document.cookie.indexOf('GiTBetaCookie=Accepted') === -1).toBe(false);
-        })
-    });
+        beforeEach(() => {
+          initApp()
 
-    describe("clicking the accept button", () => {
+          let acceptanceButton = document.getElementById("cookies-agree");
+          acceptanceButton.click();
+        }) ;
+
+        it('sets the cookie', () => {
+            expect(Cookies.get("git-cookie-preferences-v1")).not.toBe(false);
+        })
+
         it('hides the dialog', () => {
-            window.document.cookie = "";
-            application.register('cookie-acceptance', CookieAcceptanceController);
-            let acceptanceButton = document.getElementById("cookies-agree");
-            acceptanceButton.click();
             let overlay = document.getElementById('overlay');
             expect(overlay.style.display).toBe("none");
         })

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -34,14 +34,18 @@ describe('CookiePreferencesController', () => {
     setCookie(JSON.stringify(data)) ;
   }
 
-  beforeEach(() => {
+  function initCookie() {
     setJsonCookie({ first: true, second: false })
+  }
 
+  function initApp(setCookie) {
     const application = Application.start() ;
     application.register('cookie-preferences', CookiePreferencesController);
-  })
+  }
 
   describe("on page load", () => {
+    beforeEach(() => { initCookie(); initApp() })
+
     it('radios should be assigned', () => {
       expect(document.getElementById('first-yes').checked).toBe(true) ;
       expect(document.getElementById('first-no').checked).toBe(false) ;
@@ -50,13 +54,24 @@ describe('CookiePreferencesController', () => {
     })
   }) ;
 
+  describe("on page load without cookie", () => {
+    beforeEach(() => { initApp() })
+
+    it('should save cookie', () => {
+      const data = getJsonCookie() ;
+      expect(data['functional']).toBe(true) ;
+    })
+  })
+
   describe("when changing radios", () => {
+    beforeEach(() => { initCookie(); initApp() })
+
     it("cookie should be updated", () => {
-      expect(getJsonCookie()).toEqual({ first: true, second: false })
+      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
       document.getElementById('first-no').click() ;
-      expect(getJsonCookie()).toEqual({ first: false, second: false })
+      expect(getJsonCookie()).toEqual({ first: false, functional: true, second: false })
       document.getElementById('second-yes').click() ;
-      expect(getJsonCookie()).toEqual({ first: false, second: true })
+      expect(getJsonCookie()).toEqual({ first: false, functional: true, second: true })
     })
   }) ;
 }) ;

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -1,0 +1,62 @@
+import { Application } from 'stimulus' ;
+import CookiePreferencesController from 'cookie_preferences_controller.js' ;
+
+const Cookies = require('js-cookie') ;
+import CookiePreferences from 'cookie_preferences' ;
+
+describe('CookiePreferencesController', () => {
+  document.body.innerHTML =
+  `<form data-controller="cookie-preferences">
+    <fieldset data-target="cookie-preferences.category" data-category="first">
+      <input type="radio" value="0" id="first-no" name="cookies-first" data-action="cookie-preferences#toggle" />
+      <input type="radio" value="1" id="first-yes" name="cookies-first" data-action="cookie-preferences#toggle" />
+    </fieldset>
+
+    <fieldset data-target="cookie-preferences.category" data-category="second">
+      <input type="radio" value="0" id="second-no" name="cookies-second" data-action="cookie-preferences#toggle" />
+      <input type="radio" value="1" id="second-yes" name="cookies-second" data-action="cookie-preferences#toggle" />
+    </fieldset>
+  </form>` ;
+
+  function getCookie() {
+    return Cookies.get(CookiePreferences.cookieName) ;
+  }
+
+  function setCookie(content) {
+    Cookies.set(CookiePreferences.cookieName, content) ;
+  }
+
+  function getJsonCookie() {
+    return JSON.parse(getCookie()) ;
+  }
+
+  function setJsonCookie(data) {
+    setCookie(JSON.stringify(data)) ;
+  }
+
+  beforeEach(() => {
+    setJsonCookie({ first: true, second: false })
+
+    const application = Application.start() ;
+    application.register('cookie-preferences', CookiePreferencesController);
+  })
+
+  describe("on page load", () => {
+    it('radios should be assigned', () => {
+      expect(document.getElementById('first-yes').checked).toBe(true) ;
+      expect(document.getElementById('first-no').checked).toBe(false) ;
+      expect(document.getElementById('second-yes').checked).toBe(false) ;
+      expect(document.getElementById('second-no').checked).toBe(true) ;
+    })
+  }) ;
+
+  describe("when changing radios", () => {
+    it("cookie should be updated", () => {
+      expect(getJsonCookie()).toEqual({ first: true, second: false })
+      document.getElementById('first-no').click() ;
+      expect(getJsonCookie()).toEqual({ first: false, second: false })
+      document.getElementById('second-yes').click() ;
+      expect(getJsonCookie()).toEqual({ first: false, second: true })
+    })
+  }) ;
+}) ;

--- a/spec/javascript/controllers/facebook_controller_spec.js
+++ b/spec/javascript/controllers/facebook_controller_spec.js
@@ -14,6 +14,6 @@ describe('FacebookController', () => {
   // window appears to not be getting redefined between runs, so remove manually
   afterEach(() => { delete window.fbq })
 
-  AnalyticsHelper.describeWithCookieSet('facebook', FacebookController, 'fbq')
-  AnalyticsHelper.describeWhenEventFires('facebook', FacebookController, 'fbq')
+  AnalyticsHelper.describeWithCookieSet('facebook', FacebookController, 'fbq', 'marketing')
+  AnalyticsHelper.describeWhenEventFires('facebook', FacebookController, 'fbq', 'marketing')
 })

--- a/spec/javascript/controllers/gtm_controller_spec.js
+++ b/spec/javascript/controllers/gtm_controller_spec.js
@@ -10,6 +10,6 @@ describe('GtmController', () => {
   // window appears to not be getting redefined between runs, so remove manually
   afterEach(() => { delete window.gtag })
 
-  AnalyticsHelper.describeWithCookieSet('gtm', GtmController, 'gtag')
-  AnalyticsHelper.describeWhenEventFires('gtm', GtmController, 'gtag')
+  AnalyticsHelper.describeWithCookieSet('gtm', GtmController, 'gtag', 'non-functional')
+  AnalyticsHelper.describeWhenEventFires('gtm', GtmController, 'gtag', 'non-functional')
 })

--- a/spec/javascript/controllers/hotjar_controller_spec.js
+++ b/spec/javascript/controllers/hotjar_controller_spec.js
@@ -10,6 +10,6 @@ describe('HotjarController', () => {
   // window appears to not be getting redefined between runs, so remove manually
   afterEach(() => { delete window.hj })
 
-  AnalyticsHelper.describeWithCookieSet('hotjar', HotjarController, 'hj')
-  AnalyticsHelper.describeWhenEventFires('hotjar', HotjarController, 'hj')
+  AnalyticsHelper.describeWithCookieSet('hotjar', HotjarController, 'hj', 'non-functional')
+  AnalyticsHelper.describeWhenEventFires('hotjar', HotjarController, 'hj', 'non-functional')
 })

--- a/spec/javascript/controllers/pinterest_controller_spec.js
+++ b/spec/javascript/controllers/pinterest_controller_spec.js
@@ -10,6 +10,6 @@ describe('PinterestController', () => {
   // window appears to not be getting redefined between runs, so remove manually
   afterEach(() => { delete window.pintrk })
 
-  AnalyticsHelper.describeWithCookieSet('pinterest', PinterestController, 'pintrk')
-  AnalyticsHelper.describeWhenEventFires('pinterest', PinterestController, 'pintrk')
+  AnalyticsHelper.describeWithCookieSet('pinterest', PinterestController, 'pintrk', 'marketing')
+  AnalyticsHelper.describeWhenEventFires('pinterest', PinterestController, 'pintrk', 'marketing')
 })

--- a/spec/javascript/controllers/snapchat_controller_spec.js
+++ b/spec/javascript/controllers/snapchat_controller_spec.js
@@ -10,6 +10,6 @@ describe('SnapchatController', () => {
   // window appears to not be getting redefined between runs, so remove manually
   afterEach(() => { delete window.snaptr })
 
-  AnalyticsHelper.describeWithCookieSet('snapchat', SnapchatController, 'snaptr')
-  AnalyticsHelper.describeWhenEventFires('snapchat', SnapchatController, 'snaptr')
+  AnalyticsHelper.describeWithCookieSet('snapchat', SnapchatController, 'snaptr', 'marketing')
+  AnalyticsHelper.describeWhenEventFires('snapchat', SnapchatController, 'snaptr', 'marketing')
 })

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -1,0 +1,93 @@
+const Cookies = require('js-cookie') ;
+import CookiePreferences from 'cookie_preferences' ;
+
+describe('CookiePreferences', () => {
+  let prefs = null ;
+
+  function setCookie(name, content) {
+    Cookies.set(name, content) ;
+  }
+
+  function setJsonCookie(name, data) {
+    setCookie(name, JSON.stringify(data)) ;
+  }
+
+  beforeEach(() => { Cookies.remove(CookiePreferences.cookieName) })
+
+  describe("cookieName", () => {
+    it("should include version number", () => {
+      expect(CookiePreferences.cookieName).toBe("git-cookie-preferences-v1")
+    })
+  })
+
+  describe("with cookie set", () => {
+    beforeEach(() => {
+      setJsonCookie(CookiePreferences.cookieName, { required: true, marketing: false }) ;
+      prefs = new CookiePreferences ;
+    }) ;
+
+    it("#all should load settings from cookie", () => {
+      expect(prefs.all).toEqual({required: true, marketing: false}) ;
+    }) ;
+
+    describe("#allowed", () => {
+      it("should return per category values",() => {
+        expect(prefs.allowed('required')).toBe(true) ;
+        expect(prefs.allowed('marketing')).toBe(false) ;
+      })
+
+      it("should return false for unknown categories", () => {
+        expect(prefs.allowed('unknown')).toBe(false) ;
+      })
+    })
+
+    describe("#categories", () => {
+      it("should return the categories held in the cookie", () => {
+        expect(prefs.categories).toEqual(["required", "marketing"]) ;
+      }) ;
+    }) ;
+
+    describe("assigning #all", () => {
+      beforeEach(() => {})
+    })
+  })
+
+  describe("without cookie set", () => {
+    beforeEach(() => { prefs = new CookiePreferences })
+
+    describe("#all", () => {
+      it("should be null", () => { expect(prefs.all).toEqual({}) })
+    })
+
+    describe("#allowed", () => {
+      it("should return false for all categories", () => {
+        expect(prefs.allowed('required')).toBe(false)
+        expect(prefs.allowed('marketing')).toBe(false)
+      })
+    })
+
+    describe("#categories", () => {
+      it("should be empty", () => { expect(prefs.categories).toEqual([]) })
+    })
+
+    describe("assigning #all", () => {
+      beforeEach(() => { prefs.all = {required: false, functional: true} })
+
+      it("should update", () => {
+        expect(prefs.all).toEqual({required: false, functional: true})
+      })
+
+      it("should return new values for #allowed", () => {
+        expect(prefs.allowed('required')).toBe(false)
+        expect(prefs.allowed('functional')).toBe(true)
+        expect(prefs.allowed('marketing')).toBe(false)
+      })
+
+      it("should update #categories list", () => {
+        expect(prefs.categories).toEqual(['required', 'functional'])
+      }) ;
+
+      test.todo("should emit event for updates")
+    }) ;
+  }) ;
+})  

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -35,7 +35,7 @@ describe('CookiePreferences', () => {
     }) ;
 
     it("#all should load settings from cookie", () => {
-      expect(prefs.all).toEqual({required: true, marketing: false}) ;
+      expect(prefs.all).toEqual({functional: true, required: true, marketing: false}) ;
     }) ;
 
     it("should mark cookie as set", () => {
@@ -46,6 +46,7 @@ describe('CookiePreferences', () => {
       it("should return per category values",() => {
         expect(prefs.allowed('required')).toBe(true) ;
         expect(prefs.allowed('marketing')).toBe(false) ;
+        expect(prefs.allowed('functional')).toBe(true) ;
       })
 
       it("should return false for unknown categories", () => {
@@ -55,35 +56,36 @@ describe('CookiePreferences', () => {
 
     describe("#categories", () => {
       it("should return the categories held in the cookie", () => {
-        expect(prefs.categories).toEqual(["required", "marketing"]) ;
+        expect(prefs.categories).toEqual(["required", "marketing", "functional"]) ;
       }) ;
     }) ;
 
     describe("#allowedCategories", () => {
       it("should return categories set to true", () => {
-        expect(prefs.allowedCategories).toEqual(['required'])
+        expect(prefs.allowedCategories).toEqual(['required', 'functional'])
       })
     })
 
     describe("assigning #all", () => {
-      beforeEach(() => { prefs.all = {required: false, functional: true} })
+      beforeEach(() => { prefs.all = {required: false, features: true} })
 
       it("should update", () => {
-        expect(prefs.all).toEqual({required: false, functional: true})
+        expect(prefs.all).toEqual({required: false, features: true, functional: true})
       })
 
       it("should return new values for #allowed", () => {
         expect(prefs.allowed('required')).toBe(false)
-        expect(prefs.allowed('functional')).toBe(true)
+        expect(prefs.allowed('features')).toBe(true)
         expect(prefs.allowed('marketing')).toBe(false)
+        expect(prefs.allowed('functional')).toBe(true)
       })
 
       it("should update #categories list", () => {
-        expect(prefs.categories).toEqual(['required', 'functional'])
+        expect(prefs.categories).toEqual(['required', 'features', 'functional'])
       }) ;
 
       it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['functional'])
+        expect(newCategoriesEvent).toEqual(['features'])
       })
     }) ;
 
@@ -95,31 +97,7 @@ describe('CookiePreferences', () => {
       })
 
       it("updates #all", () => {
-        expect(prefs.all).toEqual({required: true, marketing: true})
-      })
-
-      it("does not update category list", () => {
-        expect(prefs.categories).toEqual(['required', 'marketing'])
-      })
-
-      it("does update allowed categories", () => {
-        expect(prefs.allowedCategories).toEqual(['required', 'marketing'])
-      })
-
-      it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['marketing'])
-      })
-    })
-
-    describe("assigning new category", () => {
-      beforeEach(() => { prefs.setCategory('functional', true) })
-
-      it("updates allowed value", () => {
-        expect(prefs.allowed('functional')).toBe(true)
-      })
-
-      it("updates #all", () => {
-        expect(prefs.all).toEqual({required: true, marketing: false, functional: true})
+        expect(prefs.all).toEqual({required: true, marketing: true, functional: true})
       })
 
       it("does not update category list", () => {
@@ -127,11 +105,51 @@ describe('CookiePreferences', () => {
       })
 
       it("does update allowed categories", () => {
-        expect(prefs.allowedCategories).toEqual(['required', 'functional'])
+        expect(prefs.allowedCategories).toEqual(['required', 'marketing', 'functional'])
       })
 
       it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['functional'])
+        expect(newCategoriesEvent).toEqual(['marketing'])
+      })
+    })
+
+    describe("assigning functational to false", () => {
+      beforeEach(() => { prefs.setCategory('functional', false) })
+
+      it("leaves the value as true", () => {
+        expect(prefs.allowed('functional')).toBe(true)
+      })
+
+      it("is included in category list", () => {
+        expect(prefs.categories.includes('functional')).toBe(true)
+      })
+
+      it("is included in the allowedCategories list", () => {
+        expect(prefs.allowedCategories.includes('functional')).toBe(true)
+      }) ;
+    }) ;
+
+    describe("assigning new category", () => {
+      beforeEach(() => { prefs.setCategory('features', true) })
+
+      it("updates allowed value", () => {
+        expect(prefs.allowed('features')).toBe(true)
+      })
+
+      it("updates #all", () => {
+        expect(prefs.all).toEqual({required: true, marketing: false, features: true, functional: true})
+      })
+
+      it("does not update category list", () => {
+        expect(prefs.categories).toEqual(['required', 'marketing', 'functional', 'features'])
+      })
+
+      it("does update allowed categories", () => {
+        expect(prefs.allowedCategories).toEqual(['required', 'functional', 'features'])
+      })
+
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['features'])
       })
     })
 
@@ -154,22 +172,23 @@ describe('CookiePreferences', () => {
     })
 
     describe("#all", () => {
-      it("should be null", () => { expect(prefs.all).toEqual({}) })
+      it("should still include functional", () => { expect(prefs.all).toEqual({'functional' : true}) })
     })
 
     describe("#allowed", () => {
       it("should return false for all categories", () => {
+        expect(prefs.allowed('functional')).toBe(true)
         expect(prefs.allowed('required')).toBe(false)
         expect(prefs.allowed('marketing')).toBe(false)
       })
     })
 
     describe("#categories", () => {
-      it("should be empty", () => { expect(prefs.categories).toEqual([]) })
+      it("should be functional only", () => { expect(prefs.categories).toEqual(['functional']) })
     })
 
     describe("#allowedCategories", () => {
-      it("should be empty", () => { expect(prefs.allowedCategories).toEqual([]) })
+      it("should be functional only", () => { expect(prefs.allowedCategories).toEqual(['functional']) })
     })
 
     describe("assigning #all", () => {
@@ -190,7 +209,7 @@ describe('CookiePreferences', () => {
       }) ;
 
       it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['functional'])
+        expect(newCategoriesEvent).toEqual([])
       })
     }) ;
 
@@ -210,7 +229,7 @@ describe('CookiePreferences', () => {
       })
 
       it("emits event", () => {
-        expect(newCategoriesEvent).toEqual(['functional'])
+        expect(newCategoriesEvent).toEqual([])
       })
     })
 

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -130,6 +130,16 @@ describe('CookiePreferences', () => {
         expect(newCategoriesEvent).toEqual(['functional'])
       })
     })
+
+    describe("allowAll", () => {
+      beforeEach(() => { prefs.allowAll() }) ;
+
+      it("sets all to true", () => {
+        expect(prefs.allowedCategories).toEqual(
+          ['functional', 'non-functional', 'marketing']
+        ) ;
+      }) ;
+    }) ;
   })
 
   describe("without cookie set", () => {
@@ -195,5 +205,15 @@ describe('CookiePreferences', () => {
         expect(newCategoriesEvent).toEqual(['functional'])
       })
     })
+
+    describe("allowAll", () => {
+      beforeEach(() => { prefs.allowAll() }) ;
+
+      it("sets all to true", () => {
+        expect(prefs.allowedCategories).toEqual(
+          ['functional', 'non-functional', 'marketing']
+        ) ;
+      }) ;
+    }) ;
   }) ;
 })  

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -48,7 +48,59 @@ describe('CookiePreferences', () => {
     }) ;
 
     describe("assigning #all", () => {
-      beforeEach(() => {})
+      beforeEach(() => { prefs.all = {required: false, functional: true} })
+
+      it("should update", () => {
+        expect(prefs.all).toEqual({required: false, functional: true})
+      })
+
+      it("should return new values for #allowed", () => {
+        expect(prefs.allowed('required')).toBe(false)
+        expect(prefs.allowed('functional')).toBe(true)
+        expect(prefs.allowed('marketing')).toBe(false)
+      })
+
+      it("should update #categories list", () => {
+        expect(prefs.categories).toEqual(['required', 'functional'])
+      }) ;
+
+      test.todo("should emit event for updates")
+    }) ;
+
+    describe("assigning existing category", () => {
+      beforeEach(() => { prefs.setCategory('marketing', true) })
+
+      it("updates allowed value", () => {
+        expect(prefs.allowed('marketing')).toBe(true)
+      })
+
+      it("updates #all", () => {
+        expect(prefs.all).toEqual({required: true, marketing: true})
+      })
+
+      it("does not update category list", () => {
+        expect(prefs.categories).toEqual(['required', 'marketing'])
+      })
+
+      test.todo("emits event") ;
+    })
+
+    describe("assigning new category", () => {
+      beforeEach(() => { prefs.setCategory('functional', true) })
+
+      it("updates allowed value", () => {
+        expect(prefs.allowed('functional')).toBe(true)
+      })
+
+      it("updates #all", () => {
+        expect(prefs.all).toEqual({required: true, marketing: false, functional: true})
+      })
+
+      it("does not update category list", () => {
+        expect(prefs.categories).toEqual(['required', 'marketing', 'functional'])
+      })
+
+      test.todo("emits event") ;
     })
   })
 
@@ -87,7 +139,25 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['required', 'functional'])
       }) ;
 
-      test.todo("should emit event for updates")
+      test.todo("emits event for updates")
     }) ;
+
+    describe("assigning new category", () => {
+      beforeEach(() => { prefs.setCategory('functional', true) })
+
+      it("updates allowed value", () => {
+        expect(prefs.allowed('functional')).toBe(true)
+      })
+
+      it("updates #all", () => {
+        expect(prefs.all).toEqual({functional: true})
+      })
+
+      it("does not update category list", () => {
+        expect(prefs.categories).toEqual(['functional'])
+      })
+
+      test.todo("emits event") ;
+    })
   }) ;
 })  

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -38,6 +38,10 @@ describe('CookiePreferences', () => {
       expect(prefs.all).toEqual({required: true, marketing: false}) ;
     }) ;
 
+    it("should mark cookie as set", () => {
+      expect(prefs.cookieSet).toBe(true) ;
+    })
+
     describe("#allowed", () => {
       it("should return per category values",() => {
         expect(prefs.allowed('required')).toBe(true) ;
@@ -144,6 +148,10 @@ describe('CookiePreferences', () => {
 
   describe("without cookie set", () => {
     beforeEach(() => { prefs = new CookiePreferences })
+
+    it("should mark cookie as set", () => {
+      expect(prefs.cookieSet).toBe(false) ;
+    })
 
     describe("#all", () => {
       it("should be null", () => { expect(prefs.all).toEqual({}) })

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -3,6 +3,7 @@ import CookiePreferences from 'cookie_preferences' ;
 
 describe('CookiePreferences', () => {
   let prefs = null ;
+  let newCategoriesEvent = null ;
 
   function setCookie(name, content) {
     Cookies.set(name, content) ;
@@ -12,7 +13,14 @@ describe('CookiePreferences', () => {
     setCookie(name, JSON.stringify(data)) ;
   }
 
-  beforeEach(() => { Cookies.remove(CookiePreferences.cookieName) })
+  document.addEventListener("cookies:accepted", (event) => {
+    newCategoriesEvent = event.detail.cookies ;
+  })
+
+  beforeEach(() => {
+    Cookies.remove(CookiePreferences.cookieName)
+    newCategoriesEvent = null ;
+  })
 
   describe("cookieName", () => {
     it("should include version number", () => {
@@ -47,6 +55,12 @@ describe('CookiePreferences', () => {
       }) ;
     }) ;
 
+    describe("#allowedCategories", () => {
+      it("should return categories set to true", () => {
+        expect(prefs.allowedCategories).toEqual(['required'])
+      })
+    })
+
     describe("assigning #all", () => {
       beforeEach(() => { prefs.all = {required: false, functional: true} })
 
@@ -64,7 +78,9 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['required', 'functional'])
       }) ;
 
-      test.todo("should emit event for updates")
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['functional'])
+      })
     }) ;
 
     describe("assigning existing category", () => {
@@ -82,7 +98,13 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['required', 'marketing'])
       })
 
-      test.todo("emits event") ;
+      it("does update allowed categories", () => {
+        expect(prefs.allowedCategories).toEqual(['required', 'marketing'])
+      })
+
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['marketing'])
+      })
     })
 
     describe("assigning new category", () => {
@@ -100,7 +122,13 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['required', 'marketing', 'functional'])
       })
 
-      test.todo("emits event") ;
+      it("does update allowed categories", () => {
+        expect(prefs.allowedCategories).toEqual(['required', 'functional'])
+      })
+
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['functional'])
+      })
     })
   })
 
@@ -122,6 +150,10 @@ describe('CookiePreferences', () => {
       it("should be empty", () => { expect(prefs.categories).toEqual([]) })
     })
 
+    describe("#allowedCategories", () => {
+      it("should be empty", () => { expect(prefs.allowedCategories).toEqual([]) })
+    })
+
     describe("assigning #all", () => {
       beforeEach(() => { prefs.all = {required: false, functional: true} })
 
@@ -139,7 +171,9 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['required', 'functional'])
       }) ;
 
-      test.todo("emits event for updates")
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['functional'])
+      })
     }) ;
 
     describe("assigning new category", () => {
@@ -157,7 +191,9 @@ describe('CookiePreferences', () => {
         expect(prefs.categories).toEqual(['functional'])
       })
 
-      test.todo("emits event") ;
+      it("emits event", () => {
+        expect(newCategoriesEvent).toEqual(['functional'])
+      })
     })
   }) ;
 })  

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe CookiePreferencesController do
+  subject { response }
+
+  describe "#show" do
+    before { get cookie_preference_path }
+    it { is_expected.to have_http_status :success }
+    it { expect(subject.body).to match "Edit your cookie settings" }
+  end
+end

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -6,6 +6,6 @@ describe CookiePreferencesController do
   describe "#show" do
     before { get cookie_preference_path }
     it { is_expected.to have_http_status :success }
-    it { expect(subject.body).to match "Edit your cookie settings" }
+    it { expect(subject.body).to match "Cookie settings" }
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5247,6 +5247,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
### JIRA ticket number

GITPB-694

### Context

As a user I expect to be able to manage my cookie preferences.

### Changes proposed in this pull request

1. Add a static page with a form to manage cookie preferences
2. Add a CookiePreferences js object to handle persisting users selection, and emitting events with changes when the user accepts new categories of cookies
3. Added CookiePreferencesController to make the form in (1) interactive, uses CookiePreferences object to manage cookies
4. Updated various analytics controllers to only fire if their category of cookies has been enabled.



