### PR TITLE
Convert remaining content to markdown

### DIFF
--- a/app/controllers/steps_to_become_a_teacher_controller.rb
+++ b/app/controllers/steps_to_become_a_teacher_controller.rb
@@ -4,6 +4,12 @@ class StepsToBecomeATeacherController < ApplicationController
   rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
 
   def show
-    render template: "content/steps-to-become-a-teacher", layout: "layouts/steps_to_become_a_teacher"
+    render template: steps_to_become_a_teacher_template, layout: "layouts/steps_to_become_a_teacher"
+  end
+
+private
+
+  def steps_to_become_a_teacher_template
+    "content/steps-to-become-a-teacher"
   end
 end

--- a/app/controllers/steps_to_become_a_teacher_controller.rb
+++ b/app/controllers/steps_to_become_a_teacher_controller.rb
@@ -1,0 +1,9 @@
+class StepsToBecomeATeacherController < ApplicationController
+  include StaticPages
+  around_action :cache_static_page, only: %i[show]
+  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+
+  def show
+    render template: "content/steps-to-become-a-teacher", layout: "layouts/steps_to_become_a_teacher"
+  end
+end

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -18,12 +18,12 @@
                 :mailinglist => @front_matter["mailinglist"]
             %>
             <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
-                <% if @front_matter["on_this_page"].present? %>
+                <% if @front_matter["jump_links"].present? %>
                   <div class="content__right">
                     <div class="link-block link-block--jump">
                       <h2 class="link-block__header">On this page:</h2>
                       <ul class="link-block__list">
-                        <% @front_matter["on_this_page"].each do |item, anchor| %>
+                        <% @front_matter["jump_links"].each do |item, anchor| %>
                           <%= link_to(item, anchor) %>
                         <% end %>
                       </ul>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -31,6 +31,20 @@
                   </div>
                 <% end %>
 
+                <% if @front_matter["related_content"].present? %>
+                  <div class="content__right">
+                    <div class="link-block link-block--related">
+                      <h2 class="link-block__header">Related Content:</h2>
+                      <ul class="link-block__list">
+                        <ul class="link-block__list">
+                          <% @front_matter["related_content"].each do |item, anchor| %>
+                            <%= link_to(item, anchor) %>
+                          <% end %>
+                        </ul>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
 
                 <% if @front_matter["fullwidth"] %>
                   <%= yield %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -13,11 +13,40 @@
                 :header => @front_matter["title"],
                 :image => @front_matter["image"],
                 :mobileimage => @front_matter["mobileimage"],
-                :deep => @front_matter["deepheader"], :subtitle =>  @front_matter["subtitle"],
+                :deep => @front_matter["deepheader"],
+                :subtitle =>  @front_matter["subtitle"],
                 :mailinglist => @front_matter["mailinglist"]
             %>
             <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
-                <%= yield %>
+                <% if @front_matter["on_this_page"].present? %>
+                  <div class="content__right">
+                    <div class="link-block link-block--jump">
+                      <h2 class="link-block__header">On this page:</h2>
+                      <ul class="link-block__list">
+                        <% @front_matter["on_this_page"].each do |item, anchor| %>
+                          <%= link_to(item, anchor) %>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
+
+
+                <% if @front_matter["fullwidth"] %>
+                  <%= yield %>
+                <% else %>
+                  <div class="content__left">
+                    <% if !@front_matter["image"] %>
+                      <%= tag.h1(@front_matter["title"]) %>
+                    <% end %>
+
+                    <% if @front_matter["alert"].present? %>
+                      <%= tag.p(@front_matter["alert"], class: "content-alert") %>
+                    <% end %>
+
+                    <%= yield %>
+                  </div>
+                <% end %>
                 <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
             </section>
         </main>

--- a/app/views/layouts/steps_to_become_a_teacher.html.erb
+++ b/app/views/layouts/steps_to_become_a_teacher.html.erb
@@ -18,19 +18,6 @@
                 :mailinglist => @front_matter["mailinglist"]
             %>
             <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
