### PR TITLE
Update event date formatting

### DIFF
--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -17,7 +17,7 @@ module Events
     end
 
     def datetime
-      format_event_date(event, stacked: false)
+      format_event_date(event, stacked: true)
     end
 
     def type_name

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -8,7 +8,7 @@ module EventsHelper
       safe_html_format(
         sprintf(
           "%{startdate} #{stacked ? '<br />' : 'at'} %{starttime} - %{endtime}",
-          startdate: event.start_at.to_date.to_formatted_s(:long_ordinal),
+          startdate: event.start_at.to_date.to_formatted_s(:long),
           starttime: event.start_at.to_formatted_s(:time),
           endtime: event.end_at.to_formatted_s(:time),
         ),
@@ -16,8 +16,8 @@ module EventsHelper
     else
       sprintf \
         "%{startdate} to %{enddate}",
-        startdate: event.start_at.to_formatted_s(:long_ordinal),
-        enddate: event.end_at.to_formatted_s(:long_ordinal)
+        startdate: event.start_at.to_formatted_s(:full),
+        enddate: event.end_at.to_formatted_s(:full)
     end
   end
 

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -38,7 +38,8 @@
         overflow: hidden;
 
         h4 {
-            margin: 0;
+            line-height: 1.3em;
+            margin: 0 0 0.4em 0;
             a:hover &, a:focus, a:active {
                 text-decoration: underline;
             }

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -3,18 +3,29 @@ require "rails_helper"
 describe Events::EventBoxComponent, type: "component" do
   include_context "stub types api"
   let(:event) { build(:event_api) }
+  let(:condensed) { false }
 
-  subject! { render_inline(Events::EventBoxComponent.new(event)) }
+  subject! { render_inline(Events::EventBoxComponent.new(event, condensed: condensed)) }
 
   specify "renders an event box" do
     expect(page).to have_css(".event-box")
   end
 
-  specify "places the date and time in the datetime div" do
-    page.find(".event-box__datetime") do |datetime_div|
-      expect(datetime_div).to have_content(event.start_at.to_date.to_formatted_s(:long_ordinal))
-      expect(datetime_div).to have_content(event.start_at.to_formatted_s(:time))
-      expect(datetime_div).to have_content(event.end_at.to_formatted_s(:time))
+  describe "heading" do
+    specify "places the date and time in the datetime div" do
+      page.find(".event-box__datetime") do |datetime_div|
+        expect(datetime_div.native.inner_html).to include(
+          "#{date_text} <br> #{start_at_text} - #{end_at_text}",
+        )
+      end
+    end
+
+    context "when condensed" do
+      let(:condensed) { true }
+
+      specify "does not display the event name" do
+        expect(page).not_to have_content(event.name)
+      end
     end
   end
 
@@ -124,5 +135,17 @@ describe Events::EventBoxComponent, type: "component" do
         expect(page).to have_css(%(.icon-pin--#{event_type.expected_colour}))
       end
     end
+  end
+
+  def date_text
+    event.start_at.to_date.to_formatted_s(:long)
+  end
+
+  def start_at_text
+    event.start_at.to_formatted_s(:time)
+  end
+
+  def end_at_text
+    event.end_at.to_formatted_s(:time)
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -12,18 +12,18 @@ describe EventsHelper, type: "helper" do
     subject { format_event_date event, stacked: stacked }
 
     context "for single day event" do
-      it { is_expected.to eql "June 1st, 2020 <br> 10:00 - 12:00" }
+      it { is_expected.to eql "1 June 2020 <br> 10:00 - 12:00" }
     end
 
     context "for multi day event" do
       let(:enddate) { DateTime.new(2020, 6, 4, 14) }
-      it { is_expected.to eql "June 1st, 2020 10:00 to June 4th, 2020 14:00" }
+      it { is_expected.to eql "1 June 2020 10:00 to 4 June 2020 14:00" }
     end
 
     context "when not stacked" do
       let(:stacked) { false }
 
-      it { is_expected.to eql "June 1st, 2020 at 10:00 - 12:00" }
+      it { is_expected.to eql "1 June 2020 at 10:00 - 12:00" }
     end
   end
 


### PR DESCRIPTION
### JIRA ticket number

[Trello-513](https://trello.com/c/zAJQrlUm/513-dev-update-date-format-on-events)

### Context

Instead of displaying the date in the format `November 3rd, 2020` we instead want to display it as ` 3 November 2020`.

### Changes proposed in this pull request

- Update event date formatting

- Tweak event box line height/margin

The event title had too much space around it; this reduces the line height and puts in a bottom margin (as the line height gave it a margin previously that we want to retain).

### Guidance to review

<img width="347" alt="Screenshot 2020-11-05 at 10 27 05" src="https://user-images.githubusercontent.com/29867726/98229161-79ba5a00-1f51-11eb-9b9d-50da56c48fb9.png">

<img width="326" alt="Screenshot 2020-11-05 at 10 47 10" src="https://user-images.githubusercontent.com/29867726/98231402-46c59580-1f54-11eb-9273-b777c9d84215.png">
