### PR TITLE
No results update

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -11,13 +11,13 @@
       <% if include_type %>
         <%= tag.div(class: input_field_classes(:type)) do %>
             <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
-            <%= f.collection_select :type, search.available_event_types, :id, :value, { include_blank: "All events" } %>
+            <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
         <% end %>
       <% end %>
 
       <%= tag.div(class: input_field_classes(:distance)) do %>
           <%= f.label :distance, "Location", class: "search-for-events__content__input__label" %>
-          <%= f.select :distance, search.available_distances, {},
+          <%= f.select :distance, search.class.available_distances, {},
                 data: { action: "conditional-field#toggle", target: "conditional-field.source" } %>
       <% end %>
 
@@ -28,7 +28,7 @@
 
       <%= tag.div(class: input_field_classes(:month)) do %>
           <%= f.label :month, "Month", class: "search-for-events__content__input__label" %>
-          <%= f.select :month, search.available_months, **month_args %>
+          <%= f.select :month, search.class.available_months, **month_args %>
       <% end %>
     </div>
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -55,6 +55,7 @@ private
   def search_events
     @events_by_type = @event_search.query_events
     @group_presenter = Events::GroupPresenter.new(@events_by_type)
+    @display_empty_types = @event_search.type.nil?
   end
 
   def load_event_search

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -80,8 +80,6 @@ module EventsHelper
 
   def event_type_color(type_id)
     case type_id
-    when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"]
-      "yellow"
     when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
       "green"
     when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -9,7 +9,7 @@ module Events
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze
 
     delegate :available_event_type_ids, :available_distance_keys, to: :class
-    
+
     attribute :type, :integer
     attribute :distance, :integer
     attribute :postcode, :string

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -8,6 +8,8 @@ module Events
     DISTANCES = [30, 50, 100].freeze
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze
 
+    delegate :available_event_type_ids, :available_distance_keys, to: :class
+    
     attribute :type, :integer
     attribute :distance, :integer
     attribute :postcode, :string
@@ -21,32 +23,34 @@ module Events
     before_validation { self.distance = nil if distance.blank? }
     before_validation(unless: :distance) { self.postcode = nil }
 
-    def available_event_types
-      @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
-        GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+    class << self
+      def available_event_types
+        @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
+          GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+        end
       end
-    end
 
-    def available_event_type_ids
-      available_event_types.map(&:id)
-    end
+      def available_event_type_ids
+        available_event_types.map(&:id)
+      end
 
-    def available_distances
-      [["Nationwide", nil]] + DISTANCES.map { |d| ["Within #{d} miles", d] }
-    end
+      def available_distance_keys
+        available_distances.map(&:last)
+      end
 
-    def available_distance_keys
-      available_distances.map(&:last)
-    end
+      def available_distances
+        [["Nationwide", nil]] + DISTANCES.map { |d| ["Within #{d} miles", d] }
+      end
 
-    def available_months
-      (0..5).map do |i|
-        month = i.months.from_now.to_date
+      def available_months
+        (0..5).map do |i|
+          month = i.months.from_now.to_date
 
-        [
-          month.to_formatted_s(:humanmonthyear),
-          month.to_formatted_s(:yearmonth),
-        ]
+          [
+            month.to_formatted_s(:humanmonthyear),
+            month.to_formatted_s(:yearmonth),
+          ]
+        end
       end
     end
 

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -9,11 +9,13 @@ module Events
     end
 
     def get_into_teaching_events
-      @get_into_teaching_events ||= events_by_type.slice(*get_into_teaching_type_ids)
+      empty_types = get_into_teaching_type_ids.product([[]]).to_h
+      @get_into_teaching_events ||= empty_types.merge!(events_by_type.slice(*get_into_teaching_type_ids))
     end
 
     def school_and_university_events
-      @school_and_university_events ||= events_by_type.slice(school_and_university_type_id)
+      empty_types = { school_and_university_type_id => [] }
+      @school_and_university_events ||= empty_types.merge!(events_by_type.slice(school_and_university_type_id))
     end
 
   private

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -4,6 +4,8 @@
   </div>
 
   <% category_groups.each do |type_id, events| %>
