### PR TITLE
Add extra copy to provider events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,7 +26,7 @@ module EventsHelper
   end
 
   def can_sign_up_online?(event)
-    event.web_feed_id && event_status_open?(event)
+    event.web_feed_id && event_status_open?(event) && !is_event_type?(event, "School or University Event")
   end
 
   def is_event_type?(event, type_name)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -29,6 +29,10 @@ module EventsHelper
     event.web_feed_id && event_status_open?(event)
   end
 
+  def is_event_type?(event, type_name)
+    event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES.dig(type_name)
+  end
+
   def embed_event_video_url(video_url)
     video_url&.sub("watch?v=", "embed/")
   end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -78,12 +78,14 @@
                   Sign up for this <span>event</span>
               <% end %>
             </p>
-            
+
             <p>
               To attend this event, you must register for a place. Once registered, you will receive log-in information and joining instructions via email.
               Please note: to access this event you will require a laptop/desktop pc and be using chrome as your browser.
             </p>
 
+          <% elsif is_event_type?(@event, "School or University Event") %>
+            <p>To register for this event, follow the instructions in the event information section.</p>
           <% elsif @event.provider_website_url %>
             <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i>.<p>
           <% elsif @event.provider_contact_email %>
@@ -95,10 +97,10 @@
           <h2 class="strapline-article">Attend online</h2>
         <% end %>
       </div>
-      
+
       <% if @event.scribble_id %>
         <div data-controller="scribble" data-scribble-id="<%= @event.scribble_id %>"></div>
       <% end %>
-      
+
       <%= render "sections/page_question" %>
 </section>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -67,8 +67,8 @@
         <% end %>
 
         <% if event_status_open?(@event) %>
+          <h2 class="strapline-article">How to attend</h2>
           <% if can_sign_up_online?(@event) %>
-            <h2 class="strapline-article">How to attend</h2>
             <p>
                 To access this event, please sign up on this page and watch out for the reminder email we will send the day before the event. It will contain an access link to the live online event and a directory of some of the local training providers.
             </p>
@@ -85,10 +85,8 @@
             </p>
 
           <% elsif @event.provider_website_url %>
-            <h2 class="strapline-article">How to attend</h2>
             <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i>.<p>
           <% elsif @event.provider_contact_email %>
-            <h2 class="strapline-article">How to attend</h2>
             <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>
           <% end %>
         <% end %>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -81,6 +81,20 @@ describe EventsHelper, type: "helper" do
     end
   end
 
+  describe "#is_event_type?" do
+    let(:matching_type) { "School or University Event" }
+    let(:non_matching_type) { "Application Workshop" }
+    let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
+
+    it "should be truthy when the type matches" do
+      expect(is_event_type?(event, matching_type)).to be_truthy
+    end
+
+    it "should be falsy when the type matches" do
+      expect(is_event_type?(event, non_matching_type)).to be_falsy
+    end
+  end
+
   describe "#event_type_color" do
     it "returns green for train to teach events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -133,6 +133,7 @@ describe EventsController do
           let(:event) { build(:event_api, web_feed_id: nil, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]) }
 
           it { is_expected.to match(%r{To register for this event, follow the instructions in the event information section}) }
+          it { is_expected.not_to match(%r{Sign up for this}) }
         end
       end
     end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -128,6 +128,12 @@ describe EventsController do
           it { is_expected.to_not match(/#{event.building.address_line2}/) }
           it { is_expected.to_not match(/#{event.building.address_postcode}/) }
         end
+
+        context %(when the event is a 'School or University Event') do
+          let(:event) { build(:event_api, web_feed_id: nil, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]) }
+
+          it { is_expected.to match(%r{To register for this event, follow the instructions in the event information section}) }
+        end
       end
     end
 


### PR DESCRIPTION
### JIRA ticket number

N/A

### Context

Small copy change for events of type 'School and University Event'

### Changes proposed in this pull request

School or University events are now considered as though they can't be signed up for online. Instead of displaying any information in the 'How to apply' section the following text directs them to the event information section where they _should_ be given all the required info.

> To register for this event, follow the instructions in the event information section.

The 'Sign up for this event' button is also hidden when the event is a 'School or University Event'.

### Guidance to review

Does it look sane? I'm not sure the additional helper is an optimal solution here, it really should be a method on the event object (or a wrapper of it).

![Screenshot from 2020-10-05 13-01-43](https://user-images.githubusercontent.com/128088/95077295-2ca55700-070b-11eb-9d0a-1ce253f372bd.png)
