### PR TITLE
Navbar current page highlight

### DIFF
--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -6,7 +6,7 @@
         <ul>
             <%= nav_link("Home", '/') %>
             <% resources.each do |resource| %>
-                <%= nav_link(resource[:front_matter]["title"], resource[:path]) %>   
+                <%= nav_link(resource[:front_matter][:title], resource[:path]) %>   
             <% end %>
             <%= nav_link("Find an event near you", events_path) %>
         </ul>

--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -6,7 +6,7 @@
         <ul>
             <%= nav_link("Home", '/') %>
             <% resources.each do |resource| %>
-                <%= nav_link(resource[:front_matter][:title], resource[:path]) %>   
+                <%= nav_link(resource[:front_matter][:title], resource[:path]) %>
             <% end %>
             <%= nav_link("Find an event near you", events_path) %>
         </ul>

--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -1,0 +1,32 @@
+<div class="navbar">
+    <div class="logo"> 
+        <%= render "components/logo" %>
+    </div>
+    <div class="navbar__desktop">
+        <ul>
+            <%= nav_link("Home", '/') %>
+            <% resources.each do |resource| %>
+                <%= nav_link(resource[:front_matter]["title"], resource[:path]) %>   
+            <% end %>
+            <%= nav_link("Find an event near you", events_path) %>
+        </ul>
+    </div>
+        
+    <div class="navbar__mobile" data-controller="navigation">
+        <div class="navbar__mobile__buttons">
+            <a data-action="click->navigation#navToggle" href="javascript:void(0);" class="icon">
+                <div data-target="navigation.hamburger" id='hamburger' class="icon-close"></div>
+                <div data-target="navigation.label" id="navbar-label" class="icon-hamburger-label">Close</div>
+            </a>
+        </div>
+        <div data-target="navigation.links" id="navbar-mobile-links" class="navbar__mobile__links">
+            <ul>
+                <li><a href="/">Home</a></li>
+                <% resources.each do |resource| %>
+                    <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                <% end %>
+                <li><%= link_to "Find an event near you", events_path %></li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -23,7 +23,7 @@
             <ul>
                 <li><a href="/">Home</a></li>
                 <% resources.each do |resource| %>
-                    <li><a href="<%= resource[:path] %>"><%= resource[:front_matter]["title"] %></a></li>
+                    <li><%= link_to resource[:front_matter][:title], resource[:path] %></li>
                 <% end %>
                 <li><%= link_to "Find an event near you", events_path %></li>
             </ul>

--- a/app/components/navbar/navbar_component.rb
+++ b/app/components/navbar/navbar_component.rb
@@ -1,5 +1,7 @@
 module Navbar
   class NavbarComponent < ViewComponent::Base
+    attr_reader :sitemap
+
     def initialize(sitemap)
       @sitemap = sitemap
     end
@@ -12,13 +14,15 @@ module Navbar
 
     def nav_link(link_text, link_path)
       class_name = "active" if first_uri_segment_matches_link?(link_path)
+
       content_tag(:li, class: class_name) do
         link_to link_text, link_path
       end
     end
 
     def first_uri_segment_matches_link?(link_path)
-      current_uri = request.env["PATH_INFO"]
+      current_uri = request.path
+
       /^\/[^\/]*/.match(current_uri)[0] == link_path
     end
   end

--- a/app/components/navbar/navbar_component.rb
+++ b/app/components/navbar/navbar_component.rb
@@ -1,15 +1,9 @@
 module Navbar
   class NavbarComponent < ViewComponent::Base
-    attr_reader :sitemap
-
-    def initialize(sitemap)
-      @sitemap = sitemap
-    end
-
   private
 
     def resources
-      helpers.navigation_resources(@sitemap)
+      helpers.navigation_resources
     end
 
     def nav_link(link_text, link_path)
@@ -22,8 +16,9 @@ module Navbar
 
     def first_uri_segment_matches_link?(link_path)
       current_uri = request.path
-
-      /^\/[^\/]*/.match(current_uri)[0] == link_path
+      if (matches = /^\/[^\/]*/.match(current_uri))
+        matches[0] == link_path
+      end
     end
   end
 end

--- a/app/components/navbar/navbar_component.rb
+++ b/app/components/navbar/navbar_component.rb
@@ -1,0 +1,25 @@
+module Navbar
+  class NavbarComponent < ViewComponent::Base
+    def initialize(sitemap)
+      @sitemap = sitemap
+    end
+
+  private
+
+    def resources
+      helpers.navigation_resources(@sitemap)
+    end
+
+    def nav_link(link_text, link_path)
+      class_name = "active" if first_uri_segment_matches_link?(link_path)
+      content_tag(:li, class: class_name) do
+        link_to link_text, link_path
+      end
+    end
+
+    def first_uri_segment_matches_link?(link_path)
+      current_uri = request.env["PATH_INFO"]
+      /^\/[^\/]*/.match(current_uri)[0] == link_path
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,11 +95,16 @@ module ApplicationHelper
     referer.gsub(root_url, root_path)
   end
 
