### PR TITLE
Bump API client version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 06cfd0441cb87f4d5697ec6aa0eca65d434f3fee
+  revision: 1e7705bb2926e244962ca7336bedc8ccd114b9c2
   specs:
     get_into_teaching_api_client (1.1.2)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.2)
+    get_into_teaching_api_client_faraday (0.1.3)
       activesupport
       faraday
       faraday-encoding


### PR DESCRIPTION
Updates the HTTP cache from 10 minutes to 5.

