### PR TITLE
Report CSP violations via Rails

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -8,4 +8,3 @@
 BAM_ID=1
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.cloudapps.digital/"
-SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a29813939539467a89d2d92062a6c7a0"

--- a/.env.production
+++ b/.env.production
@@ -9,4 +9,3 @@ BAM_ID=1
 HOTJAR_ID=1871524
 VWO_ID=524595
 TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
-SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=613c386327c3467383c35924148435e5"

--- a/.env.rolling
+++ b/.env.rolling
@@ -1,5 +1,4 @@
 # Add public environment variables here for the Rolling environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
-SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=a3b324c98fe94a858c87267a656768e8"
 BAM_ID=1
 VWO_ID=524595

--- a/.env.userresearch
+++ b/.env.userresearch
@@ -6,4 +6,3 @@ GOOGLE_TAG_MANAGER_ID=GTM-TCZDM7V
 HOTJAR_ID=1871524
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-ur.london.cloudapps.digital/"
-SENTRY_CSP_REPORT_URI="https://o225781.ingest.sentry.io/api/5276949/security/?sentry_key=7c23120dec954783b05e503003546514"

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "rinku"
 
 gem "addressable"
 
+gem "rack-attack"
+
 gem "faraday"
 gem "faraday-encoding"
 gem "faraday-http-cache"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-attack (6.3.1)
+      rack (>= 1.0, < 3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -358,6 +360,7 @@ DEPENDENCIES
   prometheus-client
   pry-byebug
   puma (~> 4.3)
+  rack-attack
   rails (~> 6.0.2)
   rails_semantic_logger
   redis

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,11 +1,26 @@
 class CspReportsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  CSP_KEYS = %w[
+    blocked-uri
+    disposition
+    document-uri
+    effective-directive
+    original-policy
+    referrer
+    script-sample
+    status-code
+    violated-directive
+  ].freeze
+  MAX_ENTRY_LENGTH = 2_000
+
   def create
     json = JSON.parse(request.body.read)
-    report = json["csp-report"]
+    report = (json["csp-report"] || {})
+      .slice(*CSP_KEYS)
+      .transform_values { |v| v.truncate(MAX_ENTRY_LENGTH) }
 
-    Rails.logger.error(report) if report
+    Rails.logger.error(report) unless report.empty?
 
     head :ok
   end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,0 +1,12 @@
+class CspReportsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    json = JSON.parse(request.body.read)
+    report = json["csp-report"]
+
+    Rails.logger.error(report) if report
+
+    head :ok
+  end
+end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -20,7 +20,7 @@ class CspReportsController < ApplicationController
       .slice(*CSP_KEYS)
       .transform_values { |v| v.truncate(MAX_ENTRY_LENGTH) }
 
-    Rails.logger.error(report) unless report.empty?
+    Rails.logger.error({ "csp-report" => report }) unless report.empty?
 
     head :ok
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,6 @@
+class Rack::Attack
+  # Throttle /csp_reports requests by IP (5rpm)
+  throttle("req/ip", limit: 5, period: 1.minute) do |req|
+    req.ip if req.path == "/csp_reports"
+  end
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
     style_src: %w['self' 'unsafe-inline' *.gov.uk *.googleapis.com] + google_analytics,
     worker_src: %w['self' *.visualwebsiteoptimizer.com blob:],
     upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/
-    report_uri: [ENV["SENTRY_CSP_REPORT_URI"]],
+    report_uri: %w[/csp_reports],
   }
 
   if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   resource "cookie_preference", only: %i[show]
   get "/cookie-policy", to: redirect("/cookies")
 
+  resource :csp_reports, only: %i[create]
+
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "CSP violation reporting" do
+  let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
+
+  before do
+    allow(Rails.logger).to receive(:error)
+    post csp_reports_path, params: params.to_json
+  end
+
+  subject { response }
+
+  it { is_expected.to have_http_status(:success) }
+  it { expect(Rails.logger).to have_received(:error).with(params["csp-report"]).once }
+
+  describe "when called without a csp-report" do
+    let(:params) { { other: "payload" } }
+
+    it { is_expected.to have_http_status(:success) }
+    it { expect(Rails.logger).to_not have_received(:error) }
+  end
+end

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -11,7 +11,7 @@ describe "CSP violation reporting" do
   subject { response }
 
   it { is_expected.to have_http_status(:success) }
