### PR TITLE
Implement stories landing page redesign

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -32,7 +32,7 @@
 <% if show_more_stories? %>
   <h2 class="strapline">More stories</h2>
   <div class="cards stories">
-    <%= render Stories::CardComponent.with_collection(more_stories) %>
+    <%= render Cards::RendererComponent.with_collection(more_stories) %>
   </div>
 <% end %>
 
@@ -41,7 +41,7 @@
   <h2>Explore Get Into Teaching</h2>
 
   <div class="cards stories">
-    <%= render Cards::StoryComponent.with_collection(explore, page_data: page_data) %>
+    <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
   </div>
 <section>
 <% end %>

--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -31,7 +31,7 @@
 
 <% if show_more_stories? %>
   <h2 class="strapline">More stories</h2>
-  <div class="cards more-stories">
+  <div class="cards stories">
     <%= render Stories::CardComponent.with_collection(more_stories) %>
   </div>
 <% end %>
@@ -40,8 +40,8 @@
 <section class="cards-with-headers">
   <h2>Explore Get Into Teaching</h2>
 
-  <div class="cards more-stories">
-    <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
+  <div class="cards stories">
+    <%= render Cards::StoryComponent.with_collection(explore, page_data: page_data) %>
   </div>
 <section>
 <% end %>

--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -24,7 +24,7 @@ module StoriesHelper
 
   def more_stories_thumbnail(path)
     tag.div(
-      class: "more-stories__thumbs__thumb__img",
+      class: "stories__thumbs__thumb__img",
       style: %(background-image:url('#{path}')),
     )
   end

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -5,19 +5,19 @@
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
 
-      <div class="stories-feature">
-        <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
-        <div class="stories-feature__content">
-          <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
-          <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
-          <%= tag.p(@front_matter.dig("featured_story", "text")) %>
-          <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
-            Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
-          <% end %>
-        </div>
-      </div>
 
       <main class="content container-1000 story-landing" role="main" id="main-content">
+        <div class="stories-feature">
+          <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
+          <div class="stories-feature__content">
+            <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
+            <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
+            <%= tag.p(@front_matter.dig("featured_story", "text")) %>
+            <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
+              Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
+            <% end %>
+          </div>
+        </div>
         <% @front_matter["sections"]&.each do |name, section| %>
           <section>
             <header>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -25,7 +25,7 @@
               <%= tag.p(section["text"]) %>
             </header>
             <% if section["stories"].present? %>
-              <div class="cards more-stories">
+              <div class="cards stories">
                 <%= render Stories::CardComponent.with_collection(section["stories"]) %>
               </div>
 

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -26,7 +26,7 @@
             </header>
             <% if section["stories"].present? %>
               <div class="cards stories">
-                <%= render Stories::CardComponent.with_collection(section["stories"]) %>
+                <%= render Cards::RendererComponent.with_collection(section["stories"]) %>
               </div>
 
               <footer>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -5,9 +5,9 @@
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <main class="content container-1000" role="main" id="main-content">
-        <%= back_link "/life-as-a-teacher/my-story-into-teaching", text: "All stories" %>
+        <%= back_link "/my-story-into-teaching", text: "All stories" %>
         <%= yield %>
-        <div class="cards">
+        <div class="cards stories">
           <%= render Stories::CardComponent.with_collection(@front_matter.dig("stories")) %>
         </div>
       </main>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -8,7 +8,7 @@
         <%= back_link "/my-story-into-teaching", text: "All stories" %>
         <%= yield %>
         <div class="cards stories">
-          <%= render Stories::CardComponent.with_collection(@front_matter.dig("stories")) %>
+          <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
         </div>
       </main>
       <%= render "sections/footer" %>

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -3,6 +3,7 @@
     padding: 2px;
 
     .card {
+        overflow: auto;
         outline: 2px solid $black;
         display: flex;
         flex-direction: column;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -55,7 +55,6 @@
     &__image {
         display: table-cell;
         width: 38%;
-        background-position: center;
         background-repeat: no-repeat;
         background-size: cover;
     }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -164,75 +164,6 @@
     }
 }
 
