### PR TITLE
GITPB-714 Check with cookie prefs before storing cookies

### DIFF
--- a/app/webpacker/controllers/banner_controller.js
+++ b/app/webpacker/controllers/banner_controller.js
@@ -1,12 +1,16 @@
-import { Controller } from "stimulus"
+const Cookies = require('js-cookie') ;
+import CookiePreferences from '../javascript/cookie_preferences' ;
+import { Controller } from "stimulus" ;
 
 export default class extends Controller {
+  cookieCategory = 'functional' ;
+
   connect() {
     this.hideOnLoad();
   }
 
   hideOnLoad() {
-    if(document.cookie.indexOf(this.cookie) != -1) {
+    if(Cookies.get(this.cookieName) == 'Hidden') {
       this.hideBanner();
     }
   }
@@ -22,11 +26,12 @@ export default class extends Controller {
   }
 
   setCookie() {
-    document.cookie = this.cookie;
+    if ((new CookiePreferences).allowed(this.cookieCategory))
+      Cookies.set(this.cookieName, 'Hidden')
   }
 
-  get cookie() {
-    return `GiTBetaBanner${this.name}=Hidden`;
+  get cookieName() {
+    return `GiTBetaBanner${this.name}`;
   }
 
   get name() {

--- a/spec/javascript/controllers/banner_controller_spec.js
+++ b/spec/javascript/controllers/banner_controller_spec.js
@@ -1,3 +1,4 @@
+const Cookies = require('js-cookie') ;
 import { Application } from 'stimulus' ;
 import BannerController from 'banner_controller';
 
@@ -8,9 +9,13 @@ describe('BannerController', () => {
   </div>
   ` ;
 
-  const application = Application.start();
-  application.register('banner', BannerController);
-  const banner = document.getElementById('banner');
+  beforeEach(() => {
+    Cookies.remove('GiTBetaBannerName') ;
+
+    const application = Application.start();
+    application.register('banner', BannerController);
+    const banner = document.getElementById('banner');
+  })
 
   describe("when the cookie is not yet set", () => {
     it("shows the banner", () => {
@@ -27,7 +32,7 @@ describe('BannerController', () => {
   });
 
   describe("when the cookie has been set", () => {
-    beforeEach(() => { document.cookie = "GiTBetaBannerName=Hidden"; });
+    beforeEach(() => { Cookies.set("GiTBetaBannerName', 'Hidden") });
 
     it('hides the banner', () => {
       expect(banner.style.display).toContain('none');


### PR DESCRIPTION
### JIRA ticket number

GITPB-714

### Context

We should check we are allowed to store cookies before acting on them

### Changes proposed in this pull request

1. Convert to use `Cookies` object instead of manually parsing cookies
2. Use CookiePreferences to check whether we are allowed to store cookies

NB: They are in the functional category so technically this is always true but if the category is changed in the future it avoids things slipping through the cracks


