### PR TITLE
Display no results message per category

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,8 +54,8 @@ private
 
   def search_events
     @events_by_type = @event_search.query_events
-    @group_presenter = Events::GroupPresenter.new(@events_by_type)
     @display_empty_types = @event_search.type.nil?
+    @group_presenter = Events::GroupPresenter.new(@events_by_type, @display_empty_types)
   end
 
   def load_event_search

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -55,6 +55,7 @@ private
   def search_events
     @events_by_type = @event_search.query_events
     @group_presenter = Events::GroupPresenter.new(@events_by_type)
+    @display_empty_types = @event_search.type.nil?
   end
 
   def load_event_search

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -1,8 +1,10 @@
 module Events
   class GroupPresenter
-    attr_accessor :events_by_type
+    attr_accessor :events_by_type, :display_empty_types
+    alias_method :display_empty_types?, :display_empty_types
 
-    def initialize(events_by_type)
+    def initialize(events_by_type, display_empty_types = false)
+      @display_empty_types = display_empty_types
       @events_by_type = events_by_type
         .transform_keys { |k| k.to_s.to_i }
         .transform_values { |v| v.sort_by { |e| [event_type_name(e.type_id), e.start_at] } }
@@ -16,6 +18,14 @@ module Events
     def school_and_university_events
       empty_types = { school_and_university_type_id => [] }
       @school_and_university_events ||= empty_types.merge!(events_by_type.slice(school_and_university_type_id))
+    end
+
+    def display_get_into_teaching_events?
+      get_into_teaching_events.values.flatten.any? || @display_empty_types
+    end
+
+    def display_school_and_university_events?
+      school_and_university_events.values.flatten.any? || @display_empty_types
     end
 
   private

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -9,11 +9,13 @@ module Events
     end
 
     def get_into_teaching_events
-      @get_into_teaching_events ||= events_by_type.slice(*get_into_teaching_type_ids)
+      empty_types = get_into_teaching_type_ids.product([[]]).to_h
+      @get_into_teaching_events ||= empty_types.merge!(events_by_type.slice(*get_into_teaching_type_ids))
     end
 
     def school_and_university_events
-      @school_and_university_events ||= events_by_type.slice(school_and_university_type_id)
+      empty_types = { school_and_university_type_id => [] }
+      @school_and_university_events ||= empty_types.merge!(events_by_type.slice(school_and_university_type_id))
     end
 
   private

--- a/app/views/events/_event_category.html.erb
+++ b/app/views/events/_event_category.html.erb
@@ -4,6 +4,8 @@
   </div>
 
   <% category_groups.each do |type_id, events| %>
-    <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
+    <% if events.any? || display_empty_types %>
+      <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
+    <% end %>
   <% end %>
 </section>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,19 +1,27 @@
+<% plural_category_name = pluralised_category_name(type_id) %>
+
 <div class="events-featured">
-  <h3><%= pluralised_category_name(type_id) %></h3>
+  <h3><%= plural_category_name %></h3>
 
   <div class="events-featured__text">
     <p><%= safe_html_format(t("find_an_event.types.#{type_id}")) %></p>
   </div>
 
-  <div class="events-featured__list">
-    <%= render partial: "event", collection: events %>
-  </div>
+  <% if events.any? %>
+    <div class="events-featured__list">
+      <%= render partial: "event", collection: events %>
+    </div>
+  <% else %>
+    <div class="search-for-events-no-results search-for-events-no-results--by-type">
+      Sorry your search has not found any events of this type, try a different location or month.
+    </div>
+  <% end %>
 
   <% show_see_all_events ||= false %>
 
   <% if show_see_all_events %>
-    <%= link_to(event_category_events_path(pluralised_category_name(type_id).parameterize)) do %>
-      <div class="call-to-action-button">See all <%= pluralised_category_name(type_id) %> <i class="fas fa-chevron-right"></i></div>
+    <%= link_to(event_category_events_path(plural_category_name.parameterize)) do %>
+      <div class="call-to-action-button">See all <%= plural_category_name %> <i class="fas fa-chevron-right"></i></div>
     <% end %>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,18 +30,26 @@
     </section>
 
     <% if @events_by_type.any? %>
-      <% if @group_presenter.get_into_teaching_events.any? %>
-        <%= render partial: "event_category", locals: { organised_by: t("event_groups.get_into_teaching"), category_groups: @group_presenter.get_into_teaching_events } %>
+      <% if @group_presenter.get_into_teaching_events.values.flatten.any? || @display_empty_types %>
+        <%= render partial: "event_category", locals: { 
+          organised_by: t("event_groups.get_into_teaching"), 
+          category_groups: @group_presenter.get_into_teaching_events,
+          display_empty_types: @display_empty_types,
+        } %>
       <% end %>
 
