### PR TITLE
Embed Scribble content for Teaching Events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 1e7705bb2926e244962ca7336bedc8ccd114b9c2
+  revision: b790c3adf3f7bf8aae0335c8c4b76d99b0326265
   specs:
-    get_into_teaching_api_client (1.1.2)
+    get_into_teaching_api_client (1.1.3)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.3)
+    get_into_teaching_api_client_faraday (0.1.4)
       activesupport
       faraday
       faraday-encoding

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -84,6 +84,15 @@
             <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>
           <% end %>
         <% end %>
+
+        <% if @event.scribble_id %>
+          <h2 class="strapline-article">Attend online</h2>
+        <% end %>
       </div>
-        <%= render "sections/page_question" %>
+      
+      <% if @event.scribble_id %>
+        <div data-controller="scribble" data-scribble-id="<%= @event.scribble_id %>"></div>
+      <% end %>
+      
+      <%= render "sections/page_question" %>
 </section>

--- a/app/webpacker/controllers/scribble_controller.js
+++ b/app/webpacker/controllers/scribble_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "stimulus" ;
+
+export default class extends Controller {
+  connect() {
+    this.load();
+  }
+
+  load() {
+    this.setId();
+    this.initService();
+  }
+
+  setId() {
+    this.element.classList.add('scrbbl-embed');
+    this.element.dataset.src = this.id;
+  }
+
+  initService() {
+    if (window.scribble != undefined) {
+      return;
+    }
+
+    window.scribble = (function(d, s, id) {var js,ijs=d.getElementsByTagName(s)[0];
+    if(d.getElementById(id))return;js=d.createElement(s);
+    js.id=id;js.src="//embed.scribblelive.com/widgets/embed.js";
+    ijs.parentNode.insertBefore(js, ijs);}(document, 'script', 'scrbbl-js'));
+  }
+
+  get id() {
+    return this.data.get('id');
+  }
+}

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -20,11 +20,11 @@ SecureHeaders::Configuration.default do |config|
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com www.facebook.com www.gov.uk],
     frame_ancestors: %w['self'],
-    frame_src: %w['self' tr.snapchat.com www.facebook.com www.youtube.com *.hotjar.com],
+    frame_src: %w['self' embed.scribblelive.com tr.snapchat.com www.facebook.com www.youtube.com *.hotjar.com],
     img_src: %w['self' linkbam.uk *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com *.visualwebsiteoptimizer.com] + google_analytics,
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %w['self' 'unsafe-inline' 'unsafe-eval' *.googleapis.com *.gov.uk code.jquery.com *.facebook.net *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com *.youtube.com *.visualwebsiteoptimizer.com] + google_analytics,
+    script_src: %w['self' 'unsafe-inline' 'unsafe-eval' embed.scribblelive.com *.googleapis.com *.gov.uk code.jquery.com *.facebook.net *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com *.youtube.com *.visualwebsiteoptimizer.com] + google_analytics,
     style_src: %w['self' 'unsafe-inline' *.gov.uk *.googleapis.com] + google_analytics,
     worker_src: %w['self' *.visualwebsiteoptimizer.com blob:],
     upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/

--- a/spec/javascript/controllers/scribble_controller_spec.js
+++ b/spec/javascript/controllers/scribble_controller_spec.js
@@ -1,0 +1,25 @@
+import { Application } from 'stimulus'
+import ScribbleController from 'scribble_controller' ;
+
+describe('ScribbleController', () => {
+  var scribble;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="scribble" data-controller="scribble" data-scribble-id="123"></div>
+    `;
+
+    const application = Application.start();
+    application.register('scribble', ScribbleController);
+    scribble = document.getElementById('scribble');
+  })
+
+  it('sets the scribble data-src and class', () => {
+    expect(scribble.dataset.src).toEqual('123');
+    expect(scribble.classList.contains('scrbbl-embed')).toBeTruthy();
+  });
+
+  it('initialises the service', () => {
+    expect(window.scribble).not.toBe(undefined);
+  });
+})

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -113,6 +113,13 @@ describe EventsController do
           it { is_expected.to match(/This event is now closed/) }
         end
 
+        context "when the event has a scribble_id" do
+          let(:event) { build(:event_api, scribble_id: "123", readable_id: event_readable_id) }
+
+          it { is_expected.to match(/Attend online/) }
+          it { is_expected.to match(/data-controller="scribble" data-scribble-id="123"/) }
+        end
+
         context "when the event is online" do
           let(:event) { build(:event_api, is_online: true) }
 


### PR DESCRIPTION
- Bump API client to include TeachingEvent scribble_id

- Display Scribble iframe for events with a scribble_id

If a `TeachingEvent` contains a `scribble_id` then we want to embed the Scribble iframe (which contains details on how to sign up, etc).

The title for the embedded Scribble content is encased in the left content section, whilst the iframe itself takes up the full container width.

<img width="1394" alt="Screenshot 2020-10-01 at 11 20 19" src="https://user-images.githubusercontent.com/29867726/94797492-19774c00-03d8-11eb-8876-a2f9d4cf2a1d.png">
