### PR TITLE
Tweak to not squish wide images in story headers

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -6,7 +6,7 @@
       <%= tag.h1(title) %>
 
       <header class="story__header">
-        <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher)) %>
+        <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
         <div class="story__header__label">
           <%= helpers.story_heading(teacher, position) %>
         </div>

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -159,12 +159,7 @@
         margin-bottom: 30px;
 
         &__thumb {
-            background-color: grey;
-            background-position: center;
-            background-repeat: no-repeat;
-            background-size: cover;
-            min-width: 200px;
-            height: 200px;
+            object-fit: cover;
         }
 
         &__label {


### PR DESCRIPTION
Remove the copied CSS and replace with just `object-fit: cover`, the image sizing's already taken care of and anything that overflows will automatically be cropped.