### PR TITLE
Added Page objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,5 +12,9 @@ Rails/UnknownEnv:
     - userresearch
     - production
 
+Lint/AmbiguousOperator:
+  Enabled: false
+
 Style/SignalException:
   Enabled: false
+

--- a/app/controllers/concerns/static_pages.rb
+++ b/app/controllers/concerns/static_pages.rb
@@ -1,8 +1,15 @@
 module StaticPages
   extend ActiveSupport::Concern
 
-  PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}.freeze
   class InvalidTemplateName < RuntimeError; end
+
+  MISSING_TEMPLATE_EXCEPTIONS = [
+    ActionView::MissingTemplate,
+    StaticPages::InvalidTemplateName,
+    Pages::Frontmatter::MissingTemplate,
+  ].freeze
+
+  PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}.freeze
 
 private
 

--- a/app/controllers/concerns/static_pages.rb
+++ b/app/controllers/concerns/static_pages.rb
@@ -6,7 +6,6 @@ module StaticPages
   MISSING_TEMPLATE_EXCEPTIONS = [
     ActionView::MissingTemplate,
     StaticPages::InvalidTemplateName,
-    Pages::Frontmatter::MissingTemplate,
   ].freeze
 
   PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}.freeze

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -1,15 +1,16 @@
 class GuidanceController < ApplicationController
   include StaticPages
   around_action :cache_static_page, only: %i[show]
-  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+  rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
   def show
-    render template: guidance_template, layout: "layouts/guidance"
+    @page = Pages::Page.find guidance_template
+    render template: @page.template, layout: "layouts/guidance"
   end
 
 private
 
   def guidance_template
-    "content/guidance/#{filtered_page_template}"
+    "/guidance/#{filtered_page_template}"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   include StaticPages
   around_action :cache_static_page, only: %i[show]
-  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+  rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
   def privacy_policy
     @page_title = "Privacy Policy"
@@ -21,7 +21,8 @@ class PagesController < ApplicationController
   end
 
   def show
-    render template: content_template, layout: page_layout
+    @page = Pages::Page.find content_template
+    render template: @page.template, layout: page_layout
   end
 
   def showblank
@@ -46,7 +47,7 @@ private
   end
 
   def content_template
-    "content/#{filtered_page_template}"
+    "/#{filtered_page_template}"
   end
 
   def rescue_missing_template

--- a/app/controllers/steps_to_become_a_teacher_controller.rb
+++ b/app/controllers/steps_to_become_a_teacher_controller.rb
@@ -1,15 +1,16 @@
 class StepsToBecomeATeacherController < ApplicationController
   include StaticPages
   around_action :cache_static_page, only: %i[show]
-  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+  rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
   def show
-    render template: steps_to_become_a_teacher_template, layout: "layouts/steps_to_become_a_teacher"
+    @page = Pages::Page.find(steps_to_become_a_teacher_template)
+    render template: @page.template, layout: "layouts/steps_to_become_a_teacher"
   end
 
 private
 
   def steps_to_become_a_teacher_template
-    "content/steps-to-become-a-teacher"
+    "/steps-to-become-a-teacher"
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,30 +1,33 @@
 class StoriesController < ApplicationController
   include StaticPages
-  rescue_from ActionView::MissingTemplate, StaticPages::InvalidTemplateName, with: :rescue_missing_template
+  rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
   def landing
-    render template: landing_template, layout: "layouts/stories/landing"
+    @page = Pages::Page.find(landing_template)
+    render template: @page.template, layout: "layouts/stories/landing"
   end
 
   def index
-    render template: index_template, layout: "layouts/stories/list"
+    @page = Pages::Page.find(index_template)
+    render template: @page.template, layout: "layouts/stories/list"
   end
 
   def show
-    render template: stories_template, layout: "layouts/stories/story"
+    @page = Pages::Page.find(stories_template)
+    render template: @page.template, layout: "layouts/stories/story"
   end
 
 private
 
   def landing_template
-    "content/my-story-into-teaching"
+    "/my-story-into-teaching"
   end
 
   def stories_template
-    "content/my-story-into-teaching/" + filtered_page_template(:story)
+    "/my-story-into-teaching/" + filtered_page_template(:story)
   end
 
   def index_template
