### PR TITLE
Design updates to event show/sign up

### DIFF
--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -21,9 +21,5 @@
               <% end %>
             <% end %>
         </div>
-
-        <div class="content__right">
-            <%= render "events/event", event: event if wizard.first_step? %>
-        </div>
     </div>
 </section>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,21 +1,9 @@
-<%= render "sections/hero",  
-    :header => @event.name, 
-    :image => "media/images/events-hero-dt.jpg",
-    :deep => false,
-    :mailinglist => false 
-%>
-
 <section class="event-info content container-1000">
-    <div class="content__right">
-        <%= render(Events::EventBoxComponent.new(@event, condensed: true)) %>
-
-        <% if can_sign_up_online?(@event) %>
-          <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button sidebar-button" do %>
-              Sign up for this <span>event</span>
-          <% end %>
-        <% end %>
-    </div>
     <div class="content__left">
+        <h1><%= @event.name %></h1>
+
+        <p class="event-info__date"><%= format_event_date(@event, stacked: false) %></p>
+
         <% unless event_status_open?(@event) %>
           <div class="content-alert content-alert--fullwidth">
             <p>This event is now closed. Search <%= link_to("here", events_path) %> for our other events.</p>
@@ -28,8 +16,16 @@
           </div>
         <% end %>
 
+        <p>
+          <% if can_sign_up_online?(@event) %>
+            <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
+                Sign up for this <span>event</span>
+            <% end %>
+          <% end %>
+        </p>
+
         <h2 class="strapline-article">Event information</h2>
-        <%= formatted_event_description(@event.description) %>
+        <p><%= formatted_event_description(@event.description) %></p>
 
         <% if @event.building && !@event.is_online %>
         <h2 class="strapline-article">Venue information</h2>

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -1,7 +1,12 @@
 .event-info {
 
     h1 {
-        margin-top: 0;
+        margin: 1em 0 5px 0
+    }
+
+    &__date {
+      font-weight: bold;
+      font-size: 1.4em;
     }
 
     &__venue {

--- a/app/webpacker/styles/links_and_buttons.scss
+++ b/app/webpacker/styles/links_and_buttons.scss
@@ -68,21 +68,6 @@ a.content-link-secondary:hover {
     @include button($bg: $grey-light, $fg: black);
 }
 
-.sidebar-button {
-    width: 100%;
-    display: block;
-    margin-top: 10px;
-    position: relative;
-    padding-right: 30px;
-    span:last-child {
-        &:after {
-            position: absolute;
-            top: calc(50% - 6px);
-            right: 13px;
-        }
-    }
-}
-
 .request-button {
     @include button($bg: $pink);
 }


### PR DESCRIPTION
### Trello card

[Trello-508](https://trello.com/c/yP1bztB3/508-develop-implement-updated-events-hub-page)

### Context

Minor design tweaks to the single event page and sign up journey:

- Remove hero section
- Add event title, date and CTA above all event information
- Wrap event information in paragraph tag to improve spacing
- Remove event box from sign up all sidebars

### Changes proposed in this pull request

- Design updates to event show/sign up journey

### Guidance to review

<img width="1287" alt="Screenshot 2020-11-23 at 15 55 47" src="https://user-images.githubusercontent.com/29867726/99984087-8f7aac80-2da4-11eb-8122-f23ff65205f3.png">
<img width="1287" alt="Screenshot 2020-11-23 at 15 55 49" src="https://user-images.githubusercontent.com/29867726/99984108-943f6080-2da4-11eb-95c7-8387687f0fe9.png">
<img width="612" alt="Screenshot 2020-11-23 at 15 55 57" src="https://user-images.githubusercontent.com/29867726/99984113-95708d80-2da4-11eb-837a-4495071d662e.png">