### PR TITLE
Rate limit pin code generation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: b790c3adf3f7bf8aae0335c8c4b76d99b0326265
+  revision: de4e6b9d429a3615f88b988d3d766b626e229fe4
   specs:
-    get_into_teaching_api_client (1.1.3)
+    get_into_teaching_api_client (1.1.4)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.4)
+    get_into_teaching_api_client_faraday (0.1.5)
       activesupport
       faraday
       faraday-encoding
@@ -118,6 +118,7 @@ GEM
       railties (>= 5.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday-encoding (0.0.5)
       faraday
     faraday-http-cache (2.2.0)
@@ -263,6 +264,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -38,8 +38,12 @@ module WizardSteps
 
 private
 
+  def client_ip
+    request.remote_ip
+  end
+
   def load_wizard
-    @wizard = wizard_class.new(wizard_store, params[:id])
+    @wizard = wizard_class.new(wizard_store, params[:id], client_ip)
   rescue Wizard::UnknownStep
     raise_not_found
   end

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -31,9 +31,15 @@ module WizardSteps
   end
 
   def resend_verification
-    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
-    GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request, x_client_ip: client_ip)
-    redirect_to authenticate_path(verification_resent: true)
+    begin
+      request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
+      GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request, x_client_ip: client_ip)
+      verification_resent = true
+    rescue GetIntoTeachingApiClient::ApiError
+      verification_resent = false
+    end
+
+    redirect_to authenticate_path(verification_resent: verification_resent)
   end
 
 private

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -32,7 +32,7 @@ module WizardSteps
 
   def resend_verification
     request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
-    GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+    GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request, x_client_ip: client_ip)
     redirect_to authenticate_path(verification_resent: true)
   end
 

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -28,10 +28,11 @@ module Wizard
 
     delegate :step, :key_index, :indexed_steps, :step_keys, to: :class
     delegate :can_proceed?, to: :find_current_step
-    attr_reader :current_key
+    attr_reader :current_key, :client_ip
 
-    def initialize(store, current_key)
+    def initialize(store, current_key, client_ip)
       @store = store
+      @client_ip = client_ip
 
       raise(UnknownStep) unless step_keys.include?(current_key)
 

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -2,17 +2,26 @@ module Wizard
   module IssueVerificationCode
     extend ActiveSupport::Concern
 
+    TOO_MANY_REQUESTS = 429
+
+    included { validate :too_many_requests }
+
     def save
       @store.purge! if previously_authenticated?
+      @too_many_requests = false
 
       if valid?
         begin
           request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
           GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request, x_client_ip: @wizard.client_ip)
           @store["authenticate"] = true
-        rescue GetIntoTeachingApiClient::ApiError
-          # Existing candidate not found or CRM is currently unavailable.
-          @store["authenticate"] = false
+        rescue GetIntoTeachingApiClient::ApiError => e
+          if e.code == TOO_MANY_REQUESTS
+            @too_many_requests = true
+          else
+            # Existing candidate not found or CRM is currently unavailable.
+            @store["authenticate"] = false
+          end
         end
       end
 
@@ -20,6 +29,12 @@ module Wizard
     end
 
   private
+
+    def too_many_requests
+      return unless @too_many_requests
+
+      errors.add(:base, :too_many_requests)
+    end
 
     def previously_authenticated?
       @store["authenticate"]

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -8,7 +8,7 @@ module Wizard
       if valid?
         begin
           request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
