### PR TITLE
GITPB-585 Disable canonical links for now

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -3,7 +3,7 @@
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
   <%= csrf_meta_tags unless @cacheable_static_page %>
   <%= csp_meta_tag %>
-  <%= canonical_tag %>
+  <%#= canonical_tag %>
   <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' %>
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>


### PR DESCRIPTION
They are not actually needed for private beta but are currently wrong so may
cause a problem in the future if they end up indexed now

Once we know all the urls these can be corrected properly

