### PR TITLE
Make Pry the default console instead of IRb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
 
   # Debugging
   gem "pry-byebug"
+  gem "pry-rails"
 
   # Testing framework
   gem "rspec-rails", "~> 4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.0.4)
       nio4r (~> 2.0)
@@ -374,6 +376,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.4)
   prometheus-client
   pry-byebug
+  pry-rails
   puma (~> 5.0)
   rack-attack
   rails (~> 6.0.2)


### PR DESCRIPTION
As we're already pulling in `pry-byebug` we may as well get the full `rails console` experience.

