### PR TITLE
Fix BAM tracking pixel

### DIFF
--- a/app/webpacker/controllers/bam_controller.js
+++ b/app/webpacker/controllers/bam_controller.js
@@ -34,6 +34,10 @@ export default class extends AnalyticsBaseController {
   }
 
   sendEvent() {
-    this.constructor.ids.forEach((id) => fetch(`https://linkbam.uk/m/${id}.png`, { mode: 'no-cors'}));
+    this.constructor.ids.forEach((id) => {
+      const img = document.createElement('img');
+      img.src = `https://linkbam.uk/m/${id}.png`;
+      this.element.appendChild(img);
+    });
   }
 }

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -15,11 +15,11 @@ SecureHeaders::Configuration.default do |config|
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self' *.youtube.com ct.pinterest.com tr.snapchat.com *.hotjar.com],
-    connect_src: %W['self' linkbam.uk #{tta_service_uri.host} #{google_analytcs} ct.pinterest.com *.hotjar.com www.facebook.com],
+    connect_src: %W['self' #{tta_service_uri.host} #{google_analytcs} ct.pinterest.com *.hotjar.com www.facebook.com],
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com www.facebook.com],
     frame_ancestors: %w['none'],
-    img_src: %W['self' *.gov.uk data: maps.gstatic.com *.googleapis.com #{google_analytcs} www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com],
+    img_src: %W['self' linkbam.uk *.gov.uk data: maps.gstatic.com *.googleapis.com #{google_analytcs} www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com],
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %W['self' 'unsafe-inline' *.googleapis.com *.gov.uk code.jquery.com #{google_analytcs} *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com],

--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
     "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.2",
     "stimulus": "^1.1.1",
-    "turbolinks": "^5.2.0",
-    "whatwg-fetch": "^3.4.1"
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "@stimulus/test": "^1.1.1",
     "jest": "^26.0.1",
-    "jest-fetch-mock": "^3.0.3",
     "webpack-dev-server": "^3.11.0"
   },
   "jest": {
@@ -29,9 +27,6 @@
       "node_modules",
       "app/webpacker/controllers",
       "app/webpacker/javascript"
-    ],
-    "setupFilesAfterEnv": [
-      "./spec/javascript/jest.setup.js"
     ]
   },
   "scripts": {

--- a/spec/javascript/controllers/bam_controller_spec.js
+++ b/spec/javascript/controllers/bam_controller_spec.js
@@ -1,4 +1,3 @@
-const Cookies = require('js-cookie');
 import AnalyticsHelper from './analytics_spec_helper';
 import BamController from 'bam_controller';
 
@@ -6,6 +5,7 @@ describe('BamController', () => {
   document.head.innerHTML = `<script></script>`;
   document.body.innerHTML = `
   <div
+    id="container"
     data-controller="bam"
     data-bam-action="test"
     data-bam-event="test"
@@ -23,26 +23,17 @@ describe('BamController', () => {
     beforeEach(() => { 
       AnalyticsHelper.setAcceptedCookie();
       AnalyticsHelper.initApp('bam', BamController, 'bam');
-      window.fetch.resetMocks();
     })
 
-    it("makes a fetch request for each pixel", () => {
-      const urls = fetch.mock.calls.map((call) => call[0]);
+    it("appends each pixel to the controller element", () => {
+      const container = document.getElementById('container');
+      const images = Array.from(container.querySelectorAll('img'));
+      const ids = BamController.ids;
 
-      expect(urls).toEqual([
-        'https://linkbam.uk/m/3g6cKlN4VmA4FAL/1SlB2.png',
-        'https://linkbam.uk/m/nis3acYUOeaVpuG/RPOzc.png',
-        'https://linkbam.uk/m/cfZRDrq9SRKrBVU/FpASD.png',
-        'https://linkbam.uk/m/V8R6qhowRkziLjG/Eg0N9.png',
-        'https://linkbam.uk/m/X4KBgSPXbMgXXon/CRJA9.png',
-        'https://linkbam.uk/m/MP8YKC867PjN6Rl/BTYf2.png',
-        'https://linkbam.uk/m/5DRPPG8Sakm5o8i/4yVXp.png',
-        'https://linkbam.uk/m/fSSR83JdeURiiQ3/YNZ99.png',
-        'https://linkbam.uk/m/nwQx6WBpT23FfAn/1hnVZ.png',
-        'https://linkbam.uk/m/3BSBg0IMtWQmpkb/wFCtJ.png',
-        'https://linkbam.uk/m/1MbhNg55GhAVDkd/3VrFR.png',
-        'https://linkbam.uk/m/Ae4BnnTfkvZ5pRz/dbgOi.png',
-      ])
+      images.forEach((image) => {
+        const match = ids.some((id) => image.src.indexOf(id) != -1);
+        expect(match).toBeTruthy();
+      });
     })
   })
 })

--- a/spec/javascript/jest.setup.js
+++ b/spec/javascript/jest.setup.js
@@ -1,1 +1,0 @@
-require('jest-fetch-mock').enableMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,13 +2773,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.4:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
-  dependencies:
-    node-fetch "2.6.1"
-
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4984,14 +4977,6 @@ jest-environment-node@^26.0.1:
     jest-mock "^26.0.1"
     jest-util "^26.0.1"
 
-jest-fetch-mock@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
-  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
-  dependencies:
-    cross-fetch "^3.0.4"
-    promise-polyfill "^8.1.3"
-
 jest-get-type@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.0.0.tgz#381e986a718998dbfafcd5ec05934be538db4039"
@@ -5980,11 +5965,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -7379,11 +7359,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-polyfill@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
-  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.3.2"
@@ -9358,11 +9333,6 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
-  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
BAM have reported issues with their tracking links, I think because we're making the requests using `fetch` and `no-cors` so their cookie is not being sent. This PR switches out `fetch` to instead append `img` tags to the  DOM, so the browser makes the requests.
