### PR TITLE
Only run the content tests against markdown files

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "content pages check", type: :feature do
 
   class << self
     def files
-      Dir["app/views/content/**/*"]
+      Dir["app/views/content/**/*.md"]
     end
 
     def remove_folders(filename)


### PR DESCRIPTION
The tests assume there's a frontmatter block at the top all the content
files but the homepage was recently switched to ERB/HTML and broken
up into partials.