### PR TITLE
Stop sending postcodes with extra spaces to API

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -59,7 +59,7 @@ module Events
       GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
         type_id: type,
         radius: distance,
-        postcode: postcode,
+        postcode: postcode&.strip,
         start_after: start_of_month,
         start_before: end_of_month,
       )


### PR DESCRIPTION

### JIRA ticket number

N/A

### Context

It appears that postcodes with leading or trailing whitespace cause the API to return a ["'Postcode' is not in the correct format." ](https://sentry.io/organizations/dfe-bat/issues/1918399446/?project=5276949&referrer=slack) error.


### Changes proposed in this pull request

`#strip` postcode values before sending to API

### Guidance to review

Is this the right approach? It would probably make sense for this to happen in Dynamics, but that might be a more substantial task :man_shrugging: 
