### PR TITLE
stop turbo links reloading the page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
 
-  <%= analytics_body_tag class: "govuk-template__body govuk-body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body" data: { controller: "link", target: "link.content" }  do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
 
-  <%= analytics_body_tag class: "govuk-template__body govuk-body" data: { controller: "link", target: "link.content" }  do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "link", target: "link.content" }  do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", target: "link.content" }, id: "body" do %>
     <div id="skiplink-container">
         <div>
             <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/stories.html.erb
+++ b/app/views/layouts/stories.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", target: "link.content" }, id: "body" do %>
         <div class="container">
             <%= render "sections/header" %>
             <section class="content container-1000" role="main" id="main-content"> 

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+
+    static targets = [ "content"];
+
+    connect() {
+        this.preventTurboLinksOnJumpLinks();
+    }
+
+    preventTurboLinksOnJumpLinks() {
+        const links = this.contentTarget.querySelectorAll('a');
+        links.forEach((l) => {
+            if (l.getAttribute('href')?.startsWith('#')) {
+                l.dataset.turbolinks = "false"
+            }
+        });
+    }
+        
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -12,3 +12,11 @@ Turbolinks.start();
 
 import "controllers";
 
+document.addEventListener("turbolinks:load", function() {
+    const links = document.querySelectorAll('a');
+    links.forEach((l) => {
+        if (l.getAttribute('href')?.startsWith('#')) {
+            l.dataset.turbolinks = "false"
+        }
+    });
+})

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,12 +11,3 @@ Rails.start();
 Turbolinks.start();
 
 import "controllers";
-
-document.addEventListener("turbolinks:load", function() {
-    const links = document.querySelectorAll('a');
-    links.forEach((l) => {
-        if (l.getAttribute('href')?.startsWith('#')) {
-            l.dataset.turbolinks = "false"
-        }
-    });
-})

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -1,0 +1,40 @@
+const Cookies = require('js-cookie') ;
+import CookiePreferences from 'cookie_preferences' ;
+import { Application } from 'stimulus' ;
+import LinkController from 'link_controller.js' ;
+
+describe('LinkController', () => {
+  function initPageTemplate() {
+    document.body.innerHTML = `
+    <div data-controller="link" data-target="link.content">
+      <div id="level-1" class="video-overlay" data-target="video.player" data-action="click->video#close">
+        <a href="#level-3" />
+        <div id="level-2">
+          <a href="#level-1" />
+          <div id="level-3">
+            <a href="#level-1" />
+          </div>
+        </div>
+      </div>
+    </div>`
+  }
+
+    describe("when first loaded", () => {
+      
+      it("adds data-turbolinks attribute to all jump links", () => {
+        var linkNodes = document.getElementsByTagName("a");
+        Object.keys(linkNodes).forEach(function (key) {
+            expect(linkNodes[key].hasAttribute('data-turbolinks')).toBe(true);
+        });
+      });
+
+      it("sets data-turbolinks attribute to value of false", () => {
+        var linkNodes = document.getElementsByTagName("a");
+        Object.keys(linkNodes).forEach(function (key) {
+            expect(linkNodes[key][data-turbolinks]).toBe(false);
+        });
+      })
+
+    });
+
+});


### PR DESCRIPTION
turbo links was interfering with anchors links/skip links/jump links so this JS snippet adds an attribute to them to stop it reloading the page
