### PR TITLE
Hide EventBox description for virtual TTT events

### DIFF
--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -11,7 +11,7 @@
 
     <%= divider %>
 
-    <% unless condensed? %>
+    <% unless description_hidden? %>
       <div class="event-box__content">
         <p><%= description %></p>
       </div>

--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -32,6 +32,10 @@ module Events
       online
     end
 
+    def description_hidden?
+      condensed? || virtual_train_to_teach_event?
+    end
+
     def heading
       condensed ? datetime : title
     end
@@ -61,6 +65,14 @@ module Events
     end
 
   private
+
+    def virtual_train_to_teach_event?
+      online? && train_to_teach_event?
+    end
+
+    def train_to_teach_event?
+      @type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
+    end
 
     def event_box_footer_icon_class
       "event-box__footer__icon"

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -29,9 +29,23 @@ describe Events::EventBoxComponent, type: "component" do
     end
   end
 
-  specify "places the description in the content div" do
-    page.find(".event-box__content") do |content_div|
-      expect(content_div).to have_content(event.summary)
+  describe "event description" do
+    specify "places the description in the content div" do
+      page.find(".event-box__content") do |content_div|
+        expect(content_div).to have_content(event.summary)
+      end
+    end
+
+    context "when the event is a virtual TTT event" do
+      let(:event) { build(:event_api, :virtual_train_to_teach_event) }
+
+      specify { expect(page).to_not have_selector(".event-box__content") }
+    end
+
+    context "when condensed" do
+      let(:condensed) { true }
+
+      specify { expect(page).to_not have_selector(".event-box__content") }
     end
   end
 

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -30,6 +30,11 @@ FactoryBot.define do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     end
 
+    trait :virtual_train_to_teach_event do
+      train_to_teach_event
+      is_online { true }
+    end
+
     trait :online_event do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
     end


### PR DESCRIPTION
### Trello card

[Trello-560](https://trello.com/c/l4PWOiEF/560-remove-snippets-from-virtual-ttt-events-on-current-events-design)

### Context

We no longer want to display the event description in the `EventBoxComponent` for virtual Train to Teach events.

### Changes proposed in this pull request

- Hide EventBox description for virtual TTT events

### Guidance to review

<img width="667" alt="Screenshot 2020-11-17 at 12 00 07" src="https://user-images.githubusercontent.com/29867726/99387903-a3b63980-28cc-11eb-8fe0-992d1136726b.png">
