### PR TITLE
Run Javascript tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,11 @@ jobs:
           name: unit_tests
           path: ${{ github.workspace }}/out/*
 
+      - name: Run Javascript Tests
+        run: |-
+          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
+            "yarn && yarn spec"
+
       - name: Lint Ruby
         run: |-
           docker run -t --rm -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,8 @@ jobs:
 
       - name: Run Javascript Tests
         run: |-
-          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
-            "yarn && yarn spec"
+          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true \
+            ${{steps.docker.outputs.DOCKER_IMAGE}} "yarn && yarn spec"
 
       - name: Lint Ruby
         run: |-


### PR DESCRIPTION
### Trello ticket

https://trello.com/c/3XjSChte

### Context

We have javascript tests and they should be getting run as part of the CI tests

### Changes proposed in this pull request

1. Add additional step to install the required dependencies and run the specs



