### PR TITLE
Rate limit transactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include UtmCodes
 
   rescue_from ActionController::RoutingError, with: :render_not_found
+  rescue_from GetIntoTeachingApiClient::ApiError, with: :handle_api_error
 
   before_action :http_basic_authenticate
   before_action :record_utm_codes
@@ -12,8 +13,18 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def handle_api_error(error)
+    render_too_many_requests && return if error.code == 429
+
+    raise
+  end
+
   def render_not_found
     render template: "errors/not_found", status: :not_found
+  end
+
+  def render_too_many_requests
+    render template: "errors/too_many_requests", status: :too_many_requests
   end
 
   def http_basic_authenticate

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -10,7 +10,9 @@ module Wizard
           request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(request_attributes)
           GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
           @store["authenticate"] = true
-        rescue GetIntoTeachingApiClient::ApiError
+        rescue GetIntoTeachingApiClient::ApiError => e
+          raise if e.code == 429
+
           # Existing candidate not found or CRM is currently unavailable.
           @store["authenticate"] = false
         end

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,8 @@
+<section class="content container-1000 error-page" role="main" id="main-content"> 
+  <p>Error 429</p>
+  <h1>Too many requests</h1>
+  <p>You have tried to access a page too often in a short space of time.</p>
+  <p>You can go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
+  <p>You can <a href="/">browse the homepage</a> or <a href="#talk-to-us">talk to us</a> if you have a question about teaching or teacher training.</p>
+</section>
+

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,59 @@
-class Rack::Attack
-  # Throttle /csp_reports requests by IP (5rpm)
-  throttle("req/ip", limit: 5, period: 1.minute) do |req|
-    req.ip if req.path == "/csp_reports"
+module Rack
+  class Attack
+    # Throttle /csp_reports requests by IP (5rpm)
+    throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if req.path == "/csp_reports"
+    end
+
+    # Throttle requests that issue a verification code by IP (5rpm)
+    throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+      issue_verification_code_paths = [
+        %r{mailinglist/signup/name},
+        %r{events/.*/apply/personal_details},
+      ]
+
+      path_issues_verification_code = issue_verification_code_paths.any? do |pattern|
+        pattern.match(req.path)
+      end
+
+      req.ip if (req.patch? || req.put?) && path_issues_verification_code
+    end
+
+    # Throttle requests that resend a verification code by IP (5rpm)
+    throttle("resend_verification_code req/ip", limit: 5, period: 1.minute) do |req|
+      path_resends_verification_code = %r{/*./resend_verification}.match?(req.path)
+
+      req.ip if req.get? && path_resends_verification_code
+    end
+
+    # Throttle mailing list sign ups by IP (5rpm)
+    throttle("mailing_list_sign_up req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if (req.patch? || req.put?) && req.path == "/mailinglist/signup/contact"
+    end
+
+    # Throttle event sign ups by IP (5rpm)
+    throttle("event_sign_up req/ip", limit: 5, period: 1.minute) do |req|
+      event_sign_up_paths = [
+        %r{events/.*/apply/personalised_updates},
+        %r{events/.*/apply/further_details},
+      ]
+
+      path_performs_event_sign_up = event_sign_up_paths.any? do |pattern|
+        pattern.match(req.path)
+      end
+
+      req.ip if (req.patch? || req.put?) && path_performs_event_sign_up
+    end
+  end
+
+  Rack::Attack.throttled_response = lambda do |env|
+    accept_html = env["HTTP_ACCEPT"].include?("text/html")
+    return [429, {}, "Rate limit exceeded"] unless accept_html
+
+    html = ApplicationController.render(
+      template: "errors/too_many_requests",
+    )
+
+    [429, { "Content-Type" => "text/html" }, [html]]
   end
 end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -6,6 +6,12 @@ describe EventStepsController do
   include_context "stub latest privacy policy api"
   include_context "stub event add attendee api"
 
+  it_behaves_like "a controller with a #resend_verification action" do
+    def perform_request
+      get resend_verification_event_steps_path(readable_event_id, redirect_path: "redirect/path")
+    end
+  end
+
   let(:readable_event_id) { "123" }
   let(:model) { Events::Steps::PersonalDetails }
   let(:step_path) { event_step_path readable_event_id, model.key }
@@ -98,17 +104,5 @@ describe EventStepsController do
       response
     end
     it { is_expected.to have_http_status :success }
