### PR TITLE
Fix for analytics not getting included in CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -7,23 +7,24 @@ SecureHeaders::Configuration.default do |config|
   config.x_permitted_cross_domain_policies = "none"
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
 
-  tta_service_uri = URI.parse(ENV["TTA_SERVICE_URL"])
-  google_analytcs = "www.google-analytics.com ssl.google-analytics.com www.googletagmanager.com"
+  tta_service_hosts = []
+  tta_service_hosts << URI.parse(ENV["TTA_SERVICE_URL"]).host if ENV["TTA_SERVICE_URL"].present?
+  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com www.googletagmanager.com]
 
   config.csp = {
     default_src: %w['none'],
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self' *.youtube.com ct.pinterest.com tr.snapchat.com *.hotjar.com],
-    connect_src: %W['self' #{tta_service_uri.host} #{google_analytcs} ct.pinterest.com *.hotjar.com www.facebook.com],
+    connect_src: %w['self' ct.pinterest.com *.hotjar.com www.facebook.com] + google_analytics + tta_service_hosts,
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com www.facebook.com www.gov.uk],
     frame_ancestors: %w['self'],
     frame_src: %w['self' tr.snapchat.com www.facebook.com www.youtube.com],
-    img_src: %W['self' linkbam.uk *.gov.uk data: maps.gstatic.com *.googleapis.com #{google_analytcs} www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com],
+    img_src: %w['self' linkbam.uk *.gov.uk data: maps.gstatic.com *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com] + google_analytics,
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %W['self' 'unsafe-inline' *.googleapis.com *.gov.uk code.jquery.com #{google_analytcs} *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com],
+    script_src: %w['self' 'unsafe-inline' *.googleapis.com *.gov.uk code.jquery.com *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com] + google_analytics,
     style_src: %w['self' 'unsafe-inline' *.gov.uk *.googleapis.com],
     worker_src: %w['self'],
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/


### PR DESCRIPTION
### Context

The google analytics code was not getting included in the CSP - this is caused by trying to interpolate one array into another

### Changes proposed in this pull request

1. Use normal array combination to include analytics

### Guidance to review

1. I'll verify this on GiT than roll the same change out to TTA

