### PR TITLE
Improve steps wrapping behaviour

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -29,7 +29,7 @@ $chevron-direction-map: (
     $degrees: map-get($chevron-direction-map, $direction);
 
     > * {
-        white-space: nowrap;
+        word-break: break-word;
 
         // after governs whether the chevron is placed after (on the right) or
         // before (on the left) of the link text


### PR DESCRIPTION
There was a minor discrepancy in the way Firefox and Chrome/Safari rendered the steps; Firefox was wrapping (reverting to `word-break: break-word` from the parent elmeent) beyond a certain point and Chrome and Safari weren't.

| Before | After |
| ------- | ------- |
| ![Screenshot from 2020-11-18 15-39-54](https://user-images.githubusercontent.com/128088/99552194-9eccb500-29b4-11eb-8588-29ecc71f6a7c.png) |  ![Screenshot from 2020-11-18 15-40-00](https://user-images.githubusercontent.com/128088/99552203-a2603c00-29b4-11eb-8170-2ad900218fcf.png) |

