### PR TITLE
Refactor Event::Search to class methods

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -11,13 +11,13 @@
       <% if include_type %>
         <%= tag.div(class: input_field_classes(:type)) do %>
             <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
-            <%= f.collection_select :type, search.available_event_types, :id, :value, { include_blank: "All events" } %>
+            <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
         <% end %>
       <% end %>
 
       <%= tag.div(class: input_field_classes(:distance)) do %>
           <%= f.label :distance, "Location", class: "search-for-events__content__input__label" %>
-          <%= f.select :distance, search.available_distances, {},
+          <%= f.select :distance, search.class.available_distances, {},
                 data: { action: "conditional-field#toggle", target: "conditional-field.source" } %>
       <% end %>
 
@@ -28,7 +28,7 @@
 
       <%= tag.div(class: input_field_classes(:month)) do %>
           <%= f.label :month, "Month", class: "search-for-events__content__input__label" %>
-          <%= f.select :month, search.available_months, **month_args %>
+          <%= f.select :month, search.class.available_months, **month_args %>
       <% end %>
     </div>
 

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -8,6 +8,8 @@ module Events
     DISTANCES = [30, 50, 100].freeze
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze
 
+    delegate :available_event_type_ids, :available_distance_keys, to: :class
+
     attribute :type, :integer
     attribute :distance, :integer
     attribute :postcode, :string
@@ -21,32 +23,34 @@ module Events
     before_validation { self.distance = nil if distance.blank? }
     before_validation(unless: :distance) { self.postcode = nil }
 
-    def available_event_types
-      @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
-        GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+    class << self
+      def available_event_types
+        @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
+          GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+        end
       end
-    end
 
-    def available_event_type_ids
-      available_event_types.map(&:id)
-    end
+      def available_event_type_ids
+        available_event_types.map(&:id)
+      end
 
-    def available_distances
-      [["Nationwide", nil]] + DISTANCES.map { |d| ["Within #{d} miles", d] }
-    end
+      def available_distance_keys
+        available_distances.map(&:last)
+      end
 
-    def available_distance_keys
-      available_distances.map(&:last)
-    end
+      def available_distances
+        [["Nationwide", nil]] + DISTANCES.map { |d| ["Within #{d} miles", d] }
+      end
 
-    def available_months
-      (0..5).map do |i|
-        month = i.months.from_now.to_date
+      def available_months
+        (0..5).map do |i|
+          month = i.months.from_now.to_date
 
-        [
-          month.to_formatted_s(:humanmonthyear),
-          month.to_formatted_s(:yearmonth),
-        ]
+          [
+            month.to_formatted_s(:humanmonthyear),
+            month.to_formatted_s(:yearmonth),
+          ]
+        end
       end
     end
 

--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :events_search, class: Events::Search do
-    type { Events::Search.new.available_event_types.first.id }
-    distance { Events::Search.new.available_distances.first[0] }
+    type { Events::Search.available_event_types.first.id }
+    distance { Events::Search.available_distances.first[0] }
     postcode { "TE57 1NG" }
     month { "2020-07" }
 

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -18,6 +18,22 @@ describe Events::Search do
     it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.values }
   end
 
+  describe ".available_months" do
+    before { travel_to(DateTime.new(2020, 11, 1)) }
+    subject { described_class.available_months }
+
+    it {
+      is_expected.to eq([
+        ["November 2020", "2020-11"],
+        ["December 2020", "2020-12"],
+        ["January 2021", "2021-01"],
+        ["February 2021", "2021-02"],
+        ["March 2021", "2021-03"],
+        ["April 2021", "2021-04"],
+      ])
+    }
+  end
+
   context "validation" do
     context "for event type" do
       it { is_expected.to allow_value(GetIntoTeachingApiClient::Constants::EVENT_TYPES["Teain to Teach event"]).for :type }


### PR DESCRIPTION
### Trello card

[Trello-426](https://trello.com/c/NRodnqt4/426-events-for-virtual-ttt-events-add-text-that-says-there-are-no-events-of-this-type-for-this-month-try-another-month)

### Context

A number of the methods on `Event::Search` can be class methods; this will come in handy when we need to make assertions in some of the specs later on (in particular referencing the `available_event_types`).

### Changes proposed in this pull request

- Refactor Event::Search to class methods

Also contains minor improvement for test coverage in `Events::Search`.

### Guidance to review

