### PR TITLE
Fix bottom margin on more stories section

### DIFF
--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -82,7 +82,7 @@
     padding: 2px;
 
     &.more-stories {
-        padding: 0 20px;
+        padding: 0 20px 20px 20px;
     }
 
     .story-card {


### PR DESCRIPTION
This was cut off after removing the bottom margin from the generic card component. Adding a bottom padding re-instates the correct spacing

<img width="1087" alt="Screenshot 2020-11-24 at 13 25 29" src="https://user-images.githubusercontent.com/29867726/100100329-8ea35280-2e58-11eb-9262-378791a40ba5.png">

