### PR TITLE
Prevent dependencies on deprecated code

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -103,23 +103,22 @@ describe ApplicationHelper do
     before { helper.request = double("request") }
 
     it "returns nil if the referrer is not set" do
-      helper.request.stub(:referer) { nil }
+      allow(helper.request).to receive(:referer).and_return nil
       expect(helper.internal_referer).to be_nil
     end
 
     it "returns nil if the referrer is empty" do
-      helper.request.stub(:referer) { " " }
+      allow(helper.request).to receive(:referer).and_return " "
       expect(helper.internal_referer).to be_nil
     end
 
     it "returns nil if the referrer is external" do
-      helper.request.stub(:referer) { "https://external.com" }
+      allow(helper.request).to receive(:referer).and_return "https://external.com"
       expect(helper.internal_referer).to be_nil
     end
 
     it "returns the referrer if internal" do
-      referer = root_url
-      helper.request.stub(:referer) { referer }
+      allow(helper.request).to receive(:referer).and_return root_url
       expect(helper.internal_referer).to eql(helper.root_path)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,4 +104,6 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  config.raise_errors_for_deprecations!
 end


### PR DESCRIPTION
### Context

We should avoid introducing deprecation warnings, particularly in light of Rails 6.1 coming out soon.

### Changes proposed in this pull request

1. Turn on RSpecs option to raise on deprecation warnings
2. Fixed some specs triggering a warning



