### PR TITLE
Work around an IE bug on word-wrapping links

### DIFF
--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -192,6 +192,16 @@
         @media (max-width: $steps-row-limit) {
             flex-direction: column;
         }
+
+        /*  This is a bit of a hack to target IE, which has a horrendous bug
+            that prevents it from wrapping text inside hyperlinks. So we
+            needn't wrap, always display the steps in a column format on IE */
+        @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+            flex-direction: column;
+            > * {
+                padding: .5em 0;
+            }
+        }
     }
 
     &__step {


### PR DESCRIPTION
[IE 11 suffers from a bug](https://www.webdevelopmentreference.com/ie-11-word-wrap-word-break/) where long links aren't properly-wrapped using `word-wrap`. Rather than go down the rabbithole of hacks to rectify this we're now just always displaying the list vertically for IE users without affecting the main audience.

| Before | After |
| ------ | ------ |
| ![Screenshot from 2020-11-23 12-22-31](https://user-images.githubusercontent.com/128088/99961739-d659a980-2d86-11eb-9ddf-2a499277b533.png) | ![Screenshot from 2020-11-23 12-21-46](https://user-images.githubusercontent.com/128088/99961750-de194e00-2d86-11eb-9971-b354f4383b51.png) |