-.more-stories {
-
-    &__thumbs {
-
-        padding-left: 20px;
-        padding-right: 20px;
-        box-sizing: border-box;
-            display: -ms-flexbox;
-            display: flexbox;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-
-        &__thumb {
-            width: calc(33% - 25px);
-            border: 2px solid $black;
-            box-sizing: border-box;
-            margin-bottom: 40px;
-            margin-right: 40px;
-            position: relative;
-            text-align: left;
-            &:nth-child(3n + 3) {
-                margin-right: 0;
-            }
-            &__img
-            {
-                width: 100%;
-                height: 230px;
-                background-position: center;
-                background-repeat: no-repeat;
-                background-size: cover;
-                position: relative;
-                overflow: hidden;
-            }
-
-            &__content {
-                box-sizing: border-box;
-                padding: 20px;
-                p {
-                    margin: 0 0 20px;
-                }
-            }
-
-            &__play {
-                @include rotated-block;
-                background-color: $pink-dark-90;
-                height: 72px;
-                width: 72px;
-                position: absolute;
-                top: 50px;
-                left: -2px;
-            
-                div {
-                    transform: rotate(3deg);
-                    margin-top: 22px;
-                    margin-left: 24px; 
-                }
-                a:hover & {
-                    background-color: $pink;
-                }
-                a:focus & {
-                    background-color: $yellow;
-                }
-            }
-            
-        }
-    }
-}
-
 .content-wrapper {
     .content__left {
         .stories-call-to-action {
@@ -307,7 +238,7 @@
                 h2 {
                     padding-left: 0px;
                     padding-top: 20px;
-                }         
+                }
             }
         }
     }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -43,6 +43,7 @@
     width: 100%;
     max-width: 1250px;
     margin: 2em auto 2em;
+    border-bottom: 2em solid $purple;
 
     &__image {
         display: table-cell;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -27,7 +27,8 @@
             }
 
             a {
-                @include button($bg: $grey, $fg: $black);
+                @include button;
+                @include chevron;
                 display: inline-block;
                 margin: 1em 0 0 0;
                 white-space: initial;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -10,6 +10,10 @@
 
         h2 {
             @include content-heading;
+            color: $black;
+            background-color: unset;
+            size: 110%;
+            margin-bottom: 0;
         }
     }
 
@@ -43,7 +47,10 @@
     width: 100%;
     max-width: 1250px;
     margin: 2em auto 2em;
-    border-bottom: 2em solid $purple;
+
+    @media only screen and (min-width: 800px) {
+      border-bottom: 2em solid $purple;
+    }
 
     &__image {
         display: table-cell;
@@ -277,7 +284,7 @@
     }
 }
 
