### PR TITLE
Instrument CSP violations

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -20,8 +20,15 @@ class CspReportsController < ApplicationController
       .slice(*CSP_KEYS)
       .transform_values { |v| v.truncate(MAX_ENTRY_LENGTH) }
 
-    Rails.logger.error({ "csp-report" => report }) unless report.empty?
+    trace_csp_violation(report) unless report.empty?
 
     head :ok
+  end
+
+private
+
+  def trace_csp_violation(report)
+    Rails.logger.error({ "csp-report" => report })
+    ActiveSupport::Notifications.instrument("app.csp_violation", report)
   end
 end

--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -54,3 +54,16 @@ ActiveSupport::Notifications.subscribe "cache_read.active_support" do |*args|
   metric = prometheus.get(:app_cache_read_total)
   metric.increment(labels: labels)
 end
+
+ActiveSupport::Notifications.subscribe "app.csp_violation" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  report = event.payload.transform_keys(&:underscore).symbolize_keys
+
+  prometheus = Prometheus::Client.registry
+
+  labels = { blocked_uri: nil, document_uri: nil, violated_directive: nil }
+  labels.merge!(report.slice(*labels.keys))
+
+  metric = prometheus.get(:app_csp_violations_total)
+  metric.increment(labels: labels)
+end

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -37,5 +37,11 @@ module Prometheus
       docstring: "A counter of cache reads",
       labels: %i[key hit],
     )
+
+    prometheus.counter(
+      :app_csp_violations_total,
+      docstring: "A counter of CSP violations",
+      labels: %i[blocked_uri document_uri violated_directive],
+    )
   end
 end

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Prometheus::Metrics do
   let(:registry) { Prometheus::Client.registry }
 
-  describe "request_total" do
+  describe "app_request_total" do
     subject { registry.get(:app_requests_total) }
 
     it { is_expected.not_to be_nil }
@@ -11,7 +11,15 @@ describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
   end
 
-  describe "request_duration_ms" do
+  describe "app_csp_violations_total" do
+    subject { registry.get(:app_csp_violations_total) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of CSP violations") }
+    it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.to_not raise_error }
+  end
+
+  describe "app_request_duration_ms" do
     subject { registry.get(:app_request_duration_ms) }
 
     it { is_expected.not_to be_nil }
@@ -19,7 +27,7 @@ describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
   end
 
-  describe "request_view_runtime_ms" do
+  describe "app_request_view_runtime_ms" do
     subject { registry.get(:app_request_view_runtime_ms) }
 
     it { is_expected.not_to be_nil }
@@ -27,7 +35,7 @@ describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
   end
 
-  describe "render_view_ms" do
+  describe "app_render_view_ms" do
     subject { registry.get(:app_render_view_ms) }
 
     it { is_expected.not_to be_nil }
@@ -35,7 +43,7 @@ describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
   end
 
-  describe "render_partial_ms" do
+  describe "app_render_partial_ms" do
     subject { registry.get(:app_render_partial_ms) }
 
     it { is_expected.not_to be_nil }
@@ -43,7 +51,7 @@ describe Prometheus::Metrics do
     it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
   end
 
-  describe "cache_read_total" do
+  describe "app_cache_read_total" do
     subject { registry.get(:app_cache_read_total) }
 
     it { is_expected.not_to be_nil }

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -4,6 +4,7 @@ describe "CSP violation reporting" do
   let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
 
   before do
+    record_csp_violation_events
     allow(Rails.logger).to receive(:error)
     post csp_reports_path, params: params.to_json
   end
@@ -12,18 +13,37 @@ describe "CSP violation reporting" do
 
   it { is_expected.to have_http_status(:success) }
   it { expect(Rails.logger).to have_received(:error).with(params).once }
+  it { expect(self).to have_recorded_csp_violation(params["csp-report"]) }
 
   describe "when called without a csp-report" do
     let(:params) { { other: "payload" } }
 
     it { is_expected.to have_http_status(:success) }
     it { expect(Rails.logger).to_not have_received(:error) }
