### PR TITLE
Fixed links to cookie policy

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -162,7 +162,7 @@
               <p>They always need to be on.</p>
 
               <p>
-                <a href="/cookie-policy">Find out more</a>
+                <%= link_to "Find out more", cookies_path %>
                 about cookies on this service
               </p>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get "/tta", to: "pages#tta_service", as: nil
 
   resource "cookie_preference", only: %i[show]
-  get "/cookie-policy", to: "pages#show", page: "cookie-policy"
+  get "/cookie-policy", to: redirect("/cookies")
 
   resources "events", path: "/events", only: %i[index show search] do
     collection do


### PR DESCRIPTION
Currently the cookie preferences page links to '/cookie-policy" but we subsequently added the page at "/cookies"