### PR TITLE
Add acronyms support

### DIFF
--- a/lib/abbreviations.rb
+++ b/lib/abbreviations.rb
@@ -1,0 +1,41 @@
+class Abbreviations
+  ABBR_REGEXP = %r{\b([A-Z][A-Z]+)\b}.freeze
+
+  def initialize(content, abbreviations)
+    @document = parse_html(content)
+    @abbreviations = abbreviations || {}
+  end
+
+  def render
+    @document.tap(&method(:replace_abbreviations)).to_html
+  end
+
+private
+
+  def parse_html(content)
+    Nokogiri::HTML::DocumentFragment.parse(content)
+  end
+
+  def replace_abbreviations(document)
+    document.traverse do |node|
+      next unless node.text?
+
+      replacements = 0
+      replacement = node.content.gsub(ABBR_REGEXP) do |abbr|
+        matched = abbreviation_for(abbr)
+        next unless matched
+
+        replacements += 1
+        matched
+      end
+
+      node.replace(replacement) unless replacements.zero?
+    end
+  end
+
+  def abbreviation_for(abbr)
+    if @abbreviations.key? abbr
+      "<abbr title=\"#{@abbreviations[abbr]}\">#{abbr}</abbr>"
+    end
+  end
+end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -5,9 +5,22 @@ module TemplateHandlers
     attr_reader :template, :source, :options
 
     DEFAULTS = {}.freeze
+    GLOBAL_FRONT_MATTER = Rails.root.join("config/frontmatter.yml").freeze
 
-    def self.call(template, source = nil)
-      new(template, source).call
+    class << self
+      def call(template, source = nil)
+        new(template, source).call
+      end
+
+      def global_front_matter
+        @global_front_matter ||= begin
+          if GLOBAL_FRONT_MATTER.exist?
+            YAML.load_file GLOBAL_FRONT_MATTER
+          else
+            {}
+          end
+        end
+      end
     end
 
     def initialize(template, source = nil, **options)
@@ -45,7 +58,7 @@ module TemplateHandlers
     end
 
     def front_matter
-      parsed.front_matter
+      @front_matter ||= self.class.global_front_matter.deep_merge(parsed.front_matter)
     end
 
     def parsed

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -1,3 +1,5 @@
+require "abbreviations"
+
 module TemplateHandlers
   class Markdown
     attr_reader :template, :source, :options
@@ -30,8 +32,12 @@ module TemplateHandlers
       Rinku.auto_link content
     end
 
+    def add_abbreviations(content)
+      Abbreviations.new(content, front_matter["abbreviations"]).render
+    end
+
     def render
-      autolink_html render_markdown
+      add_abbreviations autolink_html render_markdown
     end
 
     def markdown

--- a/spec/lib/abbreviations_spec.rb
+++ b/spec/lib/abbreviations_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "abbreviations"
+
+describe Abbreviations, type: :helper do
+  let(:content) { "All prices include VAT except where marked exVAT" }
+  let(:abbreviations) { { "VAT" => "Value added tax" } }
+
+  subject { Abbreviations.new(content, abbreviations).render }
+  it { is_expected.to match "marked exVAT" }
+  it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
+
+  context "with HTML content" do
+    let(:content) { "<a href=\"#vat\" title=\"VAT information\">VAT</a>" }
+    it { is_expected.to have_css "a abbr[title=\"Value added tax\"]", text: "VAT" }
+    it { is_expected.to have_css "a[title=\"VAT information\"]" }
+  end
+
+  context "with unknown abbreviation" do
+    let(:content) { "<p>Payments are deducted as part of PAYE</p>" }
+    it { is_expected.to have_css "p", text: "Payments are deducted as part of PAYE" }
+  end
+end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -118,4 +118,44 @@ describe TemplateHandlers::Markdown, type: :view do
         "a[title=\"VAT\"] abbr[title=\"Value added tax\"]", text: "VAT"
     end
   end
+
+  context "global frontmatter" do
+    let :global_front_matter do
+      {
+        "title" => "Default page title",
+        "abbreviations" => {
+          "CPD" => "Continuous professional development",
+          "VAT" => "Wrong definition",
+        },
+      }
+    end
+
+    let :markdown do
+      <<~MARKDOWN
+        ---
+        abbreviations:
+          PAYE: Pay as you earn
+          VAT: Value added tax
+        ---
+        I've been studying VAT and PAYE as part of my CPD
+      MARKDOWN
+    end
+
+    before do
+      allow(described_class).to \
+        receive(:global_front_matter).and_return global_front_matter
+
+      stub_template "frontmatter.md" => markdown
+      render template: "frontmatter.md"
+    end
+
+    it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
+
+    it do
+      is_expected.to \
+        have_css "abbr[title=\"Continuous professional development\"]", text: "CPD"
+    end
+
+    it { is_expected.to have_css "abbr[title=\"Pay as you earn\"]", text: "PAYE" }
+  end
 end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -89,4 +89,33 @@ describe TemplateHandlers::Markdown, type: :view do
       expect(frontmatter).to include "front" => true
     end
   end
+
+  context "with abbreviations" do
+    let :markdown do
+      <<~MARKDOWN
+        ---
+        title: My page
+        abbreviations:
+          VAT: Value added tax
+        ---
+
+        All prices include VAT unless marked as exVAT
+
+        Find out more about <a href="#vat" title="VAT">VAT</a>
+      MARKDOWN
+    end
+
+    before do
+      stub_template "frontmatter.md" => markdown
+      render template: "frontmatter.md"
+    end
+
+    it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
+    it { is_expected.to match "exVAT" } # check it honours word boundaries
+
+    it do
+      is_expected.to have_css \
+        "a[title=\"VAT\"] abbr[title=\"Value added tax\"]", text: "VAT"
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/0J164eou

### Context

We should be providing expansion for accronyms. This means marking acronyms with the `<abbr>` and expanding them where appropriate.

### Changes proposed in this pull request

1. Added a helper class, `Abbreviations` to parse HTML and replace abbreviations in text nodes, but not in attributes.
2. Update the Markdown render to filter content through the Abbreviations filter
3. Added support for a global frontmatter file, to which the per page front matter file is deep merged - this allows combining acronyms defined in both locations.

### Guidance to review

There will be a follow on PR to explain this together with some default acronyms in the content repo after this is merged

