### PR TITLE
Move degree status field to its own step

### DIFF
--- a/app/models/mailing_list/steps/degree_status.rb
+++ b/app/models/mailing_list/steps/degree_status.rb
@@ -1,0 +1,25 @@
+module MailingList
+  module Steps
+    class DegreeStatus < ::Wizard::Step
+      attribute :degree_status_id, :integer
+
+      validates :degree_status_id,
+                presence: true,
+                inclusion: { in: :degree_status_option_ids }
+
+      def degree_status_options
+        @degree_status_options ||= query_degree_status
+      end
+
+      def degree_status_option_ids
+        degree_status_options.map { |option| option.id.to_i }
+      end
+
+    private
+
+      def query_degree_status
+        GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
+      end
+    end
+  end
+end

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -6,15 +6,11 @@ module MailingList
       attribute :first_name
       attribute :last_name
       attribute :email
-      attribute :degree_status_id, :integer
       attribute :channel_id, :integer
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true, length: { maximum: 256 }
       validates :last_name, presence: true, length: { maximum: 256 }
-      validates :degree_status_id,
-                presence: true,
-                inclusion: { in: :degree_status_option_ids }
       validates :channel_id, inclusion: { in: :channel_ids, allow_nil: true }
 
       before_validation if: :email do
@@ -29,23 +25,11 @@ module MailingList
         self.last_name = last_name.to_s.strip
       end
 
-      def degree_status_options
-        @degree_status_options ||= [OpenStruct.new(id: nil, value: "Please select")] + query_degree_status
-      end
-
-      def degree_status_option_ids
-        degree_status_options.map { |option| option.id.to_i }
-      end
-
       def channel_ids
         query_channels.map { |channel| channel.id.to_i }
       end
 
     private
-
-      def query_degree_status
-        GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
-      end
 
       def query_channels
         @query_channels ||= GetIntoTeachingApiClient::TypesApi.new.get_candidate_mailing_list_subscription_channels

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -6,6 +6,7 @@ module MailingList
       Steps::Name,
       Steps::Authenticate,
       Steps::AlreadySubscribed,
+      Steps::DegreeStatus,
       Steps::TeacherTraining,
       Steps::Subject,
       Steps::Postcode,

--- a/app/views/mailing_list/steps/_degree_status.html.erb
+++ b/app/views/mailing_list/steps/_degree_status.html.erb
@@ -1,0 +1,14 @@
+<h1>Do you have a degree?</h1>
+
+<p>
+Telling us whether you have a degree, or are studying for a degree, will help us to give you the right support to become a teacher.
+</p>
+
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_collection_radio_buttons :degree_status_id,
+  f.object.degree_status_options,
+  :id,
+  ->(option) { I18n.t("helpers.answer.mailing_list_steps_degree_status.degree_status.#{option.value.parameterize(separator: "_")}", default: option.value) },
+  legend: { text: t('helpers.label.mailing_list_steps_degree_status.degree_status_id') }
+%>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -17,8 +17,3 @@
 <%= f.govuk_text_field :last_name %>
 <%= f.govuk_email_field :email %>
 <%= f.hidden_field :channel_id, value: params[:channel] %>
-
-<%= f.govuk_collection_select :degree_status_id,
-      f.object.degree_status_options,
-      :id,
-      :value %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
             email:
               blank: Enter your full email address
               invalid: Enter a valid email address
+        mailing_list/steps/degree_status:
+          attributes:
             degree_status_id:
               blank: Select your degree stage
               inclusion: Select your degree stage from the list
@@ -170,6 +172,16 @@ en:
               accepted: Accept the privacy policy to continue
 
   helpers:
+    answer:
+      mailing_list_steps_degree_status:
+        degree_status:
+          graduate_or_postgraduate: "Yes, I already have a degree"
+          final_year: "I am a final year student"
+          second_year: "I am a second year student"
+          first_year: "I am a first year student"
+          i_don_t_have_a_degree_and_am_not_studying_for_one: "No, I am not studying for a degree"
+          other: "Other"
+
     label:
       wizard_steps_authenticate:
         timed_one_time_password: Enter the verification code sent to %{email}
@@ -190,6 +202,7 @@ en:
         first_name: First name
         last_name: Surname
         email: Email address
+      mailing_list_steps_degree_status:
         degree_status_id: What stage are you at with your degree?
       mailing_list_steps_teacher_training:
         consideration_journey_stage_id: How close are you to applying for teacher training?

--- a/spec/factories/mailing_list/degree_status_factory.rb
+++ b/spec/factories/mailing_list/degree_status_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :mailing_list_degree_status, class: MailingList::Steps::DegreeStatus do
+    degree_status_id { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["First year"] }
+  end
+end

--- a/spec/factories/mailing_list/name_factory.rb
+++ b/spec/factories/mailing_list/name_factory.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
     sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }
-    degree_status_id { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["First year"] }
   end
 end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -51,7 +51,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "First year")
+    fill_in_name_step
+    click_on "Next Step"
+
+    expect(page).to have_text "What stage are you at with your degree?"
+    choose "I am a first year student"
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
@@ -87,7 +91,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path({ id: :name, channel: channel_id })
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "First year")
+    fill_in_name_step
+    click_on "Next Step"
+
+    expect(page).to have_text "What stage are you at with your degree?"
+    choose "I am a first year student"
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
@@ -126,16 +134,22 @@ RSpec.feature "Mailing list wizard", type: :feature do
       addressPostcode: "TE57 1NG",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything) { response }
 
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "Other")
+    fill_in_name_step
     click_on "Next Step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Enter the verification code sent to test@user.com", with: "123456"
