### PR TITLE
Add an Events::GroupPresenter to remove complexity from controller

### DIFF
--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -1,6 +1,6 @@
 <div class="event-box">
     <header class="event-box__header">
-        <h2><%= heading %></h2>
+        <h4><%= heading %></h4>
     </header>
 
     <% unless condensed? %>

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -82,4 +82,8 @@ module EventsHelper
       "blue"
     end
   end
+
+  def pluralised_category_name(type_id)
+    t("event_types.#{type_id}.name.plural")
+  end
 end

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -1,0 +1,40 @@
+module Events
+  class GroupPresenter
+    attr_accessor :all_events
+
+    INDEX_PAGE_CAP = 9
+
+    def initialize(events, cap: false)
+      @all_events = events.sort_by { |e| [event_type_name(e.type_id), e.start_at] }
+      @cap        = cap
+    end
+
+    def get_into_teaching_events
+      group_by_type_id(all_events.select { |event| event.type_id.in?(get_into_teaching_type_ids) })
+    end
+
+    def school_and_university_events
+      group_by_type_id(all_events.reject { |event| event.type_id.in?(get_into_teaching_type_ids) })
+    end
+
+  private
+
+    def event_type_name(type_id)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.index(type_id)
+    end
+
+    def group_by_type_id(events)
+      groups = events.group_by(&:type_id)
+
+      return groups unless @cap
+
+      groups.each.with_object({}) do |(type_id, events_in_group), capped_groups|
+        capped_groups[type_id] = events_in_group.first(INDEX_PAGE_CAP)
+      end
+    end
+
+    def get_into_teaching_type_ids
+      @get_into_teaching_type_ids ||= GetIntoTeachingApiClient::Constants::GET_INTO_TEACHING_EVENT_TYPES.values
+    end
+  end
+end

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -28,9 +28,7 @@ module Events
 
       return groups unless @cap
 
-      groups.each.with_object({}) do |(type_id, events_in_group), capped_groups|
-        capped_groups[type_id] = events_in_group.first(INDEX_PAGE_CAP)
-      end
+      groups.transform_values { |events_in_group| events_in_group.first(INDEX_PAGE_CAP) }
     end
 
     def get_into_teaching_type_ids

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,3 +1,3 @@
-<%= link_to event_path(id: event.readable_id), class: "event-link" do %>
+<%= link_to event_path(id: event.readable_id), class: "events-featured__list__item" do %>
   <%= render(Events::EventBoxComponent.new(event)) %>
 <% end %>

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -1,0 +1,9 @@
+<section class="types-of-event content container-1000">
+  <div class="content__left">
+    <h2>Organised by <%= organised_by %></h2>
+  </div>
+
+  <% category_groups.each do |type_id, events| %>
+    <%= render partial: "event_group", locals: { type_id: type_id, events: events } %>
+  <% end %>
+</section>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,26 +1,15 @@
-<% group_key, events_by_category = event_group %>
+<div class="events-featured">
+  <h3><%= pluralised_category_name(type_id) %></h3>
 
-<section class="types-of-event content container-1000">
-  <div class="content__left">
-      <h2>
-        Organised by <%= t("event_groups.#{group_key}") %>
-      </h2>
+  <div class="events-featured__text">
+    <p><%= safe_html_format(t("find_an_event.types.#{type_id}")) %></p>
   </div>
-  <% events_by_category.each do |type_id, events| %>
-    <% category_name = t("event_types.#{type_id}.name.plural") %>
-    <div class="events-featured">
-        <h3><%= category_name %></h3>
-        <div class="events-featured__text">
-          <p><%= safe_html_format(t("find_an_event.types.#{type_id}")) %></p>
-        </div>
-        <% events.in_groups_of(3, false) do |events_on_row| %>
-          <div class="events-featured__items">
-          <%= render partial: "events/event", collection: events_on_row %>
-          </div>
-        <% end %>
-        <%= link_to(event_category_events_path(category_name.parameterize)) do %>
-            <div class="call-to-action-button">See all <%= category_name %> <i class="fas fa-chevron-right"></i></div>
-        <% end %>
-    </div>
+
+  <div class="events-featured__list">
+    <%= render partial: "event", collection: events %>
+  </div>
+
+  <%= link_to(event_category_events_path(pluralised_category_name(type_id).parameterize)) do %>
+    <div class="call-to-action-button">See all <%= pluralised_category_name(type_id) %> <i class="fas fa-chevron-right"></i></div>
   <% end %>
-</section>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -32,9 +32,15 @@
         </div>
     </section>
 
-    <%= render partial: "event_group", collection: @events_by_group %>
+    <% if @events.any? %>
+      <% if @group_presenter.get_into_teaching_events.any? %>
+        <%= render partial: "event_category", locals: { organised_by: t("event_groups.get_into_teaching"), category_groups: @group_presenter.get_into_teaching_events } %>
+      <% end %>
 