-  end
-
-  describe "#resend_verification" do
-    subject do
-      get resend_verification_event_steps_path(readable_event_id, redirect_path: "redirect/path")
-      response
-    end
-
-    it do
-      is_expected.to redirect_to \
-        controller.send(:authenticate_path, verification_resent: true)
-    end
   end
 end

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -6,6 +6,12 @@ describe MailingList::StepsController do
   include_context "stub latest privacy policy api"
   include_context "stub mailing list add member api"
 
+  it_behaves_like "a controller with a #resend_verification action" do
+    def perform_request
+      get resend_verification_mailing_list_steps_path(redirect_path: "redirect/path")
+    end
+  end
+
   let(:model) { MailingList::Steps::Name }
   let(:step_path) { mailing_list_step_path model.key }
 
@@ -79,17 +85,5 @@ describe MailingList::StepsController do
       response
     end
     it { is_expected.to have_http_status :success }
-  end
-
-  describe "#resend_verification" do
-    subject do
-      get resend_verification_mailing_list_steps_path(redirect_path: "redirect/path")
-      response
-    end
-
-    it do
-      is_expected.to redirect_to \
-        controller.send(:authenticate_path, verification_resent: true)
-    end
   end
 end

--- a/spec/support/rate_limiting_support.rb
+++ b/spec/support/rate_limiting_support.rb
@@ -1,0 +1,32 @@
+shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
+  describe desc do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rack::Attack.cache).to receive(:store) { memory_store }
+      request_count.times { perform_request }
+    end
+
+    subject { response.status }
+
+    context "when fewer than rate limit" do
+      let(:request_count) { limit - 1 }
+
+      it { is_expected.to_not eq(429) }
+    end
+
+    context "when more than rate limit" do
+      let(:request_count) { limit + 1 }
+
+      it { is_expected.to eq(429) }
+
+      context "when time restriction has passed" do
+        it "allows another request" do
+          travel period + 1.second
+          perform_request
+          expect(response.status).to_not eq(429)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/resend_verification_support.rb
+++ b/spec/support/resend_verification_support.rb
@@ -1,0 +1,22 @@
+shared_examples "a controller with a #resend_verification action" do
+  describe "#resend_verification" do
+    it "redirects to the authentication_path with verification_resent: true" do
+      perform_request
+      expect(response).to redirect_to controller.send(:authenticate_path, verification_resent: true)
+    end
+
+    context "when the API returns 429 too many requests" do
+      let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
+
+      subject! do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).and_raise(too_many_requests_error)
+        perform_request
+        response.body
+      end
+
+      it { is_expected.to match(/Error 429/) }
+      it { is_expected.to match(/Too many requests/) }
+    end
+  end
+end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -55,6 +55,17 @@ shared_examples "an issue verification code wizard step" do
         expect(wizardstore["authenticate"]).to be_falsy
       end
     end
+
+    context "when the API rate limits the request" do
+      let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
+
+      it "will re-raise the ApiError (to be rescued by the ApplicationController)" do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
+          .and_raise(too_many_requests_error)
+        expect { subject.save }.to raise_error(too_many_requests_error)
+        expect(wizardstore["authenticate"]).to be_nil
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### JIRA ticket number

[Trello-352](https://trello.com/c/MjWfjLi7/352-set-rate-limiting-on-api)

### Context

The API is rate limited to 30 requests/client API key/minute for transactional/vulnerable endpoints (both apps currently share the same API key, but this will change in the future).

We want to apply per-user/IP rate limiting in the front end applications as well, to add more granular control over submissions. The rate limits initially will be 5 requests/IP/minute - this should be plenty for now, but may need tweaking as we roll out to more users (or to take into account advertising 'spikes' in traffic).

When a user encounters a rate limit we want to display a 429 error page similar to the existing 404/500 error pages.

If the user encounters an API rate limit we want to display the same page.

### Changes proposed in this pull request

- Rate limit transaction endpoints

The transaction endpoints are rate limited to 30 requests per minute by the API. We want to enforce the rate limiting client-side per user/ip as well to a maximum of 5 requests/IP/minute.

If a user encounters a rate limit, instead of returning a standard 429 and text response we instead render a 'Too many requests' error page, similar to the existing 404 and 500 error pages.

- Rescue ApiError and render 429 error page

Whilst the app itself is rate limited the API also has rate limiting. In the unlikely event that the client rate limits don't trigger and instead the API's rate limiting is enforced we want to display the same 429 error page to the user.

Raise `ApiError` up to the `ApplicationController` when the `code` is 429. The `ApplicationController` will then rescue the error and render the error page.

### Guidance to review

<img width="1247" alt="Screenshot 2020-10-29 at 14 06 59" src="https://user-images.githubusercontent.com/29867726/97584517-06b06100-19f0-11eb-938a-9995bba5163b.png">