-    <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
+    <% if events.any? || display_empty_types %>
+      <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
+    <% end %>
   <% end %>
 </section>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,19 +1,27 @@
+<% plural_category_name = pluralised_category_name(type_id) %>
+
 <div class="events-featured">
-  <h3><%= pluralised_category_name(type_id) %></h3>
+  <h3><%= plural_category_name %></h3>
 
-  <div class="events-featured__text">
-    <p><%= safe_html_format(t("find_an_event.types.#{type_id}")) %></p>
-  </div>
+    <div class="events-featured__text">
+      <p><%= safe_html_format(t("find_an_event.types.#{type_id}")) %></p>
+    </div>
 
-  <div class="events-featured__list">
-    <%= render partial: "event", collection: events %>
-  </div>
+  <% if events.any? %>
+    <div class="events-featured__list">
+      <%= render partial: "event", collection: events %>
+    </div>
+  <% else %>
+    <div class="search-for-events-no-results search-for-events-no-results--by-type">
+      There are no <%= plural_category_name %> that match your search criteria. Try widening your search and updating your results.
+    </div>
+  <% end %>
 
   <% show_see_all_events ||= false %>
 
   <% if show_see_all_events %>
-    <%= link_to(event_category_events_path(pluralised_category_name(type_id).parameterize)) do %>
-      <div class="call-to-action-button">See all <%= pluralised_category_name(type_id) %> <i class="fas fa-chevron-right"></i></div>
+    <%= link_to(event_category_events_path(plural_category_name.parameterize)) do %>
+      <div class="call-to-action-button">See all <%= plural_category_name %> <i class="fas fa-chevron-right"></i></div>
     <% end %>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,12 +30,20 @@
     </section>
 
     <% if @events_by_type.any? %>
-      <% if @group_presenter.get_into_teaching_events.any? %>
-        <%= render partial: "event_category", locals: { organised_by: t("event_groups.get_into_teaching"), category_groups: @group_presenter.get_into_teaching_events } %>
+      <% if @group_presenter.get_into_teaching_events.values.flatten.any? || @display_empty_types %>
+        <%= render partial: "event_category", locals: { 
+          organised_by: t("event_groups.get_into_teaching"), 
+          category_groups: @group_presenter.get_into_teaching_events,
+          display_empty_types: @display_empty_types,
+        } %>
       <% end %>
 
-      <% if @group_presenter.school_and_university_events.any? %>
-        <%= render partial: "event_category", locals: { organised_by:  t("event_groups.222750009"), category_groups: @group_presenter.school_and_university_events } %>
+      <% if @group_presenter.school_and_university_events.values.flatten.any?  || @display_empty_types %>
+        <%= render partial: "event_category", locals: { 
+          organised_by:  t("event_groups.222750009"), 
+          category_groups: @group_presenter.school_and_university_events,
+          display_empty_types: @display_empty_types,
+        } %>
       <% end %>
     <% else %>
       <section class="content container-1000">

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -178,10 +178,20 @@
   padding: 20px;
   font-weight: bold;
   margin-bottom: 80px;
