### PR TITLE
Revert "Revert "Added a save button to the Cookie Preferences page""

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -81,7 +81,7 @@
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional"  data-action="cookie-preferences#toggle" />
+                <input id="cookies-non-functional-no" class="govuk-radios__input" type="radio" value="0" name="cookies-non-functional" data-action="cookie-preferences#toggle" />
                 <label for="cookies-non-functional-no" class="govuk-label govuk-radios__label">
                   No
                 </label>
@@ -161,12 +161,30 @@
 
               <p>They always need to be on.</p>
 
-              <p>
-                <%= link_to "Find out more", cookies_path %>
-                about cookies on this service
-              </p>
+
             </div>
           </fieldset>
+
+          <p class="save-with-confirmation">
+            <button type="button"
+              data-action="cookie-preferences#save"
+              class="call-to-action-button">
+              Save
+            </button>
+
+            <%= fas_icon "sync", "fa-spin" %>
+            <span data-target="cookie-preferences.flash" class="save-with-confirmation__message">
+              Your cookie preferences have been saved
+            </span>
+
+            <br />
+            <%= link_to "Back to page", :back, class: "secondary-button" %>
+          </p>
+
+          <p>
+            <%= link_to "Find out more", cookies_path %>
+            about cookies on this service
+          </p>
         </div>
       </form>
 

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,6 +1,6 @@
 <section class="event-info content container-1000" role="main" id="main-content">
   <div class="content__left">
-    <%= back_link %>
+    <%= back_link internal_referer || root_path %>
 
     <h1>Cookies on Get Into Teaching</h1>
 
@@ -178,7 +178,7 @@
             </span>
 
             <br />
-            <%= link_to "Back to page", :back, class: "secondary-button" %>
+            <%= link_to "Back to page", internal_referer || root_path, class: "secondary-button" %>
           </p>
 
           <p>

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
 
   connect() {
     this.cookiePreferences = new CookiePreferences ;
-    this.cookiePreferences.writeCookie(this.cookiePreferences.all) ;
     this.assignRadios() ;
   }
 
@@ -23,9 +22,27 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    const category = event.target.name.toString().replace(/^cookies-/, '')
-    const value = event.target.value ;
+    this.data.set('save-state', 'unsaved')
+  }
 
-    this.cookiePreferences.setCategory(category, value) ;
+  save(event) {
+    event.preventDefault() ;
+
+    for (const categoryFieldset of this.categoryTargets) {
+      const category = categoryFieldset.getAttribute('data-category')
+      const field = categoryFieldset.querySelector('input[type="radio"]:checked')
+
+      if (field) {
+        this.cookiePreferences.setCategory(category, field.value)
+      }
+    }
+
+    this.data.set('save-state', 'saving')
+    window.setTimeout(this.finishSave.bind(this), 600)
+  }
+
+  finishSave() {
+    if (this.data.get('save-state') == 'saving')
+      this.data.set('save-state', 'saved')
   }
 }

--- a/app/webpacker/styles/button.scss
+++ b/app/webpacker/styles/button.scss
@@ -84,3 +84,14 @@
         }
     }
 }
+
+.secondary-button {
+  @include button;
+  background-color: $grey-light;
+  color: $black !important ;
+  text-decoration: none !important;
+
+  &:hover {
+    background-color: $grey-mid ;
+  }
+}

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -66,3 +66,30 @@ form {
 form div.hidden {
   display: none;
 }
+
+
+form {
+  .save-with-confirmation {
+    button {
+      margin-right: 1em;
+      margin-bottom: 1em;
+    }
+
+    span {
+      color: $green ;
+      display: none ;
+    }
+  }
+
+  &[data-cookie-preferences-save-state="saving"] {
+    .fa-sync.fa-spin {
+      display: inline-block ;
+    }
+  }
+
+  &[data-cookie-preferences-save-state="saved"] {
+    .save-with-confirmation__message {
+      display: inline-block ;
+    }
+  }
+}


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-app#535

And adds a fix for :back not re-running js in cdn environments

In non-cdn environments, `history.back()` will result in the earlier page being
reloaded.

In our production environment, `history.back()` restores the earlier page but
does not reload the content, or re-run the JS which means the cookie acceptance
overlay continues to be shown, even though the user has accepted cookies by this
point.