-                <% if @front_matter["on_this_page"].present? %>
-                  <div class="content__right">
-                    <div class="link-block link-block--jump">
-                      <h2 class="link-block__header">On this page:</h2>
-                      <ul class="link-block__list">
-                        <% @front_matter["on_this_page"].each do |item, anchor| %>
-                          <%= link_to(item, anchor) %>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </div>
-                <% end %>
-
                 <div class="content__left">
                   <% if @front_matter["alert"].present? %>
                     <%= tag.p(@front_matter["alert"], class: "content-alert") %>

--- a/app/views/layouts/steps_to_become_a_teacher.html.erb
+++ b/app/views/layouts/steps_to_become_a_teacher.html.erb
@@ -37,13 +37,15 @@
                   <% end %>
 
                   <div class="accordions" data-controller="accordion">
-                    <% @front_matter["steps"].each.with_index(1) do |(title, partial), i| %>
-                      <%= tag.button(class: "steps-header", id: "step-#{i}", data: { action: "click->accordion#toggle", target: "accordion.header" }, aria: { controls: "collapsable-content-#{i}", expanded: (i == 1) }) do %>
-                        <%= tag.h2(%(#{i}. #{title})) %>
-                      <% end %>
+                    <% if @front_matter["steps"].present? %>
+                      <% @front_matter["steps"].each.with_index(1) do |(title, partial), i| %>
+                        <%= tag.button(class: "steps-header", id: "step-#{i}", data: { action: "click->accordion#toggle", target: "accordion.header" }, aria: { controls: "collapsable-content-#{i}", expanded: (i == 1) }) do %>
+                          <%= tag.h2(%(#{i}. #{title})) %>
+                        <% end %>
 
-                      <%= tag.div(id: %(collapsable-content-#{i}), class: %w[steps-content collapsable], data: { target: "accordion.content" }, aria: { labelledby: %(step-#{i}) }) do %>
-                        <%= render(partial: partial) %>
+                        <%= tag.div(id: %(collapsable-content-#{i}), class: %w[steps-content collapsable], data: { target: "accordion.content" }, aria: { labelledby: %(step-#{i}) }) do %>
+                          <%= render(partial: partial) %>
+                        <% end %>
                       <% end %>
                     <% end %>
                   </div>

--- a/app/views/layouts/steps_to_become_a_teacher.html.erb
+++ b/app/views/layouts/steps_to_become_a_teacher.html.erb
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+    <%= render "sections/head" %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", target: "link.content" }, id: "body" do %>
+    <div id="skiplink-container">
+        <div>
+            <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+        </div>
+    </div>
+        <%= render "sections/header" %>
+        <main role="main" id="main-content">
+            <%= render "sections/hero",
+                :header => @front_matter["title"],
+                :image => @front_matter["image"],
+                :mobileimage => @front_matter["mobileimage"],
+                :deep => @front_matter["deepheader"],
+                :subtitle =>  @front_matter["subtitle"],
+                :mailinglist => @front_matter["mailinglist"]
+            %>
+            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
+                <% if @front_matter["on_this_page"].present? %>
+                  <div class="content__right">
+                    <div class="link-block link-block--jump">
+                      <h2 class="link-block__header">On this page:</h2>
+                      <ul class="link-block__list">
+                        <% @front_matter["on_this_page"].each do |item, anchor| %>
+                          <%= link_to(item, anchor) %>
+                        <% end %>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
+
+                <div class="content__left">
+                  <% if @front_matter["alert"].present? %>
+                    <%= tag.p(@front_matter["alert"], class: "content-alert") %>
+                  <% end %>
+
+                  <div class="accordions" data-controller="accordion">
+                    <% @front_matter["steps"].each.with_index(1) do |(title, partial), i| %>
+                      <%= tag.button(class: "steps-header", id: "step-#{i}", data: { action: "click->accordion#toggle", target: "accordion.header" }, aria: { controls: "collapsable-content-#{i}", expanded: (i == 1) }) do %>
+                        <%= tag.h2(%(#{i}. #{title})) %>
+                      <% end %>
+
+                      <%= tag.div(id: %(collapsable-content-#{i}), class: %w[steps-content collapsable], data: { target: "accordion.content" }, aria: { labelledby: %(step-#{i}) }) do %>
+                        <%= render(partial: partial) %>
+                      <% end %>
+                    <% end %>
+                  </div>
+                </div>
+
+                <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
+            </section>
+        </main>
+
+        <%= render "sections/footer" %>
+        <%= render "components/videoplayer" %>
+        <%= render "sections/cookie-acceptance" %>
+        <%= render "sections/feedback-bar" %>
+    <% end %>
+</html>
+

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -24,6 +24,14 @@ export default class extends Controller {
         links.forEach((l) => {
             if (l.getAttribute('href')?.startsWith('http')) {
               l.setAttribute('target', '_blank');
+
+              // add hidden text to inform screen reader users that
+              // link will open in a new window
+              const linkOpensInNewWindow = document.createElement("span");
+              const text = document.createTextNode("(Link opens in new window)");
+              linkOpensInNewWindow.classList.add('govuk-visually-hidden');
+              linkOpensInNewWindow.appendChild(text)
+              l.appendChild(linkOpensInNewWindow);
             }
         });
     }

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -1,20 +1,30 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-
-    static targets = [ "content"];
+    static targets = ["content"];
 
     connect() {
         this.preventTurboLinksOnJumpLinks();
+        this.openExternalContentLinksInNewWindow();
     }
 
     preventTurboLinksOnJumpLinks() {
         const links = this.contentTarget.querySelectorAll('a');
+
         links.forEach((l) => {
             if (l.getAttribute('href')?.startsWith('#')) {
                 l.dataset.turbolinks = "false"
             }
         });
     }
-        
+
+    openExternalContentLinksInNewWindow() {
+        const links = this.contentTarget.querySelectorAll('.content a');
+
+        links.forEach((l) => {
+            if (l.getAttribute('href')?.startsWith('http')) {
+              l.setAttribute('target', '_blank');
+            }
+        });
+    }
 }

--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -97,9 +97,18 @@
                 color: $black;
                 text-decoration: none;
             }
-        }
-        
 
+            // any content hyperlink that contains two slashes is
+            // deemed 'external' and will get a icon
+            &[href*="//"] {
+                &::after {
+                    content: url('../images/icon-external.svg');
+                    margin-left: 0.2em;
+                    display: inline-block;
+                    background-repeat: no-repeat;
+                }
+            }
+        }
 
         a.content-link-secondary {
             @include font;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
   get "/life-as-a-teacher/my-story-into-teaching/*story/", to: "stories#index"
 
   get "/guidance/*page", to: "guidance#show"
+  get "/steps-to-become-a-teacher", to: "steps_to_become_a_teacher#show"
 
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
     redirect_rules.each { |from, to| get from, to: redirect(to) }

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "content pages check", type: :feature do
 
   class << self
     def files
-      Dir["app/views/content/**/*.md"]
+      Dir["app/views/content/**/[^_]*.md"]
     end
 
     def remove_folders(filename)

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -63,6 +63,11 @@ describe('LinkController', () => {
         expect(contentExternalLink.hasAttribute('target')).toBe(true);
       })
 
+      it("adds a description of where the link will open for screen reader users", () => {
+        const hiddenText = document.querySelector('a#content-external-link > span');
+        expect(hiddenText.textContent).toEqual("(Link opens in new window)");
+      })
+
       it("doesn't add target='_blank' to any other links", () => {
         const linkNodes = [...document.getElementsByTagName('a')];
 

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -1,40 +1,77 @@
-const Cookies = require('js-cookie') ;
-import CookiePreferences from 'cookie_preferences' ;
 import { Application } from 'stimulus' ;
 import LinkController from 'link_controller.js' ;
 
 describe('LinkController', () => {
-  function initPageTemplate() {
-    document.body.innerHTML = `
-    <div data-controller="link" data-target="link.content">
-      <div id="level-1" class="video-overlay" data-target="video.player" data-action="click->video#close">
-        <a href="#level-3" />
-        <div id="level-2">
-          <a href="#level-1" />
-          <div id="level-3">
+  describe ("disabling turbolinks for links to anchors", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="link" data-target="link.content">
+        <div id="level-1" class="video-overlay" data-target="video.player" data-action="click->video#close">
+          <a href="#level-3" />
+          <div id="level-2">
             <a href="#level-1" />
+            <div id="level-3">
+              <a href="#level-1" />
+            </div>
           </div>
         </div>
-      </div>
-    </div>`
-  }
+      </div>`
+    });
+
+    beforeEach(() => {
+      const application = Application.start();
+      application.register('link', LinkController);
+    })
 
     describe("when first loaded", () => {
-      
       it("adds data-turbolinks attribute to all jump links", () => {
-        var linkNodes = document.getElementsByTagName("a");
-        Object.keys(linkNodes).forEach(function (key) {
-            expect(linkNodes[key].hasAttribute('data-turbolinks')).toBe(true);
-        });
+        const linkNodes = [...document.getElementsByTagName('a')];
+
+        linkNodes.forEach((link) => { expect(link.hasAttribute('data-turbolinks')).toBe(true) });
       });
 
       it("sets data-turbolinks attribute to value of false", () => {
-        var linkNodes = document.getElementsByTagName("a");
-        Object.keys(linkNodes).forEach(function (key) {
-            expect(linkNodes[key][data-turbolinks]).toBe(false);
-        });
-      })
+        const linkNodes = [...document.getElementsByTagName('a')];
 
+        linkNodes.forEach((link) => { expect(link.getAttribute('data-turbolinks')).toEqual('false') });
+      })
+    });
+  });
+
+  describe ("making external links open in new windows", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="link" data-target="link.content">
+        <div class="content">
+          <a id="content-external-link" href="https://www.sample.com/content-link">Content external link</a>
+          <a id="content-internal-link" href="/internal-link">Content internal link</a>
+          <a id="content-anchor-link" href="#subheading">Content anchor link</a>
+        </div>
+        <a href="https://www.sample.com/non-content-link">Non-content link</a>
+        <a href="https://www.sample.com/another-non-content-link">Another non-content link</a>
+      </div>`
     });
 
+    beforeEach(() => {
+      const application = Application.start();
+      application.register('link', LinkController);
+    })
+
+    describe("when loaded", () => {
+      it("adds target='_blank' to the content external link", () => {
+        const contentExternalLink = document.getElementById('content-external-link');
+        expect(contentExternalLink.hasAttribute('target')).toBe(true);
+      })
+
+      it("doesn't add target='_blank' to any other links", () => {
+        const linkNodes = [...document.getElementsByTagName('a')];
+
+        linkNodes
+          .filter(link => !link.href.startsWith("http"))
+          .forEach((link) => {
+            expect(link.hasAttribute('target')).toBe(false);
+          });
+      })
+    });
+  })
 });

--- a/spec/requests/steps_to_become_a_teacher_spec.rb
+++ b/spec/requests/steps_to_become_a_teacher_spec.rb
@@ -6,6 +6,7 @@ describe StepsToBecomeATeacherController do
 
     subject do
       get "/steps-to-become-a-teacher"
+
       response
     end
 

--- a/spec/requests/steps_to_become_a_teacher_spec.rb
+++ b/spec/requests/steps_to_become_a_teacher_spec.rb
@@ -4,6 +4,11 @@ describe StepsToBecomeATeacherController do
   describe "#show" do
     let(:template) { "testing/markdown_test" }
 
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:steps_to_become_a_teacher_template).and_return template
+    end
+
     subject do
       get "/steps-to-become-a-teacher"
 
@@ -12,10 +17,6 @@ describe StepsToBecomeATeacherController do
 
     context "viewing steps-to-become-a-teacher" do
       it { is_expected.to have_http_status :success }
-
-      it "should be the correct template" do
-        expect(subject.body).to match("Steps to become a teacher")
-      end
     end
   end
 end

--- a/spec/requests/steps_to_become_a_teacher_spec.rb
+++ b/spec/requests/steps_to_become_a_teacher_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe StepsToBecomeATeacherController do
+  describe "#show" do
+    let(:template) { "testing/markdown_test" }
+
+    subject do
+      get "/steps-to-become-a-teacher"
+      response
+    end
+
+    context "viewing steps-to-become-a-teacher" do
+      it { is_expected.to have_http_status :success }
+
+      it "should be the correct template" do
+        expect(subject.body).to match("Steps to become a teacher")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the companion PR for DFE-Digital/get-into-teaching-content/pull/134. The changes here allow more rendering responsibility to be taken on by the app by expanding the frontmatter.

* [x] Tests
* [x] Add styling for external links
* [x] Add `target="_blank"` behaviour to the external links. This will have to happen via JS I think. More investigation needed. This should also be taken as an opportunity to add the "link opens in new window" assistive text