### PR TITLE
Separate the underline and thickness directives

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -43,7 +43,8 @@
                     padding: 1em 1em 1em 1.7em;
                     margin: -4em;
 
-                    text-decoration: underline .1em;
+                    text-decoration: underline;
+                    text-decoration-thickness: .1em;
                     text-underline-offset: .25em;
 
                     font-weight: 900;


### PR DESCRIPTION
Even though the thickness of a text decoration [is supported via the shorthand syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration), it's not fully supported across browsers yet. It works on Chrome on Linux but not on Mac, and Safari doesn't support it at all.

For the time being, split them out into separate lines.
