### PR TITLE
Upgraded base image to Alpine 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine3.11
+FROM ruby:2.6.6-alpine3.12
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \


### PR DESCRIPTION
### JIRA ticket number

N/a

### Context

Alpine 12 has been out for a while

### Changes proposed in this pull request

Upgrade the base image from Ruby 2.6.6 on Alpine 11 to Ruby 2.6.6 on Alpine 12



