### PR TITLE
Fix rendering problem caused by lack of class in site footer media query selectors

### DIFF
--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -15,6 +15,7 @@ footer.site-footer {
         a {
             text-decoration: none;
         }
+
         &__social {
             display: flex;
             &__link {
@@ -150,14 +151,14 @@ footer.site-footer {
 }
 
 @media only screen and (max-width: 1155px) {
-    footer .site-footer-top__links-container {
+    footer.site-footer .site-footer-top__links-container {
         max-width: none;
     }
 }
 
 @media only screen and (max-width: 800px) {
 
-    footer {
+    footer.site-footer {
 
         .site-footer-top {
             padding-left: 20px;


### PR DESCRIPTION
This happened because the .site-footer class wasn't applied on the media
query variants of the selector. The media query rules should be inside
the main tag so we're not duplicating selectors throughout the
stylesheets. I'll revisit and fix that later.