-          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+          GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request, x_client_ip: @wizard.client_ip)
           @store["authenticate"] = true
         rescue GetIntoTeachingApiClient::ApiError
           # Existing candidate not found or CRM is currently unavailable.

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,7 +1,8 @@
 <%
   hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text", 
     link: link_to(t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.link"), resend_verification_path))
-  hint_text += "<br /><b>#{t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent")}</b>" if params[:verification_resent]
+  hint_text += "<br /><b>#{t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent")}</b>" if params[:verification_resent] == "true"
+  hint_text += "<br /><b>#{t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.resend_failed")}</b>" if params[:verification_resent] == "false"
 %>
 
 <%= f.govuk_text_field :timed_one_time_password, 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -9,4 +9,5 @@ Rails.application.config.filter_parameters += %i[
   password
   telephone
   timed_one_time_password
+  x_client_ip
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,11 @@ en:
               invalid: Enter a valid postcode
         events/steps/personal_details:
           attributes:
+            base:
+              too_many_requests: |-
+                We need to verify your email address for you to continue.
+                We can send a verification code to your email address but you have reached the limit 
+                of the number of codes you can request for now. You can try again in 1 minute.
             first_name:
               blank: Enter your first name
             last_name:
@@ -197,6 +202,11 @@ en:
 
         mailing_list/steps/name:
           attributes:
+            base:
+              too_many_requests: |-
+                We need to verify your email address for you to continue.
+                We can send a verification code to your email address but you have reached the limit 
+                of the number of codes you can request for now. You can try again in 1 minute.
             first_name:
               blank: Enter your first name
             last_name:
@@ -270,6 +280,7 @@ en:
         timed_one_time_password:
           text: Check your junk mail folder or %{link}.
           resent: We've sent you another email.
+          resend_failed: You have reached the limit of the number of verification codes that we can send to you for now. You can try again in 1 minute.
           link: resend verification
       events_steps_personalised_updates:
         address_postcode: |-

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -165,6 +165,23 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text("Phone number (optional)")
   end
 
+  scenario "Resending the verification code too many times" do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+
+    visit event_steps_path(event_id: event_readable_id)
+
+    expect(page).to have_text "Sign up for this event"
+    fill_in_personal_details_step
+    click_on "Next Step"
+
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError.new(code: 429))
+
+    click_link "resend verification"
+    expect(page).to have_text "You can try again in 1 minute"
+  end
+
   scenario "Full journey as an existing candidate that has already subscribed to the mailing list" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token)

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -202,6 +202,23 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "How close are you to applying"
   end
 
+  scenario "Resending the verification code too many times" do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+
+    visit mailing_list_steps_path
+
+    expect(page).to have_text "Sign up for email updates"
+    fill_in_name_step(degree_status: "Final year")
+    click_on "Next Step"
+
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError.new(code: 429))
+
+    click_link "resend verification"
+    expect(page).to have_text "You can try again in 1 minute"
+  end
+
   scenario "Full journey as an existing candidate that has already subscribed to the mailing list" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token)

--- a/spec/models/events/steps/authenticate_spec.rb
+++ b/spec/models/events/steps/authenticate_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Events::Steps::Authenticate do
-  include_context "wizard step"
+  include_context "wizard step", Events::Wizard
 
   it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
 

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 describe Events::Steps::ContactDetails do
-  include_context "wizard step"
-
+  include_context "wizard step", Events::Wizard
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 describe Events::Steps::FurtherDetails do
-  include_context "wizard step"
-
+  include_context "wizard step", Events::Wizard
   it_behaves_like "a wizard step"
 
   context "attributes" do

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Events::Steps::PersonalDetails do
-  include_context "wizard step"
+  include_context "wizard step", Events::Wizard
   it_behaves_like "a wizard step"
   it_behaves_like "an issue verification code wizard step"
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Events::Steps::PersonalisedUpdates do
-  include_context "wizard step"
+  include_context "wizard step", Events::Wizard
   include_context "stub types api"
 
   it_behaves_like "a wizard step"

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -17,6 +17,7 @@ describe Events::Wizard do
 
   describe "#complete!" do
     let(:uuid) { SecureRandom.uuid }
