### PR TITLE
Remove Application Workshop events from the app

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -80,8 +80,6 @@ module EventsHelper
 
   def event_type_color(type_id)
     case type_id
-    when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"]
-      "yellow"
     when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
       "green"
     when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -72,10 +72,6 @@
         background-color: $green;
     }
 
-    &__divider--application-workshop {
-      background-color: $yellow;
-    }
-
     &__content p {
       font-size: 17px;
       margin-bottom: 0;

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -47,13 +47,6 @@
     }
 }
 
-.icon-application-workshop {
-  @include icon;
-  background-image: url('../images/icon-application-workshop.svg');
-  width: 38px;
-  height: 25px;
-}
-
 .icon-pin {
     @include icon;
     background-image: url('../images/icon-pin-blue.svg');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,11 +61,6 @@ en:
           <li><span>school experience</span></li>
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
-      222750000: |-
-        <p>
-          Our Train to Teach events and application workshops offer you the chance to speak to teaching experts face-to-face. 
-          Get bespoke advice, help with your application, and meet training providers in your area – all completely free.
-        </p>
   event_groups:
     get_into_teaching: "Get into Teaching"
     222750009: "schools and universities"
@@ -122,26 +117,6 @@ en:
           <li><span>school experience</span></li>
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
-    222750000: 
-      name: 
-        singular: "Application Workshop"
-        plural: "Application Workshops"
-      description: |-
-        <p>
-          If you’re ready to apply for teacher training, we’re here to help. Our free application workshops are the perfect way to get expert 
-          advice and information that will help you create the strongest teacher training application possible. Workshops tend to fill up fast – 
-          find an event near you and reserve your place.
-        </p>
-
-        <h4>When you attend a workshop you’ll get the chance to:</h4>
-
-        <ul>
-          <li><span>Attend a presentation to get handy hints and helpful tips on how to make your application stand out</span></li>
-          <li><span>Receive one-to-one feedback from our teaching experts when you bring along your draft personal statement</span></li>
-          <li><span>Talk to current teachers about their experiences</span></li>
-        </ul>
-
-        <p>Make your application count – join us at a workshop and give yourself the best chance of success.</p>
   activemodel:
     errors:
       models:

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -4,7 +4,6 @@ module GetIntoTeachingApiClient
       {
         "Train to Teach Event" => 222_750_001,
         "Online Event" => 222_750_008,
-        "Application Workshop" => 222_750_000,
         "School or University Event" => 222_750_009,
       }.freeze
 
@@ -23,7 +22,7 @@ module GetIntoTeachingApiClient
       }.freeze
 
     GET_INTO_TEACHING_EVENT_TYPES = EVENT_TYPES.select { |key|
-      ["Train to Teach Event", "Online Event", "Application Workshop"].include?(key)
+      ["Train to Teach Event", "Online Event"].include?(key)
     }.freeze
 
     DEGREE_STATUS_OPTIONS =

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -73,12 +73,6 @@ describe Events::EventBoxComponent, type: "component" do
 
   [
     OpenStruct.new(
-      name: "Application Workshop",
-      trait: :application_workshop,
-      expected_colour: "yellow",
-      is_online: false,
-    ),
-    OpenStruct.new(
       name: "Train to Teach Event",
       trait: :train_to_teach_event,
       expected_colour: "green",

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -26,10 +26,6 @@ FactoryBot.define do
       provider_contact_email { "jim@smith.com" }
     end
 
-    trait :application_workshop do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
-    end
-
     trait :train_to_teach_event do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -99,7 +99,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#is_event_type?" do
     let(:matching_type) { "School or University Event" }
-    let(:non_matching_type) { "Application Workshop" }
+    let(:non_matching_type) { "Online Event" }
     let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
 
     it "should be truthy when the type matches" do
@@ -120,11 +120,6 @@ describe EventsHelper, type: "helper" do
     it "returns purple for online events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]
       expect(event_type_color(type_id)).to eq("purple")
-    end
-
-    it "returns yellow for application workshop" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"]
-      expect(event_type_color(type_id)).to eq("yellow")
     end
 
     it "returns blue for schools or university events" do
@@ -184,7 +179,6 @@ describe EventsHelper, type: "helper" do
       222_750_001 => "Train to Teach Events",
       222_750_008 => "Online Events",
       222_750_009 => "School and University Events",
-      222_750_000 => "Application Workshops",
     }.each do |type_id, name|
       specify "#{type_id} => #{name}" do
         expect(pluralised_category_name(type_id)).to eql(name)

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -1,24 +1,15 @@
 require "rails_helper"
 
 describe Events::GroupPresenter do
-  let(:application_workshops) { build_list(:event_api, 3, :application_workshop) }
   let(:train_to_teach_events) { build_list(:event_api, 3, :train_to_teach_event) }
   let(:online_events) { build_list(:event_api, 3, :online_event) }
   let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
-  let(:all_events) { [train_to_teach_events, application_workshops, online_events, school_and_university_events].flatten }
+  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
   let(:events_by_type) { all_events.group_by { |event| event.type_id.to_s.to_sym } }
 
   subject { Events::GroupPresenter.new(events_by_type) }
 
   describe "#get_into_teaching_events" do
-    context "application workshops" do
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
-
-      specify "should all be present" do
-        expect(subject.get_into_teaching_events.fetch(type_id)).to match_array(application_workshops)
-      end
-    end
-
     context "train to teach events" do
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
 
@@ -45,7 +36,7 @@ describe Events::GroupPresenter do
   end
 
   describe "#school_and_university_events" do
-    let(:unexpected_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+    let(:unexpected_events) { [train_to_teach_events, online_events].flatten }
 
     context "school or university events" do
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] }
@@ -55,8 +46,8 @@ describe Events::GroupPresenter do
       end
     end
 
