### PR TITLE
Add bottom margin to hero

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -1,6 +1,11 @@
 
 .hero {
     $mobile-cutoff: 800px;
+    margin-bottom: 1.5em;
+
+    @media only screen and (max-width: $mobile-cutoff) {
+      margin-bottom: .5em;
+    }
 
     > header {
         display: flex;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -11,7 +11,7 @@
         display: flex;
         position: relative;
         box-sizing: border-box;
-        
+
         height: 500px;
 
         margin-top: -1px;
@@ -102,7 +102,7 @@
 
         .hero__img {
             overflow: hidden;
-            
+
             position: absolute;
             bottom: 0;
             right: 0;
@@ -159,7 +159,7 @@
 
         @media only screen and (max-width: $mobile-cutoff) {
             padding-right: 20px;
-            
+
             > p {
             }
         }


### PR DESCRIPTION
Small CSS change, adds a little breathing room under the hero image. Requested by @sigmaben 


| Before | After | After (mobile) |
| ------ | ------ | ------ |
| ![Screenshot from 2020-12-09 11-12-22](https://user-images.githubusercontent.com/128088/101623085-d48f1780-3a0f-11eb-86bd-35d7fee619b5.png) | ![Screenshot from 2020-12-09 11-12-24](https://user-images.githubusercontent.com/128088/101623115-e07ad980-3a0f-11eb-8d87-d55dda794ca7.png)| ![Screenshot from 2020-12-09 11-13-32](https://user-images.githubusercontent.com/128088/101623161-ef618c00-3a0f-11eb-8c76-622e5643cf39.png) |


