### PR TITLE
Allow symlinking of the content directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ yarn-debug.log*
 .env
 .env*.local
 *.log
-app/views/content/**/*
+app/views/content
 /config/credentials/*.key
 /coverage

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ You will need to do this manually to have the content available on your local de
 1. Clone the following repo: https://github.com/DFE-Digital/get-into-teaching-content
 2. Copy the `content` folder from this repo and merge it into `app/views/content`
 
+Alternatively, create a [symlink](https://en.wikipedia.org/wiki/Symbolic_link)
+from `apps/views/content` to the location of your content directory by changing
+to your `app/views` directory and running `ln -s content
+/the/path/to/your/content/directory`.
+
 ## Whats included in this website
 
 - Rails 6.0 with Webpacker


### PR DESCRIPTION
### JIRA ticket number

N/A

### Context

Manually copying the content from the content repo appears to be a bit of a chore.

### Changes proposed in this pull request

Change the `.gitignore` line that ignores the contents of the content directory to ignore the directory too. This gives the developer the option of copying or symlinking.

### Guidance to review

Hopefully minimal - providing it doesn't cause any problems elsewhere that I'm not yet aware of!