-    ["content/my-story-into-teaching", filtered_page_template(:story), "index"].join("/")
+    ["/my-story-into-teaching", filtered_page_template(:story), "index"].join("/")
   end
 end

--- a/app/helpers/sitemap_helper.rb
+++ b/app/helpers/sitemap_helper.rb
@@ -1,8 +1,8 @@
 module SitemapHelper
   def navigation_resources(sitemap)
     navigation_content = sitemap[:markdown_content].select do |content|
-      content.dig(:front_matter, "navigation")
+      content.dig(:front_matter, :navigation)
     end
-    navigation_content.sort_by { |resource| resource.dig(:front_matter, "navigation") }
+    navigation_content.sort_by { |resource| resource.dig(:front_matter, :navigation) }
   end
 end

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -4,8 +4,12 @@ module Pages
     attr_reader :content_dir
 
     class << self
-      def find(template, content_dir)
+      def find(template, content_dir = nil)
         instance(content_dir).find template
+      end
+
+      def list(content_dir = nil)
+        instance(content_dir).list
       end
 
       def instance(content_dir)
@@ -22,13 +26,20 @@ module Pages
     end
 
     def initialize(content_dir = nil)
-      @content_dir = content_dir || MARKDOWN_CONTENT_DIR
+      @content_dir = content_dir ? Pathname.new(content_dir) : MARKDOWN_CONTENT_DIR
     end
 
     def find(template)
       preloaded? ? find_from_preloaded(template) : find_now(template)
     end
     alias_method :[], :find
+
+    def list
+      preload unless preloaded?
+
+      @templates
+    end
+    alias_method :to_h, :find
 
     def preload
       Dir.glob(content_pattern, &method(:add))

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -37,7 +37,7 @@ module Pages
     def list
       preload unless preloaded?
 
-      @templates
+      frontmatter
     end
     alias_method :to_h, :find
 
@@ -48,10 +48,10 @@ module Pages
     end
 
     def preloaded?
-      !@templates.nil?
+      !@frontmatter.nil?
     end
 
-    class MissingTemplate < RuntimeError
+    class NotMarkdownTemplate < RuntimeError
       def initialize(tmpl)
         super "Cannot find Markdown Page #{tmpl}.md"
       end
@@ -64,19 +64,19 @@ module Pages
     end
 
     def find_from_preloaded(template)
-      if @templates.key? template
-        @templates[template]
+      if @frontmatter.key? template
+        @frontmatter[template]
       else
-        raise MissingTemplate, template
+        raise NotMarkdownTemplate, template
       end
     end
 
-    def templates
-      @templates ||= {}
+    def frontmatter
+      @frontmatter ||= {}
     end
 
     def add(file)
-      templates[path(file)] = extract_frontmatter(file)
+      frontmatter[path(file)] = extract_frontmatter(file)
     end
 
     def path(file)
@@ -95,7 +95,7 @@ module Pages
       elsif content_dir.join("#{unprefixed}.markdown").exist?
         content_dir.join("#{unprefixed}.markdown")
       else
-        raise MissingTemplate, template
+        raise NotMarkdownTemplate, template
       end
     end
 

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -52,8 +52,8 @@ module Pages
     end
 
     class NotMarkdownTemplate < RuntimeError
-      def initialize(tmpl)
-        super "Cannot find Markdown Page #{tmpl}.md"
+      def initialize(template)
+        super "Cannot find Markdown Page #{template}.md"
       end
     end
 

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -1,0 +1,43 @@
+module Pages
+  class Frontmatter
+    MARKDOWN_CONTENT_DIR = Rails.root.join("app/views/content").freeze
+    attr_reader :content_dir
+
+    class << self
+      def find(template, content_dir)
+        new(content_dir).find template
+      end
+    end
+
+    def initialize(content_dir = nil)
+      @content_dir = content_dir || MARKDOWN_CONTENT_DIR
+    end
+
+    def find(template)
+      extract_frontmatter file_from_template(template)
+    end
+    alias_method :[], :find
+
+    class MissingTemplate < RuntimeError
+      def initialize(tmpl)
+        super "Cannot find Markdown Page #{tmpl}.md"
+      end
+    end
+
+  private
+
+    def extract_frontmatter(file)
+      FrontMatterParser::Parser.parse_file(file).front_matter.symbolize_keys
+    end
+
+    def file_from_template(template)
+      if content_dir.join("#{template}.md").exist?
+        content_dir.join("#{template}.md")
+      elsif content_dir.join("#{template}.markdown").exist?
+        content_dir.join("#{template}.markdown")
+      else
+        raise MissingTemplate, template
+      end
+    end
+  end
+end

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -69,7 +69,7 @@ module Pages
     end
 
     def path(file)
