### PR TITLE
Render 404 on Wizard::UnknownStep

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,20 @@
 class ApplicationController < ActionController::Base
   include UtmCodes
 
+  rescue_from ActionController::RoutingError, with: :render_not_found
+
   before_action :http_basic_authenticate
   before_action :record_utm_codes
 
+  def raise_not_found
+    raise ActionController::RoutingError, "Not Found"
+  end
+
 private
+
+  def render_not_found
+    render template: "errors/not_found", status: :not_found
+  end
 
   def http_basic_authenticate
     return true if ENV["HTTPAUTH_USERNAME"].blank?

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -40,6 +40,8 @@ private
 
   def load_wizard
     @wizard = wizard_class.new(wizard_store, params[:id])
+  rescue Wizard::UnknownStep
+    raise_not_found
   end
 
   def load_current_step

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -33,6 +33,12 @@ describe EventStepsController do
 
       it { is_expected.to redirect_to(event_path(id: event.readable_id)) }
     end
+
+    context "with an invalid step" do
+      let(:step_path) { event_step_path readable_event_id, :invalid }
+
+      it { is_expected.to have_http_status :not_found }
+    end
   end
 
   describe "#update" do

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -19,6 +19,12 @@ describe MailingList::StepsController do
     before { get step_path }
     subject { response }
     it { is_expected.to have_http_status :success }
+
+    context "with an invalid step" do
+      let(:step_path) { mailing_list_step_path :invalid }
+
+      it { is_expected.to have_http_status :not_found }
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
We currently fail with a 500 error if the wizard is initialised with an unknown step; this happens if the user enters a bad URL, so it would make more sense to return a 404 in this scenario.
