### PR TITLE
Allow markdown to be rendered above the accordion

### DIFF
--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -16,6 +16,8 @@
                     <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
                   <% end %>
 
+                  <%= yield %>
+
                   <% @parent_front_matter = @front_matter %>
 
                   <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>

--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -45,6 +45,12 @@
             margin: 0;
             padding: .8em;
 
+            blockquote {
+              background: $grey;
+              padding: 1em;
+              margin: 1em 0;
+            }
+
         }
 
         &.inactive {


### PR DESCRIPTION
This supports the changes made in https://github.com/DFE-Digital/get-into-teaching-content/pull/175