### PR TITLE
Redirect to first step on resend_verification bad request

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -34,6 +34,10 @@ module WizardSteps
     request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(camelized_identity_data)
     GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
     redirect_to authenticate_path(verification_resent: true)
+  rescue GetIntoTeachingApiClient::ApiError => e
+    redirect_to(first_step_path) && return if e.code == 400
+
+    raise
   end
 
 private
@@ -56,6 +60,10 @@ private
     else # all steps valid so completed
       completed_step_path
     end
+  end
+
+  def first_step_path
+    step_path(wizard_class.steps.first.key)
   end
 
   def authenticate_path(params = {})

--- a/spec/support/resend_verification_support.rb
+++ b/spec/support/resend_verification_support.rb
@@ -18,5 +18,17 @@ shared_examples "a controller with a #resend_verification action" do
       it { is_expected.to match(/Error 429/) }
       it { is_expected.to match(/Too many requests/) }
     end
+
+    context "when the API returns 400 bad request" do
+      let(:bad_request_error) { GetIntoTeachingApiClient::ApiError.new(code: 400) }
+
+      subject! do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token).and_raise(bad_request_error)
+        perform_request
+      end
+
+      it { is_expected.to redirect_to(controller.send(:step_path, controller.wizard_class.steps.first.key)) }
+    end
   end
 end


### PR DESCRIPTION
If a candidate's session expires (so they sit on the authenticate step overnight, for instance) then they hit the link to resend their verification code the app attempts to make an invalid request to the API (email, first and last name are nil). This currently results in a 500 error for the user. Instead, we rescue this condition and redirect to the first step so that they can re-authenticate.

Fixes https://sentry.io/organizations/dfe-bat/issues/2010050592/?project=5276960&referrer=slack