### PR TITLE
Try to get SonarCloud working again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,12 @@ jobs:
           docker run -t --rm -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
             rubocop app config db lib spec Gemfile --format json --out=rubocop-result.json
 
+      - name:  Keep Rubocop output
+        uses: actions/upload-artifact@v2
+        with:
+          name: Rubocop_results
+          path: ${{ github.workspace }}/rubocop-result.json
+
       - name: Run Brakeman static security scanner
         run: |-
           docker run -t --rm -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}}  brakeman --no-pager

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
 
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
-            rubocop app config db lib spec Gemfile --format json --out=rubocop-result.json
+          docker run -t --rm -v ${PWD}/out:/app/out -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
+            rubocop app config db lib spec Gemfile --format json --out=/app/out/rubocop-result.json
 
       - name:  Keep Rubocop output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
            -Dsonar.projectKey=DFE-Digital_get-into-teaching-app
            -Dsonar.testExecutionReportPaths=out/test-report.xml
            -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
+           -Dsonar.ruby.rubocop.reportPaths=${PWD}/rubocop-result.json
 
       - name: Slack Notification
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
            -Dsonar.projectKey=DFE-Digital_get-into-teaching-app
            -Dsonar.testExecutionReportPaths=out/test-report.xml
            -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
-           -Dsonar.ruby.rubocop.reportPaths=${PWD}/rubocop-result.json
+           -Dsonar.ruby.rubocop.reportPaths=${PWD}/out/rubocop-result.json
 
       - name: Slack Notification
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Lint Ruby
         run: |-
           docker run -t --rm -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
-            rubocop app config db lib spec Gemfile --format clang
+            rubocop app config db lib spec Gemfile --format json --out=rubocop-result.json
 
       - name: Run Brakeman static security scanner
         run: |-

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development, :test do
   gem "capybara", "~> 3.33"
   gem "factory_bot_rails"
   gem "rspec-sonarqube-formatter", "~> 1.3", require: false
-  gem "simplecov", "<= 0.20"
+  gem "simplecov", "~> 0.17.1"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,10 +286,11 @@ GEM
       faraday (>= 1.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
-    simplecov (0.19.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.3)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -374,7 +375,7 @@ DEPENDENCIES
   secure_headers
   sentry-raven
   shoulda-matchers
-  simplecov (<= 0.20)
+  simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.tests=./spec
 sonar.exclusions=app/assets/**/*,app/webpacker/**/*,**/fake_endpoints.rb
 sonar.ruby.coverage.framework=RSpec
 sonar.coverage.exclusions=config/**/*
+sonar.ruby.rubocop.reportPath=rubocop-result.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.exclusions=app/assets/**/*,app/webpacker/**/*,**/fake_endpoints.rb
 sonar.ruby.coverage.framework=RSpec
 sonar.coverage.exclusions=config/**/*
 sonar.ruby.rubocop.reportPath=rubocop-result.json
+sonar.ruby.coverage.reportPaths=coverage/.resultset.json


### PR DESCRIPTION
This PR fixes the sending of simplecov and rubocop's output to Sonarcloud. Simplecov changed their format at version 0.18, so it's been downgraded to 0.17.1 for the time being.