### PR TITLE
Override GOV.UK Transport with Sans-serif

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -1,14 +1,15 @@
 @charset 'UTF-8';
 
-$govuk-font-family: Sans-serif;
-
 @import './git.scss';
+
+$govuk-font-family: $git-font-family;
+
 @import "~govuk-frontend/govuk/all";
 @import './govuk-reset.scss';
 
 @import './components/map';
 
-$fa-font-path: '~@fortawesome/fontawesome-free/webfonts'; 
+$fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import '~@fortawesome/fontawesome-free/scss/regular';
 @import '~@fortawesome/fontawesome-free/scss/solid';

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -1,5 +1,7 @@
 @charset 'UTF-8';
 
+$govuk-font-family: Sans-serif;
+
 @import './git.scss';
 @import "~govuk-frontend/govuk/all";
 @import './govuk-reset.scss';

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -1,7 +1,7 @@
 @import 'colours';
 @import 'utility';
-@import 'layout';
 @import 'text';
+@import 'layout';
 @import 'links_and_buttons';
 @import 'markdown';
 @import 'featured';

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,5 +1,5 @@
 body {
-    font-family: sans-serif;
+    font-family: $git-font-family;
 
     &.govuk-body {
         margin: 0;

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -1,5 +1,7 @@
+$git-font-family: Sans-serif;
+
 @mixin font {
-    font-family: sans-serif;
+    font-family: $git-font-family;
     font-style: normal;
 }
 
@@ -118,7 +120,7 @@ a {
     &:hover {
         color: inherit;
     }
-    
+
     i {
         margin-left: 4px;
         vertical-align: middle;


### PR DESCRIPTION
This will at least keep things uniform until we get the 'official' fonts in place. Currently GDS Transport can be seen in lists, non-paragraph divs and a few other places 😞 
