### PR TITLE
Align postcodes validation with api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,6 @@ gem "faraday-encoding"
 gem "faraday-http-cache"
 gem "faraday_middleware"
 
-gem "uk_postcode"
-
 gem "dotenv-rails"
 
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,6 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
-    uk_postcode (2.1.6)
     unicode-display_width (1.7.0)
     view_component (2.19.1)
       activesupport (>= 5.0.0, < 7.0)
@@ -392,7 +391,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  uk_postcode
   view_component
   web-console (>= 3.3.0)
   webdrivers (~> 4.4)

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -24,7 +24,7 @@ module Events
     before_validation(unless: :distance) { self.postcode = nil }
 
     before_validation if: :postcode do
-      self.postcode = UKPostcode.parse(postcode).to_s
+      self.postcode = postcode.to_s.strip.upcase.presence
     end
 
     class << self

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -23,6 +23,10 @@ module Events
     before_validation { self.distance = nil if distance.blank? }
     before_validation(unless: :distance) { self.postcode = nil }
 
+    before_validation if: :postcode do
+      self.postcode = UKPostcode.parse(postcode).to_s
+    end
+
     class << self
       def available_event_types
         @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -12,7 +12,7 @@ module Events
       validates :preferred_teaching_subject_id, inclusion: { in: :teaching_subject_option_ids }
 
       before_validation if: :address_postcode do
-        self.address_postcode = UKPostcode.parse(address_postcode).to_s.presence
+        self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
 
       def skipped?

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -12,7 +12,7 @@ module Events
       validates :preferred_teaching_subject_id, inclusion: { in: :teaching_subject_option_ids }
 
       before_validation if: :address_postcode do
-        self.address_postcode = address_postcode.to_s.strip.presence
+        self.address_postcode = UKPostcode.parse(address_postcode).to_s.presence
       end
 
       def skipped?

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -5,7 +5,7 @@ module MailingList
       validates :address_postcode, postcode: true
 
       before_validation if: :address_postcode do
-        self.address_postcode = UKPostcode.parse(address_postcode).to_s.presence
+        self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
     end
   end

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -5,7 +5,7 @@ module MailingList
       validates :address_postcode, postcode: true
 
       before_validation if: :address_postcode do
-        self.address_postcode = address_postcode.to_s.strip.presence
+        self.address_postcode = UKPostcode.parse(address_postcode).to_s.presence
       end
     end
   end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,4 +1,6 @@
 class PostcodeValidator < ActiveModel::EachValidator
+  PATTERN = %r{\A([A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})\Z}.freeze
+
   def validate_each(record, attribute, value)
     if value.present? && invalid_postcode?(value)
       record.errors.add(attribute, :invalid)
@@ -8,6 +10,6 @@ class PostcodeValidator < ActiveModel::EachValidator
 private
 
   def invalid_postcode?(postcode)
-    !UKPostcode.parse(postcode).full_valid?
+    !PATTERN.match?(postcode)
   end
 end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -63,6 +63,8 @@ describe Events::Search do
       end
 
       context "with assigned distance" do
+        let(:msg) { "Enter a valid postcode" }
+
         subject do
           described_class.new distance: described_class::DISTANCES.first
         end
@@ -71,7 +73,7 @@ describe Events::Search do
         it { is_expected.not_to allow_value(nil).for :postcode }
         it { is_expected.not_to allow_value("random").for :postcode }
         it { is_expected.to allow_value("MA1 2WD").for :postcode }
-        it { is_expected.not_to allow_value("TE57 ING").for :postcode }
+        it { is_expected.not_to allow_value("TE57 ING").for(:postcode).with_message(msg) }
       end
     end
 

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -71,6 +71,7 @@ describe Events::Search do
         it { is_expected.not_to allow_value(nil).for :postcode }
         it { is_expected.not_to allow_value("random").for :postcode }
         it { is_expected.to allow_value("MA1 2WD").for :postcode }
+        it { is_expected.not_to allow_value("TE57 ING").for :postcode }
       end
     end
 
@@ -113,7 +114,7 @@ describe Events::Search do
       end
 
       context "when there's whitespace around a provided postcode" do
-        subject { build(:events_search, postcode: " te571ng  ").tap(&:validate) }
+        subject { build(:events_search, postcode: " te57 1ng  ").tap(&:validate) }
 
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -113,11 +113,11 @@ describe Events::Search do
       end
 
       context "when there's whitespace around a provided postcode" do
-        subject { build(:events_search, postcode: " TE57 1NG  ") }
+        subject { build(:events_search, postcode: " te571ng  ").tap(&:validate) }
 
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-            receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: subject.postcode.strip))
+            receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
         end
       end
     end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -38,7 +38,7 @@ describe Events::Steps::PersonalisedUpdates do
 
   context "data cleaning" do
     it "cleans the postcode" do
-      subject.address_postcode = "  TE571NG "
+      subject.address_postcode = "  TE57 1NG "
       subject.valid?
       expect(subject.address_postcode).to eq("TE57 1NG")
       subject.address_postcode = "  "

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -14,11 +14,13 @@ describe Events::Steps::PersonalisedUpdates do
   end
 
   context "validations" do
