### PR TITLE
Remove horizontal scrollbars on the homepage

### DIFF
--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -70,9 +70,9 @@
             font-size: 19px;
             line-height: 1.6;
         }
-        
+
         div.content-video {
-            margin-top: 20px;    
+            margin-top: 20px;
             width: 100%;
             text-align: left;
             overflow: hidden;
@@ -89,11 +89,11 @@
                 position: relative;
                 top: -250px;
                 left: -1px;
-            
+
                 div {
                     transform: rotate(3deg);
                     margin-top: 22px;
-                    margin-left: 24px; 
+                    margin-left: 24px;
                 }
             }
         }
@@ -160,7 +160,7 @@
         overflow: hidden;
 
         &__left {
-            padding: 0 0 20px 0px;    
+            padding: 0 0 20px 0px;
             display: block;
             width: 100%;
 

--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -3,7 +3,7 @@
     width: 100%;
     box-sizing: border-box;
     margin-bottom: 70px;
-    overflow: auto;
+    overflow: hidden auto;
     + .content {
         margin-top: -40px;
     }


### PR DESCRIPTION
### Trello card

N/A

### Context

A tiny (few px) horizontal scroll had been introduced on the homepage. It looked like the main culprit was the slanted hero text but it was actually the 'bands' across the page.

### Changes proposed in this pull request

Make the hero element a little narrower while maintaining the width of the actual heading text. Also make the content clip horizontally so as not to add scrollbars. The real solution is to rewrite the CSS and remove the calculations (`justify-item: flex-end` should do it) but that's a bigger and more-invasive task.

### Guidance to review

Sensible approach?
