### PR TITLE
Fix the event box cards in the category list

### DIFF
--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -11,16 +11,6 @@
 
 <section class="types-of-event content container-1000">
 
-    <div class="content__left">
-        <%= back_link(internal_referer || events_path, text: "All events") %>
-        <h3><%= category_name %></h3>
-        <br />
-        <%= safe_html_format(t("event_types.#{@type.id}.description")) %>
-    </div>
-
+    <%= back_link(internal_referer || events_path, text: "All events") %>
+    <%= render partial: "event_group", locals: { type_id: @type.id, events: @events } %>
 </section>
-
-<section class="search-for-events-results content container-1000">
-  <%= render partial: "event", collection: @events %>
-</section>
-

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -1,50 +1,8 @@
 .types-of-event {
-
-    vertical-align: top;
-    text-align: left;
-    width: 100%;
-
-    &__left {
-
-        box-sizing: border-box;
-        padding-left: 40px;
-        padding-right:20px;
-        padding-top: 20px;
-        padding-bottom: 20px;
-        text-align: left;
-        vertical-align: top;
-        width: calc(100% - 370px);
-
-        p.content-alert {
-            background-color: $purple;
-            color: $white;
-            box-sizing: border-box;
-            padding: 20px;
-            font-weight: bold;
-            line-height: 1.5;
-            display: inline-block;
-
-            a {
-              color: $white;
-            }
-        }
-
+    > .events-featured {
+        background-color: white;
+        padding: 1em 0 0;
     }
-
-    &__right {
-
-        margin-right: 40px;
-        padding-left: 40px;
-        padding-right:20px;
-        padding-top: 20px;
-        padding-bottom: 20px;
-        text-align: left;
-        vertical-align: top;
-        float: right;
-        width: 288px;
-
-    }
-
 }
 
 .types-of-event__header__icon {


### PR DESCRIPTION
This discrepancy is caused by the new CSS for the events grid not being shared with this older page. Now they are styled in the same manner except the category list has a white background.

| Before | After |
| ----- | ----- |
| ![Screenshot from 2020-10-20 16-35-04](https://user-images.githubusercontent.com/128088/96609548-8bb1c100-12f2-11eb-92cf-a046a6cd6e0d.png) | ![Screenshot from 2020-10-20 16-36-25](https://user-images.githubusercontent.com/128088/96609567-8fddde80-12f2-11eb-9063-474ad31826e8.png) |


