### PR TITLE
add advertise event copy block

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,13 +7,20 @@
 %>
 <section role="main" id="main-content">
     <div class="types-of-event content container-1000">
-
         <div class="content__left">
             <p>
                 <strong>Our nationwide events are informal opportunities for you to get free expert advice about your next steps into teaching.</strong>
             </p>
+            <p>
+              If you’d like to advertise your teaching event in this listing, please 
+              <a  href="https://form.education.gov.uk/fillform.php?self=1&amp;form_id=KGRAPEGQYmw&amp;type=form&amp;ShowMsg=1&amp;skipExtraPage=1&amp;form_name=Provider+event+details+-+Get+into+Teaching+website&amp;noRegister=false&amp;ret=/MyServices&amp;blackListId=KGRAPEGQYmw&amp;cancelRedirectLink=%2F&amp;noLoginPrompt=1" 
+                  title="Submit your event details on GOV.UK"   
+                  target="_blank"
+                  rel="noopener norefferer">
+                fill in our online form<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i>
+              </a>
+            </p>
         </div>
-
     </div>
 
     <section class="search-for-events">


### PR DESCRIPTION
extra block of copy about advertising for an event, taken from the current BAU site 
(request from Myles and David)
