### PR TITLE
Disable rate limiting in production-like environments

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -5,4 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
+
+  Rack::Attack.enabled = false
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -5,4 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
+
+  Rack::Attack.enabled = false
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -7,4 +7,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
   config.x.static_pages.disable_caching = true
   config.x.utm_codes = true
+
+  Rack::Attack.enabled = false
 end


### PR DESCRIPTION
We want to disable rate limiting in production-like environments (but not production) so that the integration tests can be ran successfully.