### PR TITLE
Fix event group spacing when there are no TTT events

### DIFF
--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -97,6 +97,7 @@
     float: left;
     padding: 20px;
     width: 100%;
+    margin-top: 60px;
     box-sizing: border-box;
     + .events-featured {
         margin-top: 30px;
@@ -129,10 +130,6 @@
 
     .call-to-action-button {
       margin-top: 1.5em;
-    }
-
-    &--with-logo {
-      margin-top: 88px;
     }
 
     &__logo {


### PR DESCRIPTION
The Train to Teach events have a logo in the top right, which adds on a margin to the top to push the box down below the heading. When there are no TTT events there still needs to be a margin at the top to give space below the heading. This adds the margin in both scenarios and makes it match with/without the logo being there.

<img width="1140" alt="Screenshot 2020-11-30 at 13 43 40" src="https://user-images.githubusercontent.com/29867726/100617234-21893480-3312-11eb-8db6-e600b862db56.png">

<img width="1120" alt="Screenshot 2020-11-30 at 13 43 48" src="https://user-images.githubusercontent.com/29867726/100617235-2352f800-3312-11eb-8f0f-426f7a6895c1.png">