-      <% if @group_presenter.school_and_university_events.any? %>
-        <%= render partial: "event_category", locals: { organised_by:  t("event_groups.222750009"), category_groups: @group_presenter.school_and_university_events } %>
+      <% if @group_presenter.school_and_university_events.values.flatten.any?  || @display_empty_types %>
+        <%= render partial: "event_category", locals: { 
+          organised_by:  t("event_groups.222750009"), 
+          category_groups: @group_presenter.school_and_university_events,
+          display_empty_types: @display_empty_types,
+        } %>
       <% end %>
     <% else %>
       <section class="content container-1000">
         <div class="content__left">
           <div class="search-for-events-no-results">
-            There are no events that match your search criteria. Try widening your search and updating your results.
+            Sorry your search has not found any events, try a different type, location or month.
           </div>
         </div>
       </section>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,19 +30,19 @@
     </section>
 
     <% if @events_by_type.any? %>
-      <% if @group_presenter.get_into_teaching_events.values.flatten.any? || @display_empty_types %>
+      <% if @group_presenter.display_get_into_teaching_events? %>
         <%= render partial: "event_category", locals: { 
           organised_by: t("event_groups.get_into_teaching"), 
           category_groups: @group_presenter.get_into_teaching_events,
-          display_empty_types: @display_empty_types,
+          display_empty_types: @group_presenter.display_empty_types?,
         } %>
       <% end %>
 
-      <% if @group_presenter.school_and_university_events.values.flatten.any?  || @display_empty_types %>
+      <% if @group_presenter.display_school_and_university_events? %>
         <%= render partial: "event_category", locals: { 
           organised_by:  t("event_groups.222750009"), 
           category_groups: @group_presenter.school_and_university_events,
-          display_empty_types: @display_empty_types,
+          display_empty_types: @group_presenter.display_empty_types?,
         } %>
       <% end %>
     <% else %>

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -178,10 +178,20 @@
   padding: 20px;
   font-weight: bold;
   margin-bottom: 80px;
+
+  &--by-type {
+    box-sizing: border-box;
+    margin: 0 0 30px 0;
+    width: 66.6%;
+  }
 }
 
 @media only screen and (max-width: 800px) {
     
+    .search-for-events-no-results--by-type {
+      width: 100%;
+    }
+
     .types-of-event {
         padding-top: 20px;
 

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -6,8 +6,9 @@ describe Events::GroupPresenter do
   let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
   let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
   let(:events_by_type) { all_events.group_by { |event| event.type_id.to_s.to_sym } }
+  let(:display_empty_types) { false }
 
-  subject { Events::GroupPresenter.new(events_by_type) }
+  subject { Events::GroupPresenter.new(events_by_type, display_empty_types) }
 
   describe "#get_into_teaching_events" do
     context "train to teach events" do
@@ -35,13 +36,51 @@ describe Events::GroupPresenter do
     end
 
     context "when there are no events" do
-      let(:application_workshops) { [] }
       let(:train_to_teach_events) { [] }
       let(:online_events) { [] }
 
       specify "contains a key for each event type mapping to an empty array" do
         keys = GetIntoTeachingApiClient::Constants::GET_INTO_TEACHING_EVENT_TYPES.values
         expect(subject.get_into_teaching_events).to eq(keys.product([[]]).to_h)
+      end
+    end
+  end
+
+  describe "#display_empty_types?" do
+    it "defaults to false" do
+      expect(Events::GroupPresenter.new({})).to_not be_display_empty_types
+    end
+  end
+
+  describe "#display_get_into_teaching_events?" do
+    it { expect(subject).to be_display_get_into_teaching_events }
+
+    context "when there are no get into teaching events" do
+      let(:train_to_teach_events) { [] }
+      let(:online_events) { [] }
+
+      it { expect(subject).to_not be_display_get_into_teaching_events }
+
+      context "when display_empty_types is true" do
+        let(:display_empty_types) { true }
+
+        it { expect(subject).to be_display_get_into_teaching_events }
+      end
+    end
+  end
+
+  describe "#display_school_and_university_events?" do
+    it { expect(subject).to be_display_school_and_university_events }
+
+    context "when there are no get into teaching events" do
+      let(:school_and_university_events) { [] }
+
+      it { expect(subject).to_not be_display_school_and_university_events }
+
+      context "when display_empty_types is true" do
+        let(:display_empty_types) { true }
+
+        it { expect(subject).to be_display_school_and_university_events }
       end
     end
   end

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -33,6 +33,17 @@ describe Events::GroupPresenter do
         expect(actual_events & school_and_university_events).to be_empty
       end
     end
+
+    context "when there are no events" do
+      let(:application_workshops) { [] }
+      let(:train_to_teach_events) { [] }
+      let(:online_events) { [] }
+
+      specify "contains a key for each event type mapping to an empty array" do
+        keys = GetIntoTeachingApiClient::Constants::GET_INTO_TEACHING_EVENT_TYPES.values
+        expect(subject.get_into_teaching_events).to eq(keys.product([[]]).to_h)
+      end
+    end
   end
 
   describe "#school_and_university_events" do
@@ -52,6 +63,16 @@ describe Events::GroupPresenter do
 
       specify "are absent" do
         expect(actual_events & get_into_teaching_events).to be_empty
+      end
+    end
+
+    context "when there are no events" do
+      let(:school_and_university_events) { [] }
+
+      specify "contains a key for schools or university events mapping to an empty array" do
+        expect(subject.school_and_university_events).to eq({
+          GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] => [],
+        })
       end
     end
   end

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 describe "Find an event near you" do
   include_context "stub types api"
 
-  NO_EVENTS_REGEX = /no events that match your search criteria/.freeze
+  NO_EVENTS_REGEX = /Sorry your search has not found any events/.freeze
 
+  let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
     5.times.collect do |index|
       start_at = Time.zone.today.at_end_of_month - index.days
-      build(:event_api, name: "Event #{index + 1}", start_at: start_at)
+      type_id = types[index % types.count]
+      build(:event_api, name: "Event #{index + 1}", start_at: start_at, type_id: type_id)
     end
   end
   let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
@@ -29,16 +31,17 @@ describe "Find an event near you" do
       expect(response.body.scan(/Event [1-5]/).count).to eq(5)
     end
 
-    it "presents the events in date order" do
+    it "presents the events in date order, per category" do
       headings = response.body.scan(/<h4>(.*)<\/h4>/).flatten.take(events.count)
-      expect(headings).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])
+      expect(headings).to eq(["Event 4", "Event 1", "Event 5", "Event 2", "Event 3"])
     end
 
     context "when there are no results" do
       let(:events) { [] }
 
