### PR TITLE
Update GA cookie name

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -78,7 +78,7 @@ window)</span><i class="icon icon-external"></i></a> and the third-party service
                         <td class="govuk-table__cell">2 years</th>
                     </tr>
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">_gat_UA_159214613-2</th>
+                        <td class="govuk-table__cell">UA-179982899-1</th>
                         <td class="govuk-table__cell">Used by Google Analytics, this registers a unique ID to generate statistics about how you use the website</th>
                         <td class="govuk-table__cell">1 minute</th>
                     </tr>


### PR DESCRIPTION
The GA cookie we are listing is not correct, this updates it to match what we are using in production.
