### PR TITLE
Simplify TalkToUs Stimulus controller

### DIFF
--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: %w[call-to-action call-to-action--chat-online], data: { controller: "talk-to-us" }) do %>
+<%= tag.div(class: %w[call-to-action call-to-action--chat-online], data: { controller: "talk-to-us", talk_to_us_display: "flex" }) do %>
   <%= icon %>
 
   <div class="call-to-action__content">

--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: %w[call-to-action call-to-action--chat-online talk-to-us--hidden], data: { controller: "talk-to-us", talk_to_us_display_class: "talk-to-us--display-flex" }) do %>
+<%= tag.div(class: %w[call-to-action call-to-action--chat-online], data: { controller: "talk-to-us" }) do %>
   <%= icon %>
 
   <div class="call-to-action__content">

--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: %w[call-to-action call-to-action--chat-online], data: { controller: "talk-to-us", talk_to_us_display: "flex" }) do %>
+<%= tag.div(class: %w[call-to-action call-to-action--chat-online talk-to-us--hidden], data: { controller: "talk-to-us", talk_to_us_display_class: "talk-to-us--display-flex" }) do %>
   <%= icon %>
 
   <div class="call-to-action__content">

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,4 +1,4 @@
-<section id="talk-to-us" class="talk-to-us" data-controller="talk-to-us">
+<section id="talk-to-us" class="talk-to-us">
     <div class="container-1000">
         <div class="talk-to-us__inner">
 
@@ -9,7 +9,7 @@
 
             <div class="talk-to-us__inner__table">
             
-                <div class="talk-to-us__inner__table__column" data-target="talk-to-us.chat">
+                <div class="talk-to-us__inner__table__column" data-controller="talk-to-us" data-talk-to-us-display="inline-block">
                     <p>
                         <b>Chat online</b> <br/>
                         If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service, 

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -9,7 +9,7 @@
 
             <div class="talk-to-us__inner__table">
             
-                <div class="talk-to-us__inner__table__column" data-controller="talk-to-us" data-talk-to-us-display="inline-block">
+                <div class="talk-to-us__inner__table__column talk-to-us--hidden" data-controller="talk-to-us" data-talk-to-us-display-class="talk-to-us--display-block">
                     <p>
                         <b>Chat online</b> <br/>
                         If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service, 

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -9,7 +9,7 @@
 
             <div class="talk-to-us__inner__table">
             
-                <div class="talk-to-us__inner__table__column talk-to-us--hidden" data-controller="talk-to-us" data-talk-to-us-display-class="talk-to-us--display-block">
+                <div class="talk-to-us__inner__table__column" data-controller="talk-to-us">
                     <p>
                         <b>Chat online</b> <br/>
                         If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service, 

--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     }
 
     show() {
-        this.element.style.display = this.display;
+        this.element.classList.add(this.displayClass);
     }
 
     startChat(e) {
@@ -18,7 +18,7 @@ export default class extends Controller {
         windowFeatures);
     }
 
-    get display() {
-        return this.data.get('display') || 'block';
+    get displayClass() {
+        return this.data.get('display-class');
     }
 }

--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     }
 
     show() {
-        this.element.classList.add(this.displayClass);
+        this.element.classList.add("visible");
     }
 
     startChat(e) {
@@ -16,9 +16,5 @@ export default class extends Controller {
         window.open("https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0",
         "Get into teaching: Chat online",
         windowFeatures);
-    }
-
-    get displayClass() {
-        return this.data.get('display-class');
     }
 }

--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -2,14 +2,12 @@ import { Controller } from "stimulus"
 
 export default class extends Controller {
 
-    static targets = ["chat", "tta"];
-
     connect() {
-        this.showChatControls();
+        this.show();
     }
 
-    showChatControls() {
-        this.chatTarget.style.display = 'inline-block';
+    show() {
+        this.element.style.display = this.display;
     }
 
     startChat(e) {
@@ -20,4 +18,7 @@ export default class extends Controller {
         windowFeatures);
     }
 
+    get display() {
+        return this.data.get('display') || 'block';
+    }
 }

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -7,11 +7,6 @@
         flex-direction: column;
     }
 
-    &--chat-online {
-        // Made visible by Stimulus controller if JS is enabled.
-        display: none;
-    }
-
     &__icon {
         background-color: $yellow;
         padding: 1em;

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -18,6 +18,14 @@
         }
     }
 
+    &--chat-online {
+        display: none;
+    }
+
+    &.visible {
+        display: flex;
+    }
+
     &__content {
         padding: .5em 1em 1em;
 

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -7,6 +7,11 @@
         flex-direction: column;
     }
 
+    &--chat-online {
+        // Made visible by Stimulus controller if JS is enabled.
+        display: none;
+    }
+
     &__icon {
         background-color: $yellow;
         padding: 1em;

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -35,6 +35,14 @@
 
                 a{
                     text-decoration: none;
+                }  
+            }
+
+            &__column:first-child {
+                display: none;
+            
+                &.visible {
+                    display: inline-block;
                 }
             }
 
@@ -48,18 +56,6 @@
             padding-top: 10px;
             padding-right: 10px;
         }
-    }
-
-    &--hidden {
-        display: none;
-    }
-
-    &--display-block {
-        display: block;
-    }
-
-    &--display-flex {
-        display: flex;
     }
 }
 

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -6,7 +6,6 @@
     .container-1000 {
         text-align: left;
     }
