### PR TITLE
Update validator to allow outward only postcodes in event search

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -17,7 +17,7 @@ module Events
 
     validates :type, presence: false, inclusion: { in: :available_event_type_ids, allow_nil: true }
     validates :distance, inclusion: { in: :available_distance_keys }, allow_nil: true
-    validates :postcode, presence: true, postcode: { allow_blank: true }, if: :distance
+    validates :postcode, presence: true, postcode: { allow_blank: true, outward_only_postcode: true }, if: :distance
     validates :month, presence: false, format: { with: MONTH_FORMAT, allow_blank: true }
 
     before_validation { self.distance = nil if distance.blank? }

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -17,7 +17,7 @@ module Events
 
     validates :type, presence: false, inclusion: { in: :available_event_type_ids, allow_nil: true }
     validates :distance, inclusion: { in: :available_distance_keys }, allow_nil: true
-    validates :postcode, presence: true, postcode: { allow_blank: true, outward_only_postcode: true }, if: :distance
+    validates :postcode, presence: true, postcode: { allow_blank: true, accept_partial_postcode: true }, if: :distance
     validates :month, presence: false, format: { with: MONTH_FORMAT, allow_blank: true }
 
     before_validation { self.distance = nil if distance.blank? }

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -2,14 +2,14 @@ class PostcodeValidator < ActiveModel::EachValidator
   OUTWARD_POSTCODE_PATTERN = /[A-Z][A-HJ-Y]?\d[A-Z\d]?/.freeze
   FULL_POSTCODE_PATTERN = /#{OUTWARD_POSTCODE_PATTERN} ?\d[A-Z]{2}|GIR ?0A{2}/.freeze
 