+    it { expect(self).to_not have_recorded_csp_violation }
   end
 
   describe "when the csp-report contains keys not in our whitelist" do
     let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js", "random" => "information" } } }
+    let(:expected_report) { params["csp-report"].slice("blocked-uri") }
 
     it { expect(Rails.logger).to_not have_received(:error).with(params) }
-    it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => params["csp-report"].slice("blocked-uri") }).once }
+    it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => expected_report }).once }
+    it { expect(self).to have_recorded_csp_violation(expected_report) }
+  end
+
+  def has_recorded_csp_violation?(report = nil)
+    return @events.any? if report.nil?
+
+    @events.any? { |event| event.payload == report }
+  end
+
+private
+
+  def record_csp_violation_events
+    @events = []
+    ActiveSupport::Notifications.subscribe("app.csp_violation") do |*args|
+      @events << ActiveSupport::Notifications::Event.new(*args)
+    end
   end
 end

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -6,17 +6,17 @@ describe "Instrumentation" do
   describe "process_action.action_controller" do
     after { get cookies_path }
 
-    it "increments the :requests_total metric" do
+    it "increments the :app_requests_total metric" do
       metric = registry.get(:app_requests_total)
       expect(metric).to receive(:increment).with(labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
 
-    it "observes the :request_duration_ms metric" do
+    it "observes the :app_request_duration_ms metric" do
       metric = registry.get(:app_request_duration_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
 
-    it "observes the :request_view_runtime_ms metric" do
+    it "observes the :app_request_view_runtime_ms metric" do
       metric = registry.get(:app_request_view_runtime_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: { path: "/cookies", method: "GET", status: 200 }).once
     end
@@ -25,7 +25,7 @@ describe "Instrumentation" do
   describe "render_template.action_view" do
     after { get cookie_preference_path }
 
-    it "observes the :render_view_ms metric" do
+    it "observes the :app_render_view_ms metric" do
       metric = registry.get(:app_render_view_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
         identifier: Rails.root.join("app/views/cookie_preferences/show.html.erb").to_s,
@@ -36,7 +36,7 @@ describe "Instrumentation" do
   describe "render_partial.action_view" do
     after { get root_path }
 
-    it "observes the :render_view_ms metric" do
+    it "observes the :app_render_view_ms metric" do
       metric = registry.get(:app_render_partial_ms)
       allow(metric).to receive(:observe)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
@@ -50,12 +50,37 @@ describe "Instrumentation" do
 
     after { get privacy_policy_path }
 
-    it "observes the :cache_read_total metric" do
+    it "observes the :app_cache_read_total metric" do
       metric = registry.get(:app_cache_read_total)
       expect(metric).to receive(:increment).with(labels: {
         key: instance_of(String),
         hit: false,
       }).once
+    end
+  end
+
+  describe "app.csp_violation" do
+    let(:params) do
+      {
+        "csp-report" =>
+        {
+          "blocked-uri" => "blocked-uri",
+          "document-uri" => "document-uri",
+          "violated-directive": "violated-directive",
+        },
+      }
+    end
+
+    after { post csp_reports_path, params: params.to_json }
+
+    it "increments the :app_csp_violations_total metric" do
+      metric = registry.get(:app_csp_violations_total)
+      expect(metric).to receive(:increment).with(labels:
+        {
+          blocked_uri: "blocked-uri",
+          document_uri: "document-uri",
+          violated_directive: "violated-directive",
+        }).once
     end
   end
 end


### PR DESCRIPTION
### JIRA ticket number

[Trello-446](https://trello.com/c/SNNRS9VU/446-set-up-grafana-dashboard-for-csp-violations)

### Context

We currently send CSP violations to logit.io, which is fine for debugging/investigating a violation in detail, however it does not let us easily dashboard and aggregate violations in Grafana (we can't extract from the JSON payload).

### Changes proposed in this pull request

- Instrument CSP violations

This commit instruments the CSP violations, sending them to our metrics database so that we can easily pull them out in Grafana to visualize/aggregate based on the collected labels:

- blocked_uri
- document_uri
- violated_directive

### Guidance to review