+    click_on "Next Step"
+
+    expect(page).to have_text "What stage are you at with your degree?"
+    expect(find("[name=\"mailing_list_steps_degree_status[degree_status_id]\"][checked]").value).to eq(
+      response.degree_status_id.to_s,
+    )
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
@@ -182,7 +196,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "Final year")
+    fill_in_name_step
     click_on "Next Step"
 
     expect(page).to have_text "Verify your email address"
@@ -197,7 +211,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in "Enter the verification code sent to test@user.com", with: "123456"
     click_on "Next Step"
 
-    expect(page).to have_text "How close are you to applying"
+    expect(page).to have_text "What stage are you at with your degree?"
   end
 
   scenario "Full journey as an existing candidate that has already subscribed to the mailing list" do
@@ -213,7 +227,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "Final year")
+    fill_in_name_step
     click_on "Next Step"
 
     expect(page).to have_text "Verify your email address"
@@ -237,7 +251,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "Final year")
+    fill_in_name_step
     click_on "Next Step"
 
     expect(page).to have_text "Verify your email address"
@@ -261,7 +275,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Sign up for email updates"
-    fill_in_name_step(degree_status: "Final year")
+    fill_in_name_step
     click_on "Next Step"
 
     expect(page).to have_text "Verify your email address"
@@ -281,18 +295,16 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step(email: "test2@user.com")
     click_on "Next Step"
 
-    expect(page).to have_text "We need some more details"
+    expect(page).to have_text "What stage are you at with your degree?"
   end
 
   def fill_in_name_step(
     first_name: "Test",
     last_name: "User",
-    email: "test@user.com",
-    degree_status: nil
+    email: "test@user.com"
   )
     fill_in "First name", with: first_name if first_name
     fill_in "Surname", with: last_name if last_name
     fill_in "Email address", with: email if email
-    select degree_status if degree_status
   end
 end

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe MailingList::Steps::DegreeStatus do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  let(:degree_status_option_types) do
+    GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
+      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+    end
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
+  end
+
+  it { is_expected.to respond_to :degree_status_id }
+
+  context "validations" do
+    subject { instance.tap(&:valid?).errors.messages }
+    it { is_expected.to include(:degree_status_id) }
+  end
+
+  context "degree_status_id" do
+    let(:options) { degree_status_option_types.map(&:id) }
+    it { is_expected.to allow_value(options.first).for :degree_status_id }
+    it { is_expected.to allow_value(options.last).for :degree_status_id }
+    it { is_expected.not_to allow_value(nil).for :degree_status_id }
+    it { is_expected.not_to allow_value("").for :degree_status_id }
+    it { is_expected.not_to allow_value(12_345).for :degree_status_id }
+  end
+end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -4,12 +4,6 @@ describe MailingList::Steps::Name do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
-  let(:degree_status_option_types) do
-    GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
-    end
-  end
-
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
       GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
@@ -18,22 +12,18 @@ describe MailingList::Steps::Name do
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
-      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
       receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
   end
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
   it { is_expected.to respond_to :email }
-  it { is_expected.to respond_to :degree_status_id }
 
   context "validations" do
     subject { instance.tap(&:valid?).errors.messages }
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
     it { is_expected.to include(:email) }
-    it { is_expected.to include(:degree_status_id) }
   end
 
   context "first_name" do
@@ -50,15 +40,6 @@ describe MailingList::Steps::Name do
     it { is_expected.not_to allow_value("me@you").for :email }
   end
 
-  context "degree_status_id" do
-    let(:options) { degree_status_option_types.map(&:id) }
-    it { is_expected.to allow_value(options.first).for :degree_status_id }
-    it { is_expected.to allow_value(options.last).for :degree_status_id }
-    it { is_expected.not_to allow_value(nil).for :degree_status_id }
-    it { is_expected.not_to allow_value("").for :degree_status_id }
-    it { is_expected.not_to allow_value(12_345).for :degree_status_id }
-  end
-
   context "channel_id" do
     let(:options) { channels.map(&:id) }
     it { is_expected.to allow_values(options).for :channel_id }
@@ -67,12 +48,6 @@ describe MailingList::Steps::Name do
   end
 
   context "when the step is valid" do
-    subject do
-      instance.tap do |step|
-        step.degree_status_id = degree_status_option_types.first.id
-      end
-    end
-
     it_behaves_like "an issue verification code wizard step"
   end
 end

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -9,6 +9,7 @@ describe MailingList::Wizard do
         MailingList::Steps::Name,
         MailingList::Steps::Authenticate,
         MailingList::Steps::AlreadySubscribed,
+        MailingList::Steps::DegreeStatus,
         MailingList::Steps::TeacherTraining,
         MailingList::Steps::Subject,
         MailingList::Steps::Postcode,


### PR DESCRIPTION
### Trello card

[Trello-562](https://trello.com/c/kVyEAwaw/562-remove-what-stage-are-you-at-with-your-degree-from-page-1-of-mailing-list-flow-reword-question-and-use-radio-buttons)

### Context

The question "What stage are you at with your degree?" is presumptive and might be contributing towards drop outs. We want to remove the question from page 1 and then rephrase the question/answer and add to a new page 2.

We also want to change the select box to a radio input and reword the answers.

### Changes proposed in this pull request

- Move degree status field to its own step

### Guidance to review

<img width="730" alt="Screenshot 2020-11-23 at 10 31 40" src="https://user-images.githubusercontent.com/29867726/99952148-1c0e7600-2d77-11eb-89ec-f41a4dfd5782.png">