-@media only screen and (max-width: 700px) {
+@media only screen and (max-width: 800px) {
 
     .stories {
 

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -235,7 +235,8 @@
         font-size: smaller;
 
         @media only screen and (max-width: $story-card-wrap) {
-          padding: 0;
+          margin-top: .5em;
+          padding: 0 .5em;
           font-size: initial;
         }
       }
@@ -244,6 +245,7 @@
     .card__footer {
       padding: .6em 1em;
       flex: 1 0 80%;
+      margin-left: 1em;
 
       @media only screen and (max-width: $story-card-wrap) {
         margin: 0;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -3,6 +3,11 @@
         padding: 0 20px;
         width: 66.6%;
 
+        @media only screen and (max-width: 800px) {
+          width: 100%;
+          padding: 0;
+        }
+
         h2 {
             @include content-heading;
         }
@@ -15,10 +20,17 @@
             padding: 20px;
             width: 66.6%;
 
+            @media only screen and (max-width: 800px) {
+              width: 100%;
+              margin: 0;
+              padding: 0;
+            }
+
             a {
                 @include button($bg: $grey, $fg: $black);
                 display: inline-block;
                 margin: 1em 0 0 0;
+                white-space: initial;
             }
         }
     }
@@ -74,10 +86,6 @@
 
 .content-wrapper {
     overflow: auto;
-}
-
-.cards.more-stories {
-  padding: 0 20px 20px;
 }
 
 .story {
@@ -164,6 +172,85 @@
     }
 }
 
+
+.stories {
+  grid-gap: 1em;
+  padding: 0 20px;
+  $story-card-wrap: 800px;
+
+  @media only screen and (max-width: $story-card-wrap) {
+    padding: 0;
+  }
+
+  .card {
+    flex-direction: row;
+    flex-wrap: wrap;
+    outline: none;
+    background-color: $grey;
+    align-items: center;
+
+    @media only screen and (max-width: $story-card-wrap) {
+      flex-wrap: nowrap;
+      flex-direction: column;
+      align-content: flex-start;
+    }
+
+    .card__thumb {
+      flex: 0 1 45%;
+
+      > img {
+        width: 100%;
+        object-fit: contain;
+        height: auto;
+      }
+
+      @media only screen and (max-width: $story-card-wrap) {
+        flex: 1 0 auto;
+        justify-items: center;
+        text-align: center;
+
+        > img {
+          object-fit: cover;
+          max-height: 15em;
+        }
+      }
+    }
+
+    .card__snippet {
+      flex: 0 0 50%;
+
+      @media only screen and (max-width: $story-card-wrap) {
+        flex: 1 0 auto;
+        padding: 1em;
+      }
+
+      padding: 0;
+      margin: 0;
+
+      > p {
+        padding: 0 .6em;
+        margin: 0;
+        font-size: smaller;
+
+        @media only screen and (max-width: $story-card-wrap) {
+          padding: 0;
+          font-size: initial;
+        }
+      }
+    }
+
+    .card__footer {
+      padding: .6em 1em;
+      flex: 1 0 80%;
+
+      @media only screen and (max-width: $story-card-wrap) {
+        margin: 0;
+        flex: 1 1 0;
+      }
+    }
+  }
+}
+
 .content-wrapper {
     .content__left {
         .stories-call-to-action {
@@ -188,7 +275,7 @@
 
 @media only screen and (max-width: 700px) {
 
-    .more-stories {
+    .stories {
 
         &__thumbs {
             flex-wrap: wrap;
@@ -219,28 +306,4 @@
         }
 
     }
-}
-@media only screen and (max-width: 500px) {
-    .stories {
-        .story-header {
-            display: -ms-flexbox;
-            display: flexbox;
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            &__thumb {
-                // width: 100%;
-                // height: 135px;
-            }
-
-            &__label {
-
-                h2 {
-                    padding-left: 0px;
-                    padding-top: 20px;
-                }
-            }
-        }
-    }
-
 }

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -113,7 +113,7 @@ describe Stories::StoryComponent, type: "component" do
       end
 
       specify "there should be a story card for each story" do
-        is_expected.to have_css(".cards.more-stories > .card", count: front_matter[:more_stories].length)
+        is_expected.to have_css(".cards.stories > .card", count: front_matter[:more_stories].length)
       end
     end
 
@@ -163,7 +163,7 @@ describe Stories::StoryComponent, type: "component" do
     end
 
     specify "there should be a story card for each story" do
-      is_expected.to have_css(".cards.more-stories > .card", count: more_stories)
+      is_expected.to have_css(".cards.stories > .card", count: more_stories)
     end
   end
 end

--- a/spec/helpers/stories_helper_spec.rb
+++ b/spec/helpers/stories_helper_spec.rb
@@ -39,7 +39,7 @@ describe StoriesHelper, type: "helper" do
     subject { helper.more_stories_thumbnail(path) }
 
     specify %(should generate a div with the background image set to the provided path) do
-      expect(subject).to have_css(%(div[style="background-image:url('#{path}')"]), class: "more-stories__thumbs__thumb__img")
+      expect(subject).to have_css(%(div[style="background-image:url('#{path}')"]), class: "stories__thumbs__thumb__img")
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/FgarLRT1/606-develop-create-a-redesigned-stories-page

### Context

Update the stories pages to match the redesign referenced above

### Changes proposed in this pull request

#### Change the story cards to grey with the image and snippet side-by-side at the top and the link below.

![Screenshot from 2020-12-07 15-47-18](https://user-images.githubusercontent.com/128088/101372970-5b26e600-38a4-11eb-8c70-0bf80c9db09a.png)

![Screenshot from 2020-12-07 15-47-06](https://user-images.githubusercontent.com/128088/101372977-5bbf7c80-38a4-11eb-912f-af59b316e08e.png)

#### Improve the styling on mobile

![Screenshot from 2020-12-07 15-47-45](https://user-images.githubusercontent.com/128088/101373044-6d088900-38a4-11eb-8dda-6c6835aafbc8.png)

#### Add a purple border to the bottom of the featured story

![Screenshot from 2020-12-07 15-51-41](https://user-images.githubusercontent.com/128088/101373094-7a257800-38a4-11eb-9f39-2c939b905212.png)


### Guidance to review

Do these look as expected?