### PR TITLE
Display upcoming teaching events irrespective of month

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: b790c3adf3f7bf8aae0335c8c4b76d99b0326265
+  revision: b54d486736e47a88d9d86e7080891f564c4f9dc3
   specs:
-    get_into_teaching_api_client (1.1.3)
+    get_into_teaching_api_client (1.1.5)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.4)
+    get_into_teaching_api_client_faraday (0.1.6)
       activesupport
       faraday
       faraday-encoding
@@ -116,8 +116,9 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday-encoding (0.0.5)
       faraday
     faraday-http-cache (2.2.0)
@@ -263,6 +264,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,7 @@
 class EventsController < ApplicationController
   before_action :load_events, only: %i[index search]
+  
+  MAXIMUM_EVENTS_IN_CATEGORY = 1_000
 
   def index
     @page_title = "Find an event near you"
@@ -25,7 +27,11 @@ class EventsController < ApplicationController
     render(template: "errors/not_found", status: :not_found) && return if @type.nil?
 
     api = GetIntoTeachingApiClient::TeachingEventsApi.new
-    @events = api.search_teaching_events(type_id: @type.id)
+    events_by_type = api.search_teaching_events_indexed_by_type(
+      type_id: @type.id, 
+      quantity_per_type: MAXIMUM_EVENTS_IN_CATEGORY
+    )
+    @events = events_by_type[@type.id.to_sym]
   end
 
 private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,8 +38,8 @@ private
 
   def load_events
     @event_search = Events::Search.new(event_search_params)
-    @events = @event_search.query_events
-    @group_presenter = Events::GroupPresenter.new(@events, cap: cap_results?)
+    @events_by_type = @event_search.query_events
+    @group_presenter = Events::GroupPresenter.new(@events_by_type)
   end
 
   def event_search_params
@@ -47,17 +47,5 @@ private
 
     (params[Events::Search.model_name.param_key] || defaults)
       .permit(:type, :distance, :postcode, :month)
-  end
-
-  # When there's a value in the 'distance', 'type' or 'postcode' events_search param, an actual
-  # search has been made so display all results. If none have values it's either the index page
-  # or an open-ended search ('All Events'/'Nationwide') so apply a cap so the user isn't swamped
-  # with events
-  def cap_results?
-    active_search_params = params
-      .fetch("events_search", {})
-      .reject { |_, v| v.blank? }
-
-    %i[distance type postcode].none? { |param| active_search_params.key?(param) }
   end
 end

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -4,6 +4,7 @@ module Events
     include ActiveModel::Attributes
     include ActiveModel::Validations::Callbacks
 
+    RESULTS_PER_TYPE = 9
     DISTANCES = [30, 50, 100].freeze
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze
 
@@ -50,18 +51,19 @@ module Events
     end
 
     def query_events
-      valid? ? query_events_api : []
+      valid? ? query_events_api : {}
     end
 
   private
 
     def query_events_api
-      GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
+      GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_indexed_by_type(
         type_id: type,
         radius: distance,
         postcode: postcode&.strip,
         start_after: start_of_month,
         start_before: end_of_month,
+        quantity_per_type: RESULTS_PER_TYPE,
       )
     end
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -32,7 +32,7 @@
         </div>
     </section>
 
-    <% if @events.any? %>
+    <% if @events_by_type.any? %>
       <% if @group_presenter.get_into_teaching_events.any? %>
         <%= render partial: "event_category", locals: { organised_by: t("event_groups.get_into_teaching"), category_groups: @group_presenter.get_into_teaching_events } %>
       <% end %>

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -9,11 +9,12 @@ RSpec.feature "Finding an event", type: :feature do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
+  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
   let(:event) { events.last }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events) { events }
+      receive(:search_teaching_events_indexed_by_type) { events_by_type }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { event }
   end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature "Finding an event", type: :feature do
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:upcoming_teaching_events_indexed_by_type) { events_by_type }
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_indexed_by_type) { events_by_type }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { event }

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -81,6 +81,7 @@ describe Events::Search do
         postcode: subject.postcode,
         start_after: Date.new(2020, 7, 1),
         start_before: Date.new(2020, 7, 31),
+        quantity_per_type: described_class::RESULTS_PER_TYPE,
       }
     end
 
@@ -90,7 +91,7 @@ describe Events::Search do
 
       it "calls the API" do
         expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-          receive(:search_teaching_events).with(**expected_attributes)
+          receive(:search_teaching_events_indexed_by_type).with(**expected_attributes)
       end
 
       context "when there's whitespace around a provided postcode" do