+    let(:msg) { "Enter a valid postcode, or leave blank" }
+
     it { is_expected.to allow_value("TE571NG").for :address_postcode }
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
     it { is_expected.to allow_value(" TE57 1NG ").for :address_postcode }
     it { is_expected.to allow_value("").for :address_postcode }
-    it { is_expected.not_to allow_value("unknown").for :address_postcode }
+    it { is_expected.not_to allow_value("unknown").for(:address_postcode).with_message(msg) }
 
     it { is_expected.to allow_value(subject.degree_status_option_ids.first).for :degree_status_id }
     it { is_expected.to allow_value(subject.degree_status_option_ids.last).for :degree_status_id }

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -38,7 +38,7 @@ describe Events::Steps::PersonalisedUpdates do
 
   context "data cleaning" do
     it "cleans the postcode" do
-      subject.address_postcode = "  TE57 1NG "
+      subject.address_postcode = "  TE571NG "
       subject.valid?
       expect(subject.address_postcode).to eq("TE57 1NG")
       subject.address_postcode = "  "

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -4,6 +4,8 @@ describe MailingList::Steps::Postcode do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
+  let(:msg) { "Enter a valid postcode" }
+
   it { is_expected.to respond_to :address_postcode }
 
   context "address_postcode" do
@@ -11,8 +13,8 @@ describe MailingList::Steps::Postcode do
     it { is_expected.to allow_value("  TE571NG  ").for :address_postcode }
     it { is_expected.to allow_value(nil).for :address_postcode }
     it { is_expected.to allow_value("").for :address_postcode }
-    it { is_expected.not_to allow_value("random").for :address_postcode }
-    it { is_expected.not_to allow_value("TE57 ING").for :address_postcode }
+    it { is_expected.not_to allow_value("random").for(:address_postcode).with_message(msg) }
+    it { is_expected.not_to allow_value("TE57 ING").for(:address_postcode).with_message(msg) }
   end
 
   context "data cleaning" do

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -15,8 +15,8 @@ describe MailingList::Steps::Postcode do
   end
 
   context "data cleaning" do
-    it "cleans the postcode" do
-      subject.address_postcode = "  TE57 1NG "
+    it "normalises the postcode" do
+      subject.address_postcode = "  TE57ING "
       subject.valid?
       expect(subject.address_postcode).to eq("TE57 1NG")
       subject.address_postcode = "  "

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -12,11 +12,12 @@ describe MailingList::Steps::Postcode do
     it { is_expected.to allow_value(nil).for :address_postcode }
     it { is_expected.to allow_value("").for :address_postcode }
     it { is_expected.not_to allow_value("random").for :address_postcode }
+    it { is_expected.not_to allow_value("TE57 ING").for :address_postcode }
   end
 
   context "data cleaning" do
     it "normalises the postcode" do
-      subject.address_postcode = "  TE57ING "
+      subject.address_postcode = "  te57 1ng "
       subject.valid?
       expect(subject.address_postcode).to eq("TE57 1NG")
       subject.address_postcode = "  "

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -58,7 +58,7 @@ describe "View events by category" do
   end
 
   context "filtering the results" do
-    let(:postcode) { "TE57 ING" }
+    let(:postcode) { "TE57 1NG" }
     let(:radius) { 30 }
     let(:filter) { { postcode: postcode, quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
 

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -60,7 +60,7 @@ describe "View events by category" do
   context "filtering the results" do
     let(:postcode) { "TE57 1NG" }
     let(:radius) { 30 }
-    let(:filter) { { postcode: postcode, quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
+    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -10,14 +10,14 @@ describe PostcodeValidator do
   before { instance.valid? }
   subject { instance.errors.to_h }
 
-  ["MA1 1AM", "F00BAR", "M1", "123ABC"].each do |postcode|
+  ["F00BAR", "M1", "123ABC", "TE57 ING"].each do |postcode|
     context "checking '#{postcode}'" do
       let(:instance) { TestModel.new(postcode: postcode) }
       it { is_expected.to include postcode: "is invalid" }
     end
   end
 
-  ["M1 2WD", "TE57 1NG", "", "PE7 IXR"].each do |postcode|
+  ["M1 2WD", "TE57 1NG", ""].each do |postcode|
     context "checking '#{postcode}'" do
       let(:instance) { TestModel.new(postcode: postcode) }
       it { is_expected.not_to include :postcode }

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -17,7 +17,7 @@ describe PostcodeValidator do
     end
   end
 
-  ["M1 2WD", "TE57 1NG", ""].each do |postcode|
+  ["M1 2WD", "TE57 1NG", "", "PE7 IXR"].each do |postcode|
     context "checking '#{postcode}'" do
       let(:instance) { TestModel.new(postcode: postcode) }
       it { is_expected.not_to include :postcode }


### PR DESCRIPTION
### Trello card

https://trello.com/c/32JmO988

### Context

The API implements different validation rules to the App. The app also allows through postcodes which can be auto-corrected (eg `TE57 ING` -> `TE57 1NG`) but doesn't actually auto-correct it - which means the API still receives the un-autocorrected version.

### Changes proposed in this pull request

1. Replace `UKPostcode` gem with Regex from the API
2. Added validation for the error messages
3. Upcase postcodes as part of the normalisation

