### PR TITLE
Extract path from document_uri

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -66,7 +66,11 @@ ActiveSupport::Notifications.subscribe "app.csp_violation" do |*args|
 
   labels[:violated_directive] = labels[:violated_directive].split.first if labels[:violated_directive]
   labels[:blocked_uri] = labels[:blocked_uri].split("?").first if labels[:blocked_uri]
-  labels[:document_uri] = labels[:document_uri].split("?").first if labels[:document_uri]
+
+  if labels[:document_uri]
+    document_uri = URI.parse(labels[:document_uri])
+    labels[:document_uri] = document_uri.path
+  end
 
   metric = prometheus.get(:app_csp_violations_total)
   metric.increment(labels: labels)

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -65,7 +65,7 @@ describe "Instrumentation" do
         "csp-report" =>
         {
           "blocked-uri" => "http://document-uri.com/script.js?param=test",
-          "document-uri" => "http://document-uri.com?param=test",
+          "document-uri" => "http://document-uri.com/path?param=test",
           "violated-directive": "violated-directive extra-info",
         },
       }
@@ -78,7 +78,7 @@ describe "Instrumentation" do
       expect(metric).to receive(:increment).with(labels:
         {
           blocked_uri: "http://document-uri.com/script.js",
-          document_uri: "http://document-uri.com",
+          document_uri: "/path",
           violated_directive: "violated-directive",
         }).once
     end


### PR DESCRIPTION
Using the path as the label (removing the hostname, which is always the same for this attribute) makes the visualisation nicer in Grafana.