### PR TITLE
Use fa_icon helper for the icons in the footer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,9 +55,12 @@ module ApplicationHelper
     end
   end
 
-  def fa_icon(icon_name, *additional_classes)
-    classes = ["fas", "fa-#{icon_name}"] + additional_classes
-    content_tag :i, "", class: classes.join(" ")
+  # FA supports several styles:
+  # fas = solid, fab = brand, far = regular, fal = light, fad = duotone
+  # https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use
+  def fa_icon(icon_name, *additional_classes, style: "fas")
+    classes = [style, "fa-#{icon_name}"] + additional_classes
+    tag.span("", class: classes)
   end
   alias_method :fas, :fa_icon
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,7 +62,14 @@ module ApplicationHelper
     classes = [style, "fa-#{icon_name}"] + additional_classes
     tag.span("", class: classes)
   end
-  alias_method :fas, :fa_icon
+
+  def fas_icon(*args)
+    fa_icon(*args, style: "fas")
+  end
+
+  def fab_icon(*args)
+    fa_icon(*args, style: "fab")
+  end
 
   def govuk_form_for(*args, **options, &block)
     merged = options.dup

--- a/app/views/events/_search_form.html.erb
+++ b/app/views/events/_search_form.html.erb
@@ -37,6 +37,6 @@
   <% end %>
 
   <div class="search-for-events__content__update">
-    <button class="request-button">Update results <%= fas "sync" %></button>
+    <button class="request-button">Update results <%= fas_icon "sync" %></button>
   </div>
 <% end %>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -3,26 +3,26 @@
   <div class="site-footer-top">
     <div class="site-footer-top__social">
       <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <i class="fab fa-facebook-f"></i>
+        <%= fa_icon("facebook-f", "icon", style: "fab") %>
         <span class="visually-hidden">Facebook - opens in a new tab</span>
       </a>
       <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <i class="fab fa-instagram"></i>
+        <%= fa_icon("instagram", "icon", style: "fab") %>
         <span class="visually-hidden">Instagram - opens in a new tab</span>
       </a>
       <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <i class="fab fa-linkedin-in"></i>
+        <%= fa_icon("linkedin-in", "icon", style: "fab") %>
         <span class="visually-hidden">LinkedIn - opens in a new tab</span>
       </a>
       <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <i class="fab fa-twitter"></i>
+        <%= fa_icon("twitter", "icon", style: "fab") %>
         <span class="visually-hidden">Twitter - opens in a new tab</span>
       </a>
       <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <i class="fab fa-youtube"></i>
+        <%= fa_icon("youtube", "icon", style: "fab") %>
         <span class="visually-hidden">Youtube - opens in a new tab</span>
       </a>
-    </div>     
+    </div>
     <div class="site-footer-top__links-container">
       <%= link_to("Home", page_path(page: :home)) %>
       <% navigation_resources(@sitemap).each_with_index do |resource, index| %>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -3,23 +3,23 @@
   <div class="site-footer-top">
     <div class="site-footer-top__social">
       <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fa_icon("facebook-f", "icon", style: "fab") %>
+        <%= fab_icon("facebook-f", "icon") %>
         <span class="visually-hidden">Facebook - opens in a new tab</span>
       </a>
       <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fa_icon("instagram", "icon", style: "fab") %>
+        <%= fab_icon("instagram", "icon") %>
         <span class="visually-hidden">Instagram - opens in a new tab</span>
       </a>
       <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fa_icon("linkedin-in", "icon", style: "fab") %>
+        <%= fab_icon("linkedin-in", "icon") %>
         <span class="visually-hidden">LinkedIn - opens in a new tab</span>
       </a>
       <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fa_icon("twitter", "icon", style: "fab") %>
+        <%= fab_icon("twitter", "icon") %>
         <span class="visually-hidden">Twitter - opens in a new tab</span>
       </a>
       <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fa_icon("youtube", "icon", style: "fab") %>
+        <%= fab_icon("youtube", "icon") %>
         <span class="visually-hidden">Youtube - opens in a new tab</span>
       </a>
     </div>

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -22,7 +22,7 @@ footer.site-footer {
                 color: white;
                 display: block;
                 margin-right: 20px;
-                i {
+                .icon {
                     font-size: 33px;
                 }
                 &:hover {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -123,4 +123,31 @@ describe ApplicationHelper do
       expect(helper.internal_referer).to be(referer)
     end
   end
+
+  describe "#fa_icon" do
+    let(:icon_name) { "myspace" }
+    subject { helper.fa_icon(icon_name) }
+
+    it "returns an empty span with the default classes" do
+      expect(subject).to have_css("span.fas.fa-#{icon_name}")
+    end
+
+    context "FA styles" do
+      let(:style) { "fad" }
+      subject { helper.fa_icon(icon_name, style: style) }
+
+      it "returns an empty span with provided style class" do
+        expect(subject).to have_css("span.#{style}.fa-#{icon_name}")
+      end
+    end
+
+    context "extra clases" do
+      let(:extra_classes) { %w[abc def] }
+      subject { helper.fa_icon(icon_name, *extra_classes) }
+
+      it "returns an empty span with the extra classes" do
+        expect(subject).to have_css(%(span.fa-#{icon_name}.#{extra_classes.join('.')}))
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -150,4 +150,24 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#fab_icon" do
+    let(:icon_name) { "friendster" }
+    subject { helper.fab_icon(icon_name) }
+    after { subject }
+
+    it %(it returns a span with class 'fab') do
+      expect(helper).to receive(:fa_icon).once.with(icon_name, style: "fab")
+    end
+  end
+
+  describe "#fas_icon" do
+    let(:icon_name) { "orkut" }
+    subject { helper.fas_icon(icon_name) }
+    after { subject }
+
+    it %(it returns a span with class 'fas') do
+      expect(helper).to receive(:fa_icon).once.with(icon_name, style: "fas")
+    end
+  end
 end


### PR DESCRIPTION
Begin the move towards using the `#fa_icon` helper for font awesome icons. This was originally going to be the start of removing `<i>` tags from everywhere [where they're not semantically-correct](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i) but that's a _big job_ (the content repo is full of them!), so let's start small.

Also add some tests for the helper and allow [icon styles to be set](https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use).