-
   def nav_link(link_text, link_path)
-    class_name = 'active' if current_page?(link_path)
+    class_name = 'active' if first_uri_segment_matches_link?(link_path)
     content_tag(:li, :class => class_name) do
       link_to link_text, link_path
     end
+  end
+
+  def first_uri_segment_matches_link?(link_path)
+    current_uri = request.env['PATH_INFO']
+    first_path_segment = /^\/[^\/]*/.match(current_uri)
+    return first_path_segment[0] == link_path
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,17 +94,4 @@ module ApplicationHelper
 
     referer.gsub(root_url, root_path)
   end
-
-  def nav_link(link_text, link_path)
-    class_name = 'active' if first_uri_segment_matches_link?(link_path)
-    content_tag(:li, :class => class_name) do
-      link_to link_text, link_path
-    end
-  end
-
-  def first_uri_segment_matches_link?(link_path)
-    current_uri = request.env['PATH_INFO']
-    first_path_segment = /^\/[^\/]*/.match(current_uri)
-    return first_path_segment[0] == link_path
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,4 +94,12 @@ module ApplicationHelper
 
     referer.gsub(root_url, root_path)
   end
+
+
+  def nav_link(link_text, link_path)
+    class_name = 'active' if current_page?(link_path)
+    content_tag(:li, :class => class_name) do
+      link_to link_text, link_path
+    end
+  end
 end

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -8,42 +8,5 @@
             <a href="#" data-action="click->banner#hide">Hide this message</a>
         </p>
     </section>
-<<<<<<< master
-
-    <div class="navbar">
-        <div class="logo"> 
-            <%= render "components/logo" %>
-        </div>
-        <div class="navbar__desktop">
-            <ul>
-                <%= nav_link("Home", '/') %>
-                <% navigation_resources(@sitemap).each do |resource| %>
-                    <%= nav_link(resource[:front_matter]["title"], resource[:path]) %>   
-                <% end %>
-                <%= nav_link("Find an event near you", events_path) %>
-            </ul>
-        </div>
-        
-        <div class="navbar__mobile" data-controller="navigation">
-            <div class="navbar__mobile__buttons">
-                <a data-action="click->navigation#navToggle" href="javascript:void(0);" class="icon">
-                    <div data-target="navigation.hamburger" id='hamburger' class="icon-close"></div>
-                    <div data-target="navigation.label" id="navbar-label" class="icon-hamburger-label">Close</div>
-                </a>
-            </div>
-            <div data-target="navigation.links" id="navbar-mobile-links" class="navbar__mobile__links">
-                <ul>
-                    <li><a href="/">Home</a></li>
-                    <% navigation_resources.each do |resource| %>
-                        <li><a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a></li>
-                    <% end %>
-                    <li><%= link_to "Find an event near you", events_path %></li>
-                </ul>
-            </div>
-        </div>
-
-    </div>
-=======
     <%= render(Navbar::NavbarComponent.new(@sitemap)) %>
->>>>>>> Move navbar into component
 </nav>

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -8,5 +8,5 @@
             <a href="#" data-action="click->banner#hide">Hide this message</a>
         </p>
     </section>
-    <%= render(Navbar::NavbarComponent.new(@sitemap)) %>
+    <%= render(Navbar::NavbarComponent.new) %>
 </nav>

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -15,11 +15,11 @@
         </div>
         <div class="navbar__desktop">
             <ul>
-                <li><a href="/">Home</a></li>
-                <% navigation_resources.each do |resource| %>
-                    <li><a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a></li>
+                <%= nav_link("Home", '/') %>
+                <% navigation_resources(@sitemap).each do |resource| %>
+                    <%= nav_link(resource[:front_matter]["title"], resource[:path]) %>   
                 <% end %>
-                <li><%= link_to "Find an event near you", events_path %></li>
+                <%= nav_link("Find an event near you", events_path) %>
             </ul>
         </div>
         

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -8,6 +8,7 @@
             <a href="#" data-action="click->banner#hide">Hide this message</a>
         </p>
     </section>
+<<<<<<< master
 
     <div class="navbar">
         <div class="logo"> 
@@ -42,4 +43,7 @@
         </div>
 
     </div>
+=======
+    <%= render(Navbar::NavbarComponent.new(@sitemap)) %>
+>>>>>>> Move navbar into component
 </nav>

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -73,6 +73,7 @@
     
         li {
             float: right;
+            padding: 8px 16px;
         }
     
         li a {
@@ -80,7 +81,6 @@
             font-size: 16px;
             display: block;
             text-align: center;
-            padding: 8px 16px;
             text-decoration: none;
             text-align: right;
             font-weight: bold;
@@ -89,10 +89,24 @@
             line-height: 1;
         }
 
