### PR TITLE
Remove static routes, add guidance controller/layout

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -1,0 +1,15 @@
+class GuidanceController < ApplicationController
+  include StaticPages
+  around_action :cache_static_page, only: %i[show]
+  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+
+  def show
+    render template: guidance_template, layout: "layouts/guidance"
+  end
+
+private
+
+  def guidance_template
+    "content/guidance/#{filtered_page_template}"
+  end
+end

--- a/app/views/layouts/guidance.html.erb
+++ b/app/views/layouts/guidance.html.erb
@@ -1,0 +1,696 @@
+<html lang="en" class=" show-global-bar show-global-bar show-global-bar"><!--<![endif]-->
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style type="text/css" id="alertifyCSS">.alertify-logs>*{padding:12px 24px;color:#fff;box-shadow:0 2px 5px 0 rgba(0,0,0,.2);border-radius:1px}.alertify-logs>*,.alertify-logs>.default{background:rgba(0,0,0,.8)}.alertify-logs>.error{background:rgba(244,67,54,.8)}.alertify-logs>.success{background:rgba(76,175,80,.9)}.alertify{position:fixed;background-color:rgba(0,0,0,.3);left:0;right:0;top:0;bottom:0;width:100%;height:100%;z-index:2}.alertify.hide{opacity:0;pointer-events:none}.alertify,.alertify.show{box-sizing:border-box;transition:all .33s cubic-bezier(.25,.8,.25,1)}.alertify,.alertify *{box-sizing:border-box}.alertify .dialog{padding:12px}.alertify .alert,.alertify .dialog{width:100%;margin:0 auto;position:relative;top:50%;-webkit-transform:translateY(-50%);transform:translateY(-50%)}.alertify .alert>*,.alertify .dialog>*{width:400px;max-width:95%;margin:0 auto;text-align:center;padding:12px;background:#fff;box-shadow:0 2px 4px -1px rgba(0,0,0,.14),0 4px 5px 0 rgba(0,0,0,.098),0 1px 10px 0 rgba(0,0,0,.084)}.alertify .alert .msg,.alertify .dialog .msg{padding:12px;margin-bottom:12px;margin:0;text-align:left}.alertify .alert input:not(.form-control),.alertify .dialog input:not(.form-control){margin-bottom:15px;width:100%;font-size:100%;padding:12px}.alertify .alert input:not(.form-control):focus,.alertify .dialog input:not(.form-control):focus{outline-offset:-2px}.alertify .alert nav,.alertify .dialog nav{text-align:right}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button),.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button){background:transparent;box-sizing:border-box;color:rgba(0,0,0,.87);position:relative;outline:0;border:0;display:inline-block;-webkit-align-items:center;-ms-flex-align:center;-ms-grid-row-align:center;align-items:center;padding:0 6px;margin:6px 8px;line-height:36px;min-height:36px;white-space:nowrap;min-width:88px;text-align:center;text-transform:uppercase;font-size:14px;text-decoration:none;cursor:pointer;border:1px solid transparent;border-radius:2px}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover{background-color:rgba(0,0,0,.05)}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus{border:1px solid rgba(0,0,0,.1)}.alertify .alert nav button.btn,.alertify .dialog nav button.btn{margin:6px 4px}.alertify-logs{position:fixed;z-index:1}.alertify-logs.bottom,.alertify-logs:not(.top){bottom:16px}.alertify-logs.left,.alertify-logs:not(.right){left:16px}.alertify-logs.left>*,.alertify-logs:not(.right)>*{float:left;-webkit-transform:translateZ(0);transform:translateZ(0);height:auto}.alertify-logs.left>.show,.alertify-logs:not(.right)>.show{left:0}.alertify-logs.left>*,.alertify-logs.left>.hide,.alertify-logs:not(.right)>*,.alertify-logs:not(.right)>.hide{left:-110%}.alertify-logs.right{right:16px}.alertify-logs.right>*{float:right;-webkit-transform:translateZ(0);transform:translateZ(0)}.alertify-logs.right>.show{right:0;opacity:1}.alertify-logs.right>*,.alertify-logs.right>.hide{right:-110%;opacity:0}.alertify-logs.top{top:0}.alertify-logs>*{box-sizing:border-box;transition:all .4s cubic-bezier(.25,.8,.25,1);position:relative;clear:both;-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-perspective:1000;perspective:1000;max-height:0;margin:0;padding:0;overflow:hidden;opacity:0;pointer-events:none}.alertify-logs>.show{margin-top:12px;opacity:1;max-height:1000px;padding:12px;pointer-events:auto}</style>
+    <meta property="og:description" content="<%= @front_matter["title"] %>">
+    <meta property="og:title" content="<%= @front_matter["title"] %>">
+    <meta property="og:url" content="https://beta-getintoteaching.education.gov.uk/guidance">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="GOV.UK">
+    <meta name="twitter:card" content="summary">
+    <meta name="govuk:themes" content="education">
+    <meta name="govuk:analytics:organisations" content="&lt;EO1216&gt;">
+    <meta name="govuk:content-has-history" content="true">
+    <meta name="govuk:content-id" content="e4e2c852-7c5d-43c0-bebf-f5787d12cd89">
+    <meta name="govuk:schema-name" content="detailed_guide">
+    <meta name="govuk:publishing-application" content="whitehall">
+    <meta name="govuk:format" content="detailed_guide">
+    <meta name="csrf-token" content="7nEyrE02wOQwmk/XuMW8Pt/EXRHvKUviRNfu/w94kT83HpAxE4Vvw9Gd+A6aNoguHx10WmcFKBmN5HAwwo+Lng==">
+    <meta name="csrf-param" content="authenticity_token">
+    <script>
+      <%- if ENV["HOTJAR_ID"].present? -%>
+    (function(h,o,t,j,a,r){
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+      h._hjSettings={hjid:<%= ENV["HOTJAR_ID"] %>,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    <%- end -%>
+
+  <%- if ENV["GOOGLE_TAG_MANAGER_ID"].present? -%>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= ENV["GOOGLE_TAG_MANAGER_ID"] %>');
+    <%- end -%>
+    </script>
+    <title lang="en">
+      <%= @front_matter["title"] %>
+    </title>
+    <!--[if gt IE 8]><!-->
+      <link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/govuk-template-ec01c15a0e8793975bcaf519e4eb3ec0d68a99610c6b262fa7a1b3c7f76f6176.css">
+      <!--<![endif]-->
+      <!--[if IE 8]><link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/govuk-template-ie8-d542fa9c0b1884e3f91f37f9ae1574f44a5a83d506d645292555c2b5572498e9.css" /><![endif]-->
+      <link rel="stylesheet" media="print" href="https://www.gov.uk/assets/static/govuk-template-print-1076519521c2fffbbf75ab3b0d3b32ee2d96ac7e9778f1cdfac1771eefd1a1c0.css">
+      <link rel="stylesheet" media="all" href="https://www.gov.uk/assets/static/fonts-c57ab80a95f2b1764162611b3c98a4c098b356f8e30baf1e50cd63edea464c01.css"> 
+      <!--[if lt IE 9]><script src="https://www.gov.uk/assets/static/ie-a4524544a53d57a7e259b4bb966b9c32557c98c920b77e52d09304642b68401a.js"></script><![endif]-->
+      <link rel="shortcut icon" href="https://www.gov.uk/assets/static/favicon-8d811b8c3badbc0b0e2f6e25d3660a96cc0cca7993e6f32e98785f205fc40907.ico" type="image/x-icon">
+      <link rel="mask-icon" href="https://www.gov.uk/assets/static/gov.uk_logotype_crown-de738c3fcce8ce2a91b67e89787090dc24a5cda0275ab6b75f6226c5b9619d3d.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" sizes="180x180" href="https://www.gov.uk/assets/static/apple-touch-icon-180x180-ea1cbb1cbbeddfff275dfa6e8e46b84cd530892df79dc4882a8f99b802b49a90.png">
+      <link rel="apple-touch-icon" sizes="167x167" href="https://www.gov.uk/assets/static/apple-touch-icon-167x167-181e404a50c572923285fb83f0fbd78da6b4e38e3ce52f8e6b8e29da8586450a.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="https://www.gov.uk/assets/static/apple-touch-icon-152x152-02457fcdcee8d309276305af2233d41bfb8fd055e855727d355e61bce7ffa9bb.png">
+      <link rel="apple-touch-icon" href="https://www.gov.uk/assets/static/apple-touch-icon-a318f305290c523aed80082456175b46c95350c0eeac93f42e78a71c7a55544e.png">
+      <meta name="theme-color" content="#0b0c0c">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/core-layout-9cb3fbb510e7fdfc3852b0e6b017557267dad3c1c27b714d75104324dc28ebbe.css">
+      <!--[if lte IE 8]><link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/core-layout-ie8-773f4cacc5b2d19e924e37800dca2a1e66acd94c661e1cd95a8a165021bdc667.css" /><script>var ieVersion = 8;</script><![endif]-->
+      <link rel="stylesheet" media="print" href="https://www.gov.uk/assets/static/core-layout-print-8e40ee8bf8b49850b34ea341226ca4421597a64ffda587b0f72111677fd368bd.css">
+      <style>
+.app-back-to-top__icon {
+  display: inline-block;
+  width: .8em;
+  height: 1em;
+  margin-top: -5px;
+  margin-right: 10px;
+  vertical-align: middle;
+}
+      </style>
+      <meta property="og:image" content="https://www.gov.uk/assets/static/opengraph-image-a1f7d89ffd0782738b1aeb0da37842d8bd0addbd724b8e58c3edbc7287cc11de.png">
+      <link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/government-frontend/application-a9e9ca7583296f69d7826edbb0a55c79d5aab10ac83d94ff748db38655b9cbe8.css">
+      <link rel="stylesheet" media="print" href="https://www.gov.uk/assets/government-frontend/print-0d530d98c978539f18ef97c5644385ea4d38780dbc8679da5a8a1603a218044c.css">
+      <link rel="canonical" href="https://www.gov.uk/guidance/employing-an-apprentice-technical-guide-for-employers">
+      <meta name="govuk:rendering-application" content="government-frontend">
+
+      <style>
+        #markdown-toc {
+          list-style: none;
+          font-size: 90%;
+        }
+
+        #markdown-toc li::before {
+          margin-left: 0em;
+          content: "\2014";
+          padding-right: .5em;
+        }
+
+        #markdown-toc li {
+          margin: 0.8em 0;
+        }
+      </style>
+  </head>
+
+  <body>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
+    </div>
+
+    <header role="banner" id="global-header" class=" with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" class="content govuk-header__link govuk-header__link--homepage" id="logo" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+              <span class="govuk-header__logotype">
+                <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                  <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
+                  </path>
+                  <image src="https://www.gov.uk/assets/static/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32">
+                  </image>
+                </svg>
+                <span class="govuk-header__logotype-text">
+                  GOV.UK
+                </span>
+              </span>
+            </a>
+          </div>
+          <a href="#search" class="search-toggle js-header-toggle">Search</a>
+          <form id="search" class="site-search govuk-clearfix" action="https://www.gov.uk/search" method="get" role="search">
+            <div class="content govuk-clearfix">
+              <label for="site-search-text">Search</label>
+              <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+              <input class="submit" type="submit" value="Search">
+            </div>
+          </form>
+
+        </div>
+
+        <div class="header-proposition">
+          <div class="content">
+            <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+            <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation" aria-label="Proposition menu"></nav>>
+            <ul id="proposition-links">
+              <li>
+                <a class="" href="https://www.gov.uk/government/organisations">
+                  Departments
+                </a>
+              </li>
+              <li>
+                <a class="" href="https://www.gov.uk/government/world">
+                  Worldwide
+                </a>
+              </li>
+              <li>
+                <a class="" href="https://www.gov.uk/government/how-government-works">
+                  How government works
+                </a>
+              </li>
+              <li>
+                <a class="" href="https://www.gov.uk/government/get-involved">
+                  Get involved
+                </a>
+              </li>
+              <li class="clear-child">
+                <a class="" href="https://www.gov.uk/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&amp;amp;content_store_document_type%5B%5D=closed_consultations">
+                  Consultations
+                </a>
+              </li>
+              <li>
+                <a class="" href="https://www.gov.uk/search/research-and-statistics">
+                  Statistics
+                </a>
+              </li>
+              <li>
+                <a class="" href="https://www.gov.uk/news-and-communications">
+                  News and communications
+                </a>
+              </li>
+            </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="user-satisfaction-survey-container"></div>
+
+
+    <div id="global-header-bar"></div>
+
+    <div id="global-bar" class="global-bar dont-print" data-module="global-bar" data-global-bar-permanent="true" data-nosnippet="">
+      <div class="global-bar-message govuk-width-container">
+
+
+        <div class="global-bar-covid-wrapper">
+          <div class="gem-c-action-link gem-c-action-link--light-text gem-c-action-link--with-subtext govuk-!-margin-bottom-0">
+
+            <span class="gem-c-action-link__contents-wrapper">      <span class="gem-c-action-link__link-wrapper">
+
+                <a class="govuk-link gem-c-action-link__link js-call-to-action" href="https://www.gov.uk/coronavirus">
+                  Coronavirus (COVID-19)
+
+
+                </a>      </span>
+
+                <span class="gem-c-action-link__subtext-wrapper">
+                  <span class="gem-c-action-link__subtext">Guidance and support</span>
+                </span>
+            </span>
+          </div>
+
+        </div>
+      </div>
+
+    </div>
+
+
+    <div id="wrapper" class="direction-ltr">
+
+      <div class="gem-c-contextual-breadcrumbs">
+        <div class="gem-c-breadcrumbs govuk-breadcrumbs gem-c-breadcrumbs--collapse-on-mobile" data-module="track-click">
+          <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item" aria-current="false">
+              <a class="govuk-breadcrumbs__link" aria-current="false" href="https://www.gov.uk/">Home</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item" aria-current="false">
+              <a class="govuk-breadcrumbs__link" aria-current="false" href="https://www.gov.uk/browse/education">Education and learning</a>
+            </li>
+          </ol>
+        </div>
+      </div>
+
+
+      <main role="main" id="content" class="detailed-guide" lang="en">
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="gem-c-title govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+              <span class="govuk-caption-xl gem-c-title__context">
+                Guidance
+              </span>
+              <h1 class="gem-c-title__text gem-c-title__text--long" id="top">
+                <%= @front_matter["title"] %>
+              </h1>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="govuk-grid-row">
+          <div class="metadata-logo-wrapper">
+            <div class="govuk-grid-column-two-thirds metadata-column">
+              <div class="app-c-publisher-metadata" lang="en">
+                <div class="app-c-published-dates " lang="en">
+                  Published 23 June 2020
+                </div>
+
+                <div class="app-c-publisher-metadata__other">
+                  <dl data-module="track-click">
+                    <dt class="app-c-publisher-metadata__term">
+                    From:
+                    </dt>
+                    <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
+                    <span class="app-c-publisher-metadata__definition-sentence">
+                      <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
+                    </span>
+                    </dd>
+                  </dl>
+                </div>
+              </div>
+
+            </div>
+            <div class="govuk-grid-column-one-third">
+            </div>
+          </div>
+        </div>
+
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="app-c-important-metadata app-c-important-metadata--bottom-margin">
+              <dl data-module="track-click">
+                <dt class="app-c-important-metadata__term">Applies to: </dt>
+                <dd class="app-c-important-metadata__definition">England</dd>
+              </dl>
+            </div>
+
+
+            <div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
+              <div class="govspeak">
+                <%= yield %>
+              </div>
+            </div>
+
+
+            <div class="responsive-bottom-margin">
+              <div class="app-c-published-dates " lang="en">
+                Published 23 June 2020
+              </div>
+
+            </div>
+
+          </div>
+
+          <div class="govuk-grid-column-one-third">
+            <div class="gem-c-contextual-sidebar">
+
+              <div class="gem-c-related-navigation">
+                <% if @front_matter["related_content"] %>
+                  <h2 id="related-nav-related_items-8be55305" class="gem-c-related-navigation__main-heading" data-track-count="sidebarRelatedItemSection">
+                    Related content
+                  </h2>
+                  <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-8be55305" data-module="gem-toggle">
+                    <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+                      <% @front_matter["related_content"].each do |related_content| %>
+
+                        <%= tag.li(class: "gem-c-related-navigation__link") do %>
+                          <%= link_to(related_content["name"], related_content["link"], class: "gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other") %>
+                        <% end %>
+
+                      <% end %>
+                    </ul>
+                  </nav>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+        </div>
+    </div>
+
+      </main>
+
+        <div class="gem-c-feedback" data-module="feedback">
+
+          <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
+            <div class="gem-c-feedback__prompt-questions js-prompt-questions">
+              <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
+              <!-- Maybe button exists only to try and capture clicks by bots -->
+              <a class="gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" role="button" style="display: none;" hidden="hidden" aria-hidden="true" href="https://www.gov.uk/contact/govuk">
+                Maybe
+              </a>    <ul class="gem-c-feedback__option-list">
+                <li class="gem-c-feedback__option-list-item">
+                  <a class="gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" aria-expanded="false" role="button" href="https://www.gov.uk/contact/govuk">
+                    Yes <span class="govuk-visually-hidden">this page is useful</span>
+                  </a>      </li>
+                  <li class="gem-c-feedback__option-list-item">
+                    <a class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" role="button" href="https://www.gov.uk/contact/govuk">
+                      No <span class="govuk-visually-hidden">this page is not useful</span>
+                    </a>      </li>
+              </ul>
+            </div>
+            <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+              Thank you for your feedback
+            </div>
+            <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
+              <a class="gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" role="button" href="https://www.gov.uk/contact/govuk">
+                Is there anything wrong with this page?
+              </a>  </div>
+          </div>
+
+          <form action="https://www.gov.uk/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" method="post" aria-hidden="true">
+            <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+
+                <input type="hidden" name="url" value="https://www.gov.uk/guidance/employing-an-apprentice-technical-guide-for-employers">
+
+                <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+                <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
+
+
+                <div class="govuk-form-group">
+
+                  <label for="input-f8a6fd2a" class="gem-c-label govuk-label">What were you doing?</label>
+
+
+
+
+
+
+                  <input name="what_doing" class="gem-c-input govuk-input" id="input-f8a6fd2a" type="text" aria-describedby="feedback_explanation">
+                </div>
+
+
+                <div class="govuk-form-group">
+
+                  <label for="input-bb2ef2df" class="gem-c-label govuk-label">What went wrong?</label>
+
+
+
+
+
+
+                  <input name="what_wrong" class="gem-c-input govuk-input" id="input-bb2ef2df" type="text">
+                </div>
+
+
+
+
+                <button class="gem-c-button govuk-button" type="submit">Send</button>
+
+
+              </div>
+            </div>
+            <input type="hidden" name="javascript_enabled" value="true"><input type="hidden" name="referrer" value="unknown"></form>
+
+          <form action="https://www.gov.uk/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form" method="post" aria-hidden="true">
+            <a href="#" class="gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds" id="survey-wrapper">
+                <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+
+                <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
+                <input name="email_survey_signup[survey_source]" type="hidden" value="/guidance/employing-an-apprentice-technical-guide-for-employers">
+
+                <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+                <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
+
+
+                <div class="govuk-form-group">
+
+                  <label for="input-9c3543c1" class="gem-c-label govuk-label">Email address</label>
+
+
+
+
+
+
+                  <input name="email_survey_signup[email_address]" class="gem-c-input govuk-input" id="input-9c3543c1" type="email" autocomplete="email" aria-describedby="survey_explanation">
+                </div>
+
+
+
+
+                <button class="gem-c-button govuk-button" type="submit">Send me the survey</button>
+
+
+              </div>
+            </div>
+          </form>
+
+        </div>
+
+        </div>
+
+
+        <footer class="group js-footer" id="footer" role="contentinfo">
+          <div class="govuk-width-container">
+            <div class="footer-container govuk-main-wrapper">
+              <div class="govuk-grid-row footer-categories" data-module="track-click">
+                <div class="govuk-grid-column-two-thirds">
+                  <h2>Coronavirus (COVID-19)</h2>
+                  <ul>
+                    <li>
+                      <a data-track-category="footerClicked" data-track-action="coronavirusLinks" data-track-label="Coronavirus (COVID-19): guidance and support" href="https://www.gov.uk/coronavirus" class="govuk-link">
+                        Coronavirus (COVID-19): guidance and support
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div class="govuk-grid-column-one-third">
+                  <h2>The UK has left the EU</h2>
+                  <ul>
+                    <li>
+                      <a data-track-category="footerClicked" data-track-action="transitionLinks" data-track-label="Transition period: get ready for 2021" href="https://www.gov.uk/transition" class="govuk-link">
+                        Transition period: get ready for 2021
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div class="govuk-grid-row footer-categories" data-module="track-click">
+                <div class="govuk-grid-column-two-thirds">
+                  <h2>Services and information</h2>
+
+                  <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-half">
+                      <ul>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Benefits" href="https://www.gov.uk/browse/benefits">
+                            Benefits
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Births, deaths, marriages and care" href="https://www.gov.uk/browse/births-deaths-marriages">
+                            Births, deaths, marriages and care
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Business and self-employed" href="https://www.gov.uk/browse/business">
+                            Business and self-employed
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="" href="https://www.gov.uk/browse/childcare-parenting">
+                            Childcare and parenting
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Citizenship and living in the UK" href="https://www.gov.uk/browse/citizenship">
+                            Citizenship and living in the UK
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Crime, justice and the law" href="https://www.gov.uk/browse/justice">
+                            Crime, justice and the law
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Disabled people" href="https://www.gov.uk/browse/disabilities">
+                            Disabled people
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Driving and transport" href="https://www.gov.uk/browse/driving">
+                            Driving and transport
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                    <div class="govuk-grid-column-one-half">
+                      <ul>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Education and learning" href="https://www.gov.uk/browse/education">
+                            Education and learning
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Employing people" href="https://www.gov.uk/browse/employing-people">
+                            Employing people
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Environment and countryside" href="https://www.gov.uk/browse/environment-countryside">
+                            Environment and countryside
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Housing and local services" href="https://www.gov.uk/browse/housing-local-services">
+                            Housing and local services
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Money and tax" href="https://www.gov.uk/browse/tax">
+                            Money and tax
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Passports, travel and living abroad" href="https://www.gov.uk/browse/abroad">
+                            Passports, travel and living abroad
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Visas and immigration" href="https://www.gov.uk/browse/visas-immigration">
+                            Visas and immigration
+                          </a>
+                        </li>
+                        <li>
+                          <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Working, jobs and pensions" href="https://www.gov.uk/browse/working">
+                            Working, jobs and pensions
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="govuk-grid-column-one-third">
+                  <h2>Departments and policy</h2>
+
+                  <ul>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="How government works" href="https://www.gov.uk/government/how-government-works">
+                        How government works
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Departments" href="https://www.gov.uk/government/organisations">
+                        Departments
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Worldwide" href="https://www.gov.uk/world">
+                        Worldwide
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Services" href="https://www.gov.uk/search/services">
+                        Services
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Guidance and regulation" href="https://www.gov.uk/search/guidance-and-regulation">
+                        Guidance and regulation
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="News and communications" href="https://www.gov.uk/search/news-and-communications">
+                        News and communications
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Research and statistics" href="https://www.gov.uk/search/research-and-statistics">
+                        Research and statistics
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Policy papers and consultations" href="https://www.gov.uk/search/policy-papers-and-consultations">
+                        Policy papers and consultations
+                      </a>
+                    </li>
+                    <li>
+                      <a class="govuk-link" data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Transparency and freedom of information releases" href="https://www.gov.uk/search/transparency-and-freedom-of-information-releases">
+                        Transparency and freedom of information releases
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <hr>
+              </div>
+
+
+              <div class="footer-meta">
+                <div class="footer-meta-inner">
+                  <h2 class="visuallyhidden">Support links</h2>
+                  <ul>
+                    <li><a class="govuk-link" href="https://www.gov.uk/help">Help</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/help/privacy-notice">Privacy</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/help/cookies">Cookies</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/contact">Contact</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/help/accessibility-statement">Accessibility statement</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/help/terms-conditions">Terms and conditions</a></li>
+                    <li><a class="govuk-link" href="https://www.gov.uk/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
+                    <li>
+                      Built by the
+                      <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-link">
+                        Government Digital Service
+                      </a>
+                    </li>
+                  </ul>
+
+
+
+                  <div class="open-government-licence">
+                    <p class="logo">
+                    <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license" class="govuk-link open-government-licence__logo-link">
+                      Open Government Licence
+                    </a>
+                    </p>
+                    <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license" class="govuk-link">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                  </div>
+                </div>
+
+                <div class="copyright">
+                  <a class="govuk-link" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+                    © Crown copyright
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+
+        <div id="global-app-error" class="app-error hidden"></div>
+
+        <div id="back-to-top-link" style="display: none" data-sticky-element="" class="app-c-contents-list-with-body__link-wrapper govuk-sticky-element--stuck-to-window">
+              <div class="app-c-contents-list-with-body__link-container">
+                <a class="govuk-link app-c-back-to-top dont-print" href="#top">
+                  <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+                    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+                  </svg>
+                  Contents
+                </a>
+              </div>
+            </div>
+        </div>
+
+
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+
+        <script src="https://www.gov.uk/assets/static/header-footer-only-b40a2139e794b00c053ad6f4ade31cedd5e091d679a259f0042664549a66d3bb.js"></script>
+
+        <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+        <script src="https://www.gov.uk/assets/government-frontend/application-e6e189e655c0c3d1835298a128f8f68fa8b56785858230797bba7b8c5acfdfbf.js"></script>
+
+        <script>
+          $(document).scroll(function() {
+            const backToTopLink = $('#back-to-top-link');
+
+            if ($(this).scrollTop() > 1000) {
+              backToTopLink.fadeIn();
+            } else {
+              backToTopLink.fadeOut();
+            }
+          });
+        </script>
+
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,10 +57,7 @@ Rails.application.routes.draw do
   )
   get "/life-as-a-teacher/my-story-into-teaching/*story/", to: "stories#index"
 
