### PR TITLE
Fix featured links with overhanging chevrons

### DIFF
--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -42,28 +42,32 @@
 
     &__content {
         height: calc(100% - 230px);
-        span {
-            display: block;
-            margin-bottom: 10px;
-        }
     }
 
     &__link {
+        margin-top: 10px;
+        display: block;
         text-decoration: none;
         font-weight: bold;
+
         &:hover {
             text-decoration: underline;
         }
-        &:after {
-            content: "";
-            display: inline-block;
-            position: relative;
-            width: 10px;
-            height: 10px;
-            border: 4px solid $black;
-            border-width: 3px 3px 0px 0px;
-            transform: rotate(45deg);
-            top: 1px;
+
+        .link-chevron {
+            white-space: nowrap;
+
+            &:after {
+                content: "";
+                display: inline-block;
+                position: relative;
+                width: 10px;
+                height: 10px;
+                border: 4px solid $black;
+                border-width: 3px 3px 0px 0px;
+                transform: rotate(45deg);
+                top: 1px;
+            }
         }
     }
 


### PR DESCRIPTION
Now the final word in the content will be wrapped in a span.link-chevron and they will wrap together, meaning the chevron can't be orphaned.

This needs to be merged at the same time as DFE-Digital/get-into-teaching-content/pull/130

|  Before | After |
| ------- | ------- |
| ![Screenshot from 2020-11-04 11-29-19](https://user-images.githubusercontent.com/128088/98111353-61d2cf80-1e98-11eb-982c-3193a861016c.png) | ![Screenshot from 2020-11-04 12-22-23](https://user-images.githubusercontent.com/128088/98111396-71521880-1e98-11eb-8532-5a1802ee8a4e.png)|

