### PR TITLE
Add and configure a stories landing page layout

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -2,6 +2,10 @@ class StoriesController < ApplicationController
   include StaticPages
   rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
 
+  def landing
+    render template: landing_template, layout: "layouts/stories/landing"
+  end
+
   def index
     render template: index_template, layout: "layouts/stories/list"
   end
@@ -11,6 +15,10 @@ class StoriesController < ApplicationController
   end
 
 private
+
+  def landing_template
+    "content/life-as-a-teacher/my-story-into-teaching"
+  end
 
   def stories_template
     "content/life-as-a-teacher/my-story-into-teaching/" + filtered_page_template(:story)

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+    <%= render "sections/head" %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", target: "link.content" }, id: "body" do %>
+      <%= render "sections/header" %>
+      <%= render "sections/hero",
+          :header => @front_matter["title"],
+          :image => @front_matter["image"],
+          :mobileimage => @front_matter["mobileimage"],
+          :deep => @front_matter["deepheader"], :subtitle =>  @front_matter["subtitle"],
+          :mailinglist => @front_matter["mailinglist"]
+      %>
+
+      <div class="stories-feature">
+        <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.png')"></div>
+        <div class="stories-feature__content">
+          <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
+          <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
+          <%= tag.p(@front_matter.dig("featured_story", "text")) %>
+          <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
+            Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
+          <% end %>
+        </div>
+      </div>
+
+      <main class="content container-1000 story-landing" role="main" id="main-content">
+        <% @front_matter["sections"].each do |name, section| %>
+          <section>
+            <header>
+              <%= tag.h2(name) %>
+              <%= tag.p(section["text"]) %>
+            </header>
+            <% if section["stories"].present? %>
+              <div class="story-cards more-stories">
+                <%= render Stories::CardComponent.with_collection(section["stories"]) %>
+              </div>
+
+              <footer>
+                <%= link_to section["link"] do %>
+                  Read all stories about <%= name.downcase %>
+                <% end %>
+              </footer>
+            <% end %>
+          </section>
+        <% end %>
+      </main>
+      <%= render "sections/footer" %>
+      <%= render "components/videoplayer" %>
+      <%= render "sections/cookie-acceptance" %>
+    <% end %>
+</html>
+

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <main class="content container-1000 story-landing" role="main" id="main-content">
-        <% @front_matter["sections"].each do |name, section| %>
+        <% @front_matter["sections"]&.each do |name, section| %>
           <section>
             <header>
               <%= tag.h2(name) %>
@@ -49,4 +49,3 @@
       <%= render "sections/cookie-acceptance" %>
     <% end %>
 </html>
-

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -1,3 +1,35 @@
+.story-landing {
+    header {
+        padding: 0 20px;
+        width: 66.6%;
+
+        h2 {
+            font-size: 1.8em;
+            border-bottom: 8px solid #2781be;
+        }
+    }
+
+    > section {
+        margin-bottom: 3em;
+
+        > footer {
+            padding: 20px;
+            width: 66.6%;
+
+            a {
+                background-color: $grey;
+                font-weight: bold;
+                text-decoration: none;
+                padding: 1em;
+
+                &:hover {
+                    background-color: darken($grey, 10%);
+                }
+            }
+        }
+    }
+}
+
 .stories-feature {
 
     display: table;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
 
   # if the story path contains a slash followed by any text, it's a story
   # if it has no slashes or ends in a slash, it's an index page
+  get "/life-as-a-teacher/my-story-into-teaching", to: "stories#landing"
   get(
     "/life-as-a-teacher/my-story-into-teaching/*story/",
     to: "stories#show",

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -1,14 +1,64 @@
 require "rails_helper"
 
+shared_examples "page cannot be found" do |template|
+  context "for unknown page" do
+    let(:template) { template }
+    it { is_expected.to have_http_status :not_found }
+    it { is_expected.to have_attributes body: %r{Page not found} }
+  end
+
+  context "for invalid page page" do
+    let(:template) { "../../secrets.txt" }
+    it { is_expected.to have_http_status :not_found }
+    it { is_expected.to have_attributes body: %r{Page not found} }
+  end
+end
+
 describe StoriesController do
   let(:template) { "testing/markdown_test" }
 
-  before do
-    allow_any_instance_of(described_class).to \
-      receive(:stories_template).and_return template
+  context "#landing" do
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:landing_template).and_return template
+    end
+
+    subject do
+      get "/life-as-a-teacher/my-story-into-teaching/"
+      response
+    end
+
+    context "for known page" do
+      it { is_expected.to have_http_status :success }
+    end
+
+    include_examples "page cannot be found", "testing/unknown"
+  end
+
+  context "#index" do
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:index_template).and_return template
+    end
+
+    subject do
+      get "/life-as-a-teacher/my-story-into-teaching/returners"
+      response
+    end
+
+    context "for known page" do
+      it { is_expected.to have_http_status :success }
+    end
+
+    include_examples "page cannot be found", "testing/unknown"
   end
 
   context "#show" do
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:stories_template).and_return template
+    end
+
     subject do
       get "/life-as-a-teacher/my-story-into-teaching/returners/known-page"
       response
@@ -18,16 +68,6 @@ describe StoriesController do
       it { is_expected.to have_http_status :success }
     end
 
-    context "for unknown page" do
-      let(:template) { "testing/unknown" }
-      it { is_expected.to have_http_status :not_found }
-      it { is_expected.to have_attributes body: %r{Page not found} }
-    end
-
-    context "for invalid page page" do
-      let(:template) { "../../secrets.txt" }
-      it { is_expected.to have_http_status :not_found }
-      it { is_expected.to have_attributes body: %r{Page not found} }
-    end
+    include_examples "page cannot be found", "testing/unknown"
   end
 end


### PR DESCRIPTION
This page will be built entirely from the frontmatter provided in the content repo. Much of the CSS is now shared with the other pages, the unused rules can now be safely culled. I've also added a little more spacing between the sections to make it clearer which links belong to which.

Related (and depends on) to DFE-Digital/get-into-teaching-content/pull/118

## Examples

![Screenshot from 2020-10-27 14-28-53](https://user-images.githubusercontent.com/128088/97315956-27967c00-1861-11eb-9fd9-20b77b90dee6.png)

![Screenshot from 2020-10-27 14-31-08](https://user-images.githubusercontent.com/128088/97316034-3d0ba600-1861-11eb-9e8c-0fb7fb4ce628.png)