@@ -98,7 +99,7 @@ describe Events::Search do
 
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-            receive(:search_teaching_events).with(**expected_attributes.merge(postcode: subject.postcode.strip))
+            receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: subject.postcode.strip))
         end
       end
     end
@@ -108,7 +109,7 @@ describe Events::Search do
 
       it "does not call the API" do
         expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).not_to \
-          receive(:search_teaching_events)
+          receive(:search_teaching_events_indexed_by_type)
         subject.query_events
       end
     end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -9,16 +9,17 @@ describe "View events by category" do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
+  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events) { events }
+      receive(:search_teaching_events_indexed_by_type) { events_by_type }
   end
 
   context "when viewing a category" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events) { events }
+        receive(:search_teaching_events_indexed_by_type) { events_by_type }
       get event_category_events_path("train-to-teach-events")
     end
 
@@ -39,7 +40,7 @@ describe "View events by category" do
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events).with(type_id: type_id.to_s)
+        receive(:search_teaching_events_indexed_by_type).with(type_id: type_id.to_s, quantity_per_type: 1_000)
       get event_category_events_path("school-and-university-events")
     end
   end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -8,20 +8,11 @@ describe EventsController do
     let(:events) { [build(:event_api, name: "First"), build(:event_api, name: "Second")] }
     let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
     let(:parsed_response) { Nokogiri.parse(response.body) }
-    let(:expected_request_attributes) do
-      {
-        postcode: nil,
-        quantity_per_type: results_per_type,
-        radius: nil,
-        start_after: Time.zone.today.beginning_of_month,
-        start_before: Time.zone.today.end_of_month,
-        type_id: nil,
-      }
-    end
+    let(:expected_request_attributes) { { quantity_per_type: results_per_type } }
 
     before do
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type)
+        receive(:upcoming_teaching_events_indexed_by_type)
         .with(a_hash_including(expected_request_attributes)) { events_by_type }
     end
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -12,14 +12,15 @@ describe "Find an event near you" do
     end
   end
   let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
-  before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_indexed_by_type) { events_by_type }
-  end
 
   subject { response }
 
   context "when landing on the page initially" do
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:upcoming_teaching_events_indexed_by_type) { events_by_type }
+    end
+
     before { get events_path }
 
     it { is_expected.to have_http_status :success }
@@ -64,6 +65,12 @@ describe "Find an event near you" do
 
   context "when searching for an event by type" do
     let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+    end
+
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
     it "displays all events of that type" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -11,9 +11,10 @@ describe "Find an event near you" do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
+  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events) { events }
+      receive(:search_teaching_events_indexed_by_type) { events_by_type }
   end
 
   subject { response }


### PR DESCRIPTION
### JIRA ticket number

[Trello-427](https://trello.com/c/6YY80hFQ/427-events-for-virtual-ttt-events-show-next-months-events-if-none-exist-for-that-month-on-home-page)

### Context

We want to display the next 9 upcoming events by type when landing on the events index page, regardless of month.

We also want to update the search results to only show a maximum of 9 events per type.

The event category page should continue to display all results.

There are two new endpoints in the API for retrieving events indexed by type and limiting the results per type. The current `search_teaching_events` endpoint is being deprecated.

### Changes proposed in this pull request

- Bump API client version

Update includes new `*_indexed_by_type` API endpoints.

- Transition events#show_category to new search method

We are transitioning away from the `search_teaching_events` method to the new `search_teaching_events_indexed_by_type` as events are categorised in the majority of places.

Updates `events#show_category` to use new categorised events method. The amount is set somewhat arbitrarily to 1,000 for now, we are expecting to change this in the future to be paginated.

- Migrate index/show to search_teaching_events_indexed_by_type

Updates the `Events::Search` model to use the new search endpoint. This now returns events grouped by type and also supports limiting results, which allows us to simplify the the `Events::GroupPresenter`.

We have also decided to limit both the events index page and search results to at most 9 events per group.

- Switch index page to use upcoming_search_events_indexed_by_type

We want to display the upcoming events regardless of month when landing on the events index page, up to a maximum of the next 9 by type.

The event search is also limited to 9 per type but the events will not cross month boundaries.

### Guidance to review

Best reviewed by commit.

The event category results have a somewhat arbitrary limit of 1,000 - this is just because the API expects a value, so it should be high enough to ensure all events are returned. We expect to migrate away from this to a paginated results set in the near future.

More can probably be done to simplify the `EventsController`, but I'd rather this was picked up in a follow up PR.