-      Pathname.new(file).sub_ext("").relative_path_from(content_dir).to_s
+      Pathname.new(file).sub_ext("").relative_path_from(content_dir).to_s.prepend("/")
     end
 
     def extract_frontmatter(file)
@@ -77,10 +77,12 @@ module Pages
     end
 
     def file_from_template(template)
-      if content_dir.join("#{template}.md").exist?
-        content_dir.join("#{template}.md")
-      elsif content_dir.join("#{template}.markdown").exist?
-        content_dir.join("#{template}.markdown")
+      unprefixed = template.delete_prefix("/")
+
+      if content_dir.join("#{unprefixed}.md").exist?
+        content_dir.join("#{unprefixed}.md")
+      elsif content_dir.join("#{unprefixed}.markdown").exist?
+        content_dir.join("#{unprefixed}.markdown")
       else
         raise MissingTemplate, template
       end

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -1,0 +1,24 @@
+module Pages
+  class Page
+    TEMPLATES_FOLDER = "content".freeze
+
+    attr_reader :path, :frontmatter
+
+    delegate :title, :image, :backlink, :backlink_text, to: :frontmatter
+
+    class << self
+      def find(path)
+        new path, Frontmatter.find(path)
+      end
+    end
+
+    def initialize(path, frontmatter)
+      @path = path
+      @frontmatter = OpenStruct.new(frontmatter)
+    end
+
+    def template
+      TEMPLATES_FOLDER + path
+    end
+  end
+end

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -8,7 +8,9 @@ module Pages
 
     class << self
       def find(path)
-        new path, Frontmatter.find(path)
+        new path, Pages::Frontmatter.find(path)
+      rescue Pages::Frontmatter::NotMarkdownTemplate
+        new path, {}
       end
     end
 

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -26,7 +26,7 @@
     <div class="site-footer-top__links-container">
       <%= link_to("Home", page_path(page: :home)) %>
       <% navigation_resources(@sitemap).each_with_index do |resource, index| %>
-        <a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a>
+        <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
       <% end %>
       <%= link_to "Find an event near you", events_path %>
     </div>

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -17,7 +17,7 @@
             <ul>
                 <li><a href="/">Home</a></li>
                 <% navigation_resources(@sitemap).each do |resource| %>
-                    <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                    <li><a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a></li>
                 <% end %>
                 <li><%= link_to "Find an event near you", events_path %></li>
             </ul>
@@ -34,7 +34,7 @@
                 <ul>
                     <li><a href="/">Home</a></li>
                     <% navigation_resources(@sitemap).each do |resource| %>
-                        <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                        <li><a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a></li>
                     <% end %>
                     <li><%= link_to "Find an event near you", events_path %></li>
                 </ul>

--- a/lib/template_handlers/erb.rb
+++ b/lib/template_handlers/erb.rb
@@ -1,7 +1,5 @@
 module TemplateHandlers
   class ERB < ActionView::Template::Handlers::ERB
-    MARKDOWN_CONTENT_DIR = Rails.root.join("app/views/content").freeze
-
     def call(template, source = nil)
       # inspect objects to Ruby strings which can be eval'd
       %(@sitemap = #{self.class.sitemap.inspect}; #{super}.html_safe)
@@ -15,31 +13,22 @@ module TemplateHandlers
       end
 
       def build_sitemap
-        markdown_content = Dir.glob(markdown_content_pattern).map do |file|
-          {
-            path: path(file),
-            front_matter: front_matter(file),
-          }
-        end
-
-        { markdown_content: markdown_content }
+        {
+          markdown_content: mapped_markdown_content,
+        }
       end
 
-      def path(file)
-        pathname = Pathname.new(file).sub_ext("")
-        "/#{pathname.relative_path_from(MARKDOWN_CONTENT_DIR)}"
+    private
+
+      def mapped_markdown_content
+        Pages::Frontmatter.list.map(&method(:map_markdown_page))
       end
 
-      def markdown_content_pattern
-        "#{MARKDOWN_CONTENT_DIR}/**/*.{md,markdown}"
-      end
-
-      def front_matter(file)
-        parse(file).front_matter
-      end
-
-      def parse(file)
-        FrontMatterParser::Parser.parse_file(file)
+      def map_markdown_page(path, front_matter)
+        {
+          path: path,
+          front_matter: front_matter,
+        }
       end
     end
   end

--- a/spec/components/sections/header_component_spec.rb
+++ b/spec/components/sections/header_component_spec.rb
@@ -5,7 +5,7 @@ describe Sections::HeaderComponent, type: "component" do
     {
       title: "Teaching, it's pretty awesome",
       image: "media/images/hero-home-dt.jpg",
-    }.with_indifferent_access
+    }
   end
 
   let(:component) { Sections::HeaderComponent.new(front_matter) }

