### PR TITLE
Rename personalised updates to email updates

### DIFF
--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -21,7 +21,7 @@ module MailingList
     end
 
     def set_page_title
-      @page_title = "Sign up for personalised updates"
+      @page_title = "Sign up for email updates"
       unless @current_step.nil?
         @page_title += ", #{@current_step.title.downcase} step"
       end

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -9,9 +9,9 @@
             <p><%= format_event_date @event, stacked: false %></p>
 
             <%- if params[:subscribed].to_s == "1" -%>
-            <h3>You've also signed up for personalised updates</h3>
+            <h3>You've also signed up for email updates</h3>
             <p>
-                You're ready to receive personalised updates to help you get
+                You're ready to receive email updates to help you get
                 into teaching.
             </p>
             <%- end -%>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -1,4 +1,4 @@
-<h1>Sign up for personalised updates to help you get into teaching</h1>
+<h1>Sign up for email updates to help you get into teaching</h1>
 
 <p>
   We know you’ll only want to receive updates that help you 

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -2,7 +2,7 @@
     <div class="content container-1000">
         <div class="content__left">
             <h1 class="strapline">You've signed up</h1>
-            <p>You’re ready to receive personalised updates to help you get into teaching.</p>
+            <p>You’re ready to receive email updates to help you get into teaching.</p>
 
             <h2>What happens next?</h2>
 

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
-    expect(page).to have_text "signed up for personalised updates"
+    expect(page).to have_text "signed up for email updates"
   end
 
   scenario "Full journey as a new candidate declining the mailing list option" do
@@ -81,7 +81,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
-    expect(page).not_to have_text "signed up for personalised updates"
+    expect(page).not_to have_text "signed up for email updates"
   end
 
   scenario "Full journey as an existing candidate" do
@@ -130,7 +130,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
-    expect(page).to have_text "signed up for personalised updates"
+    expect(page).to have_text "signed up for email updates"
   end
 
   scenario "Full journey as a returning candidate that resends the verification code" do
@@ -204,7 +204,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
-    expect(page).not_to have_text "signed up for personalised updates"
+    expect(page).not_to have_text "signed up for email updates"
   end
 
   scenario "Full journey as an existing candidate that has already subscribed to the teacher training adviser service" do
@@ -246,7 +246,7 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "What happens next"
-    expect(page).not_to have_text "signed up for personalised updates"
+    expect(page).not_to have_text "signed up for email updates"
   end
 
   def fill_in_personal_details_step(

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "First year")
     click_on "Next Step"
 
@@ -85,7 +85,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     channel_id = channels.first.id
     visit mailing_list_steps_path({ id: :name, channel: channel_id })
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "First year")
     click_on "Next Step"
 
@@ -131,7 +131,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "Other")
     click_on "Next Step"
 
@@ -183,7 +183,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "Final year")
     click_on "Next Step"
 
@@ -214,7 +214,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "Final year")
     click_on "Next Step"
 
@@ -238,7 +238,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "Final year")
     click_on "Next Step"
 
@@ -262,7 +262,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(degree_status: "Final year")
     click_on "Next Step"
 
@@ -279,7 +279,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
-    expect(page).to have_text "Sign up for personalised updates"
+    expect(page).to have_text "Sign up for email updates"
     fill_in_name_step(email: "test2@user.com")
     click_on "Next Step"
 


### PR DESCRIPTION
Content have requested we rename 'personalised updates' to 'email updates'.