### PR TITLE
Sanitize metrics for better aggregation

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -7,6 +7,8 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*a
   labels = { path: nil, method: nil, status: nil }
   labels.merge!(payload.slice(*labels.keys))
 
+  labels[:path] = labels[:path].split("?").first if labels[:path]
+
   metric = prometheus.get(:app_requests_total)
   metric.increment(labels: labels)
 
@@ -27,6 +29,8 @@ ActiveSupport::Notifications.subscribe "render_template.action_view" do |*args|
   labels = { identifier: nil }
   labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
 
+  labels[:identifier] = labels[:identifier].split("/app/views/").last if labels[:identifier]
+
   metric = prometheus.get(:app_render_view_ms)
   metric.observe(event.duration, labels: labels)
 end
@@ -38,6 +42,8 @@ ActiveSupport::Notifications.subscribe "render_partial.action_view" do |*args|
 
   labels = { identifier: nil }
   labels.merge!(event.payload.symbolize_keys.slice(*labels.keys))
+
+  labels[:identifier] = labels[:identifier].split("/app/views/").last if labels[:identifier]
 
   metric = prometheus.get(:app_render_partial_ms)
   metric.observe(event.duration, labels: labels)

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -4,7 +4,7 @@ describe "Instrumentation" do
   let(:registry) { Prometheus::Client.registry }
 
   describe "process_action.action_controller" do
-    after { get cookies_path }
+    after { get cookies_path(query: "param") }
 
     it "increments the :app_requests_total metric" do
       metric = registry.get(:app_requests_total)
@@ -28,7 +28,7 @@ describe "Instrumentation" do
     it "observes the :app_render_view_ms metric" do
       metric = registry.get(:app_render_view_ms)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
-        identifier: Rails.root.join("app/views/cookie_preferences/show.html.erb").to_s,
+        identifier: "cookie_preferences/show.html.erb",
       }).once
     end
   end
@@ -40,7 +40,7 @@ describe "Instrumentation" do
       metric = registry.get(:app_render_partial_ms)
       allow(metric).to receive(:observe)
       expect(metric).to receive(:observe).with(instance_of(Float), labels: {
-        identifier: Rails.root.join("app/views/sections/_head.html.erb").to_s,
+        identifier: "sections/_head.html.erb",
       }).once
     end
   end


### PR DESCRIPTION
Aggregating the metrics on path doesn't provide a good insight at present due to the query parameters being included in the path. By removing the query parameters we can aggregate on the underlying path/action.

Similarly, the view metrics contain the absolute path to the views directory which makes displaying them in a table awkward. Removing the `/path/to/app/views/` prefix leaves us with the template identifier.