### PR TITLE
Support both HTML and plain text event descriptions

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -37,6 +37,14 @@ module EventsHelper
     video_url&.sub("watch?v=", "embed/")
   end
 
+  def formatted_event_description(description)
+    if strip_tags(description) != description
+      safe_html_format(description)
+    else
+      safe_format(description)
+    end
+  end
+
   def event_has_provider_info?(event)
     event.provider_website_url ||
       event.provider_target_audience ||

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -25,7 +25,7 @@
         <% end %>
 
         <h2 class="strapline-article">Event information</h2>
-        <%= safe_html_format @event.description %>
+        <%= formatted_event_description(@event.description) %>
 
         <% if @event.building && !@event.is_online %>
         <h2 class="strapline-article">Venue information</h2>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -27,6 +27,22 @@ describe EventsHelper, type: "helper" do
     end
   end
 
+  describe "#formatted_event_description" do
+    subject { formatted_event_description(description) }
+
+    context "when plain text" do
+      let(:description) { "Some\nText" }
+
+      it { is_expected.to eq("<p>Some\n<br />Text</p>") }
+    end
+
+    context "when HTML" do
+      let(:description) { "<p>Some <b>text</b></p>" }
+
+      it { is_expected.to eq("<p>Some <b>text</b></p>") }
+    end
+  end
+
   describe "#event_location_map" do
     subject { event_location_map(event) }
 


### PR DESCRIPTION
The current event descriptions are plain text (with line breaks) - the CRM team are  migrating to a WYSIWYG for inputting event descriptions that will return HTML. We need to be able to support both while they perform the migration.

Checks to see if the event description contains any HTML tags, if it does then it runs it through `sanitize`, otherwise continue to use `simple_format`.

If we run through both `simple_format` and `sanitize` instead we end up getting extra spacing between lines.