--- a/spec/helpers/sitemap_helper_spec.rb
+++ b/spec/helpers/sitemap_helper_spec.rb
@@ -5,9 +5,9 @@ describe SitemapHelper, type: :helper do
     let(:sitemap) do
       {
         markdown_content: [
-          { title: "Page 1", front_matter: { "navigation" => 10 } },
-          { title: "Page 2", front_matter: { "navigation" => 30 } },
-          { title: "Page 3", front_matter: { "navigation" => 20 } },
+          { title: "Page 1", front_matter: { navigation: 10 } },
+          { title: "Page 2", front_matter: { navigation: 30 } },
+          { title: "Page 3", front_matter: { navigation: 20 } },
         ],
       }
     end

--- a/spec/lib/template_handlers/erb_spec.rb
+++ b/spec/lib/template_handlers/erb_spec.rb
@@ -4,6 +4,8 @@ describe TemplateHandlers::ERB, type: :view do
   subject { rendered }
 
   context "generic ERB page accessing the @sitemap" do
+    include_context "use fixture markdown pages"
+
     let(:erb) do
       <<~ERB
         <%= pluralize(@sitemap[:markdown_content].count, "resource") %>
@@ -14,7 +16,6 @@ describe TemplateHandlers::ERB, type: :view do
 
     before do
       TemplateHandlers::ERB.sitemap = nil # clear cache
-      stub_const("TemplateHandlers::ERB::MARKDOWN_CONTENT_DIR", "#{file_fixture_path}/markdown_content")
       stub_template "test.erb" => erb
       render template: "test.erb"
     end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Pages::Frontmatter do
     end
   end
 
+  shared_examples "a listing of all pages" do
+    it { is_expected.to have_attributes keys: %w[/page1 /subfolder/page2] }
+    it { is_expected.to include "/page1" => { title: "Hello World 1" } }
+  end
+
   describe ".perform_caching" do
     subject { described_class.perform_caching }
 
@@ -45,6 +50,12 @@ RSpec.describe Pages::Frontmatter do
 
       it_behaves_like "page loading"
     end
+  end
+
+  describe ".list" do
+    subject { described_class.list content_dir }
+
+    it_behaves_like "a listing of all pages"
   end
 
   describe "#find" do
@@ -71,7 +82,12 @@ RSpec.describe Pages::Frontmatter do
   describe "#preload" do
     subject { instance.preload.send(:templates) }
 
-    it { is_expected.to have_attributes keys: %w[/page1 /subfolder/page2] }
-    it { is_expected.to include "/page1" => { title: "Hello World 1" } }
+    it_behaves_like "a listing of all pages"
+  end
+
+  describe "#list" do
+    subject { instance.list }
+
+    it_behaves_like "a listing of all pages"
   end
 end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Pages::Frontmatter do
       let(:page) { "/unknown" }
 
       it "should raise an exception" do
-        expect { subject }.to raise_exception Pages::Frontmatter::MissingTemplate
+        expect { subject }.to raise_exception Pages::Frontmatter::NotMarkdownTemplate
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe Pages::Frontmatter do
   end
 
   describe "#preload" do
-    subject { instance.preload.send(:templates) }
+    subject { instance.preload.send(:frontmatter) }
 
     it_behaves_like "a listing of all pages"
   end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe Pages::Frontmatter do
 
   shared_examples "page loading" do
     context "with known page" do
-      let(:page) { "page1" }
+      let(:page) { "/page1" }
 
       it { is_expected.to include title: "Hello World 1" }
     end
 
     context "with nested page" do
