### PR TITLE
Updated Pull Request template - we are now using Trello

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-### JIRA ticket number
+### Trello card
 
 ### Context
 


### PR DESCRIPTION
### JIRA ticket number

N/a

### Context

Currently the template references JIRA instead of Trello

### Changes proposed in this pull request

1. Reference trello instead