-    
 
     &__inner {
         position: relative;
@@ -39,10 +38,6 @@
                 }
             }
 
-            &__column:first-child {
-                display: none;
-            }
-
             &__column:last-child {
                 flex: 1;
             }
@@ -53,6 +48,18 @@
             padding-top: 10px;
             padding-right: 10px;
         }
+    }
+
+    &--hidden {
+        display: none;
+    }
+
+    &--display-block {
+        display: block;
+    }
+
+    &--display-flex {
+        display: flex;
     }
 }
 

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -5,7 +5,7 @@ describe('TalkToUsController', () => {
 
     document.body.innerHTML = 
     `
-    <section data-controller="talk-to-us" data-talk-to-us-display-class="talk-to-us--display-block" id="element">
+    <section data-controller="talk-to-us" id="element">
         <div data-target="talk-to-us.chat" id="chat">
             <a href="#" data-action="click->talk-to-us#startChat" id="startChat">Chat Online</a>
         </div>
@@ -20,9 +20,9 @@ describe('TalkToUsController', () => {
         jest.spyOn(global, "window", "get").mockImplementation(() => ({ open }));
     });
 
-    it("makes the controller element visible, using the correct display class", () => {
+    it("makes the controller element visible", () => {
         var element = document.getElementById('element');
-        expect(element.classList).toContain('talk-to-us--display-block');
+        expect(element.classList).toContain('visible');
     });
 
     describe("startChat", () => {

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -5,7 +5,7 @@ describe('TalkToUsController', () => {
 
     document.body.innerHTML = 
     `
-    <section data-controller="talk-to-us" data-talk-to-us-display="flex" id="element">
+    <section data-controller="talk-to-us" data-talk-to-us-display-class="talk-to-us--display-block" id="element">
         <div data-target="talk-to-us.chat" id="chat">
             <a href="#" data-action="click->talk-to-us#startChat" id="startChat">Chat Online</a>
         </div>
@@ -20,9 +20,9 @@ describe('TalkToUsController', () => {
         jest.spyOn(global, "window", "get").mockImplementation(() => ({ open }));
     });
 
-    it("makes the controller element visible, using the correct display mode", () => {
+    it("makes the controller element visible, using the correct display class", () => {
         var element = document.getElementById('element');
-        expect(element.style.display).toEqual('flex');
+        expect(element.classList).toContain('talk-to-us--display-block');
     });
 
     describe("startChat", () => {

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -5,46 +5,34 @@ describe('TalkToUsController', () => {
 
     document.body.innerHTML = 
     `
-    <section id="talk-to-us" class="talk-to-us" data-controller="talk-to-us">
-
-        <div class="talk-to-us__inner__table__column" data-target="talk-to-us.chat" id="1">
-            <p>
-                <b>Chat online</b> <br/>
-                If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service, 
-                Monday-Friday between 8.30am and 5pm.
-            </p>
-            <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
-                Chat <span>online</span>
-            </a>
+    <section data-controller="talk-to-us" data-talk-to-us-display="flex" id="element">
+        <div data-target="talk-to-us.chat" id="chat">
+            <a href="#" data-action="click->talk-to-us#startChat" id="startChat">Chat Online</a>
         </div>
-
-        <div class="talk-to-us__inner__table__column" data-target="talk-to-us.tta" id="2">
-            <p>
-                <b>Get an adviser</b> <br/>
-                If you're ready to get into teaching, you can get support from a dedicated and experienced teaching professional 
-                who can guide you through each step of the process.
-            </p>
-            <p>
-                If you’re returning to teaching and are qualified to teach maths, physics or languages, you can also get support by using this service.
-            </p>
-            <%= tta_service_link class: "call-to-action-button" do %>
-                Get an <span>adviser</span>
-            <% end %>
-        </div>
-
     </section>
     `;
 
-    const application = Application.start() ;
-    application.register('talk-to-us', TalkToUsController) ;
+    const open = jest.fn();
+    const application = Application.start();
+    application.register('talk-to-us', TalkToUsController);
 
-    describe("when first loaded", () => {
-
-        it("should make the chat section visible", () => {
-            var chat = document.getElementById('1');
-            expect(chat.style.display).toContain('inline-block');
-        });
-
+    beforeEach(() => {
+        jest.spyOn(global, "window", "get").mockImplementation(() => ({ open }));
     });
 
+    it("makes the controller element visible, using the correct display mode", () => {
+        var element = document.getElementById('element');
+        expect(element.style.display).toEqual('flex');
+    });
+
+    describe("startChat", () => {
+        it("opens the chat session", () => {
+            var startChat = document.getElementById("startChat");
+            startChat.click();
+            const url = "https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0";
+            const target = "Get into teaching: Chat online";
+            const features = "menubar=no,location=yes,resizable=yes,scrollbars=no,status=yes,width=340,height=480";
+            expect(open).toBeCalledWith(url, target, features);
+        });
+    });
 });


### PR DESCRIPTION
This controller previously had two targets, `chat` and `tta`. The `tta` target was unused so could be removed and the `chat` target was used to show the chat CTA if Javascript is enabled.

There was a bug introduced when another chat partial used the `TalkToUsController` but didn't specify a `chat` target. Instead, this commit refactors the controller to use the built in `element` target as the chat element. It now also accepts a display type as DOM state, since the other use case required a `flex` display type (and the initial use case used `inline-block`).

Updates the test cases to simplify the stub HTML and cover the `startChat` method.