### PR TITLE
Added a save button to the Cookie Preferences page

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -176,6 +176,9 @@
             <span data-target="cookie-preferences.flash" class="save-with-confirmation__message">
               Your cookie preferences have been saved
             </span>
+
+            <br />
+            <%= link_to "Back to page", :back, class: "secondary-button" %>
           </p>
 
           <p>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -81,7 +81,7 @@
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional"  data-action="cookie-preferences#toggle" />
+                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
                 <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
                   No
                 </label>
@@ -161,12 +161,27 @@
 
               <p>They always need to be on.</p>
 
-              <p>
-                <%= link_to "Find out more", cookies_path %>
-                about cookies on this service
-              </p>
+
             </div>
           </fieldset>
+
+          <p class="save-with-confirmation">
+            <button type="button"
+              data-action="cookie-preferences#save"
+              class="call-to-action-button">
+              Save
+            </button>
+
+            <%= fas_icon "sync", "fa-spin" %>
+            <span data-target="cookie-preferences.flash" class="save-with-confirmation__message">
+              Your cookie preferences have been saved
+            </span>
+          </p>
+
+          <p>
+            <%= link_to "Find out more", cookies_path %>
+            about cookies on this service
+          </p>
         </div>
       </form>
 

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
 
   connect() {
     this.cookiePreferences = new CookiePreferences ;
-    this.cookiePreferences.writeCookie(this.cookiePreferences.all) ;
     this.assignRadios() ;
   }
 

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -23,9 +23,27 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    const category = event.target.name.toString().replace(/^cookies-/, '')
-    const value = event.target.value ;
+    this.data.set('save-state', 'unsaved')
+  }
 
-    this.cookiePreferences.setCategory(category, value) ;
+  save(event) {
+    event.preventDefault() ;
+
+    for (const categoryFieldset of this.categoryTargets) {
+      const category = categoryFieldset.getAttribute('data-category')
+      const field = categoryFieldset.querySelector('input[type="radio"]:checked')
+
+      if (field) {
+        this.cookiePreferences.setCategory(category, field.value)
+      }
+    }
+
+    this.data.set('save-state', 'saving')
+    window.setTimeout(this.finishSave.bind(this), 600)
+  }
+
+  finishSave() {
+    if (this.data.get('save-state') == 'saving')
+      this.data.set('save-state', 'saved')
   }
 }

--- a/app/webpacker/styles/button.scss
+++ b/app/webpacker/styles/button.scss
@@ -84,3 +84,14 @@
         }
     }
 }