-      let(:page) { "subfolder/page2" }
+      let(:page) { "/subfolder/page2" }
 
       it { is_expected.to include title: "Hello World 2" }
     end
 
     context "with unknown page" do
-      let(:page) { "unknown" }
+      let(:page) { "/unknown" }
 
       it "should raise an exception" do
         expect { subject }.to raise_exception Pages::Frontmatter::MissingTemplate
@@ -71,7 +71,7 @@ RSpec.describe Pages::Frontmatter do
   describe "#preload" do
     subject { instance.preload.send(:templates) }
 
-    it { is_expected.to have_attributes keys: %w[page1 subfolder/page2] }
-    it { is_expected.to include "page1" => { title: "Hello World 1" } }
+    it { is_expected.to have_attributes keys: %w[/page1 /subfolder/page2] }
+    it { is_expected.to include "/page1" => { title: "Hello World 1" } }
   end
 end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Pages::Frontmatter do
+  let(:content_dir) { Rails.root.join("spec/fixtures/files/markdown_content") }
+  let(:instance) { described_class.new content_dir }
+
+  shared_examples "page loading" do
+    context "with known page" do
+      let(:page) { "page1" }
+
+      it { is_expected.to include title: "Hello World 1" }
+    end
+
+    context "with nested page" do
+      let(:page) { "subfolder/page2" }
+
+      it { is_expected.to include title: "Hello World 2" }
+    end
+
+    context "with unknown page" do
+      let(:page) { "unknown" }
+
+      it "should raise an exception" do
+        expect { subject }.to raise_exception Pages::Frontmatter::MissingTemplate
+      end
+    end
+  end
+
+  describe "#find" do
+    subject { instance.find page }
+
+    it_behaves_like "page loading"
+  end
+
+  subject "#[]" do
+    subject { instance[page] }
+
+    it_behaves_like "page loading"
+  end
+
+  describe ".find" do
+    subject { described_class.find page, content_dir }
+
+    it_behaves_like "page loading"
+  end
+end

--- a/spec/models/pages/page_spec.rb
+++ b/spec/models/pages/page_spec.rb
@@ -4,11 +4,22 @@ RSpec.describe Pages::Page do
   include_context "use fixture markdown pages"
 
   describe "#find" do
-    subject { described_class.find "/page1" }
+    context "with markdown page" do
+      subject { described_class.find "/page1" }
 
-    it { is_expected.to be_instance_of Pages::Page }
-    it { is_expected.to have_attributes title: "Hello World 1" }
-    it { is_expected.to have_attributes path: "/page1" }
-    it { is_expected.to have_attributes template: "content/page1" }
+      it { is_expected.to be_instance_of Pages::Page }
+      it { is_expected.to have_attributes title: "Hello World 1" }
+      it { is_expected.to have_attributes path: "/page1" }
+      it { is_expected.to have_attributes template: "content/page1" }
+    end
+
+    context "with non markdown page" do
+      subject { described_class.find "/unknown" }
+
+      it { is_expected.to be_instance_of Pages::Page }
+      it { is_expected.to have_attributes title: nil }
+      it { is_expected.to have_attributes path: "/unknown" }
+      it { is_expected.to have_attributes template: "content/unknown" }
+    end
   end
 end

--- a/spec/models/pages/page_spec.rb
+++ b/spec/models/pages/page_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Pages::Page do
+  include_context "use fixture markdown pages"
+
+  describe "#find" do
+    subject { described_class.find "/page1" }
+
+    it { is_expected.to be_instance_of Pages::Page }
+    it { is_expected.to have_attributes title: "Hello World 1" }
+    it { is_expected.to have_attributes path: "/page1" }
+    it { is_expected.to have_attributes template: "content/page1" }
+  end
+end

--- a/spec/requests/guidance_pages_spec.rb
+++ b/spec/requests/guidance_pages_spec.rb
@@ -2,11 +2,7 @@ require "rails_helper"
 
 describe GuidanceController do
   describe "#show" do
-    let(:template) { "testing/markdown_test" }
-    before do
-      allow_any_instance_of(described_class).to \
-        receive(:guidance_template).and_return template
-    end
+    include_context "always render testing page"
 
     subject do
       get "/guidance/become-a-teacher-in-england"

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,12 +1,7 @@
 require "rails_helper"
 
 describe PagesController do