+
+  &--by-type {
+    box-sizing: border-box;
+    margin: 0 0 30px 0;
+    width: 66.6%;
+  }
 }
 
 @media only screen and (max-width: 800px) {
     
+    .search-for-events-no-results--by-type {
+      width: 100%;
+    }
+
     .types-of-event {
         padding-top: 20px;
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,11 +61,6 @@ en:
           <li><span>school experience</span></li>
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
-      222750000: |-
-        <p>
-          Our Train to Teach events and application workshops offer you the chance to speak to teaching experts face-to-face. 
-          Get bespoke advice, help with your application, and meet training providers in your area – all completely free.
-        </p>
   event_groups:
     get_into_teaching: "Get into Teaching"
     222750009: "schools and universities"
@@ -122,26 +117,6 @@ en:
           <li><span>school experience</span></li>
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
-    222750000: 
-      name: 
-        singular: "Application Workshop"
-        plural: "Application Workshops"
-      description: |-
-        <p>
-          If you’re ready to apply for teacher training, we’re here to help. Our free application workshops are the perfect way to get expert 
-          advice and information that will help you create the strongest teacher training application possible. Workshops tend to fill up fast – 
-          find an event near you and reserve your place.
-        </p>
-
-        <h4>When you attend a workshop you’ll get the chance to:</h4>
-
-        <ul>
-          <li><span>Attend a presentation to get handy hints and helpful tips on how to make your application stand out</span></li>
-          <li><span>Receive one-to-one feedback from our teaching experts when you bring along your draft personal statement</span></li>
-          <li><span>Talk to current teachers about their experiences</span></li>
-        </ul>
-
-        <p>Make your application count – join us at a workshop and give yourself the best chance of success.</p>
   activemodel:
     errors:
       models:

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -4,7 +4,6 @@ module GetIntoTeachingApiClient
       {
         "Train to Teach Event" => 222_750_001,
         "Online Event" => 222_750_008,
-        "Application Workshop" => 222_750_000,
         "School or University Event" => 222_750_009,
       }.freeze
 
@@ -23,7 +22,7 @@ module GetIntoTeachingApiClient
       }.freeze
 
     GET_INTO_TEACHING_EVENT_TYPES = EVENT_TYPES.select { |key|
-      ["Train to Teach Event", "Online Event", "Application Workshop"].include?(key)
+      ["Train to Teach Event", "Online Event"].include?(key)
     }.freeze
 
     DEGREE_STATUS_OPTIONS =

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -73,12 +73,6 @@ describe Events::EventBoxComponent, type: "component" do
 
   [
     OpenStruct.new(
-      name: "Application Workshop",
-      trait: :application_workshop,
-      expected_colour: "yellow",
-      is_online: false,
-    ),
-    OpenStruct.new(
       name: "Train to Teach Event",
       trait: :train_to_teach_event,
       expected_colour: "green",

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -26,10 +26,6 @@ FactoryBot.define do
       provider_contact_email { "jim@smith.com" }
     end
 
-    trait :application_workshop do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
-    end
-
     trait :train_to_teach_event do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     end

--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :events_search, class: Events::Search do
-    type { Events::Search.new.available_event_types.first.id }
-    distance { Events::Search.new.available_distances.first[0] }
+    type { Events::Search.available_event_types.first.id }
+    distance { Events::Search.available_distances.first[0] }
     postcode { "TE57 1NG" }
     month { "2020-07" }
 

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -99,7 +99,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#is_event_type?" do
     let(:matching_type) { "School or University Event" }
-    let(:non_matching_type) { "Application Workshop" }
+    let(:non_matching_type) { "Online Event" }
     let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
 
     it "should be truthy when the type matches" do
@@ -120,11 +120,6 @@ describe EventsHelper, type: "helper" do
     it "returns purple for online events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]
       expect(event_type_color(type_id)).to eq("purple")
-    end
-
-    it "returns yellow for application workshop" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"]
-      expect(event_type_color(type_id)).to eq("yellow")
     end
 
     it "returns blue for schools or university events" do
@@ -184,7 +179,6 @@ describe EventsHelper, type: "helper" do
       222_750_001 => "Train to Teach Events",
       222_750_008 => "Online Events",
       222_750_009 => "School and University Events",
-      222_750_000 => "Application Workshops",
     }.each do |type_id, name|
       specify "#{type_id} => #{name}" do
         expect(pluralised_category_name(type_id)).to eql(name)

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -18,6 +18,22 @@ describe Events::Search do
     it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.values }
   end
 
+  describe ".available_months" do
+    before { travel_to(DateTime.new(2020, 11, 1)) }
+    subject { described_class.available_months }
+
+    it {
+      is_expected.to eq([
+        ["November 2020", "2020-11"],
+        ["December 2020", "2020-12"],
+        ["January 2021", "2021-01"],
+        ["February 2021", "2021-02"],
+        ["March 2021", "2021-03"],
+        ["April 2021", "2021-04"],
+      ])
+    }
+  end
+
   context "validation" do
     context "for event type" do
       it { is_expected.to allow_value(GetIntoTeachingApiClient::Constants::EVENT_TYPES["Teain to Teach event"]).for :type }

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -42,6 +42,17 @@ describe Events::GroupPresenter do
         expect(actual_events & school_and_university_events).to be_empty
       end
     end
+
+    context "when there are no events" do
+      let(:application_workshops) { [] }
+      let(:train_to_teach_events) { [] }
+      let(:online_events) { [] }
+
+      specify "contains a key for each event type mapping to an empty array" do
+        keys = GetIntoTeachingApiClient::Constants::GET_INTO_TEACHING_EVENT_TYPES.values
+        expect(subject.get_into_teaching_events).to eq(keys.product([[]]).to_h)
+      end
+    end
   end
 
   describe "#school_and_university_events" do
@@ -61,6 +72,16 @@ describe Events::GroupPresenter do
 
       specify "are absent" do
         expect(actual_events & get_into_teaching_events).to be_empty
+      end
+    end
+
+    context "when there are no events" do
+      let(:school_and_university_events) { [] }
+
+      specify "contains a key for schools or university events mapping to an empty array" do
+        expect(subject.school_and_university_events).to eq({
+          GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] => [],
+        })
       end
     end
   end

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -1,24 +1,15 @@
 require "rails_helper"
 
 describe Events::GroupPresenter do
