### PR TITLE
Renamed Abbreviations class to Acronyms

### DIFF
--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -1,13 +1,13 @@
-class Abbreviations
+class Acronyms
   ABBR_REGEXP = %r{\b([A-Z][A-Z]+)\b}.freeze
 
-  def initialize(content, abbreviations)
+  def initialize(content, acronyms)
     @document = parse_html(content)
-    @abbreviations = abbreviations || {}
+    @acronyms = acronyms || {}
   end
 
   def render
-    @document.tap(&method(:replace_abbreviations)).to_html
+    @document.tap(&method(:replace_acronyms)).to_html
   end
 
 private
@@ -16,13 +16,13 @@ private
     Nokogiri::HTML::DocumentFragment.parse(content)
   end
 
-  def replace_abbreviations(document)
+  def replace_acronyms(document)
     document.traverse do |node|
       next unless node.text?
 
       replacements = 0
-      replacement = node.content.gsub(ABBR_REGEXP) do |abbr|
-        matched = abbreviation_for(abbr)
+      replacement = node.content.gsub(ABBR_REGEXP) do |acronym|
+        matched = acronym_for(acronym)
         next unless matched
 
         replacements += 1
@@ -33,9 +33,9 @@ private
     end
   end
 
-  def abbreviation_for(abbr)
-    if @abbreviations.key? abbr
-      "<abbr title=\"#{@abbreviations[abbr]}\">#{abbr}</abbr>"
+  def acronym_for(acronym)
+    if @acronyms.key? acronym
+      "<abbr title=\"#{@acronyms[acronym]}\">#{acronym}</abbr>"
     end
   end
 end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -45,12 +45,12 @@ module TemplateHandlers
       Rinku.auto_link content
     end
 
-    def add_abbreviations(content)
+    def add_acronyms(content)
       Acronyms.new(content, front_matter["acronyms"]).render
     end
 
     def render
-      add_abbreviations autolink_html render_markdown
+      add_acronyms autolink_html render_markdown
     end
 
     def markdown

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -1,4 +1,4 @@
-require "abbreviations"
+require "acronyms"
 
 module TemplateHandlers
   class Markdown
@@ -46,7 +46,7 @@ module TemplateHandlers
     end
 
     def add_abbreviations(content)
-      Abbreviations.new(content, front_matter["abbreviations"]).render
+      Acronyms.new(content, front_matter["acronyms"]).render
     end
 
     def render

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
-require "abbreviations"
+require "acronyms"
 
-describe Abbreviations, type: :helper do
+describe Acronyms, type: :helper do
   let(:content) { "All prices include VAT except where marked exVAT" }
   let(:abbreviations) { { "VAT" => "Value added tax" } }
 
-  subject { Abbreviations.new(content, abbreviations).render }
+  subject { described_class.new(content, abbreviations).render }
   it { is_expected.to match "marked exVAT" }
   it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
 

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -3,9 +3,9 @@ require "acronyms"
 
 describe Acronyms, type: :helper do
   let(:content) { "All prices include VAT except where marked exVAT" }
-  let(:abbreviations) { { "VAT" => "Value added tax" } }
+  let(:acronyms) { { "VAT" => "Value added tax" } }
 
-  subject { described_class.new(content, abbreviations).render }
+  subject { described_class.new(content, acronyms).render }
   it { is_expected.to match "marked exVAT" }
   it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
 
@@ -15,7 +15,7 @@ describe Acronyms, type: :helper do
     it { is_expected.to have_css "a[title=\"VAT information\"]" }
   end
 
-  context "with unknown abbreviation" do
+  context "with unknown acronym" do
     let(:content) { "<p>Payments are deducted as part of PAYE</p>" }
     it { is_expected.to have_css "p", text: "Payments are deducted as part of PAYE" }
   end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -90,12 +90,12 @@ describe TemplateHandlers::Markdown, type: :view do
     end
   end
 
-  context "with abbreviations" do
+  context "with acronyms" do
     let :markdown do
       <<~MARKDOWN
         ---
         title: My page
-        abbreviations:
+        acronyms:
           VAT: Value added tax
         ---
 
@@ -123,7 +123,7 @@ describe TemplateHandlers::Markdown, type: :view do
     let :global_front_matter do
       {
         "title" => "Default page title",
-        "abbreviations" => {
+        "acronyms" => {
           "CPD" => "Continuous professional development",
           "VAT" => "Wrong definition",
         },
@@ -133,7 +133,7 @@ describe TemplateHandlers::Markdown, type: :view do
     let :markdown do
       <<~MARKDOWN
         ---
-        abbreviations:
+        acronyms:
           PAYE: Pay as you earn
           VAT: Value added tax
         ---


### PR DESCRIPTION
### Context

The Abbreviations class only really supports acronyms at present so renaming it to avoid future confusion

### Changes proposed in this pull request

1. Renamed the class from `Abbreviations` to `Acronyms`
2. Renamed the frontmatter key from `abbreviations` to `acronyms`