-      it "displays the no results message" do
-        expect(response.body).to match(NO_EVENTS_REGEX)
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
       end
     end
 
@@ -64,6 +67,7 @@ describe "Find an event near you" do
 
   context "when searching for an event by type" do
     let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    let(:events) { [build(:event_api, type_id: type_id)] }
 
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -72,7 +76,37 @@ describe "Find an event near you" do
 
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
-    it "displays all events of that type" do
+    it "displays only the category filtered to" do
+      headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+      expected_headings = ["Train to Teach Events"]
+
+      expect(headings).to eq(expected_headings)
+    end
+
+    context "when there are no results" do
+      let(:events) { [] }
+
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
+      end
+
+      it "does not display any categories" do
+        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        expect(headings).to be_empty
+      end
+    end
+  end
+
+  context "when searching for an event" do
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+    end
+
+    before { get search_events_path(events_search: { month: "2020-07" }) }
+
+    it "displays events" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)
     end
 
@@ -88,8 +122,21 @@ describe "Find an event near you" do
     context "when there are no results" do
       let(:events) { [] }
 
-      it "displays the no results message" do
-        expect(response.body).to match(NO_EVENTS_REGEX)
+      it "displays a single no results message" do
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(no_results_messages.count).to eq(1)
+      end
+    end
+
+    context "when there are results for a subset of categories" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+      let(:events) { [build(:event_api, type_id: type_id)] }
+
+      it "displays the no results message per category" do
+        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        expect(headings.count).to eq(Events::Search.available_event_types.count)
+        expect(headings.count - 1).to eq(no_results_messages.count)
       end
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-426](https://trello.com/c/NRodnqt4/426-events-for-virtual-ttt-events-add-text-that-says-there-are-no-events-of-this-type-for-this-month-try-another-month)

### Context

Currently, if there are no results we display a single 'no results' message to the user. We want to change this behaviour such that;

- If a user searches across all types and there are no results for some of the types, we still want to display the type sections but have a 'no results' message in each section that has no events.
- If a user searches across all types and there are no results in any of the types, the existing behaviour remains (single 'no results' message).
- If the user searches by a specific type, the existing behaviour remains (single 'no results' message).
- If there are no results on the landing page for a specific type, we want to hide the section completely (retaining the existing behaviour).

### Changes proposed in this pull request

- Display no results message per category

### Guidance to review

<img width="1023" alt="Screenshot 2020-11-06 at 15 48 15" src="https://user-images.githubusercontent.com/29867726/98385945-815c2a80-2047-11eb-9f57-b1803a8c8331.png">
