### PR TITLE
Remove uses of html_safe

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,14 +1,18 @@
 module EventsHelper
+  include TextFormattingHelper
+
   def format_event_date(event, stacked: true)
     return if event.start_at.blank?
 
     if event.start_at.to_date == event.end_at.to_date
-      sprintf(
-        "%{startdate} #{stacked ? '<br />' : 'at'} %{starttime} - %{endtime}",
-        startdate: event.start_at.to_date.to_formatted_s(:long_ordinal),
-        starttime: event.start_at.to_formatted_s(:time),
-        endtime: event.end_at.to_formatted_s(:time),
-      ).html_safe
+      safe_html_format(
+        sprintf(
+          "%{startdate} #{stacked ? '<br />' : 'at'} %{starttime} - %{endtime}",
+          startdate: event.start_at.to_date.to_formatted_s(:long_ordinal),
+          starttime: event.start_at.to_formatted_s(:time),
+          endtime: event.end_at.to_formatted_s(:time),
+        ),
+      )
     else
       sprintf \
         "%{startdate} to %{enddate}",

--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -7,6 +7,6 @@ module TextFormattingHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b], attributes: %w[href]
+    sanitize html, tags: %w[strong a ul li p b br], attributes: %w[href target]
   end
 end

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -4,7 +4,7 @@
     privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }))
 %>
 
-<%= f.govuk_check_boxes_fieldset :privacy_policy, legend: { text: legend_text.html_safe } do %>
+<%= f.govuk_check_boxes_fieldset :privacy_policy, legend: { text: safe_html_format(legend_text) } do %>
   <%= f.hidden_field :privacy_policy, value: false %>
   <%= f.govuk_check_box :privacy_policy, true,
         multiple: false, link_errors: true,

--- a/app/views/mailing_list/steps/_contact.html.erb
+++ b/app/views/mailing_list/steps/_contact.html.erb
@@ -15,7 +15,7 @@
     privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }))
 %>
 
-<%= f.govuk_check_boxes_fieldset :accept_privacy_policy, legend: { text: legend_text.html_safe } do %>
+<%= f.govuk_check_boxes_fieldset :accept_privacy_policy, legend: { text: safe_html_format(legend_text) } do %>
   <%= f.hidden_field :accept_privacy_policy, value: 0 %>
   <%= f.govuk_check_box :accept_privacy_policy, 1,
         multiple: false, link_errors: true,

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -6,4 +6,4 @@
 
 <%= f.govuk_text_field :timed_one_time_password, 
 label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', email: email) }, 
-hint_text: hint_text.html_safe %>
+hint_text: safe_html_format(hint_text) %>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -12,7 +12,7 @@ describe EventsHelper, type: "helper" do
     subject { format_event_date event, stacked: stacked }
 
     context "for single day event" do
-      it { is_expected.to eql "June 1st, 2020 <br /> 10:00 - 12:00" }
+      it { is_expected.to eql "June 1st, 2020 <br> 10:00 - 12:00" }
     end
 
     context "for multi day event" do

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -32,5 +32,10 @@ describe TextFormattingHelper, type: :helper do
       let(:html) { "<a href=\"http://test.com\" onclick=\"somethingNasty();\">boom</a>" }
       it { is_expected.to eql "<a href=\"http://test.com\">boom</a>" }
     end
+
+    context "with anchor tags" do
+      let(:html) { "<a href=\"http://test.com\" target=\"blank\">open</a>" }
+      it { is_expected.to eql html }
+    end
   end
 end


### PR DESCRIPTION
We should be using `simple_format` to safely allow whitelisted HTML elements and attributes.

