### PR TITLE
Upgrade to latest formbuilder version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (1.2.0)
+    govuk_design_system_formbuilder (2.1.1)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -6,4 +6,4 @@
 
 <%= f.govuk_text_field :timed_one_time_password, 
 label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', email: email) }, 
-hint_text: safe_html_format(hint_text) %>
+hint: { text: safe_html_format(hint_text) } %>


### PR DESCRIPTION
`hint_text: 'blah'` is now supplied has `hint: { text: 'blah' }`, everything else remains the same.

Closes #504 