-  let(:application_workshops) { build_list(:event_api, 3, :application_workshop) }
   let(:train_to_teach_events) { build_list(:event_api, 3, :train_to_teach_event) }
   let(:online_events) { build_list(:event_api, 3, :online_event) }
   let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
-  let(:all_events) { [train_to_teach_events, application_workshops, online_events, school_and_university_events].flatten }
+  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
   let(:events_by_type) { all_events.group_by { |event| event.type_id.to_s.to_sym } }
 
   subject { Events::GroupPresenter.new(events_by_type) }
 
   describe "#get_into_teaching_events" do
-    context "application workshops" do
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
-
-      specify "should all be present" do
-        expect(subject.get_into_teaching_events.fetch(type_id)).to match_array(application_workshops)
-      end
-    end
-
     context "train to teach events" do
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
 
@@ -44,7 +35,6 @@ describe Events::GroupPresenter do
     end
 
     context "when there are no events" do
-      let(:application_workshops) { [] }
       let(:train_to_teach_events) { [] }
       let(:online_events) { [] }
 
@@ -56,7 +46,7 @@ describe Events::GroupPresenter do
   end
 
   describe "#school_and_university_events" do
-    let(:unexpected_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+    let(:unexpected_events) { [train_to_teach_events, online_events].flatten }
 
     context "school or university events" do
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] }
@@ -66,8 +56,8 @@ describe Events::GroupPresenter do
       end
     end
 
-    context "get into teaching events, online events and application workshops" do
-      let(:get_into_teaching_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+    context "get into teaching events and online events" do
+      let(:get_into_teaching_events) { [train_to_teach_events, online_events].flatten }
       let(:actual_events) { subject.school_and_university_events.values.flatten.map(&:id) }
 
       specify "are absent" do
@@ -88,10 +78,10 @@ describe Events::GroupPresenter do
 
   describe "sorting" do
     context "within an event type" do
-      let(:early) { build(:event_api, :application_workshop, start_at: 1.week.from_now) }
-      let(:middle) { build(:event_api, :application_workshop, start_at: 2.weeks.from_now) }
-      let(:late) { build(:event_api, :application_workshop, start_at: 3.weeks.from_now) }
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
+      let(:early) { build(:event_api, :online_event, start_at: 1.week.from_now) }
+      let(:middle) { build(:event_api, :online_event, start_at: 2.weeks.from_now) }
+      let(:late) { build(:event_api, :online_event, start_at: 3.weeks.from_now) }
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
       let(:unsorted_events) { [middle, late, early] }
 
       subject { Events::GroupPresenter.new({ type_id => unsorted_events }) }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 describe "Find an event near you" do
   include_context "stub types api"
 
-  NO_EVENTS_REGEX = /no events that match your search criteria/.freeze
+  NO_EVENTS_REGEX = /There are no .* that match your search criteria/.freeze
 
+  let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
     5.times.collect do |index|
       start_at = Time.zone.today.at_end_of_month - index.days
-      build(:event_api, name: "Event #{index + 1}", start_at: start_at)
+      type_id = types[index % types.count]
+      build(:event_api, name: "Event #{index + 1}", start_at: start_at, type_id: type_id)
     end
   end
   let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
@@ -29,16 +31,17 @@ describe "Find an event near you" do
       expect(response.body.scan(/Event [1-5]/).count).to eq(5)
     end
 
-    it "presents the events in date order" do
+    it "presents the events in date order, per category" do
       headings = response.body.scan(/<h4>(.*)<\/h4>/).flatten.take(events.count)
-      expect(headings).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])
+      expect(headings).to eq(["Event 5", "Event 1", "Event 2", "Event 3", "Event 4"])
     end
 
     context "when there are no results" do
       let(:events) { [] }
 
