### PR TITLE
Restore the missing APP SHA in the /etc file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
                  ${{env.APP_REPOSITORY}}:sha-${{ steps.sha.outputs.short }}
           push: true
           build-args: |
-                      CONTENT_SHA=${{ steps.sha.outputs.short }}
+                      SHA=${{ steps.sha.outputs.short }}
 
       - name: Set DOCKER_IMAGE environment variable
         id:   docker


### PR DESCRIPTION
### Trello card

https://trello.com/c/9lMe3WsU

### Context

Currently the App sha is not being reported in the App

### Changes proposed in this pull request

1. Corrected the variable name

Wondering if this would be better as part of the Docker build file (copy file relevant ref out of `.git`) but this is easier for now

