### PR TITLE
set category name in hero title

### DIFF
--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -3,7 +3,7 @@
 <% @page_title = category_name %>
 
 <%= render "sections/hero",  
-  header: "Train to teach events", 
+  header: category_name,
   image: "media/images/events-hero-dt.jpg",
   deep: false,
   mailinglist: false 


### PR DESCRIPTION
On the category type listings page the title always reads "Train to Teach events" even when looking at other categories such as Online Events.

This was hard coded, simple fix to replace with category title variable

