### PR TITLE
Discover image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,9 +189,18 @@ jobs:
           cd content
           git show HEAD
 
-      - name: Push the commit
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.BUILD_CONTENT_TOKEN }}
+      # - name: Push the commit
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.BUILD_CONTENT_TOKEN }}
+      #   run: |-
+      #     cd content
+      #     git push origin master
+
+      - name: Trigger build in Content repo
         run: |-
-          cd content
-          git push origin master
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.BUILD_CONTENT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/${{ env.CONTENT_REPOSITORY }}/dispatches \
+            --data '{"event_type": "Build triggered from App repo", "client_payload": { "parent_sha": "'"5fe203c5c4e7898d2c3e6e0c30d4361f419b720b"'"  }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,4 +166,4 @@ jobs:
       - name: Update Dockerfile
         run: |-
            cd content &&
-            cat Dockerfile.experiment | echo "s/FROM .*/FROM ${{ steps.docker-image.outputs.image }}/"
+            cat Dockerfile.experiment | echo "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,9 @@ jobs:
           git config user.name "GitHub Workflow - get-into-teaching-app"
           git config user.email "get-into-teaching-tech@digital.education.gov.uk"
           git add Dockerfile.experiment
-          git commit -m "Updated base image to ${{ steps.sha.outputs.short}}\\n\\n${{ steps.docker-image.outputs.image }}"
+          git commit -m "Updated base image to ${{ steps.sha.outputs.short}}
+
+          ${{ steps.docker-image.outputs.image }}"
 
       - name: Show last commit
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
           git config user.name "GitHub Workflow - get-into-teaching-app"
           git config user.email "get-into-teaching-tech@digital.education.gov.uk"
           git add Dockerfile.experiment
-          git commit -m "Updated base image to ${{ steps.sha.outputs.short}}\n\n${{ steps.docker-image.outputs.image }}"
+          git commit -m "Updated base image to ${{ steps.sha.outputs.short}}\\n\\n${{ steps.docker-image.outputs.image }}"
 
       - name: Show last commit
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,8 @@ jobs:
       - name: Commit changes to Dockerfile
         run: |-
           cd content
-          git config user.name "GitHub Workflow - get-into-teaching-app"
-          git config user.email "get-into-teaching-tech@digital.education.gov.uk"
+          git config user.name "Get into Teaching Bot"
+          git config user.email "<>"
           git add Dockerfile.experiment
           git commit -m "Updated base image to ${{ steps.sha.outputs.short}}
 
@@ -188,3 +188,8 @@ jobs:
         run: |-
           cd content
           git show HEAD
+
+      - name: Push the commit
+        run: |-
+          cd content
+          git push origin master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build and Deploy 
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -141,3 +142,21 @@ jobs:
            SLACK_TITLE: 'Failure: ${{ github.workflow }}'
            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
+  update_content_repo:
+    name: Update the base image used in the Content repo
+    runs-on: ubuntu-latest
+    # if: github.ref == 'refs/heads/master'
+    needs: build
+    steps:
+      - name: Set App Repo SHA
+        id: sha
+        run: echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)
+
+      - name: Set docker-image variable
+        id: docker-image
+        run: |-
+          echo ::set-output name=image::${{ env.APP_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
+
+      - name: Print discovered docker-image variable
+        run: |-
+          echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,10 +148,14 @@ jobs:
     # if: github.ref == 'refs/heads/master'
     # needs: build
     steps:
+      - name: Set short sha
+        id: sha
+        run: echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)
+
       - name: Set docker-image variable
         id: docker-image
         run: |-
-          echo ::set-output name=image::${{ env.APP_REPOSITORY }}:sha-$(echo "${{ github.sha }}" | cut -c -7)
+          echo ::set-output name=image::${{ env.APP_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
 
       - name: Print discovered docker-image variable
         run: |-
@@ -165,5 +169,7 @@ jobs:
 
       - name: Update Dockerfile
         run: |-
-           cd content &&
-            cat Dockerfile.experiment | sed "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"
+          sed -i "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~" content/Dockerfile.experiment
+
+      - name: Print updated Dockerfile
+        run: cat content/Dockerfile.experiment 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,4 +172,15 @@ jobs:
           sed -i "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~" content/Dockerfile.experiment
 
       - name: Print updated Dockerfile
-        run: cat content/Dockerfile.experiment 
+        run: cat content/Dockerfile.experiment
+
+      - name: Commit changes to Dockerfile
+        run: |-
+          cd content
+          git add Dockerfile.experiment
+          git commit -m "Updated base image to ${{ steps.sha.outputs.short}}\n\n${{ steps.docker-image.outputs.image }}"
+
+      - name: Show last commit
+        run: |-
+          cd content
+          git show HEAD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,3 +162,8 @@ jobs:
 
       - name: List content repo
         run: cd content && ls
+
+      - name: Update Dockerfile
+        run: |-
+           cd content &&
+            cat Dockerfile.experiment | sed "s/FROM .*/FROM ${{ steps.docker-image.outputs.image }}/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,4 +166,4 @@ jobs:
       - name: Update Dockerfile
         run: |-
            cd content &&
-            cat Dockerfile.experiment | cat "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"
+            cat Dockerfile.experiment | sed "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,8 @@ jobs:
       - name: Commit changes to Dockerfile
         run: |-
           cd content
+          git config user.name "GitHub Workflow - get-into-teaching-app"
+          git config user.email "get-into-teaching-tech@digital.education.gov.uk"
           git add Dockerfile.experiment
           git commit -m "Updated base image to ${{ steps.sha.outputs.short}}\n\n${{ steps.docker-image.outputs.image }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Commit changes to Dockerfile
         run: |-
           cd content
-          git config user.name "Get into Teaching Bot"
+          git config user.name "GiT Workflow Bot"
           git config user.email "<>"
           git add Dockerfile.experiment
           git commit -m "Updated base image to ${{ steps.sha.outputs.short}}
@@ -190,6 +190,8 @@ jobs:
           git show HEAD
 
       - name: Push the commit
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.BUILD_CONTENT_TOKEN }}
         run: |-
           cd content
           git push origin master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,19 +148,6 @@ jobs:
     # if: github.ref == 'refs/heads/master'
     # needs: build
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-
-      - name: Git SHA
-        run: echo "${{ github.sha }}"
-
-      - name: Git SHA FROM REPO
-        run: ls
-
-      - name: Set App Repo SHA
-        id: sha
-        run: echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)
-
       - name: Set docker-image variable
         id: docker-image
         run: |-
