### PR TITLE
Prefix the classes on main footer with site-footer to ease selecting

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,29 +1,29 @@
-<footer>
+<footer class="site-footer">
   <%= render "sections/talk-to-us" %>
-  <div class="footer-top">
-    <div class="footer-top__social">
-      <a href="https://www.facebook.com/getintoteaching" class="footer-top__social__link" target="_blank" rel="noopener noreferrer">
+  <div class="site-footer-top">
+    <div class="site-footer-top__social">
+      <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-facebook-f"></i>
         <span class="visually-hidden">Facebook - opens in a new tab</span>
       </a>
-      <a href="https://www.instagram.com/get_into_teaching/" class="footer-top__social__link" target="_blank" rel="noopener noreferrer">
+      <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-instagram"></i>
         <span class="visually-hidden">Instagram - opens in a new tab</span>
       </a>
-      <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="footer-top__social__link" target="_blank" rel="noopener noreferrer">
+      <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-linkedin-in"></i>
         <span class="visually-hidden">LinkedIn - opens in a new tab</span>
       </a>
-      <a href="https://twitter.com/getintoteaching" class="footer-top__social__link" target="_blank" rel="noopener noreferrer">
+      <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-twitter"></i>
         <span class="visually-hidden">Twitter - opens in a new tab</span>
       </a>
-      <a href="http://www.youtube.com/user/getintoteaching" class="footer-top__social__link" target="_blank" rel="noopener noreferrer">
+      <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-youtube"></i>
         <span class="visually-hidden">Youtube - opens in a new tab</span>
       </a>
     </div>     
-    <div class="footer-top__links-container">
+    <div class="site-footer-top__links-container">
       <%= link_to("Home", page_path(page: :home)) %>
       <% navigation_resources(@sitemap).each_with_index do |resource, index| %>
         <a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a>
@@ -31,17 +31,17 @@
       <%= link_to "Find an event near you", events_path %>
     </div>
   </div>
-  <div class="footer-bottom">
-    <div class="footer-bottom__logo-container">
+  <div class="site-footer-bottom">
+    <div class="site-footer-bottom__logo-container">
       <img src="<%= asset_pack_path 'media/images/dfelogo.png' %>" alt="Department for Education">
     </div>
-    <div class="footer-bottom__links-container">
+    <div class="site-footer-bottom__links-container">
       <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSfIBfaYUk07Fb6dxUKAokiPoGGL73ZYVGHM1mSNyA-K-6QRbA/viewform">Feedback</a>
       <%= link_to "Cookies", cookies_path %>
       <%= link_to "Privacy notice", privacy_policy_path %>
       <%= link_to("Accessibility", page_path(page: :accessibility)) %>
       <a target="_blank" rel="noopener noreferrer" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
-      <div class="footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated</div>
+      <div class="site-footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated</div>
     </div>
   </div>
 </footer>

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -1,7 +1,7 @@
-body > footer {
+footer.site-footer {
     background-color: $black;
 
-    .footer-top {
+    .site-footer-top {
         width: 100%;
         padding-left: 40px;
         padding-right: 40px;
@@ -70,7 +70,7 @@ body > footer {
         }
     }
 
-    .footer-bottom {
+    .site-footer-bottom {
         height: 140px;
         width: 100%;
         padding-left: 40px;
@@ -150,7 +150,7 @@ body > footer {
 }
 
 @media only screen and (max-width: 1155px) {
-    footer .footer-top__links-container {
+    footer .site-footer-top__links-container {
         max-width: none;
     }
 }
@@ -159,7 +159,7 @@ body > footer {
 
     footer {
 
-        .footer-top {
+        .site-footer-top {
             padding-left: 20px;
             padding-right: 20px;
             padding-top: 20px;
@@ -197,7 +197,7 @@ body > footer {
             }
         }
 
-        .footer-bottom {
+        .site-footer-bottom {
             display: block;
             height: 360px;
             padding-left: 20px;


### PR DESCRIPTION
Previously they were all contained in just a `<footer>` tag which made using footers on other elements more difficult. Now the main footer and everything related to it has a class (or prefix) of `site-footer`.