### PR TITLE
Fix margin for Train to Teach results box

### DIFF
--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -103,6 +103,10 @@
         margin-top: 30px;
     }
 
+    &--with-logo {
+      margin-top: 90px;
+    }
+
     &__heading {
       > h3 {
         font-size: 28px;
@@ -287,6 +291,10 @@
     .events-featured {
         &__text {
           max-width: 100%;
+        }
+
+        &--with-logo {
+          margin-top: 60px;
         }
 
         &__heading {


### PR DESCRIPTION
When the train to teach results appear in a search the margin at the top is too small and it cuts off the top of the logo. This adds a bit of extra margin for the TTT results box.

Before:
<img width="1034" alt="Screenshot 2020-12-03 at 08 11 24" src="https://user-images.githubusercontent.com/29867726/100982290-c50b5c80-353f-11eb-89cc-89b1bc07d6aa.png">

After:
<img width="1082" alt="Screenshot 2020-12-03 at 08 11 13" src="https://user-images.githubusercontent.com/29867726/100982286-c3da2f80-353f-11eb-9f82-acf32da58a02.png">
