### PR TITLE
Add stories spec

### DIFF
--- a/app/controllers/concerns/static_pages.rb
+++ b/app/controllers/concerns/static_pages.rb
@@ -34,6 +34,7 @@ private
       format.html do
         render \
           template: "errors/not_found",
+          layout: "application",
           status: :not_found
       end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,5 +1,6 @@
 class StoriesController < ApplicationController
   include StaticPages
+  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
 
   def show
     new_stories = ["becoming-a-mum-sparked-my-interest-in-teaching"]
@@ -7,18 +8,6 @@ class StoriesController < ApplicationController
     layout = is_new_story ? "layouts/stories" : "layouts/stories_old"
 
     render template: stories_template, layout: layout
-  rescue ActionView::MissingTemplate
-    respond_to do |format|
-      format.html do
-        render \
-          template: "errors/not_found",
-          status: :not_found
-      end
-
-      format.all do
-        render status: :not_found, body: nil
-      end
-    end
   end
 
 private

--- a/app/views/layouts/stories.html.erb
+++ b/app/views/layouts/stories.html.erb
@@ -42,36 +42,17 @@
                 <div class="more-stories">
                     <h2 class="more-stories_header strapline">More stories</h2>
                     <div class="more-stories__thumbs">
-                        <% if @front_matter["more_stories"].count > 0 %>
+                        <% Array.wrap(@front_matter["more_stories"]).slice(0, 3).each do |story| %>
                             <div class="more-stories__thumbs__thumb">
-                                <a href="<%= @front_matter["more_stories"][0]["url"] %>">
-                                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('<%= @front_matter["more_stories"][0]["image"] %>')"></div>
+                                <a href="<%= story["url"] %>">
+                                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('<%= story["image"] %>')"></div>
                                 </a>
                                 <div class="more-stories__thumbs__thumb__content">
-                                    <p><%= @front_matter["more_stories"][0]["title"] %></p>
-                                    <a class="git-link" href="<%= @front_matter["more_stories"][0]["url"] %>"><%= @front_matter["more_stories"][0]["cta"] %>  <i class="fas fa-chevron-right"></i></a>
-                                </div>
-                            </div>
-                        <% end %>
-                        <% if @front_matter["more_stories"].count > 1 %>
-                            <div class="more-stories__thumbs__thumb">
-                                <a href="<%= @front_matter["more_stories"][1]["url"] %>">
-                                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('<%= @front_matter["more_stories"][1]["image"] %>')"></div>
-                                </a>
-                                <div class="more-stories__thumbs__thumb__content">
-                                    <p><%= @front_matter["more_stories"][1]["title"] %></p>
-                                    <a class="git-link" href="<%= @front_matter["more_stories"][1]["url"] %>"><%= @front_matter["more_stories"][1]["cta"] %>  <i class="fas fa-chevron-right"></i></a>
-                                </div>
-                            </div>
-                        <% end %>
-                        <% if @front_matter["more_stories"].count > 2 %>
-                            <div class="more-stories__thumbs__thumb">
-                                <a href="<%= @front_matter["more_stories"][2]["url"] %>">
-                                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('<%= @front_matter["more_stories"][2]["image"] %>')"></div>
-                                </a>
-                                <div class="more-stories__thumbs__thumb__content">
-                                    <p><%= @front_matter["more_stories"][2]["title"] %></p>
-                                    <a class="git-link" href="<%= @front_matter["more_stories"][2]["url"] %>"><%= @front_matter["more_stories"][2]["cta"] %> <i class="fas fa-chevron-right"></i></a>
+                                    <p><%= story[0]["title"] %></p>
+                                    <%= link_to story["url"], class: "git-link" do %>
+                                      <%= story["cta"] %>
+                                      <i class="fas fa-chevron-right"></i>
+                                    <% end %>
                                 </div>
                             </div>
                         <% end %>

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe StoriesController do
+  let(:template) { "testing/markdown_test" }
+
+  before do
+    allow_any_instance_of(described_class).to \
+      receive(:stories_template).and_return template
+  end
+
+  context "#show" do
+    subject do
+      get "/life-as-a-teacher/my-story-into-teaching/known-page"
+      response
+    end
+
+    context "for known page" do
+      it { is_expected.to have_http_status :success }
+    end
+
+    context "for unknown page" do
+      let(:template) { "testing/unknown" }
+      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_attributes body: %r{Page not found} }
+    end
+
+    context "for invalid page page" do
+      let(:template) { "../../secrets.txt" }
+      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_attributes body: %r{Page not found} }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently the stories controller is untested.

### Changes proposed in this pull request

1. Added a simple request spec
2. Fixed the 500 that occurs for a missing page - whilst the origin exception is rescued, due to layout inheritance rails attempts to automatically use the stories `layout` to render the error - that layout assumes the presence of frontmatter resulting in a further exception being raised.
3. Fixed the stories layout to not assume the presence of a 'more_stories' section in `@front_matter`



