### PR TITLE
Link validator

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "content pages check", type: :feature do
+RSpec.feature "content pages check", type: :feature, content: true do
   IGNORE = %w[
     /test
     /guidance_archive
@@ -28,9 +28,44 @@ RSpec.feature "content pages check", type: :feature do
   end
 
   content_urls.each do |url|
-    scenario "visiting #{url}" do
-      visit url
-      expect(page).to have_http_status :success
+    describe "visiting #{url}" do
+      let(:url) { url }
+      before { visit(url) }
+      let(:document) { Nokogiri.parse(page.body) }
+
+      scenario "checking that #{url} responds with success" do
+        expect(page).to have_http_status :success
+      end
+
+      scenario "the anchor links reference existing IDs" do
+        document
+          .css("a")
+          .map { |fragment| fragment["href"] }
+          .select { |href| href.start_with?("#") }
+          .reject { |href| href == "#" }
+          .each do |href|
+            expect(page).to have_css(href)
+          end
+      end
+
+      scenario "the internal links reference existing pages" do
+        document
+          .css("a")
+          .map { |fragment| fragment["href"] }
+          .reject { |href| href.start_with?(Regexp.union("http", "tel", "mailto")) }
+          .reject { |href| href.match?(Regexp.union("privacy-policy", "events", "javascript")) }
+          .select { |href| href.start_with?(Regexp.union("/", /\w+/)) }
+          .uniq
+          .each do |href|
+            visit(href)
+
+            expect(page).to(have_http_status(:success), %(invalid link on #{url} - #{href}))
+
+            if (fragment = URI.parse(href).fragment)
+              expect(page).to(have_css("#" + fragment), %(invalid link on #{url} - #{href}, (missing fragment #{fragment})))
+            end
+          end
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card

N/A

### Context

We had a few broken/malformed links knocking around our content repo but finding them manually is difficult.

### Changes proposed in this pull request

Add some specs that ensure the internal links are valid. We're not checking external ones because a site that's down could affect our build.

The link checker is only interested in internal links and anchors, it specifically ignores:

* any link that starts with http (external)
* any telephone or email links
* links to any events pages (which call external APIs)
* links to the privacy policy page (again, external API)
* links that trigger JavaScript actions

It's disabled by default but now there's a new step in the workflow that runs the just the specs tagged with `link_checks`, or it can be run manually via `be rspec --tag link_checks`

### Guidance to review

Sensible approach?

**Note** there's a related change that's required in the content repo [here](DFE-Digital/get-into-teaching-content/pull/153).


### Extra notes

These checks take about ~45 seconds on my machine but they are tagged with `content`, so if you want to ignore them on your own machine add `--tag ~content` to your `~/.rspec` file!