### PR TITLE
Tweak EventBox icon sizes

### DIFF
--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -14,7 +14,9 @@
     <footer class="event-box__footer">
       <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] %>
         <div class="event-box__footer__item">
-          <%= event_type_icon %>
+          <div class="event-box__footer__icon-wrapper">
+            <%= event_type_icon %>
+          </div>
           <div class="event-box__footer__meta">
             <%= type_name %>
           </div>

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -83,10 +83,14 @@
               display: table-row;
             }
 
-            &__icon,
+            &__icon-wrapper,
             &__meta {
               display: table-cell;
               vertical-align: middle;
+            }
+
+            &__icon-wrapper {
+              text-align: center;
             }
 
             &__meta {

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -31,15 +31,15 @@
 .icon-online-event {
   @include icon;
   background-image: url('../images/icon-online-blue.svg');
-  width: 38px;
-  height: 25px;
+  width: 34px;
+  height: 34px;
 }
 
 .icon-moved-online-event {
   @include icon;
   background-image: url('../images/icon-moved-online-blue.svg');
-  width: 38px;
-  height: 25px;
+  width: 36px;
+  height: 36px;
 
   &--purple {
     background-image: url('../images/icon-moved-online-purple.svg');
@@ -70,15 +70,15 @@
 .icon-school-or-university-event {
     @include icon;
     background-image: url('../images/icon-school-blue.svg');
-    width: 33px;
-    height: 22px;
+    width: 36px;
+    height: 36px;
 }
 
 .icon-train-to-teach-event {
     @include icon;
     background-image: url('../images/icon-ttt.svg');
-    width: 34px;
-    height: 34px;
+    width: 32px;
+    height: 32px;
 }
 
 .icon-quote {


### PR DESCRIPTION
The `EventBox` icon sizes weren't adhering to what was in the CSS due to the display type being `table-cell`. Instead, the icon is wrapped in a `div` with the display type and the icons then take their correct dimensions.

Tweaks the icon sizes so that they look more uniform (the sizes are different but it looks more uniform to the naked eye).

|   Before   |       After       | 
|----------|-------------|
|<img width="1616" alt="Screenshot 2020-11-27 at 13 46 56" src="https://user-images.githubusercontent.com/29867726/100455948-82690080-30b7-11eb-8517-8c8a463fa87f.png">|<img width="1572" alt="Screenshot 2020-11-27 at 13 46 53" src="https://user-images.githubusercontent.com/29867726/100455924-7715d500-30b7-11eb-84e0-8d3c9df31341.png">|
