### PR TITLE
Change home-hero font-weight and underline. remove caps from homepage.

### DIFF
--- a/app/webpacker/styles/sections/header.scss
+++ b/app/webpacker/styles/sections/header.scss
@@ -38,7 +38,6 @@
             text-decoration-thickness: 5px;
             text-underline-offset: .25em;
 
-            font-weight: 900;
             font-size: 3.38rem;
             line-height: 1.4;
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -50,11 +50,6 @@
                     padding: 20px 40px 25px 40px;
                     margin: 0 0 30px 0;
 
-                    text-decoration: underline;
-                    text-decoration-thickness: 5px;
-                    text-underline-offset: .25em;
-
-                    font-weight: 900;
                     font-size: 3.38rem;
                     line-height: 1.4;
 
@@ -62,13 +57,8 @@
                     min-width: 490px;
                     box-sizing: border-box;
 
-                    &::after {
-                        content: "."
-                    }
-
                     @media only screen and (max-width: $mobile-cutoff) {
                         font-size: 28px;
-                        text-decoration-thickness: 4px;
                         margin: 0 0 10px 0;
                         width: calc(100% - 50px);
                         max-width: 400px;
@@ -76,6 +66,16 @@
                     }
                     @media only screen and (min-width: 1500px) {
                         font-size: 3.6vw;
+                    }
+
+                    span {
+                        border-bottom: 5px solid $black;
+                        padding-bottom: 5px;
+
+                        @media only screen and (max-width: $mobile-cutoff) {
+                        border-bottom: 4px solid $black;
+                        padding-bottom: 4px;
+                        }
                     }
                 }
             }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -73,8 +73,8 @@
                         padding-bottom: 5px;
 
                         @media only screen and (max-width: $mobile-cutoff) {
-                        border-bottom: 4px solid $black;
-                        padding-bottom: 4px;
+                            border-bottom: 4px solid $black;
+                            padding-bottom: 4px;
                         }
                     }
                 }

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -79,7 +79,6 @@ a {
 
     &--small {
       font-size: 0.8em;
-      text-transform: uppercase;
 
       &:after {
         content: "";


### PR DESCRIPTION

Remove 900 font-weight from page titles as Is displaying super bold on some browsers.

Changed the text underline to border-bottom as was not rendering consistently across browsers. 

removed text-transform: uppercase from homepage labels.