### PR TITLE
Allow <div> tags in safe_html_format

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -7,6 +7,6 @@ module TextFormattingHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b br], attributes: %w[href target]
+    sanitize html, tags: %w[strong a ul li p b br div], attributes: %w[href target]
   end
 end

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -19,7 +19,7 @@ describe TextFormattingHelper, type: :helper do
     subject { safe_html_format html }
 
     context "with allowed HTML" do
-      let(:html) { "<p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
+      let(:html) { "<div>test</div><p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
       it { is_expected.to eql html }
     end
 


### PR DESCRIPTION
The CRM appears to use `<div>` tags instead `<p>` tags; we currently strip these out so some of the text that should be on a new paragraph is squashed onto the end of other text. Allowing the `<div>` tag correctly puts the text on a new line.

|   Before   |       After       | 
|----------|-------------|
|<img width="668" alt="Screenshot 2020-12-01 at 11 35 28" src="https://user-images.githubusercontent.com/29867726/100735581-5a381500-33c9-11eb-8557-3c1ea89b9ab8.png">|<img width="697" alt="Screenshot 2020-12-01 at 11 35 07" src="https://user-images.githubusercontent.com/29867726/100735551-4e4c5300-33c9-11eb-816b-922f166cea66.png">|
