### PR TITLE
Add contact details to Mailing List completion page

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -11,6 +11,15 @@
               You can unsubscribe if you change your mind. To find out how we
               handle your personal data, you can read our privacy policy.
             </p>
+
+            <h2>Want to speak to us?</h2>
+
+            <p>
+              If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm.
+            </p>
+            <p>
+              You can also use this number to update or amend any of your details.
+            </p>
         </div>
         <span data-controller="pinterest"
                 data-pinterest-action="track"


### PR DESCRIPTION
### Trello card

[Trello-558](https://trello.com/c/cCgnnS4R/558-design-add-service-phone-number-to-ml-completion-page)

### Context

We want to add a section of help text in case the candidate has questions/wants to speak to an adviser after their mailing list sign up. This is to provide an easy way for them to contact the service as we no longer will be prompting for their phone number on sign up.

### Changes proposed in this pull request

- Add contact details to Mailing List completion pag

### Guidance to review

<img width="737" alt="Screenshot 2020-11-18 at 11 16 05" src="https://user-images.githubusercontent.com/29867726/99523818-7aaaad00-298f-11eb-86cc-ada771b475ab.png">