### PR TITLE
Extract window.focus to method and mock

### DIFF
--- a/app/webpacker/controllers/video_controller.js
+++ b/app/webpacker/controllers/video_controller.js
@@ -38,11 +38,10 @@ export default class extends Controller {
         for(var link of this.linkTargets) {
             link.removeAttribute('target');
         }
-        var myFrame = this.iframeTarget;
         
-        this.closeTarget.addEventListener('blur', function (e) {
+        this.closeTarget.addEventListener('blur', (e) => {
             e.preventDefault();
-            myFrame.contentWindow.focus();
+            this.focusIframeWindow();
         });
     }
 
@@ -54,12 +53,16 @@ export default class extends Controller {
         var link = event.target.closest('a');
         this.iframeTarget.src = link.href.replace('https://www.youtube.com/watch?v=','https://www.youtube.com/embed/');
         this.playerTarget.style.display = "flex";
-        this.iframeTarget.contentWindow.focus();
+        this.focusIframeWindow();
     }
 
     close() {
         this.linkTarget.focus();
         this.playerTarget.style.display = "none";
         this.iframeTarget.src = this.iframeTarget.src;
+    }
+
+    focusIframeWindow() {
+      this.iFrameTarget.contentWindow.focus();
     }
 }

--- a/spec/javascript/controllers/video_controller_spec.js
+++ b/spec/javascript/controllers/video_controller_spec.js
@@ -4,6 +4,8 @@ import { Application } from 'stimulus' ;
 import VideoController from 'video_controller.js' ;
 
 describe('AccordionController', () => {
+  const iframeFocusMock = jest.fn();
+
   function initPageTemplate() {
     document.body.innerHTML = `
     <div data-controller="video">
@@ -45,6 +47,11 @@ describe('AccordionController', () => {
     Cookies.set("git-cookie-preferences-v1", data) ;
   }
 
+  function mockIframeFocus() {
+    iframeFocusMock.mockClear();
+    VideoController.prototype.focusIframeWindow = iframeFocusMock;
+  }
+
   function acceptCookies() {
     (new CookiePreferences).allowAll() ;
   }
@@ -56,6 +63,7 @@ describe('AccordionController', () => {
   }
 
   beforeEach(() => {
+    mockIframeFocus() ;
     Cookies.remove("git-cookie-preferences-v1") ;
   }) ;
 
@@ -93,6 +101,10 @@ describe('AccordionController', () => {
         const videoplayer = document.getElementById('the-video-player');
         expect(videoplayer.style.display).toBe('flex');
       });
+
+      it("focuses on the video player iframe", () => {
+        expect(iframeFocusMock).toHaveBeenCalled();
+      })
     });
 
     describe("when the dismiss button is clicked", () => {


### PR DESCRIPTION
We aren't able to mock the iFrame `contentWindow.focus` from Jest; instead, the call gets extracted to a method which can then be mocked from the specs.

Quietens the 'method not implemented' error Jest was throwing in the test suite.
