### PR TITLE
extra guidance routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,9 @@ Rails.application.routes.draw do
   get "/life-as-a-teacher/my-story-into-teaching/*story", to: "stories#show"
 
   get "/guidance", to: "pages#showblank", page: "guidance"
+  get "/finance-guidance", to: "pages#showblank", page: "finance-guidance"
+  get "/ways-to-train-guidance", to: "pages#showblank", page: "ways-to-train-guidance"
+  get "/returning-to-teaching-guidance", to: "pages#showblank", page: "returning-to-teaching-guidance"
 
   get "*page", to: "pages#show", as: :page
 end


### PR DESCRIPTION
extra blank page routes

 get "/guidance", to: "pages#showblank", page: "guidance"
  get "/finance-guidance", to: "pages#showblank", page: "finance-guidance"
  get "/ways-to-train-guidance", to: "pages#showblank", page: "ways-to-train-guidance"
  get "/returning-to-teaching-guidance", to: "pages#showblank", page: "returning-to-teaching-guidance"