-  let(:template) { "testing/markdown_test" }
-
-  before do
-    allow_any_instance_of(described_class).to \
-      receive(:content_template).and_return template
-  end
+  include_context "always render testing page"
 
   context "#show" do
     context "without caching enabled" do

--- a/spec/requests/steps_to_become_a_teacher_spec.rb
+++ b/spec/requests/steps_to_become_a_teacher_spec.rb
@@ -2,12 +2,7 @@ require "rails_helper"
 
 describe StepsToBecomeATeacherController do
   describe "#show" do
-    let(:template) { "testing/markdown_test" }
-
-    before do
-      allow_any_instance_of(described_class).to \
-        receive(:steps_to_become_a_teacher_template).and_return template
-    end
+    include_context "always render testing page"
 
     subject do
       get "/steps-to-become-a-teacher"

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -15,10 +15,7 @@ shared_examples "page cannot be found" do |template|
 end
 
 describe StoriesController do
-  let(:template) { "testing/markdown_test" }
-  let(:page) { double Pages::Page, template: template }
-
-  before { allow(Pages::Page).to receive(:find).and_return page }
+  include_context "always render testing page"
 
   context "#landing" do
     subject do

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -16,13 +16,11 @@ end
 
 describe StoriesController do
   let(:template) { "testing/markdown_test" }
+  let(:page) { double Pages::Page, template: template }
+
+  before { allow(Pages::Page).to receive(:find).and_return page }
 
   context "#landing" do
-    before do
-      allow_any_instance_of(described_class).to \
-        receive(:landing_template).and_return template
-    end
-
     subject do
       get "/my-story-into-teaching/"
       response
@@ -36,11 +34,6 @@ describe StoriesController do
   end
 
   context "#index" do
-    before do
-      allow_any_instance_of(described_class).to \
-        receive(:index_template).and_return template
-    end
-
     subject do
       get "/my-story-into-teaching/returners"
       response
@@ -54,11 +47,6 @@ describe StoriesController do
   end
 
   context "#show" do
-    before do
-      allow_any_instance_of(described_class).to \
-        receive(:stories_template).and_return template
-    end
-
     subject do
       get "/my-story-into-teaching/returners/known-page"
       response

--- a/spec/support/page_support.rb
+++ b/spec/support/page_support.rb
@@ -1,0 +1,5 @@
+shared_context "use fixture markdown pages" do
+  let(:md_files) { "#{file_fixture_path}/markdown_content" }
+  let(:frontmatter) { Pages::Frontmatter.new md_files }
+  before { allow(Pages::Frontmatter).to receive(:instance).and_return frontmatter }
+end

--- a/spec/support/page_support.rb
+++ b/spec/support/page_support.rb
@@ -3,3 +3,9 @@ shared_context "use fixture markdown pages" do
   let(:frontmatter) { Pages::Frontmatter.new md_files }
   before { allow(Pages::Frontmatter).to receive(:instance).and_return frontmatter }
 end
+
+shared_context "always render testing page" do
+  let(:template) { "testing/markdown_test" }
+  let(:page) { double Pages::Page, template: template }
+  before { allow(Pages::Page).to receive(:find).and_return page }
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/xmUzKlT8

### Context

Currently we can't access either data or frontmatter from the controller, we also don't have any way of accessing page related data from either the templates or view components.

This is primarily a refactor aimed at addressing the above issue

### Changes proposed in this pull request

1. Add a `Pages::Frontmatter` class to parse out all the front matter - this does dynamic loading (to avoid needing server restarts) in `development` and `test` environments and caches the frontmatter in memory in `production`-like environments.

2. Add a `Pages::Page` class to represent a page - at the moment this is minimal and just provides access to frontmatter but in a follow on PR it will allows loading data into pages

3. Change the ERB template handler to load the sitemap using `Pages::Frontmatter` - this could probably be dropped at somepoint and use the @page variable.

### Guidance to review

1. Visual checking - both Markdown and ERB pages should load identically
2. Navigation menus should show the same

*Note:* this does add a semantic change - keys on frontmatter are now symbolized _but_ nested keys are not. Its done to optimize memory use (symbols are reused). Whether nested keys/no keys should be symbolized is open for debate, I'm looking for feedback on that - easy to change if they should be?