-  get "/guidance", to: "pages#showblank", page: "guidance"
-  get "/financial-support-for-teacher-training", to: "pages#showblank", page: "financial-support-for-teacher-training"
-  get "/train-to-become-a-teacher", to: "pages#showblank", page: "train-to-become-a-teacher"
-  get "/returning-to-teaching-guidance", to: "pages#showblank", page: "returning-to-teaching-guidance"
+  get "/guidance/*page", to: "guidance#show"
 
   get "*page", to: "pages#show", as: :page
 end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -38,7 +38,7 @@ module TemplateHandlers
   private
 
     def render_markdown
-      Kramdown::Document.new(markdown).to_html
+      Kramdown::Document.new(markdown, { toc_levels: 1..2 }).to_html
     end
 
     def autolink_html(content)

--- a/spec/requests/guidance_pages_spec.rb
+++ b/spec/requests/guidance_pages_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe GuidanceController do
+  describe "#show" do
+    let(:template) { "testing/markdown_test" }
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:guidance_template).and_return template
+    end
+
+    subject do
+      get "/guidance/become-a-teacher-in-england"
+      response
+    end
+
+    context "for known page" do
+      it { is_expected.to have_http_status :success }
+    end
+
+    context "for unknown page" do
+      let(:template) { "testing/other-page" }
+
+      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_attributes body: %r{Page not found} }
+    end
+  end
+end


### PR DESCRIPTION
### Context

The app and content repos are coupled by some 'special' routes.

Also see https://github.com/DFE-Digital/get-into-teaching-content/pull/125

### Changes proposed in this pull request

Remove them and restructure the guidance accordingly. Now any markdown file that's in `content/guidance` will be rendered with the guidance template and will look like this:

![Screenshot from 2020-10-30 15-06-56](https://user-images.githubusercontent.com/128088/97721865-e650d700-1ac1-11eb-8322-ad868f95c94a.png)

* [x] Create template
* [x] Configure [Kramdown table of contents](https://kramdown.gettalong.org/converter/html.html#toc)
* [x] Shift the three guidance pages over to new strucutre
* [x] Find and fix all the remaining links
* [x] Add a spec for the new route

### Guidance to review

Have I missed anything?

