### PR TITLE
Stop overwriting the frontmatter for partials

### DIFF
--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -18,12 +18,8 @@
 
                   <%= yield %>
 
-                  <% @parent_front_matter = @front_matter %>
-
                   <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
-
                     <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered")) do |accordion| %>
-
                       <%= accordion.slot(
                         :content_before_accordion,
                         partial: accordion_fm.dig("content_before_accordion", "partial"),
@@ -43,8 +39,6 @@
                       ) %>
                     <% end %>
                   <% end %>
-
-                  <% @front_matter = @parent_front_matter %>
                 </div>
 
                 <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -32,6 +32,8 @@ module TemplateHandlers
 
     def call
       # inspect objects to Ruby strings which can be eval'd
+      return %(#{render.inspect}.html_safe) if front_matter.empty?
+
       %(@front_matter = #{front_matter.inspect}; #{render.inspect}.html_safe)
     end
 

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -90,6 +90,26 @@ describe TemplateHandlers::Markdown, type: :view do
     end
   end
 
+  context "with empty front matter" do
+    let(:original_front_matter) { { "title": "Outer page" } }
+    let :markdown do
+      <<~MARKDOWN
+        # Page without frontmatter (a partial)
+      MARKDOWN
+    end
+
+    before { view.instance_variable_set("@front_matter", original_front_matter) }
+
+    before do
+      stub_template "test.md" => markdown
+      render template: "test.md"
+    end
+
+    it "won't overwrite existing frontmatter with no data" do
+      expect(view.instance_variable_get("@front_matter")).to eql(original_front_matter)
+    end
+  end
+
   context "with acronyms" do
     let :markdown do
       <<~MARKDOWN


### PR DESCRIPTION
Now we're using markdown partials more and more we're hitting a problem where the template handler tries to set the front matter for each partial despite them having none.

This change will only amend the front matter if there is some present in the template we're currently rendering. This will pave the way for us breaking up pages into section partials and rendering CTAs inbetween.

If for some reason there _is_ front matter inside a partial the old behaviour will continue.