### PR TITLE
Take first token of violated-directive

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -63,6 +63,7 @@ ActiveSupport::Notifications.subscribe "app.csp_violation" do |*args|
 
   labels = { blocked_uri: nil, document_uri: nil, violated_directive: nil }
   labels.merge!(report.slice(*labels.keys))
+  labels[:violated_directive] = labels[:violated_directive].split.first if labels[:violated_directive]
 
   metric = prometheus.get(:app_csp_violations_total)
   metric.increment(labels: labels)

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -66,7 +66,7 @@ describe "Instrumentation" do
         {
           "blocked-uri" => "blocked-uri",
           "document-uri" => "document-uri",
-          "violated-directive": "violated-directive",
+          "violated-directive": "violated-directive extra-info",
         },
       }
     end


### PR DESCRIPTION
The `violated-directive` of the CSP report sometimes comes through with more information that is useful for aggregating on:

``` violated-directive: img-src *.google.com *.gov.uk ```

Instead, we only care about the root directive/first token `img-src`. This will let us get a better breakdown of which CSP  directives are being violated most frequently.
