### PR TITLE
Remove 'See all events' link from category pages

### DIFF
--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -4,6 +4,6 @@
   </div>
 
   <% category_groups.each do |type_id, events| %>
-    <%= render partial: "event_group", locals: { type_id: type_id, events: events } %>
+    <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
   <% end %>
 </section>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -9,7 +9,11 @@
     <%= render partial: "event", collection: events %>
   </div>
 
-  <%= link_to(event_category_events_path(pluralised_category_name(type_id).parameterize)) do %>
-    <div class="call-to-action-button">See all <%= pluralised_category_name(type_id) %> <i class="fas fa-chevron-right"></i></div>
+  <% show_see_all_events ||= false %>
+
+  <% if show_see_all_events %>
+    <%= link_to(event_category_events_path(pluralised_category_name(type_id).parameterize)) do %>
+      <div class="call-to-action-button">See all <%= pluralised_category_name(type_id) %> <i class="fas fa-chevron-right"></i></div>
+    <% end %>
   <% end %>
 </div>

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -29,6 +29,10 @@ describe "View events by category" do
     it "displays all events in the category" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)
     end
+
+    it "does not display the 'See all events' button" do
+      expect(response.body.scan(/see all train to teach events/i)).to be_empty
+    end
   end
 
   context "when viewing the schools and university events category" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -38,6 +38,10 @@ describe EventsController do
         expect(parsed_response.css(".events-featured__list__item").count).to eql(events_cap)
       end
     end
+
+    specify "rendering the see all events button" do
+      expect(subject.body).to match(/see all train to teach events/i)
+    end
   end
 
   describe "#search" do


### PR DESCRIPTION
The link links to the current page, it can be toggled via
show_see_all_events and is off by default.

### JIRA ticket number

https://trello.com/c/rIzaetoX/478-implement-the-new-functionality-in-schools-and-university-see-all-events-page-search-pagination-reduced-info-being-shown

### Context

Now the partial is being shared the display of the button needs to be controlled.

### Changes proposed in this pull request

Add a `show_see_all_events` argument to the `event_group` partial and default it to false. Set it to true only on the events index page.

### Guidance to review

Does it look sensible? The next step is probably to wrap this in a component and pull the logic out of the template.
