### PR TITLE
Filter sensitive information from logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[
+  address_postcode
+  email
+  first_name
+  last_name
+  password
+  telephone
+  timed_one_time_password
+]


### PR DESCRIPTION
We don't want to capture any personally identifiable information in our logs by accident.
