### PR TITLE
Fix Scribble not loading on Turbolinks page change

### DIFF
--- a/app/webpacker/controllers/scribble_controller.js
+++ b/app/webpacker/controllers/scribble_controller.js
@@ -16,14 +16,10 @@ export default class extends Controller {
   }
 
   initService() {
-    if (window.scribble != undefined) {
-      return;
-    }
-
-    window.scribble = (function(d, s, id) {var js,ijs=d.getElementsByTagName(s)[0];
-    if(d.getElementById(id))return;js=d.createElement(s);
-    js.id=id;js.src="//embed.scribblelive.com/widgets/embed.js";
-    ijs.parentNode.insertBefore(js, ijs);}(document, 'script', 'scrbbl-js'));
+    const scribble = document.createElement("script");
+    scribble.id = "scrbbl-js";
+    scribble.src = "//embed.scribblelive.com/widgets/embed.js";
+    this.element.appendChild(scribble);
   }
 
   get id() {


### PR DESCRIPTION
The Scribble `script` tag was being inserted into the `head` of the document by default, causing it to not be re-evaluated by Turbolinks on a page change.

Instead, we append the script inside the Stimulus controller element so it will be executed on every instance of the controller loading.