### PR TITLE
Simplify the accordion controller

### DIFF
--- a/app/views/layouts/steps_to_become_a_teacher.html.erb
+++ b/app/views/layouts/steps_to_become_a_teacher.html.erb
@@ -26,13 +26,15 @@
                   <div class="accordions" data-controller="accordion">
                     <% if @front_matter["steps"].present? %>
                       <% @front_matter["steps"].each.with_index(1) do |(title, partial), i| %>
-                        <%= tag.button(class: "steps-header", id: "step-#{i}", data: { action: "click->accordion#toggle", target: "accordion.header" }, aria: { controls: "collapsable-content-#{i}", expanded: (i == 1) }) do %>
-                          <%= tag.h2(%(#{i}. #{title}), class: "steps-header__text") %>
-                          <div class="steps-header__chevron"> </div>
-                        <% end %>
+                        <%= tag.section(id: "step-#{i}", class: "step", data: { id: i }) do %>
+                          <%= tag.button(class: "step-header", data: { action: "click->accordion#toggle", target: "accordion.header" }, aria: { controls: "collapsable-content-#{i}"}) do %>
+                            <%= tag.h2(%(#{i}. #{title}), class: "step-header__text") %>
+                            <div class="step-header__chevron"> </div>
+                          <% end %>
 
-                        <%= tag.div(id: %(collapsable-content-#{i}), class: %w[steps-content collapsable], data: { target: "accordion.content" }, aria: { labelledby: %(step-#{i}) }) do %>
-                          <%= render(partial: partial) %>
+                          <%= tag.div(id: %(collapsable-content-#{i}), class: %w[step-content collapsable], data: { target: "accordion.content" }, aria: { labelledby: %(step-#{i}) }) do %>
+                            <%= render(partial: partial) %>
+                          <% end %>
                         <% end %>
                       <% end %>
                     <% end %>

--- a/app/webpacker/controllers/accordion_controller.js
+++ b/app/webpacker/controllers/accordion_controller.js
@@ -5,71 +5,61 @@ export default class extends Controller {
     static targets = ["header", "content"]
 
     connect() {
-        this.foldUp();
+        this.setup();
     }
 
     toggle(event) {
-        const header = event.target.closest('.steps-header');
-        var elementId = header.getAttribute('id')
-        var frags = elementId.split('-');
-        var last = frags[frags.length-1];
-        this.toggleCollapsable(last);
-}
+        this.toggleCollapsable(
+            event
+                .target
+                .closest('.step')
+                .getAttribute('data-id')
+        );
+    }
 
-    toggleCollapsable(item) {
+    toggleCollapsable(step) {
+        const stepElement = this.retrieveStepElement(step);
 
-        //toggle icon
-        var stepHeaderName = 'step-' + item;
-        var stepHeader = document.getElementById(stepHeaderName);
-        if (stepHeader) {
-            // stepHeader.classList.toggle('inactive');
-            if (stepHeader.classList.contains('inactive')) {
-                stepHeader.classList.remove('inactive');
-            } else {
-                stepHeader.classList.add('inactive');
-            }
-        }
-
-        //toggle content
-        var contentName = 'collapsable-content-' + item;
-        var content = document.getElementById(contentName);
-        if(content) {
-            if(content.style.display === 'block' || content.style.display === '') {
-                content.style.display = 'none';
-            } else {
-                content.style.display = 'block';
-            }
+        if (this.stepActive(stepElement)) {
+            this.deactivate(stepElement);
+        } else {
+            this.activate(stepElement);
         }
     }
 
-    foldUp() {
-        var stepnumber;
-        var dontScroll = false;
-        if(window.location.hash) {
-            stepnumber = window.location.hash.replace('#step-','');
-        }
-
-        if(!stepnumber) {
-            stepnumber = "1";
-            dontScroll = true;
-        }
-        
-        for(var i=1; i<= this.contentTargets.length; i+=1) {
-            var elementId = this.contentTargets[i-1].getAttribute('id');
-            if(stepnumber === i.toString()) continue;
-            if(elementId) {
-                var frags = elementId.split('-');
-                var last = frags[frags.length-1];
-                this.toggleCollapsable(last);
-            }
-        }
-
-        if(!dontScroll) {
-            let element = document.getElementById('step-' + stepnumber);
-            if(element) {
-                element.scrollIntoView(true,{smooth:true});
-            }
-        }
+    activate(stepElement) {
+        stepElement.classList.remove('inactive');
     }
 
+    deactivate(stepElement) {
+        stepElement.classList.add('inactive');
+    }
+
+    retrieveStepElement(step) {
+        return document.getElementById("step-" + step);
+    }
+
+    stepActive(step) {
+        return !step.classList.contains('inactive');
+    }
+
+    setup() {
+        // disable all the steps except the nominated one or the first
+        const stepMatcher = /step-([\d])/;
+        const stepFromHash = window.location.hash.match(stepMatcher);
+
+        let activeStep = "step-1";
+
+        if (stepFromHash) {
+            activeStep = stepFromHash[0];
+        }
+
+        document
+            .querySelectorAll(`.step:not(#${activeStep})`)
+            .forEach(step => this.deactivate(step));
+    }
+
+    allStepElements() {
+        return document.querySelectorAll('.step');
+    }
 }

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -37,3 +37,7 @@ body {
     white-space: nowrap;
     width: 1px;
 }
+
+.hidden {
+    display: none;
+}

--- a/app/webpacker/styles/links_and_buttons.scss
+++ b/app/webpacker/styles/links_and_buttons.scss
@@ -17,6 +17,7 @@
         color: #1D1D1B;
         background-color: $yellow;
         box-shadow: 0 -2px $yellow, 0 4px #1D1D1B;
+        z-index: 100;
     }
 }
 

--- a/app/webpacker/styles/steps-to-become-a-teacher/content.scss
+++ b/app/webpacker/styles/steps-to-become-a-teacher/content.scss
@@ -1,48 +1,68 @@
 .accordions {
-    display: flex;
-    flex-direction: column;
-
-    .steps-header {
-        @include button($bg: $pink, $fg: $white);
-
-        display: flex;
-        align-items: center;
-
-        &:not(:first-child) {
+    .step {
+        & + .step {
             margin-top: 1em;
         }
 
-        .steps-header__text {
-            text-align: left;
-            border: 0;
-            margin: 0;
-            font-size: 140%;
-            flex-grow: 2;
+        display: flex;
+        flex-direction: column;
 
-            @media only screen and (max-width: 800px) {
-                font-size: 100%;
+        .step-header {
+            @include button($bg: $pink, $fg: $white);
+
+            display: flex;
+            align-items: center;
+
+            .step-header__text {
+                text-align: left;
+                border: 0;
+                margin: 0;
+                font-size: 140%;
+                flex-grow: 2;
+
+                @media only screen and (max-width: 800px) {
+                    font-size: 100%;
+                }
             }
+
+            .step-header__chevron {
+                flex-shrink: 0;
+                margin-top: 5px;
+                @include chevron-icon($color: $white, $dimensions: .7em, $rotate: unquote(map-get($chevron-direction-map, 'up')));
+            }
+
+            &:focus {
+                .step-header__chevron {
+                    @include chevron-icon($color: $black, $dimensions: .7em, $rotate: unquote(map-get($chevron-direction-map, 'up')));
+                }
+            }
+
         }
 
-        .steps-header__chevron {
-            flex-shrink: 0;
-            margin-top: 5px;
-            @include chevron-icon($color: $white, $dimensions: .7em, $rotate: map-get($chevron-direction-map, 'up'));
+        .step-content {
+            background-color: $grey;
+            margin: 0;
+            padding: .8em;
+
         }
 
         &.inactive {
-            .steps-header__chevron {
-                margin-top: -5px;
-                @include chevron-icon($color: $white, $dimensions: .7em, $rotate: map-get($chevron-direction-map, 'down'));
+            .step-header {
+                .step-header__chevron {
+                    margin-top: 0px;
+                    @include chevron-icon($color: $white, $dimensions: .7em, $rotate: map-get($chevron-direction-map, 'down'));
+                }
+
+                &:focus {
+                    .step-header__chevron {
+                        @include chevron-icon($color: $black, $dimensions: .7em, $rotate: map-get($chevron-direction-map, 'down'));
+                    }
+                }
+            }
+
+            .step-content {
+                display: none;
             }
         }
     }
-
-    .steps-content {
-        background-color: $grey;
-        margin: 0 0 1em 0;
-        padding: .8em;
-
-    }
-
 }

--- a/spec/javascript/controllers/accordion_controller_spec.js
+++ b/spec/javascript/controllers/accordion_controller_spec.js
@@ -3,81 +3,67 @@ import AccordionController from 'accordion_controller.js' ;
 
 describe('AccordionController', () => {
 
-    document.body.innerHTML = 
-    `
+    document.body.innerHTML = `
     <div data-controller="accordion">
-        <div class="steps-header" id="step-1" data-action="click->accordion#toggle" data-target="accordion.header">
-            <h1>
-                <div class="steps-header__number"><span>1</span></div>
-                Header 1
-                <button><i id="collapsable-icon-1" class="fas fa-chevron-up"></i></button>
-            </h1>
-        </div>
-        <div id="collapsable-content-1" class="collapsable" data-target="accordion.content">
-            Content 1
-        </div>
-        <div class="steps-header" id="step-2" data-action="click->accordion#toggle" data-target="accordion.header">
-            <h1>
-                <div class="steps-header__number"><span>2</span></div>
-                Header 2
-                <button><i id="collapsable-icon-2" class="fas fa-chevron-up"></i></button>
-            </h1>
-        </div>
-        <div id="collapsable-content-2" class="collapsable" data-target="accordion.content">
-            Content 2
-        </div>
-        <div class="steps-header" id="step-3" data-action="click->accordion#toggle" data-target="accordion.header">
-            <h1>
-                <div class="steps-header__number"><span>2</span></div>
-                Header 3
-                <button><i id="collapsable-icon-3" class="fas fa-chevron-up"></i></button>
-            </h1>
-        </div>
-        <div id="collapsable-content-3" class="collapsable" data-target="accordion.content">
-            Content 3
-        </div>
-    </div>   
+        <section id="step-1" class="step" data-id="1">
+            <button id="button-1" class="step-header" data-action="click->accordion#toggle" data-target="accordion.header">
+              Button 1
+            </button>
+            <div id="collapsable-content-1" data-target="accordion.content">
+                Content 1
+            </div>
+        </section>
+
+        <section id="step-2" class="step" data-id="2">
+            <button id="button-2" class="step-header" data-action="click->accordion#toggle" data-target="accordion.header">
+              Button 2
+            </button>
+            <div id="collapsable-content-2" data-target="accordion.content">
+                Content 2
+            </div>
+        </section>
+
+        <section id="step-3" class="step" data-id="3">
+            <button id="button-3" class="step-header" data-action="click->accordion#toggle" data-target="accordion.header">
+              Button 3
+            </button>
+            <div id="collapsable-content-3" data-target="accordion.content">
+                Content 3
+            </div>
+        </section>
+    </div>
     ` ;
 
     const application = Application.start() ;
     application.register('accordion', AccordionController) ;
 
-
     describe("when first loaded", () => {
         it("only first step should be opened", () => {
-            const headers = document.getElementsByClassName('steps-header');
-            for(let i=0;i<headers.length;i+=1){
-                let stepHeaders = headers[i];
-                if (!stepHeaders.length) break;
-                let stepHeader = stepHeaders[0];
-                if(i === 0) {
-                    expect(stepHeader.className).not.toContain('inactive');
-                } else {
-                    expect(stepHeader.className).toContain('inactive');
-                }
-            }
+          expect(document.getElementById("step-1").classList).not.toContain("inactive");
+
+          expect(document.getElementById("step-2").classList).toContain("inactive");
+          expect(document.getElementById("step-3").classList).toContain("inactive");
         });
     })
 
     describe("when open header is toggled", () => {
         it("should close", () => {
-            let headers = document.getElementsByClassName('steps-header');
-            let stepHeader = headers[0];
-            expect(stepHeader.className).not.toContain('inactive');
-            headers[0].click();
-            expect(stepHeader.className).toContain('inactive');
+          expect(document.getElementById("step-1").classList).not.toContain("inactive");
+
+          document.getElementById("button-1").click();
+
+          expect(document.getElementById("step-1").classList).toContain("inactive");
         });
     });
 
     describe("when closed header is toggled", () => {
         it("should open", () => {
-            let headers = document.getElementsByClassName('steps-header');
-            let stepHeader = headers[0];
-            expect(stepHeader.className).toContain('inactive');
-            headers[0].click();
-            expect(stepHeader.className).not.toContain('inactive');
+          expect(document.getElementById("step-2").classList).toContain("inactive");
+
+          document.getElementById("button-2").click();
+
+          expect(document.getElementById("step-2").classList).not.toContain("inactive");
         });
     });
-
 });
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/PVtlFla9/442-review-javascript-and-remove-use-of-style-in-favour-of-changing-css-classes

### Context

**This follows on from #561**, that should be reviewed first.

### Changes proposed in this pull request
https://trello.com/c/PVtlFla9/442-review-javascript-and-remove-use-of-style-in-favour-of-changing-css-classes
The accordion Javascript was complicated and operated on a list of buttons and content, identifying each by its `id` every time.

This simplified approach wraps each pair (button and content) in a `<section>` element and toggles a single `inactive` class on it, the display of the contents are then controlled via CSS.

### Guidance to review

Review (and hopefully approve #561) before this, only 7328126 is relevant here.

