### PR TITLE
Revert "Allow HTML in event descriptions"

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -25,7 +25,7 @@
         <% end %>
 
         <h2 class="strapline-article">Event information</h2>
-        <%= safe_html_format @event.description %>
+        <%= safe_format @event.description %>
 
         <% if @event.building && !@event.is_online %>
         <h2 class="strapline-article">Venue information</h2>

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     web_feed_id { "123" }
     status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
-    sequence(:description) { |i| "<b>Become a Teacher #{i} event description</b>" }
+    sequence(:description) { |i| "Become a Teacher #{i} event description" }
     sequence(:summary) { |i| "Become a Teacher #{i} event summary" }
     message { "An important message" }
     video_url { "https://video.com" }


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-app#436 - this broke some of the line break formatting; I think we just need to change the tag from `span` to `p` in the helper but reverting for now as it's low priority.