-    <% if @events.empty? %>
+      <% if @group_presenter.school_and_university_events.any? %>
+        <%= render partial: "event_category", locals: { organised_by:  t("event_groups.222750009"), category_groups: @group_presenter.school_and_university_events } %>
+      <% end %>
+    <% else %>
       <section class="content container-1000">
         <div class="content__left">
           <div class="search-for-events-no-results">

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -37,7 +37,7 @@
         width: 100%;
         overflow: hidden;
 
-        h2 {
+        h4 {
             margin: 0;
             a:hover &, a:focus, a:active {
                 text-decoration: underline;

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -246,19 +246,28 @@
       margin-bottom: 30px;
     }
 
-    &__items {
-        display: flex;
-        margin-left: -10px;
-        margin-right: -10px;
-        margin-bottom: 30px;
-        a {
-            box-sizing: border-box;
-            width: 33.3333%;
-            padding: 0 10px;
-            .event-box {
-                height: 100%;
-            }
+    &__list {
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      grid-gap: 1em;
+      align-items: stretch;
+      margin-bottom: 1.5em;
+
+      &__item {
+        // if there's no grid support the events
+        // will be shown in a single column, so
+        // add a margin between them.
+        @supports not (display: grid) {
+          div {
+            margin-bottom: 1.5em;
+          }
         }
+
+        list-style: none;
+        display: flex;
+        text-decoration: none;
+      }
     }
 }
 
@@ -349,12 +358,8 @@
     }
 
     .events-featured {
-        &__items {
-            flex-wrap: wrap;
-            a {
-                width: 100%;
-            margin-bottom: 20px;
-            }
+        &__list {
+            grid-template-columns: none;
         }
 
         &__text {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -248,20 +248,30 @@
 
     &__list {
       padding: 0;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      grid-gap: 1em;
-      align-items: stretch;
+
+      // fall back to flexbox if there's no
+      // css grid support
+      display: flex;
+      flex-wrap: wrap;
       margin-bottom: 1.5em;
 
+      @supports (display: grid) {
+        display: grid;
+        align-items: stretch;
+        grid-template-columns: repeat(3, 1fr);
+        grid-gap: 1em;
+      }
+
       &__item {
-        // if there's no grid support the events
-        // will be shown in a single column, so
-        // add a margin between them.
-        @supports not (display: grid) {
-          div {
-            margin-bottom: 1.5em;
-          }
+        flex: 0 1;
+        flex-basis: 14em;
+        margin-right: 1em;
+        margin-bottom: 1em;
+
+        @supports (display: grid) {
+          width: 100%;
+          margin-right: 0;
+          margin-bottom: 0;
         }
 
         list-style: none;
@@ -360,6 +370,10 @@
     .events-featured {
         &__list {
             grid-template-columns: none;
+            &__item {
+              flex: 1;
+              flex-basis: auto;
+            }
         }
 
         &__text {

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
     end
 
+    trait :school_or_university_event do
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] }
+    end
+
     trait :no_event_type do
       type_id { nil }
     end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -162,4 +162,17 @@ describe EventsHelper, type: "helper" do
       expect(embed_event_video_url(embed_url)).to eq(embed_url)
     end
   end
+
+  describe "#pluralised_category_name" do
+    {
+      222_750_001 => "Train to Teach Events",
+      222_750_008 => "Online Events",
+      222_750_009 => "School and University Events",
+      222_750_000 => "Application Workshops",
+    }.each do |type_id, name|
+      specify "#{type_id} => #{name}" do
+        expect(pluralised_category_name(type_id)).to eql(name)
+      end
+    end
+  end
 end

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+describe Events::GroupPresenter do
+  let(:application_workshops) { build_list(:event_api, 3, :application_workshop) }
+  let(:train_to_teach_events) { build_list(:event_api, 3, :train_to_teach_event) }
+  let(:online_events) { build_list(:event_api, 3, :online_event) }
+  let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
+  let(:all_events) { [train_to_teach_events, application_workshops, online_events, school_and_university_events].flatten }
+
+  subject { Events::GroupPresenter.new(all_events) }
+
+  describe "#get_into_teaching_events" do
+    context "application workshops" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
+
+      specify "should all be present" do
+        expect(subject.get_into_teaching_events.fetch(type_id)).to match_array(application_workshops)
+      end
+    end
+
+    context "train to teach events" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+
+      specify "should all be present" do
+        expect(subject.get_into_teaching_events.fetch(type_id)).to match_array(train_to_teach_events)
+      end
+    end
+
+    context "online events" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+
+      specify "should all be present" do
+        expect(subject.get_into_teaching_events.fetch(type_id)).to match_array(online_events)
+      end
+    end
+
+    context "school or university events" do
+      let(:actual_events) { subject.get_into_teaching_events.values.flatten.map(&:id) }
+
+      specify "are absent" do
+        expect(actual_events & school_and_university_events).to be_empty
+      end
+    end
+  end
+
+  describe "#school_and_university_events" do
+    let(:unexpected_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+
+    context "school or university events" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] }
+
+      specify "should all be present" do
+        expect(subject.school_and_university_events.fetch(type_id)).to match_array(school_and_university_events)
+      end
+    end
+
+    context "get into teaching events, online events and application workshops" do
+      let(:get_into_teaching_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+      let(:actual_events) { subject.school_and_university_events.values.flatten.map(&:id) }
+
+      specify "are absent" do
+        expect(actual_events & get_into_teaching_events).to be_empty
+      end
+    end
+  end
+
+  describe "sorting" do
+    context "by event type" do
+      let(:application_workshop) { build(:event_api, :application_workshop) }
+      let(:train_to_teach_event) { build(:event_api, :train_to_teach_event) }
+      let(:online_event) { build(:event_api, :online_event) }
+      let(:unsorted_events) { [online_event, train_to_teach_event, application_workshop] }
+
+      subject { Events::GroupPresenter.new(unsorted_events) }
+
+      specify "events should be sorted by their event type" do
+        # note these match the order in GetIntoTeachingApiClient::Constants::EVENT_TYPES
+        expect(subject.all_events).to eql([train_to_teach_event, online_event, application_workshop])
+      end
+    end
+
+    context "within an event type" do
+      let(:early) { build(:event_api, :application_workshop, start_at: 1.week.from_now) }
+      let(:middle) { build(:event_api, :application_workshop, start_at: 2.weeks.from_now) }
+      let(:late) { build(:event_api, :application_workshop, start_at: 3.weeks.from_now) }
+      let(:unsorted_events) { [middle, late, early] }
+
+      subject { Events::GroupPresenter.new(unsorted_events) }
+
+      specify "events of the same type should be sorted by date" do
+        expect(subject.all_events).to eql([early, middle, late])
+      end
+    end
+  end
+
+  describe "capping" do
+    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
+    let(:all_events) { build_list(:event_api, 10, :application_workshop) }
+    subject { Events::GroupPresenter.new(all_events, cap: cap).get_into_teaching_events }
+
+    context "when enabled" do
+      let(:cap) { true }
+
+      specify "should be capped at the INDEX_PAGE_CAP number" do
+        expect(subject.fetch(type_id).size).to eql(Events::GroupPresenter::INDEX_PAGE_CAP)
+      end
+    end
+
+    context "when not enabled" do
+      let(:cap) { false }
+
+      specify "should not be capped (all events are present)" do
+        expect(subject.fetch(type_id).size).to eql(all_events.size)
+      end
+    end
+  end
+end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -35,7 +35,7 @@ describe EventsController do
       let(:parsed_response) { Nokogiri.parse(response.body) }
 
       specify "only the first 9 should be rendered" do
-        expect(parsed_response.css(".event-link").count).to eql(events_cap)
+        expect(parsed_response.css(".events-featured__list__item").count).to eql(events_cap)
       end
     end
   end
@@ -99,7 +99,7 @@ describe EventsController do
         end
 
         specify "all events should be rendered" do
-          expect(parsed_response.css(".event-link").count).to eql(events_count)
+          expect(parsed_response.css(".events-featured__list__item").count).to eql(events_count)
         end
       end
 
@@ -115,7 +115,7 @@ describe EventsController do
         end
 
         specify "only the first 9 should be rendered" do
-          expect(parsed_response.css(".event-link").count).to eql(events_cap)
+          expect(parsed_response.css(".events-featured__list__item").count).to eql(events_cap)
         end
       end
     end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe EventsController do
   include_context "stub types api"
-  let(:events_cap) { EventsController::INDEX_EVENTS_PER_TYPE_CAP }
+  let(:events_cap) { Events::GroupPresenter::INDEX_PAGE_CAP }
 
   describe "#index" do
     let(:first_readable_id) { "123" }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -28,7 +28,7 @@ describe "Find an event near you" do
     end
 
     it "presents the events in date order" do
-      headings = response.body.scan(/<h2>(.*)<\/h2>/).flatten.take(events.count)
+      headings = response.body.scan(/<h4>(.*)<\/h4>/).flatten.take(events.count)
       expect(headings).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])
     end
 


### PR DESCRIPTION
### JIRA ticket number

N/A

### Context

The `EventsController` was a little logic-heavy. This has been moved out to the new `Events::GroupPresenter` class that takes care of grouping, sorting and capping events.

### Changes proposed in this pull request

* Move logic from the events controller to the events presenter
* Remove the row-by-row rendering of the events list and instead render it inline, using CSS to position the event cards
* Drop the event titles from `<h2>` to `<h4>` for a better document structure

### Guidance to review

There should be no noticeable changes to the app from a user perspective. Hopefully the categorising and grouping logic is easier to follow and everything makes sense!

### Preview

![Screenshot from 2020-10-09 16-00-06](https://user-images.githubusercontent.com/128088/95599251-bf662e80-0a48-11eb-9980-61cadd7ac7e8.png)

[Full page](https://user-images.githubusercontent.com/128088/95599261-c2611f00-0a48-11eb-81a7-b40453a977b5.jpg)


