### PR TITLE
Added a fallback for when VWO code is not enabled

### DIFF
--- a/app/views/sections/_vwo_code.html.erb
+++ b/app/views/sections/_vwo_code.html.erb
@@ -1,6 +1,6 @@
-<%- if ENV["VWO_ID"].present? -%>
 <!-- Start VWO Async SmartCode -->
 <script type="text/javascript">
+<%- if ENV["VWO_ID"].present? -%>
   window._vwo_code = window._vwo_code || (function(){
   var account_id="<%= ENV["VWO_ID"] %>",
   settings_tolerance=2000,
@@ -70,6 +70,8 @@
       document.dispatchEvent(new CustomEvent("vwo:completed")) ;
     }
   }], 5000 /*MAXIMUM TIME IN SECONDS IN WHICH GA CODE WILL EXECUTE ANYWAY*/ );
+<%- else -%>
+  window.willRedirectionOccurByVWO = false ;
+<%- end -%>
 </script>
 <!-- End VWO Async SmartCode -->
-<%- end -%>


### PR DESCRIPTION
### Context

The analytics are not being fired if the VWO code is not enabled

### Changes proposed in this pull request

1. This is caused by a missing global variable so always assign it to false when not enabled



