### PR TITLE
Prevent insecure request upgrades in development

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -27,7 +27,7 @@ SecureHeaders::Configuration.default do |config|
     script_src: %w['self' 'unsafe-inline' *.googleapis.com *.gov.uk code.jquery.com *.facebook.net *.googletagmanager.com *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com] + google_analytics,
     style_src: %w['self' 'unsafe-inline' *.gov.uk *.googleapis.com],
     worker_src: %w['self'],
-    upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
+    upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: [ENV["SENTRY_CSP_REPORT_URI"]],
   }
 


### PR DESCRIPTION
In development we don't support SSL, so upgrading insecure requests has can have a strange knock-on behaviour that results in requests from Turbolinks being made multiple times.