### PR TITLE
Make internal_referer return path rather than URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,9 +88,9 @@ module ApplicationHelper
 
   def internal_referer
     referer = request.referer
-    internal = referer.to_s.include?(root_url)
-    return nil unless internal
 
-    referer
+    return unless referer.present? && referer.start_with?(root_url)
+
+    referer.gsub(root_url, root_path)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -120,7 +120,7 @@ describe ApplicationHelper do
     it "returns the referrer if internal" do
       referer = root_url
       helper.request.stub(:referer) { referer }
-      expect(helper.internal_referer).to be(referer)
+      expect(helper.internal_referer).to eql(helper.root_path)
     end
   end
 


### PR DESCRIPTION
As we're targetting external links by whether they contain a `//` in the CSS, some 'Back' links were picking up the styling due to the `#internal_referer` method returning the full referer URL rather than just the path.

This change replaces the full referer URL with just the path for internal links only.
