### PR TITLE
GITPB-689 LogIt integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,5 +91,12 @@ group :test do
   gem "webmock"
 end
 
+group :rolling, :preprod, :userresearch, :production do
+  # loading the Gem monkey patches rails logger
+  # only load in prod-like environments when we actually need it
+  gem "amazing_print"
+  gem "rails_semantic_logger"
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.2.1)
     ast (2.4.0)
     bindex (0.8.1)
     bootsnap (1.4.6)
@@ -197,6 +198,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.4)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.3.3)
       actionpack (= 6.0.3.3)
       activesupport (= 6.0.3.3)
@@ -272,6 +277,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.7.2)
+      concurrent-ruby (~> 1.0)
     semantic_range (2.3.0)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
@@ -333,6 +340,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  amazing_print
   bootsnap (>= 1.1.0)
   brakeman
   byebug
@@ -354,6 +362,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.2)
+  rails_semantic_logger
   redis
   rinku
   rspec-rails (~> 4.0.0)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,3 +41,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+on_worker_boot do
+  if defined? SemanticLogger
+    # Re-open appenders after forking the process
+    SemanticLogger.reopen
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

GITPB-689

### Context

We should be generating logs which are useful to LogIt - initially that means single line logs, or logs where the multiple parts of a request can be grouped togther

### Changes proposed in this pull request

1. Make STDOUT logs synchronous
2. Only load Semantic logging if either SEMANTIC_LOGGING or CF_INSTANCE_GUID are set
3. Make puma reopen the log output when if it forks a worker if running with semantic logging

### Notes

1. I've tested to make sure param filtering is honoured - visiting `http://localhost:3000/?first_name=Joe` shows as `[FILTERED]`