-    context "get into teaching events, online events and application workshops" do
-      let(:get_into_teaching_events) { [application_workshops, train_to_teach_events, online_events].flatten }
+    context "get into teaching events and online events" do
+      let(:get_into_teaching_events) { [train_to_teach_events, online_events].flatten }
       let(:actual_events) { subject.school_and_university_events.values.flatten.map(&:id) }
 
       specify "are absent" do
@@ -67,10 +58,10 @@ describe Events::GroupPresenter do
 
   describe "sorting" do
     context "within an event type" do
-      let(:early) { build(:event_api, :application_workshop, start_at: 1.week.from_now) }
-      let(:middle) { build(:event_api, :application_workshop, start_at: 2.weeks.from_now) }
-      let(:late) { build(:event_api, :application_workshop, start_at: 3.weeks.from_now) }
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Application Workshop"] }
+      let(:early) { build(:event_api, :online_event, start_at: 1.week.from_now) }
+      let(:middle) { build(:event_api, :online_event, start_at: 2.weeks.from_now) }
+      let(:late) { build(:event_api, :online_event, start_at: 3.weeks.from_now) }
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
       let(:unsorted_events) { [middle, late, early] }
 
       subject { Events::GroupPresenter.new({ type_id => unsorted_events }) }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -54,7 +54,6 @@ describe "Find an event near you" do
         expected_headings = [
           "Train to Teach Events",
           "Online Events",
-          "Application Workshops",
           "School and University Events",
         ]
 


### PR DESCRIPTION
### Trello card

[Trello-426](https://trello.com/c/NRodnqt4/426-events-for-virtual-ttt-events-add-text-that-says-there-are-no-events-of-this-type-for-this-month-try-another-month)

### Context

As there are no Application Workshop events in the CRM at the moment, we want to hide it as an option in the search type drop down and from any search results.

We are also removing the Application Workshops category page and associated content.

### Changes proposed in this pull request

- Remove Application Workshop events from the app

### Guidance to review

