### PR TITLE
Fix for multiple acronyms in a single node

### DIFF
--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -22,14 +22,14 @@ private
 
       replacements = 0
       replacement = node.content.gsub(ABBR_REGEXP) do |acronym|
-        matched = acronym_for(acronym)
-        next unless matched
+        expanded = acronym_for(acronym)
+        next acronym unless expanded
 
         replacements += 1
-        matched
+        expanded
       end
 
-      node.replace(replacement) unless replacements.zero?
+      node.replace(replacement) if replacements.positive?
     end
   end
 

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -19,4 +19,15 @@ describe Acronyms, type: :helper do
     let(:content) { "<p>Payments are deducted as part of PAYE</p>" }
     it { is_expected.to have_css "p", text: "Payments are deducted as part of PAYE" }
   end
+
+  context "with nil acronyms" do
+    let(:acronyms) { nil }
+    it { is_expected.to have_css "p", text: "All prices include VAT except where marked exVAT" }
+  end
+
+  context "with multiple acronyms in the same node" do
+    let(:content) { "Taxes you may encounter include VAT and PAYE" }
+    it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
+    fit { is_expected.to match "and PAYE" }
+  end
 end


### PR DESCRIPTION
The replacement logic uses a gsub loop to find the replacements for each
acronym. When there was not a replacement it exited the loop early, but the
output from the loop was being used to update the string.

The early exit from the loop was returning nil, so replacing the unknown acronym
with a nil instead of leaving it as is.

