### PR TITLE
Minor event box and category page styling updates

### DIFF
--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -32,8 +32,10 @@
 </section>
 
 <section class="types-of-event content container-1000">
-  <div class="events-featured__list">
-    <%= render partial: "event", collection: @events %>
+  <div class="events-featured">
+    <div class="events-featured__list">
+      <%= render partial: "event", collection: @events %>
+    </div>
   </div>
 </section>
 

--- a/app/webpacker/styles/components/cards-grid.scss
+++ b/app/webpacker/styles/components/cards-grid.scss
@@ -8,7 +8,6 @@
     // css grid support
     display: flex;
     flex-wrap: wrap;
-    margin-bottom: 1.5em;
 
     @supports (display: grid) {
         display: grid;

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -15,15 +15,15 @@
     box-sizing: border-box;
     padding: 20px;
     display: inline-block;
-    border: 2px solid $black;
     overflow: hidden;
     text-align: left;
     margin: 0;
+    border: 2px solid $white;
     width: 100%;
     color: $black;
     background-color: $white;
     a:hover &{
-        background-color: $grey;
+      border: 2px solid $black;
     }
 
     a:focus & {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -1,10 +1,3 @@
-.types-of-event {
-    > .events-featured {
-        background-color: white;
-        padding: 1em 0 0;
-    }
-}
-
 .types-of-event__header__icon {
   margin-bottom: 5px;
 }
@@ -132,6 +125,10 @@
         display: flex;
         text-decoration: none;
       }
+    }
+
+    .call-to-action-button {
+      margin-top: 1.5em;
     }
 
     &--with-logo {

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -18,6 +18,8 @@
 
             a {
                 @include button($bg: $grey, $fg: $black);
+                display: inline-block;
+                margin: 1em 0 0 0;
             }
         }
     }


### PR DESCRIPTION
Minor follow up PR to complete the updated styling to the event boxes and the event category page.

- Remove the border from the `EventBoxComponent` (show on hover).
- Add in off-white background to event boxes in event category page.
- Remove margin from cards-grid mixin (re-apply on more stories button).

<img width="1119" alt="Screenshot 2020-11-23 at 13 58 47" src="https://user-images.githubusercontent.com/29867726/99970652-0a879700-2d94-11eb-94ff-10617d229cdd.png">
