### PR TITLE
Standardising the layouts

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -7,24 +7,23 @@
             <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
         </div>
     </div>
-        <div class="container">
-            <%= render "sections/header" %>
-            <div  role="main" id="main-content">
-                <%= render "sections/hero", 
-                    :header => @front_matter["title"],
-                    :image => @front_matter["image"], 
-                    :mobileimage => @front_matter["mobileimage"], 
-                    :deep => @front_matter["deepheader"], :subtitle =>  @front_matter["subtitle"], 
-                    :mailinglist => @front_matter["mailinglist"] 
-                %>
-                <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>"> 
-                    <%= render "sections/phase-banner" %>
-                    <%= yield %>
-                    <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
-                </section>
-            </div>
-            <%= render "sections/footer" %>     
-        </div>
+        <%= render "sections/header" %>
+        <main role="main" id="main-content">
+            <%= render "sections/hero",
+                :header => @front_matter["title"],
+                :image => @front_matter["image"],
+                :mobileimage => @front_matter["mobileimage"],
+                :deep => @front_matter["deepheader"], :subtitle =>  @front_matter["subtitle"],
+                :mailinglist => @front_matter["mailinglist"]
+            %>
+            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
+                <%= render "sections/phase-banner" %>
+                <%= yield %>
+                <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
+            </section>
+        </main>
+
+        <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>
         <%= render "sections/feedback-prompt" %>

--- a/app/views/layouts/stories.html.erb
+++ b/app/views/layouts/stories.html.erb
@@ -2,13 +2,11 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", target: "link.content" }, id: "body" do %>
-        <div class="container">
-            <%= render "sections/header" %>
-            <section class="content container-1000" role="main" id="main-content"> 
-                <%= yield %>
-            </section>
-            <%= render "sections/footer" %>     
-        </div>
+        <%= render "sections/header" %>
+        <main class="content container-1000" role="main" id="main-content">
+            <%= yield %>
+        </main>
+        <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -13,6 +13,16 @@ body {
     max-width: 1000px;
     text-align: center;
     margin: 0 auto;
+
+    @media only screen and (max-width: 800px) {
+        box-sizing: border-box;
+        padding-left: 20px;
+        padding-right: 20px;
+        .content & {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
 }
 
 .visually-hidden {
@@ -23,17 +33,4 @@ body {
     position: absolute;
     white-space: nowrap;
     width: 1px;
-}
-
-@media only screen and (max-width: 800px) {
-    
-    .container-1000 {
-        box-sizing: border-box;
-        padding-left: 20px;
-        padding-right: 20px;
-        .content & {
-            padding-left: 0;
-            padding-right: 0;
-        }
-    }
 }

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -4,12 +4,6 @@ body {
     padding: 0;
 }
 
-.container {
-    min-height: 100vh;
-    margin:0 auto;
-    overflow: hidden;
-}
-
 .no-hero {
     border-top: 1px solid $grey-light;
 }


### PR DESCRIPTION
### JIRA ticket number

N/A

### Context

The structure of the pages had seemingly unnecessary differences caused by a `.container`. It's easier if they all follow the same format.

### Changes proposed in this pull request

Remove the container for more consistency between the layouts. This should hopefully help avoid bugs like #445 

### Guidance to review

I've checked this side-by-side and can't spot any visual differences. There shouldn't be any but I'd be interested to hear if I've missed something.

