### PR TITLE
Stop double chevrons appearing on cookie notice

### DIFF
--- a/app/views/sections/_cookie-acceptance.html.erb
+++ b/app/views/sections/_cookie-acceptance.html.erb
@@ -19,10 +19,10 @@
                 website for all of our users.
             </p>
             <a href="#" class="call-to-action-button" data-action="click->cookie-acceptance#accept" data-target="cookie-acceptance.agree" id="cookies-agree">
-                Accept all cookies <i class="fas fa-chevron-right"></i>
+                <span>Accept all cookies</span>
             </a>
             <a class="secondary-link" href="/cookie_preference" data-target="cookie-acceptance.disagree" id="cookies-disagree">
-                Set cookie preferences <i class="fas fa-chevron-right"></i>
+                <span>Set cookie preferences</span>
             </a>
         </div>
     </div>

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -80,6 +80,8 @@
       }
 
       .secondary-link {
+          @include chevron($color: $blue);
+
           display: inline-block;
           cursor: pointer;
           font-weight: bold;

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -23,7 +23,7 @@ $chevron-direction-map: (
     'down': 135deg
 );
 
-@mixin chevron($color: $white, $after: true, $direction: right, $dimensions: .6em) {
+@mixin chevron($color: $white, $after: true, $direction: right, $dimensions: .6em, $focus-color: $black) {
     $chevron-margin: .1em;
 
     $degrees: map-get($chevron-direction-map, $direction);
@@ -45,6 +45,12 @@ $chevron-direction-map: (
 
                 margin-right: $chevron-margin;
             }
+        }
+    }
+
+    &:focus > * {
+        &:after, &:before {
+            border-color: $focus-color;
         }
     }
 }


### PR DESCRIPTION
Minor tweak to the buttons to fix their appearance. Also improve the colouring of the chevrons when buttons are focussed.

![Screenshot from 2020-11-26 10-03-08](https://user-images.githubusercontent.com/128088/100337128-ecf24180-2fce-11eb-8fc7-11e0656fa477.png)
![Screenshot from 2020-11-26 10-03-00](https://user-images.githubusercontent.com/128088/100337133-ed8ad800-2fce-11eb-882b-673a49ceae4f.png)