@@ -169,3 +156,6 @@ jobs:
       - name: Print discovered docker-image variable
         run: |-
           echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
+
+      - name: Clone content repo
+        run: echo "Content repo - '${{ env.CONTENT_REPOSITORY }}'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,8 +162,6 @@ jobs:
           echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
 
       - name: Clone content repo
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.BUILD_CONTENT_TOKEN }}
         run: git clone --depth=1 https://github.com/${{ env.CONTENT_REPOSITORY }}.git content
 
       - name: List content repo
@@ -193,7 +191,7 @@ jobs:
 
       - name: Push the commit
         env:
-          GITHUB_API_TOKEN: ${{ secrets.BUILD_CONTENT_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.BUILD_CONTENT_TOKEN }}
         run: |-
           cd content
           git push origin master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,8 @@ jobs:
           echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
 
       - name: Clone content repo
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.BUILD_CONTENT_TOKEN }}
         run: git clone --depth=1 https://github.com/${{ env.CONTENT_REPOSITORY }}.git content
 
       - name: List content repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,4 +158,7 @@ jobs:
           echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
 
       - name: Clone content repo
-        run: echo "Content repo - '${{ env.CONTENT_REPOSITORY }}'"
+        run: git clone --depth=1 https://github.com/${{ env.CONTENT_REPOSITORY }}.git content
+
+      - name: List content repo
+        run: cd content && ls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,4 +166,4 @@ jobs:
       - name: Update Dockerfile
         run: |-
            cd content &&
-            cat Dockerfile.experiment | echo "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"
+            cat Dockerfile.experiment | cat "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Build and Deploy 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: false
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     name: Update the base image used in the Content repo
     runs-on: ubuntu-latest
     # if: github.ref == 'refs/heads/master'
-    needs: build
+    # needs: build
     steps:
       - name: Set App Repo SHA
         id: sha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,15 @@ jobs:
     # if: github.ref == 'refs/heads/master'
     # needs: build
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Git SHA
+        run: echo "${{ github.sha }}"
+
+      - name: Git SHA FROM REPO
+        run: ls
+
       - name: Set App Repo SHA
         id: sha
         run: echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,4 +166,4 @@ jobs:
       - name: Update Dockerfile
         run: |-
            cd content &&
-            cat Dockerfile.experiment | sed "s/FROM .*/FROM ${{ steps.docker-image.outputs.image }}/"
+            cat Dockerfile.experiment | echo "s/FROM .*/FROM ${{ steps.docker-image.outputs.image }}/"

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -9,6 +9,7 @@ jobs:
   cve:
     name: CVE scanner 
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### JIRA ticket number

N/a

### Context

Currently only changes to the content repo will result in a release of a new image through to production. Changes in this repo will be ignored at the point of deploying to TEST and PROD environments.

This is caused by TEST and PROD only having access to the Git SHA for the Content repo. This SHA is insufficient to correctly identify the appropriate docker image so a docker image with only the Content SHA is used. When the build occurs a new image is built but with the same docker image tag (because it uses only the Content SHA and that has not changed).

When terraform comes to deploy, because the docker image tag has not changed, it will succeed but not actually pull the new image. This is ineffect the same issue as when pipelines try to deploy `:latest`

### Changes proposed in this pull request

1. Rather than dispatching an event to the Content repo, instead the FROM line in Dockerfile is changed and a new commit created. This will trigger the pipeline the same, but deploying the single sha version is now succesfully because the Sha in the Content repo has also changed as a result of the commit.

2. Removed using curl to trigger an event dispatch in the content repo