-  OUTWARD_OR_FULL_POSTCODE_REGEX = %r{\A(#{OUTWARD_POSTCODE_PATTERN})\Z|\A(#{FULL_POSTCODE_PATTERN})\Z}.freeze
-  FULL_POSTCODE_REGEX = %r{\A(#{FULL_POSTCODE_PATTERN})\Z}.freeze
+  OUTWARD_OR_FULL_POSTCODE_REGEX = %r{\A(#{OUTWARD_POSTCODE_PATTERN})\z|\A(#{FULL_POSTCODE_PATTERN})\z}.freeze
+  FULL_POSTCODE_REGEX = %r{\A(#{FULL_POSTCODE_PATTERN})\z}.freeze
 
-  attr_reader :outward_only_postcode
+  attr_reader :accept_partial_postcode
 
   def initialize(options)
     super
-    @outward_only_postcode = options[:outward_only_postcode]
+    @accept_partial_postcode = options[:accept_partial_postcode]
   end
 
   def validate_each(record, attribute, value)
@@ -21,7 +21,7 @@ class PostcodeValidator < ActiveModel::EachValidator
 private
 
   def validation_regex
-    outward_only_postcode ? OUTWARD_OR_FULL_POSTCODE_REGEX : FULL_POSTCODE_REGEX
+    accept_partial_postcode ? OUTWARD_OR_FULL_POSTCODE_REGEX : FULL_POSTCODE_REGEX
   end
 
   def invalid_postcode?(postcode)

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,5 +1,16 @@
 class PostcodeValidator < ActiveModel::EachValidator
-  PATTERN = %r{\A([A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})\Z}.freeze
+  OUTWARD_POSTCODE_PATTERN = /[A-Z][A-HJ-Y]?\d[A-Z\d]?/.freeze
+  FULL_POSTCODE_PATTERN = /#{OUTWARD_POSTCODE_PATTERN} ?\d[A-Z]{2}|GIR ?0A{2}/.freeze
+
+  OUTWARD_OR_FULL_POSTCODE_REGEX = %r{\A(#{OUTWARD_POSTCODE_PATTERN})\Z|\A(#{FULL_POSTCODE_PATTERN})\Z}.freeze
+  FULL_POSTCODE_REGEX = %r{\A(#{FULL_POSTCODE_PATTERN})\Z}.freeze
+
+  attr_reader :outward_only_postcode
+
+  def initialize(options)
+    super
+    @outward_only_postcode = options[:outward_only_postcode]
+  end
 
   def validate_each(record, attribute, value)
     if value.present? && invalid_postcode?(value)
@@ -9,7 +20,11 @@ class PostcodeValidator < ActiveModel::EachValidator
 
 private
 
+  def validation_regex
+    outward_only_postcode ? OUTWARD_OR_FULL_POSTCODE_REGEX : FULL_POSTCODE_REGEX
+  end
+
   def invalid_postcode?(postcode)
-    !PATTERN.match?(postcode)
+    !validation_regex.match?(postcode)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,22 +62,22 @@ en:
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
   event_types:
-    222750001: 
+    222750001:
       name:
         singular: "Train to Teach Event"
         plural: "Train to Teach Events"
       description: |-
         Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training 
         will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
-    222750008: 
-      name: 
+    222750008:
+      name:
         singular: "Online Event"
         plural: "Online Events"
       description: |-
         In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train. 
         Get fast answers to your questions so you can take the next step to becoming a teacher.
-    222750009: 
-      name: 
+    222750009:
+      name:
         singular: "School or University Event"
         plural: "School and University Events"
       description: |-
@@ -104,8 +104,8 @@ en:
             distance:
               inclusion: Select a distance from the list
             postcode:
-              blank: Enter your postcode
-              invalid: Enter a valid postcode
+              blank: Enter full postcode or first part
+              invalid: Enter valid full postcode or first part
         events/steps/personal_details:
           attributes:
             first_name:

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -63,7 +63,7 @@ describe Events::Search do
       end
 
       context "with assigned distance" do
-        let(:msg) { "Enter a valid postcode" }
+        let(:msg) { "Enter valid full postcode or first part" }
 
         subject do
           described_class.new distance: described_class::DISTANCES.first

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -3,24 +3,37 @@ require "rails_helper"
 describe PostcodeValidator do
   class TestModel
     include ActiveModel::Model
-    attr_accessor :postcode
-    validates :postcode, postcode: true
+    attr_accessor :postcode, :outward_only_postcode
+    validates :postcode, postcode: { outward_only_postcode: :outward_only_postcode }
   end
 
   before { instance.valid? }
   subject { instance.errors.to_h }
 
-  ["F00BAR", "M1", "123ABC", "TE57 ING"].each do |postcode|
-    context "checking '#{postcode}'" do
-      let(:instance) { TestModel.new(postcode: postcode) }
-      it { is_expected.to include postcode: "is invalid" }
+  context "with invalid full postcodes" do
+    ["F00BAR", "123ABC", "TE57 ING"].each do |postcode|
+      context "checking '#{postcode}'" do
+        let(:instance) { TestModel.new(postcode: postcode) }
+        it { is_expected.to include postcode: "is invalid" }
+      end
     end
   end
 
-  ["M1 2WD", "TE57 1NG", ""].each do |postcode|
-    context "checking '#{postcode}'" do
-      let(:instance) { TestModel.new(postcode: postcode) }
-      it { is_expected.not_to include :postcode }
+  context "with valid full postcodes" do
+    ["M1 2WD", "TE57 1NG", ""].each do |postcode|
+      context "checking '#{postcode}'" do
+        let(:instance) { TestModel.new(postcode: postcode) }
+        it { is_expected.not_to include :postcode }
+      end
+    end
+  end
+
+  context "with valid outward only postcodes" do
+    %w[ST6 M1 TE57].each do |postcode|
+      context "checking '#{postcode}'" do
+        let(:instance) { TestModel.new(postcode: postcode, outward_only_postcode: true) }
+        it { is_expected.not_to include :postcode }
+      end
     end
   end
 end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe PostcodeValidator do
   class TestModel
     include ActiveModel::Model
-    attr_accessor :postcode, :outward_only_postcode
-    validates :postcode, postcode: { outward_only_postcode: :outward_only_postcode }
+    attr_accessor :postcode, :accept_partial_postcode
+    validates :postcode, postcode: { accept_partial_postcode: :accept_partial_postcode }
   end
 
   before { instance.valid? }
@@ -31,7 +31,7 @@ describe PostcodeValidator do
   context "with valid outward only postcodes" do
     %w[ST6 M1 TE57].each do |postcode|
       context "checking '#{postcode}'" do
-        let(:instance) { TestModel.new(postcode: postcode, outward_only_postcode: true) }
+        let(:instance) { TestModel.new(postcode: postcode, accept_partial_postcode: true) }
         it { is_expected.not_to include :postcode }
       end
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/qGLRMZNe

### Context
Allow half-postcodes in the events search

### Changes proposed in this pull request

### Guidance to review

