### PR TITLE
Fix event box alignment when < 3 panels

### DIFF
--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -252,6 +252,7 @@
         margin-right: -10px;
         margin-bottom: 30px;
         a {
+            box-sizing: border-box;
             width: 33.3333%;
             padding: 0 10px;
             .event-resultbox {


### PR DESCRIPTION
When there are < 3 panels in a row the spacing is off due to the padding being added on to the 33.3% width. Changing to `box-sizing: border-box` results in the padding being part of the width calculation, so it's even across panels when there are < 3.

