### PR TITLE
Change styling of content headings

### DIFF
--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -16,12 +16,12 @@
 
             .step-header__text {
                 text-align: left;
-                border: 0;
                 margin: 0;
                 font-size: 140%;
                 flex-grow: 2;
                 white-space: initial;
-                padding-right: 2em;
+                padding: 0 2em 0 0;
+                background: transparent;
 
                 @media only screen and (max-width: 800px) {
                     font-size: 100%;

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -6,10 +6,11 @@
   box-sizing: border-box;
   width: auto;
   h2 {
-      border: 0;
       margin-bottom: 5px;
       margin-top:0;
       font-size: 28px;
+      background: transparent;
+      color: $black;
   }
 
   p:last-child {

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -1,0 +1,9 @@
+@mixin content-heading {
+    font-size: 36px;
+    font-weight: bold;
+    color: $white;
+    background-color: $blue;
+    margin: 0 -20px 20px -20px;
+    padding: 10px 20px;
+    display: inline-block;
+}

--- a/app/webpacker/styles/content.scss
+++ b/app/webpacker/styles/content.scss
@@ -31,12 +31,7 @@
         }
 
         h2 {
-            font-size: 36px;
-            font-weight: bold;
-            border-bottom: 8px solid $blue;
-            margin: 0;
-            padding: 0;
-            margin-bottom: 20px;
+            @include content-heading;
         }
 
         h3 {

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -21,6 +21,7 @@
 @import './sections/talk-to-us';
 
 @import './components/mixins/cards-grid';
+@import './components/mixins/headings';
 @import './components/cards.scss';
 @import './components/event-box';
 @import './components/content-nav';

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -4,8 +4,7 @@
         width: 66.6%;
 
         h2 {
-            font-size: 1.8em;
-            border-bottom: 8px solid #2781be;
+            @include content-heading;
         }
     }
 
@@ -100,7 +99,10 @@
             h2 {
                 font-size: 32px;
                 border-bottom: none;
-                padding-left: 20px;
+                padding: 0 20px;
+                margin: 0;
+                color: $black;
+                background: transparent;
             }
         }
     }

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -91,7 +91,6 @@ a {
     color: $black;
     font-size: 36px;
     background-color: transparent;
-    border-bottom: 8px solid $blue;
     padding-bottom: 5px;
 }
 


### PR DESCRIPTION
### Trello card

[Trello-596](https://trello.com/c/L9vaAu1m/596-development-implement-design-for-full-content-pages-where-the-heading-blue-underlines-are-removed)

### Context

Instead of having black text with a blue underline we want to have white text on a blue background.

### Changes proposed in this pull request

- Change styling of content headings

### Guidance to review

Since we set this as the default styling on a `.content__left h2` there were a few instances where we override `h2` in other content components; I think I've updated them all but it would be good for someone else to do a quick run through.

| Before | After |
| ----------- | ----------- |
|    <img width="785" alt="Screenshot 2020-12-10 at 10 47 40" src="https://user-images.githubusercontent.com/29867726/101762316-2e0d4a00-3ad5-11eb-9b23-cf9cd8d40449.png">   | <img width="808" alt="Screenshot 2020-12-10 at 10 47 30" src="https://user-images.githubusercontent.com/29867726/101762307-2c438680-3ad5-11eb-914b-156f6f72f042.png">       |

