### PR TITLE
Format Event Description when viewing event

### DIFF
--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -8,11 +8,6 @@
             <h1>Sign up for this event:</h1>
             <h2><%= event.name %></h2>
 
-            <p>
-              <%= event.description if wizard.first_step? %>
-            </p>
-
-
             <%= govuk_form_for current_step, url: step_path do |f| %>
               <%= f.govuk_error_summary %>
 
@@ -29,7 +24,6 @@
 
         <div class="content__right">
             <%= render "events/event", event: event if wizard.first_step? %>
-        </div>
         </div>
     </div>
 </section>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -31,7 +31,7 @@
         <% end %>
 
         <h2 class="strapline-article">Event information</h2>
-        <p><%= @event.description %></p>
+        <%= safe_format @event.description %>
 
         <% if @event.building && !@event.is_online %>
         <h2 class="strapline-article">Venue information</h2>

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -27,7 +27,6 @@
 
   h2 {
       font-size: 28px;
-      margin: 0;
       border: 0;
   }
 


### PR DESCRIPTION
### Context

Event descriptions should be formatted correctly on the Events page and not shown when applying for an event

### Changes proposed in this pull request

1. Use the safe_format helper to show descriptions
2. Removed description from application process


