### PR TITLE
Persist event filters in category back link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,4 +74,12 @@ module ApplicationHelper
 
     link_to text, path, **options
   end
+
+  def internal_referer
+    referer = request.referer
+    internal = referer.to_s.include?(root_url)
+    return nil unless internal
+
+    referer
+  end
 end

--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -10,7 +10,7 @@
 <section class="types-of-event content container-1000">
 
     <div class="content__left">
-        <%= link_to "All events", events_path, class: "backlink" %>
+        <%= back_link(internal_referer || events_path, text: "All events") %>
         <h3><%= category_name.pluralize %></h3>
         <br />
         <%= safe_html_format(t("event_categories.#{category_name.parameterize(separator: "_")}")) %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -93,4 +93,29 @@ describe ApplicationHelper do
       it { is_expected.to have_css "body.homepage" }
     end
   end
+
+  describe "#internal_referer" do
+    before { helper.request = double("request") }
+
+    it "returns nil if the referrer is not set" do
+      helper.request.stub(:referer) { nil }
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns nil if the referrer is empty" do
+      helper.request.stub(:referer) { " " }
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns nil if the referrer is external" do
+      helper.request.stub(:referer) { "https://external.com" }
+      expect(helper.internal_referer).to be_nil
+    end
+
+    it "returns the referrer if internal" do
+      referer = root_url
+      helper.request.stub(:referer) { referer }
+      expect(helper.internal_referer).to be(referer)
+    end
+  end
 end


### PR DESCRIPTION
When navigating from a filtered set of search results to an event category we display a back link to 'All events'. Currently, this links to `/events` and you lose your filters; instead, we want to persist the filters and display the results the user navigated away from initially.

Use the referrer to point back to the filtered results; if the referrer was external or not available we fallback to the `/events` path.