-  it { expect(Rails.logger).to have_received(:error).with(params["csp-report"]).once }
+  it { expect(Rails.logger).to have_received(:error).with(params).once }
 
   describe "when called without a csp-report" do
     let(:params) { { other: "payload" } }
@@ -23,7 +23,7 @@ describe "CSP violation reporting" do
   describe "when the csp-report contains keys not in our whitelist" do
     let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js", "random" => "information" } } }
 
-    it { expect(Rails.logger).to_not have_received(:error).with(params["csp-report"]) }
-    it { expect(Rails.logger).to have_received(:error).with(params["csp-report"].slice("blocked-uri")).once }
+    it { expect(Rails.logger).to_not have_received(:error).with(params) }
+    it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => params["csp-report"].slice("blocked-uri") }).once }
   end
 end

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -19,4 +19,11 @@ describe "CSP violation reporting" do
     it { is_expected.to have_http_status(:success) }
     it { expect(Rails.logger).to_not have_received(:error) }
   end
+
+  describe "when the csp-report contains keys not in our whitelist" do
+    let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js", "random" => "information" } } }
+
+    it { expect(Rails.logger).to_not have_received(:error).with(params["csp-report"]) }
+    it { expect(Rails.logger).to have_received(:error).with(params["csp-report"].slice("blocked-uri")).once }
+  end
 end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "Rate limiting" do
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before { allow(Rack::Attack.cache).to receive(:store) { memory_store } }
+
+  describe "POST /csp_reports" do
+    let(:limit) { 1 }
+    let(:ip) { "1.2.3.4" }
+
+    before { limit.times { post csp_reports_path, params: {}.to_json, headers: { "REMOTE_ADDR" => ip } } }
+
+    subject { response.status }
+
+    context "when fewer than rate limit" do
+      let(:limit) { 4 }
+
+      it { is_expected.to_not eq(429) }
+    end
+
+    context "when more than rate limit" do
+      let(:limit) { 6 }
+
+      it do
+        is_expected.to eq(429)
+      end
+
+      context "when time restriction has passed" do
+        it "allows another request" do
+          travel 1.minute
+          post csp_reports_path, params: {}.to_json, headers: { "REMOTE_ADDR" => ip }
+          expect(response.status).to_not eq(429)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA ticket number

[Trello-429](https://trello.com/c/j2g8AgvM/429-send-csp-violations-to-kibana-instead-of-sentry)

### Context

We are using up a bunch of our Sentry quota on CSP violations that we have no control over (browser plugins/extensions etc). Instead, we want to move our CSP reporting to logit.io so we can put together a dashboard in Grafana.

### Changes proposed in this pull request

- Add CspReportsController

Introduce a `CspReportsController` that accepts a CSP violation report (any JSON payload with a `csp-report` key) and logs it as an error.

- Report CSP violations via Rails

Instead of the CSP violations going directly to Sentry, we're going to send them instead to Rails where they get logged out and will end up in logit.io. We can then setup a Grafana dashboard to track them.

Any requests with a malformed body are ignored, hopefully reducing the exploitability a little.

- Whitelist CSP keys and cap entry length

To help prevent malicious usage of the endpoint we ensure the `csp-report` only contains valid keys and truncate the length of all values (hopefully avoiding someone maliciously filling up our logstash).

I thought about setting up the CSP report as a model to add further validation (ensure the blocked-uri is a URL, for example) but it feels like more hassle than it's worth.

- Rate limit CSP reporting

As the CSP reporting endpoint allows POST requests directly from clients that end up in our logs, we want to restrict how frequently it can be called by a client.

Restricts POST /csp_reports to 5rpm per IP address.

### Guidance to review

I've testing this locally so far as it logs out the CSP in the Rails console when there is a violation, so it should go through to logit.io.