### PR TITLE
Correct typo in cookie policy

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -56,7 +56,7 @@ window)</span><i class="icon icon-external"></i></a> and the third-party service
             </table>
         </p>
 
-        <h3>2. Non functional cookies</h3>
+        <h3>2. Non-functional cookies</h3>
         <p>These cookies allow us to provide a more enhanced service and help us to learn what content our users like or don’t like, so we can make the service even better. They also help us to provide you with personalised content and teaching-related advertisements to help you with your consideration of Initial Teacher Training and returning to teaching. Whilst these cookies don’t collect your name or address, they do collect a unique user identifier code, which is linked to your device.</p>
         <p>The types of non-functional cookies we set are:</p>
         


### PR DESCRIPTION
Rename 'Non functional' to 'Non-functional'
