### PR TITLE
Remove "No Preference" and "Other" from preferred teaching subject options

### DIFF
--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -39,7 +39,9 @@ module Events
 
       def teaching_subject_options
         @teaching_subject_options ||=
-          GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
+          GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.reject do |type|
+            GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
+          end
       end
 
       def teaching_subject_option_ids

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -17,7 +17,9 @@ module MailingList
     private
 
       def query_teaching_subjects
-        GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
+        GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.reject do |type|
+          GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
+        end
       end
     end
   end

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -50,7 +50,12 @@ module GetIntoTeachingApiClient
         "Art and design" => "7e2655a1-2afa-e811-a981-000d3a276620",
         "Maths" => "a42655a1-2afa-e811-a981-000d3a276620",
         "Pyhsics" => "ac2655a1-2afa-e811-a981-000d3a276620",
-        "No preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
+      }.freeze
+
+    IGNORED_PREFERRED_TEACHING_SUBJECTS =
+      {
+        "Other" => "bc2655a1-2afa-e811-a981-000d3a276620",
+        "No Preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
       }.freeze
   end
 end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -65,4 +65,23 @@ describe Events::Steps::PersonalisedUpdates do
       it { is_expected.to be_skipped }
     end
   end
+
+  describe "#teaching_subject_options" do
+    let(:teaching_subject_types) do
+      subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
+        GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
+      )
+      subjects.map { |k, v| GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k }) }
+    end
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        receive(:get_teaching_subjects).and_return(teaching_subject_types)
+    end
+
+    subject { instance.teaching_subject_options }
+
+    it { expect(subject.map(&:id)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
+    it { expect(subject.map(&:value)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.keys) }
+  end
 end

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -25,4 +25,17 @@ describe MailingList::Steps::Subject do
     it { is_expected.not_to allow_value("").for :preferred_teaching_subject_id }
     it { is_expected.not_to allow_value("random").for :preferred_teaching_subject_id }
   end
+
+  describe "#teaching_subject_ids" do
+    let(:teaching_subject_types) do
+      subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
+        GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
+      )
+      subjects.map { |k, v| GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k }) }
+    end
+
+    subject { instance.teaching_subject_ids }
+
+    it { is_expected.to eq([nil] + GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
+  end
 end


### PR DESCRIPTION
- Remove No Preference/Other from MailingList::Steps::Subject
- Remove No Preference/Other from Event::Steps::PersonalisedUpdates

We no longer want "No Preference" or "Other" to be available values when selecting your preferred teaching subject.