-      it "displays the no results message" do
-        expect(response.body).to match(NO_EVENTS_REGEX)
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
       end
     end
 
@@ -54,7 +57,6 @@ describe "Find an event near you" do
         expected_headings = [
           "Train to Teach Events",
           "Online Events",
-          "Application Workshops",
           "School and University Events",
         ]
 
@@ -65,6 +67,7 @@ describe "Find an event near you" do
 
   context "when searching for an event by type" do
     let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    let(:events) { [build(:event_api, type_id: type_id)] }
 
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -73,7 +76,37 @@ describe "Find an event near you" do
 
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
-    it "displays all events of that type" do
+    it "displays only the category filtered to" do
+      headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+      expected_headings = ["Train to Teach Events"]
+
+      expect(headings).to eq(expected_headings)
+    end
+
+    context "when there are no results" do
+      let(:events) { [] }
+
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
+      end
+
+      it "does not display any categories" do
+        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        expect(headings).to be_empty
+      end
+    end
+  end
+
+  context "when searching for an event" do
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+    end
+
+    before { get search_events_path(events_search: { month: "2020-07" }) }
+
+    it "displays events" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)
     end
 
@@ -89,8 +122,21 @@ describe "Find an event near you" do
     context "when there are no results" do
       let(:events) { [] }
 
-      it "displays the no results message" do
-        expect(response.body).to match(NO_EVENTS_REGEX)
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
+      end
+    end
+
+    context "when there are results for a subset of categories" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+      let(:events) { [build(:event_api, type_id: type_id)] }
+
+      it "displays the no results message per category" do
+        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(headings.count).to eq(Events::Search.available_event_types.count)
+        expect(headings.count - 1).to eq(no_results_messages.count)
       end
     end
   end

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -33,7 +33,7 @@ describe "Find an event near you" do
 
     it "presents the events in date order, per category" do
       headings = response.body.scan(/<h4>(.*)<\/h4>/).flatten.take(events.count)
-      expect(headings).to eq(["Event 5", "Event 1", "Event 2", "Event 3", "Event 4"])
+      expect(headings).to eq(["Event 4", "Event 1", "Event 5", "Event 2", "Event 3"])
     end
 
     context "when there are no results" do


### PR DESCRIPTION
### Trello card

[Trello-426](https://trello.com/c/NRodnqt4/426-events-for-virtual-ttt-events-add-text-that-says-there-are-no-events-of-this-type-for-this-month-try-another-month)

### Context

Currently, if there are no results we display a single 'no results' message to the user. We want to change this behaviour such that;

- If a user searches across all types and there are no results for _some_ of the types, we still want to display the type sections but have a 'no results' message in each section that has no events.
- If a user searches across all types and there are no results in _any_ of the types, the existing behaviour remains (single 'no results' message).
- If the user searches by a specific type, the existing behaviour remains (single 'no results' message).
- If there are no results on the landing page for a specific type, we want to hide the section completely (retaining the existing behaviour).

We also want to remove the Application Workshop events from the application, as there are none in the CRM at the moment and aren't likely to be any in the near future.

### Changes proposed in this pull request

- Refactor Event::Search to class methods
- Display no results message per category
- Remove Application Workshop events from the app

### Guidance to review

<img width="1066" alt="Screenshot 2020-11-06 at 10 40 21" src="https://user-images.githubusercontent.com/29867726/98357045-7cce4c80-201c-11eb-9427-d1d7bfff7dec.png">
