### PR TITLE
element.getElementById causing console errors in chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 #  DFE-Digital Get into Teaching website
 
-
-
-
 ## Prerequisites
 
 - Ruby 2.6.6

--- a/app/webpacker/controllers/accordion_controller.js
+++ b/app/webpacker/controllers/accordion_controller.js
@@ -65,7 +65,10 @@ export default class extends Controller {
         }
 
         if(!dontScroll) {
-            this.element.getElementById('step-' + stepnumber).scrollIntoView(true,{smooth:true});
+            let element = document.getElementById('step-' + stepnumber);
+            if(element) {
+                element.scrollIntoView(true,{smooth:true});
+            }
         }
     }
 


### PR DESCRIPTION
element.getelementById is causing errors in chrome
not sure how this call managed to get in there by replacing it with document.getelementById retains functionality, all tests still pass and also fixes the console errors.

added in an additional check to make sure the element exists also
