### PR TITLE
Silence CSP violation errors

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
 GIT_API_TOKEN=test
 GIT_API_ENDPOINT=https://host.api/endpoint
-
+TTA_SERVICE_URL=http://tta-service.test

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,7 +32,7 @@ class PagesController < ApplicationController
       url += "?" + session[:utm].to_param
     end
 
-    redirect_to url
+    redirect_to(url, turbolinks: false)
   end
 
 private

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -15,14 +15,14 @@ SecureHeaders::Configuration.default do |config|
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self' *.youtube.com],
     connect_src: %W['self' #{tta_service_uri.host}],
-    font_src: %w['self'],
+    font_src: %w['self' *.gov.uk],
     form_action: %w['self'],
     frame_ancestors: %w['none'],
-    img_src: %w['self'],
+    img_src: %w['self' *.gov.uk],
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %w['self' *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
-    style_src: %w['self' 'unsafe-inline'],
+    script_src: %w['self' 'unsafe-inline' *.gov.uk code.jquery.com *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com *.sc-static.net],
+    style_src: %w['self' 'unsafe-inline' *.gov.uk],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: [ENV["SENTRY_CSP_REPORT_URI"]],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,12 +6,15 @@ SecureHeaders::Configuration.default do |config|
   config.x_download_options = "noopen"
   config.x_permitted_cross_domain_policies = "none"
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
+
+  tta_service_uri = URI.parse(ENV["TTA_SERVICE_URL"])
+
   config.csp = {
     default_src: %w['none'],
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self' *.youtube.com],
-    connect_src: %w['self'],
+    connect_src: %W['self' #{tta_service_uri.host}],
     font_src: %w['self'],
     form_action: %w['self'],
     frame_ancestors: %w['none'],


### PR DESCRIPTION
- Add TTA service to connect_src

Sentry flagged a CSP violation against linking out to the TTA service. It happens due to the link appearing as an internal
path `/tta_service`, which then redirects to an external URL (the TTA service host).

Adding `turbolinks: false` to the `redirect_to` should cause a full page reload, but for some reason Turbolinks is still
performing the XHR request.

Adding the `TTA_SERVICE_URL` host to the `connect_src` CSP silences the error and should be safe enough as this is one of
our services.

 - Add CSP sources for guidance page

These are GOV.UK for various scripts/styles/fonts and `code.jquery.com` for the latest version of jQuery. There is also inline JS so we need `unsafe-inline` until we can remove it.