+
+.secondary-button {
+  @include button;
+  background-color: $grey-light;
+  color: $black !important ;
+  text-decoration: none !important;
+
+  &:hover {
+    background-color: $grey-mid ;
+  }
+}

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -66,3 +66,30 @@ form {
 form div.hidden {
   display: none;
 }
+
+
+form {
+  .save-with-confirmation {
+    button {
+      margin-right: 1em;
+      margin-bottom: 1em;
+    }
+
+    span {
+      color: $green ;
+      display: none ;
+    }
+  }
+
+  &[data-cookie-preferences-save-state="saving"] {
+    .fa-sync.fa-spin {
+      display: inline-block ;
+    }
+  }
+
+  &[data-cookie-preferences-save-state="saved"] {
+    .save-with-confirmation__message {
+      display: inline-block ;
+    }
+  }
+}

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -5,18 +5,26 @@ const Cookies = require('js-cookie') ;
 import CookiePreferences from 'cookie_preferences' ;
 
 describe('CookiePreferencesController', () => {
-  document.body.innerHTML =
-  `<form data-controller="cookie-preferences">
-    <fieldset data-target="cookie-preferences.category" data-category="first">
-      <input type="radio" value="0" id="first-no" name="cookies-first" data-action="cookie-preferences#toggle" />
-      <input type="radio" value="1" id="first-yes" name="cookies-first" data-action="cookie-preferences#toggle" />
-    </fieldset>
+  function clearPage() {
+    document.body.innerHTML = '' ;
+  }
 
-    <fieldset data-target="cookie-preferences.category" data-category="second">
-      <input type="radio" value="0" id="second-no" name="cookies-second" data-action="cookie-preferences#toggle" />
-      <input type="radio" value="1" id="second-yes" name="cookies-second" data-action="cookie-preferences#toggle" />
-    </fieldset>
-  </form>` ;
+  function initPage() {
+    document.body.innerHTML =
+    `<form data-controller="cookie-preferences">
+      <fieldset data-target="cookie-preferences.category" data-category="first">
+        <input type="radio" value="0" id="first-no" name="cookies-first" data-action="cookie-preferences#toggle" />
+        <input type="radio" value="1" id="first-yes" name="cookies-first" data-action="cookie-preferences#toggle" />
+      </fieldset>
+
+      <fieldset data-target="cookie-preferences.category" data-category="second">
+        <input type="radio" value="0" id="second-no" name="cookies-second" data-action="cookie-preferences#toggle" />
+        <input type="radio" value="1" id="second-yes" name="cookies-second" data-action="cookie-preferences#toggle" />
+      </fieldset>
+
+      <button type="submit" data-action="cookie-preferences#save">Save</save>
+    </form>` ;
+  }
 
   function getCookie() {
     return Cookies.get(CookiePreferences.cookieName) ;
@@ -38,13 +46,18 @@ describe('CookiePreferencesController', () => {
     setJsonCookie({ first: true, second: false })
   }
 
-  function initApp(setCookie) {
-    const application = Application.start() ;
-    application.register('cookie-preferences', CookiePreferencesController);
+  function getState() {
+    const form = document.querySelector('form[data-controller="cookie-preferences"]')
+    return form.getAttribute('data-cookie-preferences-save-state') ;
   }
 
+  const application = Application.start() ;
+  application.register('cookie-preferences', CookiePreferencesController);
+
+  beforeEach(clearPage) ;
+
   describe("on page load", () => {
-    beforeEach(() => { initCookie(); initApp() })
+    beforeEach(() => { initCookie(); initPage() })
 
     it('radios should be assigned', () => {
       expect(document.getElementById('first-yes').checked).toBe(true) ;
@@ -55,7 +68,7 @@ describe('CookiePreferencesController', () => {
   }) ;
 
   describe("on page load without cookie", () => {
-    beforeEach(() => { initApp() })
+    beforeEach(() => { initPage() })
 
     it('should save cookie', () => {
       const data = getJsonCookie() ;
@@ -64,14 +77,34 @@ describe('CookiePreferencesController', () => {
   })
 
   describe("when changing radios", () => {
-    beforeEach(() => { initCookie(); initApp() })
+    beforeEach(() => { initCookie(); initPage() })
 
-    it("cookie should be updated", () => {
+    it("cookie should only be updated when they click save", () => {
       expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
-      document.getElementById('first-no').click() ;
-      expect(getJsonCookie()).toEqual({ first: false, functional: true, second: false })
-      document.getElementById('second-yes').click() ;
+      document.getElementById('first-no').click()
+      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
+      document.getElementById('second-yes').click()
+      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
+
+      document.querySelector('button').click()
       expect(getJsonCookie()).toEqual({ first: false, functional: true, second: true })
     })
   }) ;
+
+  describe("save state", () => {
+    beforeEach(() => { initCookie(); initPage() })
+
+    it("should change state when clicking save", () => {
+      expect(getState()).toEqual(null) ;
+
+      document.getElementById('first-no').click()
+      expect(getState()).toEqual('unsaved')
+
+      document.querySelector('button').click()
+      expect(getState()).toEqual('saving')
+
+      document.getElementById('second-yes').click()
+      expect(getState()).toEqual('unsaved')
+    })
+  })
 }) ;

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -72,7 +72,7 @@ describe('CookiePreferencesController', () => {
 
     it('should save cookie', () => {
       const data = getJsonCookie() ;
-      expect(data['functional']).toBe(true) ;
+      expect(data['functional']).toBe(undefined) ;
     })
   })
 
@@ -80,11 +80,11 @@ describe('CookiePreferencesController', () => {
     beforeEach(() => { initCookie(); initPage() })
 
     it("cookie should only be updated when they click save", () => {
-      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
+      expect(getJsonCookie()).toEqual({ first: true, second: false })
       document.getElementById('first-no').click()
-      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
+      expect(getJsonCookie()).toEqual({ first: true, second: false })
       document.getElementById('second-yes').click()
-      expect(getJsonCookie()).toEqual({ first: true, functional: true, second: false })
+      expect(getJsonCookie()).toEqual({ first: true, second: false })
 
       document.querySelector('button').click()
       expect(getJsonCookie()).toEqual({ first: false, functional: true, second: true })


### PR DESCRIPTION
### Trello card

https://trello.com/c/oyXVIACa

### Context

Currently the user does not realise their changes are being saved as they update their cookie preferences

### Changes proposed in this pull request

1. Added a save button
2. Only save when save button is clicked
3. Show a message to the user notifying them that their preferences are being saved
4. Hide the message if the user subsequently updates their preferences

### Guidance to review

Probably worth downloading the PR locally and having a play with it

