### PR TITLE
Add config-based redirection route building

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -1,0 +1,7 @@
+# this file will be replaced with config/redirects.yml from the content repo
+# during the docker build. The values below are used by the redirection tests
+redirects:
+  "/old-path": "/new-path"
+  "/old/deeply-nested/path": "/new/deeply-nested/path"
+  "/converging-path-one": "/converged-path"
+  "/converging-path-two": "/converged-path"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,5 +62,9 @@ Rails.application.routes.draw do
   get "/train-to-become-a-teacher", to: "pages#showblank", page: "train-to-become-a-teacher"
   get "/returning-to-teaching-guidance", to: "pages#showblank", page: "returning-to-teaching-guidance"
 
+  YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
+    redirect_rules.each { |from, to| get from, to: redirect(to) }
+  end
+
   get "*page", to: "pages#show", as: :page
 end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "Redirects" do
+  redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")
+
+  redirects.each do |from, to|
+    specify "'#{from}' redirects to '#{to}'" do
+      expect(get(from)).to eql(301)
+      expect(response).to redirect_to(to)
+    end
+  end
+end


### PR DESCRIPTION

### JIRA ticket number

N/A

### Context

Recently we had an issue where paths changed and the old locations were referenced in emails; recipients following these links saw a 404.

### Changes proposed in this pull request

Allow us to maintain a list of moved files and their new locations in the content repo (see DFE-Digital/get-into-teaching-content/pull/127) which, as part of the docker build will replace the dummy one in this repo (in `config/redirects.yml`).

The dummy one is present for testing, it means we don't need to inject the routes we want to test while the app is running.

### Guidance to review

Is this a sensible approach?