### PR TITLE
Remove repeated external link icon

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,7 +17,7 @@
                   title="Submit your event details on GOV.UK"   
                   target="_blank"
                   rel="noopener norefferer">
-                fill in our online form<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i>
+                fill in our online form
               </a>
             </p>
         </div>


### PR DESCRIPTION
Minor bug fix, the icon was repeated due to it being hardcoded _and_ added via CSS.

### Before

![Screenshot from 2020-11-10 14-10-41](https://user-images.githubusercontent.com/128088/98684865-96460000-235e-11eb-8141-02228747379a.png)

### After

![Screenshot from 2020-11-10 14-10-48](https://user-images.githubusercontent.com/128088/98684875-99d98700-235e-11eb-95c6-5b0d62e6c2f9.png)