-        li a:hover {
-            text-decoration: underline;
+        $border-width: 2.5px;
+        $padding-space: 2.5px;
+      
+        %hover-shared {
+          padding-bottom: 2.5px;
+          margin-bottom: -$border-width - $padding-space;
         }
-
+      
+        a:hover:not(:focus):not(.active) {
+          @extend %hover-shared;
+          border-bottom: solid $border-width $black;
+        }
+      
+        .active a:hover:not(:focus) {
+          @extend %hover-shared;
+          border-bottom: solid $border-width $white;
+        }
+      
         .active {
           background-color: $blue-dark;
           a {

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -92,6 +92,13 @@
         li a:hover {
             text-decoration: underline;
         }
+
+        .active {
+          background-color: $blue-dark;
+          a {
+            color: $white;
+          }
+        }
     }
 
     &__mobile {

--- a/spec/components/navbar/navbar_component_spec.rb
+++ b/spec/components/navbar/navbar_component_spec.rb
@@ -9,10 +9,16 @@ describe Navbar::NavbarComponent, type: "component" do
     allow(Pages::Frontmatter).to receive(:list).and_return all_frontmatter
   end
 
-  subject! { render_inline(Navbar::NavbarComponent.new(all_frontmatter)) }
+  subject! { render_inline(Navbar::NavbarComponent.new) }
 
   describe "Desktop navbar component" do
     context "when rendered" do
+      it "includes links from content" do
+        expect(page).to have_css(".navbar__desktop ul") do |ul|
+          expect(ul).to have_link("Mock title", href: "/mock-path")
+        end
+      end
+
       it "shows background colour on link that matches the current page" do
         expect(page).to have_css("li.active") do |active_li|
           expect(active_li).to have_link("Home", href: "/")
@@ -21,6 +27,16 @@ describe Navbar::NavbarComponent, type: "component" do
 
       it "shows no background colour on links that do not match the current page" do
         page.all(".navbar__desktop li.active", count: 1)
+      end
+    end
+  end
+
+  describe "Mobile navbar component" do
+    context "when rendered" do
+      it "includes links from content" do
+        expect(page).to have_css(".navbar__mobile ul") do |ul|
+          expect(ul).to have_link("Mock title", href: "/mock-path")
+        end
       end
     end
   end

--- a/spec/components/navbar/navbar_component_spec.rb
+++ b/spec/components/navbar/navbar_component_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Navbar::NavbarComponent, type: "component" do
+  let(:all_frontmatter) do
+    { "/mock-path" => { title: "Mock title", navigation: 20 } }
+  end
+
+  before do
+    allow(Pages::Frontmatter).to receive(:list).and_return all_frontmatter
+  end
+
+  subject! { render_inline(Navbar::NavbarComponent.new(all_frontmatter)) }
+
+  describe "Desktop navbar component" do
+    context "when rendered" do
+      it "shows background colour on link that matches the current page" do
+        desktop_navbar = page.find(".navbar__desktop")
+        home_link = desktop_navbar.find("a", text: "Home")
+        parent_li = home_link.find(:xpath, "..")
+
+        expect(parent_li["class"]).to match("active")
+      end
+
+      it "shows no background colour on links that do not match the current page" do
+        desktop_navbar = page.find(".navbar__desktop")
+        home_links = desktop_navbar.all("a").reject do |anchor|
+          anchor.native.children.text == "Home"
+        end
+        parent_lis = []
+        home_links.each { |anchor| parent_lis.push(anchor.find(:xpath, "..")) }
+
+        parent_lis.each do |li|
+          expect(li["class"]).to_not match("active")
+        end
+      end
+    end
+  end
+end

--- a/spec/components/navbar/navbar_component_spec.rb
+++ b/spec/components/navbar/navbar_component_spec.rb
@@ -14,24 +14,13 @@ describe Navbar::NavbarComponent, type: "component" do
   describe "Desktop navbar component" do
     context "when rendered" do
       it "shows background colour on link that matches the current page" do
-        desktop_navbar = page.find(".navbar__desktop")
-        home_link = desktop_navbar.find("a", text: "Home")
-        parent_li = home_link.find(:xpath, "..")
-
-        expect(parent_li["class"]).to match("active")
+        expect(page).to have_css("li.active") do |active_li|
+          expect(active_li).to have_link("Home", href: "/")
+        end
       end
 
       it "shows no background colour on links that do not match the current page" do
-        desktop_navbar = page.find(".navbar__desktop")
-        home_links = desktop_navbar.all("a").reject do |anchor|
-          anchor.native.children.text == "Home"
-        end
-        parent_lis = []
-        home_links.each { |anchor| parent_lis.push(anchor.find(:xpath, "..")) }
-
-        parent_lis.each do |li|
-          expect(li["class"]).to_not match("active")
-        end
+        page.all(".navbar__desktop li.active", count: 1)
       end
     end
   end


### PR DESCRIPTION
### Trello card
[567](https://trello.com/c/DJDXN592/567-develop-move-funding-after-steps-in-top-nav-bar-and-add-highlight-to-page-title-in-nav-when-you-are-on-that-page)

### Context
background highlight on current navbar links

### Changes proposed in this pull request

### Guidance to review
This was reverted yesterday as I forgot to update the mobile links to reflect the changes in the content. I have added some tests to prevent that happening again
