### PR TITLE
Make homepage steps into a column

### DIFF
--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -4,15 +4,15 @@
     box-sizing: border-box;
     display: table;
     width: 100%;
-    
+
     &__left {
-        
+
         display: table-cell;
         vertical-align: top;
         width: 370px;
         min-width: 370px;
         height: 240px;
-        
+
         &__video {
             margin-left: 20px;
             width: 370px;
@@ -37,11 +37,11 @@
                 a:focus & {
                     background-color: $yellow;
                 }
-            
+
                 div {
                     transform: rotate(3deg);
                     margin-top: 22px;
-                    margin-left: 5px; 
+                    margin-left: 5px;
                 }
             }
         }
@@ -124,7 +124,7 @@
 
     white-space: nowrap;
     overflow: hidden;
-    
+
     &__pic {
         display: inline-block;
         box-sizing: border-box;
@@ -358,15 +358,15 @@
     box-sizing: border-box;
     display: table;
     width: 100%;
-    
+
     &__left {
-        
+
         display: table-cell;
         vertical-align: top;
         width: 370px;
         min-width: 370px;
         height: 240px;
-        
+
         &__map {
             margin-left: 20px;
             width: 370px;
@@ -379,7 +379,7 @@
             &__pin {
                 position: relative;
                 top: 60px;
-            
+
                 div {
                     margin-top: 10px;
                 }
@@ -412,7 +412,7 @@
 
 @media only screen and (max-width: 800px) {
 
-    .steps { 
+    .steps {
 
         &__table {
             margin-top: 0px;
@@ -427,16 +427,16 @@
                 margin-bottom: 10px;
             }
         }
-    
+
     }
 
     .my-story {
-        
+
         padding-top: 70px;
         padding-bottom: 20px;
         padding-left:0px;
         padding-right: 0px;
-        
+
         &__left {
             display: block;
 
@@ -467,12 +467,12 @@
     }
 
     .find-an-event {
-        
+
         padding-top: 70px;
         padding-bottom: 20px;
         padding-left: 0px;
         padding-right: 0px;
-        
+
         &__left {
             display: block;
 
@@ -524,7 +524,7 @@
                 display: block;
             }
         }
-        
+
     }
 
     .find-an-event {
@@ -559,7 +559,7 @@
         p {
             margin-top: 0;
         }
-        
+
         &__img {
             height: 300px;
         }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -185,24 +185,6 @@
         background-color: $blue;
     }
 
-    &__wrapper {
-        display: flex;
-
-        @media (max-width: $steps-row-limit) {
-            flex-direction: column;
-        }
-
-        /*  This is a bit of a hack to target IE, which has a horrendous bug
-            that prevents it from wrapping text inside hyperlinks. So we
-            needn't wrap, always display the steps in a column format on IE */
-        @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-            flex-direction: column;
-            > * {
-                padding: .5em 0;
-            }
-        }
-    }
-
     &__step {
         display: flex;
         align-items: center;
@@ -224,15 +206,12 @@
         text-decoration: none;
         font-size: smaller;
         padding: 0.5em;
+        margin-left: 0.5em;
+        font-size: inherit;
 
         &:hover {
             color: $black;
             text-decoration: underline;
-        }
-
-        @media (max-width: $steps-row-limit) {
-            margin-left: 0.5em;
-            font-size: inherit;
         }
     }
 


### PR DESCRIPTION
### Trello card

N/A

### Context

This is an experiment to see whether just showing a regular list is clearer when the items are longer. They can look squished:

| Before | After |
| ----- | ----- |
| ![Screenshot from 2020-12-08 13-43-00](https://user-images.githubusercontent.com/128088/101493262-c254a100-395d-11eb-9dd1-0b1484d5de64.png) | ![Screenshot from 2020-12-08 13-52-24](https://user-images.githubusercontent.com/128088/101493297-ced8f980-395d-11eb-8b3c-6734c020178a.png) | 


### Changes proposed in this pull request

Make the list always vertical (rather than just when the screen is <800px wide)

### Guidance to review

There should probably be a discussion around this first.  cc @MylesJarvis @sigmaben 