+    let(:client_ip) { "1.2.3.4" }
     let(:store) do
       { uuid => {
         "event_id" => "abc123",
@@ -32,7 +33,7 @@ describe Events::Wizard do
       )
     end
 
-    subject { described_class.new wizardstore, "personalised_updates" }
+    subject { described_class.new wizardstore, "personalised_updates", client_ip }
 
     before { allow(subject).to receive(:valid?).and_return true }
     before do

--- a/spec/models/mailing_list/steps/already_subscribed_spec.rb
+++ b/spec/models/mailing_list/steps/already_subscribed_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::AlreadySubscribed do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   it { is_expected.to_not be_can_proceed }

--- a/spec/models/mailing_list/steps/authenticate_spec.rb
+++ b/spec/models/mailing_list/steps/authenticate_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::Authenticate do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
 
   it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
 

--- a/spec/models/mailing_list/steps/contact_spec.rb
+++ b/spec/models/mailing_list/steps/contact_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::Contact do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::Name do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   let(:degree_status_option_types) do

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::Postcode do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :address_postcode }

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::Subject do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   let(:teaching_subject_types) do

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe MailingList::Steps::TeacherTraining do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   let(:consideration_journey_stage_types) do

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -19,6 +19,7 @@ describe MailingList::Wizard do
 
   describe "#complete!" do
     let(:uuid) { SecureRandom.uuid }
+    let(:client_ip) { "1.2.3.4" }
     let(:store) do
       { uuid => {
         "email" => "email@address.com",
@@ -33,7 +34,7 @@ describe MailingList::Wizard do
       )
     end
 
-    subject { described_class.new wizardstore, "contact" }
+    subject { described_class.new wizardstore, "contact", client_ip }
 
     before { allow(subject).to receive(:valid?).and_return true }
     before do

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -4,7 +4,14 @@ describe Wizard::Base do
   include_context "wizard store"
 
   let(:wizardclass) { TestWizard }
-  let(:wizard) { wizardclass.new wizardstore, "age" }
+  let(:client_ip) { "1.2.3.4" }
+  let(:wizard) { wizardclass.new wizardstore, "age", client_ip }
+
+  describe ".client_ip" do
+    subject { wizard.client_ip }
+
+    it { is_expected.to eq(client_ip) }
+  end
 
   describe ".indexed_steps" do
     subject { wizardclass.indexed_steps }
@@ -51,32 +58,32 @@ describe Wizard::Base do
 
   describe ".new" do
     it "should return instance for known step" do
-      expect(wizardclass.new(wizardstore, "name")).to be_instance_of wizardclass
+      expect(wizardclass.new(wizardstore, "name", client_ip)).to be_instance_of wizardclass
     end
 
     it "should raise exception for unknown step" do
-      expect { wizardclass.new wizardstore, "unknown" }.to \
+      expect { wizardclass.new wizardstore, "unknown", client_ip }.to \
         raise_exception Wizard::UnknownStep
     end
   end
 
   describe "#can_proceed?" do
-    subject { wizardclass.new(wizardstore, "name") }
+    subject { wizardclass.new(wizardstore, "name", client_ip) }
     it { is_expected.to be_can_proceed }
   end
 
   describe "#current_key" do
-    subject { wizardclass.new(wizardstore, "name").current_key }
+    subject { wizardclass.new(wizardstore, "name", client_ip).current_key }
     it { is_expected.to eql "name" }
   end
 
   describe "#later_keys" do
-    subject { wizardclass.new(wizardstore, "name").later_keys }
+    subject { wizardclass.new(wizardstore, "name", client_ip).later_keys }
     it { is_expected.to eql %w[age postcode] }
   end
 
   describe "#earlier_keys" do
-    subject { wizardclass.new(wizardstore, "postcode").earlier_keys }
+    subject { wizardclass.new(wizardstore, "postcode", client_ip).earlier_keys }
     it { is_expected.to eql %w[name age] }
   end
 
@@ -147,7 +154,7 @@ describe Wizard::Base do
   end
 
   describe "complete!" do
-    subject { wizardclass.new wizardstore, "postcode" }
+    subject { wizardclass.new wizardstore, "postcode", client_ip }
     before { allow(subject).to receive(:valid?).and_return steps_valid }
 
     context "when valid" do
@@ -180,7 +187,7 @@ describe Wizard::Base do
     end
 
     let(:current_step) { "name" }
-    subject { wizardclass.new wizardstore, current_step }
+    subject { wizardclass.new wizardstore, current_step, client_ip }
 
     context "for the first step" do
       it { is_expected.to have_attributes first_step?: true }

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Wizard::Steps::Authenticate do
-  include_context "wizard step"
+  include_context "wizard step", MailingList::Wizard
   it_behaves_like "a wizard step"
 
   before { allow(instance).to receive(:perform_existing_candidate_request).with(anything) { {} } }

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -82,10 +82,23 @@ describe MailingList::StepsController do
   end
 
   describe "#resend_verification" do
-    subject do
-      get resend_verification_mailing_list_steps_path(redirect_path: "redirect/path")
-      response
+    let(:request_attributes) do
+      {
+        "email" => "email@address.com",
+        "first_name" => "first",
+        "last_name" => "last",
+      }
     end
+    let(:session) { { mailinglist: request_attributes } }
+
+    before do
+      expect_any_instance_of(ApplicationController).to receive(:session) { session }
+      expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+        receive(:create_candidate_access_token).with(having_attributes(request_attributes), x_client_ip: "127.0.0.1")
+      get resend_verification_mailing_list_steps_path(redirect_path: "redirect/path")
+    end
+
+    subject { response }
 
     it do
       is_expected.to redirect_to \

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -50,6 +50,16 @@ shared_examples "an issue verification code wizard step" do
       end
     end
 
+    context "when the candidate has made too many verification code requests" do
+      it "adds an error to the base model" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).with(request, x_client_ip: client_ip)
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 429))
+        subject.save
+        expect(subject.tap(&:valid?).errors[:base]).to_not be_empty
+      end
+    end
+
     context "when a new candidate or CRM is unavailable" do
       it "will skip the authenticate step" do
         allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request, x_client_ip: client_ip)


