### PR TITLE
Check Redis and API connection in healthcheck.json

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -9,10 +9,27 @@ class Healthcheck
     read_file "/etc/get-into-teaching-content-sha"
   end
 
+  def test_api
+    GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
+    true
+  rescue Faraday::Error
+    false
+  end
+
+  def test_redis
+    return nil unless ENV["REDIS_URL"]
+
+    Redis.current.ping == "PONG"
+  rescue RuntimeError
+    false
+  end
+
   def to_h
     {
       app_sha: app_sha,
       content_sha: content_sha,
+      api: test_api,
+      redis: test_redis,
     }
   end
 

--- a/spec/features/password_protection_spec.rb
+++ b/spec/features/password_protection_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Password protection", type: :feature do
   before do
+    allow_any_instance_of(Healthcheck).to receive(:test_api).and_return true
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("HTTPAUTH_USERNAME") { username }
     allow(ENV).to receive(:[]).with("HTTPAUTH_PASSWORD") { password }

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -37,6 +37,56 @@ describe Healthcheck do
         body: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map { |k, v| { id: v, value: k } }.to_json
   end
 
+  describe "test_api" do
+    subject { described_class.new.test_api }
+
+    context "with working api connection" do
+      it { is_expected.to be true }
+    end
+
+    context "with broken connection" do
+      before do
+        stub_request(:get, "#{git_api_endpoint}/api/types/teaching_subjects")
+          .to_timeout
+          .then.to_timeout
+          .then.to_timeout
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#test_redis" do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("REDIS_URL").and_return \
+        "redis://localhost:6379/1"
+    end
+
+    subject { described_class.new.test_redis }
+
+    context "with working connection" do
+      before do
+        allow(Redis).to receive(:current).and_return double(Redis, ping: "PONG")
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "with broken connection" do
+      before do
+        allow(Redis).to receive(:current).and_raise Redis::CannotConnectError
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with no configured connection" do
+      before { allow(ENV).to receive(:[]).with("REDIS_URL").and_return nil }
+      it { is_expected.to be nil }
+    end
+  end
+
   describe "#to_h" do
     subject { described_class.new.to_h }
     it { is_expected.to include :app_sha }

--- a/spec/requests/healthchecks_controller_spec.rb
+++ b/spec/requests/healthchecks_controller_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 describe HealthchecksController do
+  before do
+    allow_any_instance_of(Healthcheck).to receive(:test_api).and_return true
+  end
+
   describe "#show" do
     before { get healthcheck_path }
     it { expect(response).to have_http_status(:success) }


### PR DESCRIPTION
### Context

We should be able to see if we're getting connectivity issues to either API or Redis

### Changes proposed in this pull request

1. Extend the /healthcheck.json end point to show if connections to API and Redis are working 



