### PR TITLE
Tweak the header alignment to pull image right

### DIFF
--- a/app/webpacker/styles/sections/header.scss
+++ b/app/webpacker/styles/sections/header.scss
@@ -13,7 +13,9 @@
     }
 
     &__title {
+        flex-grow: 1;
         @media only screen and (max-width: $mobile-cutoff) {
+            flex-grow: 0;
             align-self: flex-start;
         }
 


### PR DESCRIPTION
Previously it was stacking after the header and looked a little odd.

| Before | After |
| ----- | ----- |
| ![Screenshot from 2020-11-25 09-50-17](https://user-images.githubusercontent.com/128088/100211144-af74b200-2f03-11eb-8f2e-8f2f6740fdef.png) | ![Screenshot from 2020-11-25 09-50-31](https://user-images.githubusercontent.com/128088/100211157-b3a0cf80-2f03-11eb-8809-1ef9865bda04.png) |

