### PR TITLE
Behaviour changes to the Feedback Prompt

### DIFF
--- a/app/webpacker/controllers/feedback_prompt_controller.js
+++ b/app/webpacker/controllers/feedback_prompt_controller.js
@@ -96,7 +96,8 @@ export default class extends Controller {
   };
 
   get cookiesAccepted() {
-    return (new CookiePreferences).allowed(this.cookieCategory) ;
+    const cookiePreferences = new CookiePreferences();
+    return cookiePreferences.cookieSet && cookiePreferences.allowed(this.cookieCategory);
   }
 
   get disabled() {

--- a/app/webpacker/controllers/feedback_prompt_controller.js
+++ b/app/webpacker/controllers/feedback_prompt_controller.js
@@ -8,14 +8,21 @@ export default class extends Controller {
   topExitSensitivity = 0;
   topScrollEndSensitivity = 300;
   topScrollMinimumDistance = 700;
+  delayInMilliseconds = 20000;
   cookieCategory = 'functional' ;
 
   connect() {
-    if (isTouchDevice()) {
-      this.setupTouchDevice();
-    } else {
-      this.setupDesktop();
-    }
+    this.delayTimeout = setTimeout(() => {
+      if (isTouchDevice()) {
+        this.setupTouchDevice();
+      } else {
+        this.setupDesktop();
+      }
+    }, this.delayInMilliseconds);
+  }
+
+  disconnect() {
+    clearTimeout(this.delayTimeout);
   }
   
   setupDesktop() {

--- a/app/webpacker/controllers/feedback_prompt_controller.js
+++ b/app/webpacker/controllers/feedback_prompt_controller.js
@@ -5,7 +5,7 @@ import isTouchDevice from 'is-touch-device';
 
 export default class extends Controller {
   static targets = ['dialog'];
-  topExitSensitivity = 20;
+  topExitSensitivity = 0;
   topScrollEndSensitivity = 300;
   topScrollMinimumDistance = 700;
   cookieCategory = 'functional' ;

--- a/spec/javascript/controllers/feedback_prompt_controller_spec.js
+++ b/spec/javascript/controllers/feedback_prompt_controller_spec.js
@@ -38,10 +38,14 @@ describe('FeedbackPromptController', () => {
     window.pageYOffset = end;
   };
 
-  const attachController = () => {
+  const attachController = (bypassDelay = false) => {
     jest.resetModules();
     application.register('feedback-prompt', require("feedback_prompt_controller").default);
     dialog = document.getElementById('dialog');
+
+    if (bypassDelay) {
+      jest.advanceTimersByTime(21000);
+    }
   }
 
   const mockTouchDevice = () => {
@@ -62,85 +66,101 @@ describe('FeedbackPromptController', () => {
       expect(dialog.style.display).toContain("none");
     });
 
-    describe("on desktop", () => {
+    describe("when the delay time has not yet passed", () => {
       beforeEach(() => {
         mockDesktop();
-        attachController();
+        attachController(false);
       });
 
-      it("prompts on mouseleave", () => {
+      it("does not prompt", () => {
         mouseLeave();
-        expect(dialog.style.display).toContain("flex");
+        expect(dialog.style.display).toContain("none");
+      });
+    });
+
+    describe("when the delay time has passed", () => {
+      describe("on desktop", () => {
+        beforeEach(() => {
+          mockDesktop();
+          attachController(true);
+        });
+  
+        it("prompts on mouseleave", () => {
+          mouseLeave();
+          expect(dialog.style.display).toContain("flex");
+        });
+    
+        it("prompts according to the sensitivity value", () => {
+          mouseLeave(1);
+          expect(dialog.style.display).toContain("none");
+          mouseLeave(0);
+          expect(dialog.style.display).toContain("flex");
+        });
       });
   
-      it("prompts according to the sensitivity value", () => {
-        mouseLeave(1);
-        expect(dialog.style.display).toContain("none");
-        mouseLeave(0);
-        expect(dialog.style.display).toContain("flex");
+      describe("on a touch device", () => {
+        beforeEach(() => {
+          mockTouchDevice();
+          attachController(true);
+        });
+  
+        it("prompts on long scroll to top", () => {
+          longScrollToTop();
+          jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+          expect(dialog.style.display).toContain("flex");
+        });
+  
+        it("prompts according to the distance sensitivity value", () => {
+          longScrollToTop(699);
+          jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+          expect(dialog.style.display).toContain("none");
+          longScrollToTop(701);
+          jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+          expect(dialog.style.display).toContain("flex");
+        });
+  
+        it("prompts according to the end sensitivity value", () => {
+          longScrollToTop(700, 301);
+          jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+          expect(dialog.style.display).toContain("none");
+          longScrollToTop(700, 299);
+          jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+          expect(dialog.style.display).toContain("flex");
+        });
       });
-    });
-
-    describe("on a touch device", () => {
-      beforeEach(() => {
-        mockTouchDevice();
-        attachController();
+  
+      describe("clicking the close button", () => {
+        beforeEach(() => {
+          mockDesktop();
+          attachController(true);
+          mouseLeave();
+          expect(dialog.style.display).toContain("flex");
+          const closeButton = document.getElementById('closeButton');
+          closeButton.click();
+        });
+  
+        it("closes the dialog", () => {
+          expect(dialog.style.display).toContain("none");
+        });
+  
+        it("set the cookie", () => {
+          expect(Cookies.get('GiTBetaFeedbackPrompt')).toEqual("Disabled");
+        });
       });
-
-      it("prompts on long scroll to top", () => {
-        longScrollToTop();
-        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
-        expect(dialog.style.display).toContain("flex");
-      });
-
-      it("prompts according to the distance sensitivity value", () => {
-        longScrollToTop(699);
-        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
-        expect(dialog.style.display).toContain("none");
-        longScrollToTop(701);
-        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
-        expect(dialog.style.display).toContain("flex");
-      });
-
-      it("prompts according to the end sensitivity value", () => {
-        longScrollToTop(700, 301);
-        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
-        expect(dialog.style.display).toContain("none");
-        longScrollToTop(700, 299);
-        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
-        expect(dialog.style.display).toContain("flex");
-      });
-    });
-
-    describe("clicking the close button", () => {
-      beforeEach(() => {
-        attachController();
-        mouseLeave();
-        expect(dialog.style.display).toContain("flex");
-        const closeButton = document.getElementById('closeButton');
-        closeButton.click();
-      });
-
-      it("closes the dialog", () => {
-        expect(dialog.style.display).toContain("none");
-      });
-
-      it("set the cookie", () => {
-        expect(Cookies.get('GiTBetaFeedbackPrompt')).toEqual("Disabled");
-      });
-    });
-
-    describe("clicking the action button", () => {
-      beforeEach(() => {
-        attachController();
-        mouseLeave();
-        expect(dialog.style.display).toContain("flex");
-        const actionButton = document.getElementById('actionButton');
-        actionButton.click();
-      });
-
-      it("set the cookie", () => {
-        expect(Cookies.get('GiTBetaFeedbackPrompt')).toEqual("Disabled");
+  
+      describe("clicking the action button", () => {
+        beforeEach(() => {
+          mockDesktop();
+          attachController(true);
+          mouseLeave();
+          expect(dialog.style.display).toContain("flex");
+          const actionButton = document.getElementById('actionButton');
+          actionButton.click();
+        });
+  
+        it("set the cookie", () => {
+          expect(Cookies.get('GiTBetaFeedbackPrompt')).toEqual("Disabled");
+        });
       });
     });
   });
@@ -152,6 +172,7 @@ describe('FeedbackPromptController', () => {
     });
 
     it("no longer prompts", () => {
+      mockDesktop();
       attachController();
       mouseLeave();
       expect(dialog.style.display).toContain("none");
@@ -165,6 +186,7 @@ describe('FeedbackPromptController', () => {
     });
 
     it("no longer prompts", () => {
+      mockDesktop();
       attachController();
       mouseLeave();
       expect(dialog.style.display).toContain("none");

--- a/spec/javascript/controllers/feedback_prompt_controller_spec.js
+++ b/spec/javascript/controllers/feedback_prompt_controller_spec.js
@@ -7,6 +7,8 @@ describe('FeedbackPromptController', () => {
   var application;
 
   beforeEach(() => {
+    jest.useFakeTimers();
+
     Cookies.remove(CookiePreferences.cookieName) ;
     Cookies.remove('GiTBetaFeedbackPrompt') ;
 
@@ -85,37 +87,28 @@ describe('FeedbackPromptController', () => {
         attachController();
       });
 
-      it("prompts on long scroll to top", (done) => {
+      it("prompts on long scroll to top", () => {
         longScrollToTop();
-
-        setTimeout(() => {
-          expect(dialog.style.display).toContain("flex");
-          done();
-        }, 100); // Wait for timeout indicating scroll end.
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
       });
 
-      it("prompts according to the distance sensitivity value", (done) => {
+      it("prompts according to the distance sensitivity value", () => {
         longScrollToTop(699);
-        setTimeout(() => {
-          expect(dialog.style.display).toContain("none");
-          longScrollToTop(701);
-          setTimeout(() => {
-            expect(dialog.style.display).toContain("flex");
-            done();
-          }, 100); // Wait for timeout indicating scroll end.
-        }, 100); // Wait for timeout indicating scroll end.
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("none");
+        longScrollToTop(701);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
       });
 
-      it("prompts according to the end sensitivity value", (done) => {
+      it("prompts according to the end sensitivity value", () => {
         longScrollToTop(700, 301);
-        setTimeout(() => {
-          expect(dialog.style.display).toContain("none");
-          longScrollToTop(700, 299);
-          setTimeout(() => {
-            expect(dialog.style.display).toContain("flex");
-            done();
-          }, 100); // Wait for timeout indicating scroll end.
-        }, 100); // Wait for timeout indicating scroll end.
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("none");
+        longScrollToTop(700, 299);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
       });
     });
 

--- a/spec/javascript/controllers/feedback_prompt_controller_spec.js
+++ b/spec/javascript/controllers/feedback_prompt_controller_spec.js
@@ -72,9 +72,9 @@ describe('FeedbackPromptController', () => {
       });
   
       it("prompts according to the sensitivity value", () => {
-        mouseLeave(21);
+        mouseLeave(1);
         expect(dialog.style.display).toContain("none");
-        mouseLeave(19);
+        mouseLeave(0);
         expect(dialog.style.display).toContain("flex");
       });
     });


### PR DESCRIPTION
- Reduce topExitSensitivty to 0

With the top sensitivity set to 20 the feedback prompt will appear if the mouse gets within 20 pixels of the top of the viewport. We feel this is too sensitive given that it likely overlaps the navigation menu a little and will cause a false positive if someone moves their cursor over the top edge of a menu item they are trying to click.

Reduce to 0 so that the cursor has to exit the view port entirely before the feedback prompt is triggered.

- Convert tests to use jest.useFakeTimers()

Previously we were using `setTimeout` within the spec itself to delay before making an assertion. This is fine for short timeouts, but we are introducing a longer 20 second timeout to delay the feedback prompt appearing - using jest fake timers will let us advance the time instantly and avoid slow tests.

- Prevent feedback prompt overlaying cookie prompt

When we migrated to `CookiePreferences` this behaviour was lost; in addition to checking if functional cookies are allowed we also need to ensure `cookieSet` is `true` (functional cookies are allowed even before the user accepts cookies). The `cookieSet` flag indicates that the user has manually accepted cookies and the prompt has disappeared.

- Delay feedback prompt for 20 seconds

When the user loads the page if they immediately move their mouse to the top of the viewport (or scroll up on mobile) the feedback prompt will display. This doesn't give much time for the user to interact with the website and may annoy them if they have just landed on a page they didn't want to be on. Instead, this commit adds a 20 second delay, so the user must view the page for at least 20 seconds before their behaviour will trigger the feedback prompt to appear.