### PR DESCRIPTION
### JIRA ticket number

[Trello-352](https://trello.com/c/MjWfjLi7/352-set-rate-limiting-on-api)

### Context

The API will begin rate limiting requests that issue a verification code. In order to do that we need to send an `X-Client-IP` header with the `create_access_token` requests. We should also display a suitable message to the user if they issue too many requests.

### Changes proposed in this pull request

- Retain client IP address in Wizard

We want to be able to access the end user IP address from the wizard step that makes the request to the `create_candidate_access_token` endpoint. If we pass this as the `X-Client-IP` header value it will cause the API to rate limit the endpoint for the individual user, instead of for the app as a whole (based it's API key).

- Update get_into_teaching_api_client_faraday

Add support for passing `x_client_ip` option to API requests.

- Send x_client_ip with access token requests

We want the API to be able to rate limit candidate access token requests by the end user that is using the website; it determines the end user based on the `x_client_ip` header, if provided.

- Display message when verification code rate limit exceeded

When the user attempts to request a verification code more than 3 times/minute the API will respond with `429` - too many requests.

We catch this response and display a suitable message to the user, asking them to wait a minute before attempting to request another verification code.

### Guidance to review

**NOTE: the API is not yet rate limiting requests; we are going to ship this ahead of enforcing the rate limits, but this will be user tested as part of that work**

![Screenshot 2020-10-22 at 15 18 56](https://user-images.githubusercontent.com/29867726/96887906-f2fb7c80-147c-11eb-96d6-0520da828ccf.png)

![Screenshot 2020-10-26 at 16 06 13](https://user-images.githubusercontent.com/29867726/97197162-3881b780-17a5-11eb-9345-3cd6e277890b.png)
