### PR TITLE
Hero alignment tweaks

### DIFF
--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -54,6 +54,10 @@
         text-decoration: none;
         font-weight: bold;
 
+        > span {
+            white-space: nowrap;
+        }
+
         &:hover {
             text-decoration: underline;
             color: inherit;

--- a/app/webpacker/styles/links_and_buttons.scss
+++ b/app/webpacker/styles/links_and_buttons.scss
@@ -6,6 +6,7 @@
     color: $fg;
     padding: 14px 20px;
     font-size: 19px;
+    white-space: nowrap;
     border: none;
 
     &:hover {

--- a/app/webpacker/styles/sections/header.scss
+++ b/app/webpacker/styles/sections/header.scss
@@ -23,11 +23,11 @@
             text-decoration: underline;
             text-decoration-thickness: .1em;
             text-underline-offset: .25em;
-            padding: 0 1.5em;
+            padding: 0 .5em;
 
             @media only screen and (max-width: $mobile-cutoff) {
                 font-size: 200%;
-                padding: 1em;
+                padding: 1em .3em .5em;
             }
         }
     }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -60,12 +60,12 @@
 
             &__subtitle {
                 transform: rotate(-3deg);
-                margin: 3em .5em;
+                margin: 3em .5em 3em 1.9em;
                 font-size: 120%;
                 font-weight: 700;
 
                 @media only screen and (max-width: $mobile-cutoff) {
-                    margin: 1em 1em 1em;
+                    margin: 1em 1em 1em 1.5em;
                     font-size: 140%;
                 }
             }


### PR DESCRIPTION
A couple of very minor alignment fixes on the back of #580 

### Hero

Make the subtitle and title line up better:

| Desktop | Mobile |
| ------ | ------ |
| ![Screenshot from 2020-11-24 11-20-58](https://user-images.githubusercontent.com/128088/100087974-64956480-2e47-11eb-89bc-75d601c474c0.png) | ![Screenshot from 2020-11-24 11-21-10](https://user-images.githubusercontent.com/128088/100087984-68c18200-2e47-11eb-87f9-47f03b3491cb.png) |

### Heading

Align the title with the site logo:

| Desktop | Mobile |
| ------ | ------ |
| ![Screenshot from 2020-11-24 11-22-12](https://user-images.githubusercontent.com/128088/100088022-770f9e00-2e47-11eb-9d73-050a2ed6cd67.png) | ![Screenshot from 2020-11-24 11-22-23](https://user-images.githubusercontent.com/128088/100088039-7d057f00-2e47-11eb-8fc3-38bba3e3536f.png) |

