### PR TITLE
Minor fix to background colour of events

### DIFF
--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -1,4 +1,4 @@
-<section class="types-of-event content container-1000">
+<section class="content container-1000">
   <div class="content__left">
     <h2>Organised by <%= organised_by %></h2>
   </div>


### PR DESCRIPTION
The events lists on the search page should have a off-white background, but on the event category pages should have a white background. This removes the `.types-of-event` class from index/search page to style them accordingly:

### Index/Search pages

![Screenshot from 2020-10-27 08-51-43](https://user-images.githubusercontent.com/128088/97278746-09655780-1832-11eb-989d-fe73131b860d.png)



### Category list

![Screenshot from 2020-10-27 08-51-35](https://user-images.githubusercontent.com/128088/97278736-066a6700-1832-11eb-9aa8-eaf6c97dd0ef.png)
