### PR TITLE
Rescue ApiError 404 in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ private
 
   def handle_api_error(error)
     render_too_many_requests && return if error.code == 429
+    render_not_found && return if error.code == 404
 
     raise
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,8 +19,6 @@ class EventsController < ApplicationController
   def show
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
     @page_title = @event.name
-  rescue GetIntoTeachingApiClient::ApiError
-    render template: "errors/not_found", status: :not_found
   end
 
   def show_category

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -20,7 +20,7 @@ describe EventStepsController do
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_teaching_event).and_return event
+      receive(:get_teaching_event).with(readable_event_id) { event }
   end
 
   describe "#index" do
@@ -42,6 +42,19 @@ describe EventStepsController do
 
     context "with an invalid step" do
       let(:step_path) { event_step_path readable_event_id, :invalid }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+
+    context "when the event does not exist" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+          receive(:get_teaching_event).with("456")
+          .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
+      end
+
+      before { get event_steps_path("456") }
+      subject { response }
 
       it { is_expected.to have_http_status :not_found }
     end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -182,7 +182,7 @@ describe EventsController do
     context "for unknown event" do
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-          receive(:get_teaching_event).and_raise GetIntoTeachingApiClient::ApiError
+          receive(:get_teaching_event).and_raise GetIntoTeachingApiClient::ApiError.new(code: 404)
 
         get(event_path(id: event_readable_id))
       end


### PR DESCRIPTION
If the API ever returns a 404 error we would most likely want to display the 404 page to the user.

Rescue the `ApiError` 404 at the `ApplicationController` level.

The dynamic render highlighted by Brakeman is a false positive; the event ID is whitelisted by the API and I think the use of ViewComponents is confusing it.