### PR TITLE
Fix explore strapline on mailing list completed page

### DIFF
--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -3,7 +3,7 @@
   border-top: 1px solid $grey-light;
   padding-top: 70px;
 
-  .govuk-checkboxes__item, .govuk-form-group 
+  .govuk-checkboxes__item, .govuk-form-group
   {
       margin-bottom: 10px;
   }
@@ -32,8 +32,8 @@
       max-width: 375px;
       margin-bottom: 15px;
       margin-left: 0;
-  }  
-  
+  }
+
   button.call-to-action-button {
     margin-top: 20px;
   }
@@ -43,10 +43,10 @@
 @media only screen and (max-width: 800px) {
 
   .event-reg-main,
-  .mailing-reg-main { 
+  .mailing-reg-main {
 
       &__content {
-      
+
           display: block;
 
           &__left {

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -3,12 +3,6 @@
   border-top: 1px solid $grey-light;
   padding-top: 70px;
 
-  .strapline {
-      background-color: $green;
-      margin-bottom: 30px;
-      margin-left: -20px;
-  }
-
   .govuk-checkboxes__item, .govuk-form-group 
   {
       margin-bottom: 10px;


### PR DESCRIPTION
### Trello card

N/A

### Context

The 'Explore' strapline wasn't aligned correctly.

![Screenshot from 2020-12-09 10-48-33](https://user-images.githubusercontent.com/128088/101620199-2897fd00-3a0c-11eb-9c51-db9425d5c01c.png)

### Changes proposed in this pull request

Remove the custom styling so it falls in line with straplines on other pages

![Screenshot from 2020-12-09 10-43-28](https://user-images.githubusercontent.com/128088/101620259-38174600-3a0c-11eb-87e4-96ab8b532f4c.png)



