### PR TITLE
Allow for simple calls to action without a title

### DIFF
--- a/app/components/calls_to_action/simple_component.rb
+++ b/app/components/calls_to_action/simple_component.rb
@@ -2,11 +2,13 @@ module CallsToAction
   class SimpleComponent < ViewComponent::Base
     attr_accessor :icon, :title, :text, :link
 
-    def initialize(icon:, title:, text: nil, link_text:, link_target:)
+    def initialize(icon:, title: nil, text: nil, link_text:, link_target:)
       @icon  = icon_element(icon)
       @title = title
       @text  = text
       @link  = link_to(tag.span(link_text), link_target)
+
+      fail(ArgumentError, "a title or text must be present") if title.nil? && text.nil?
     end
 
   private

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -7,29 +7,39 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
   let(:link_text) { "Click here" }
   let(:link_target) { "/some-dir/some-page" }
 
-  let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target } }
+  describe "rendering the component" do
+    let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target } }
 
-  let(:component) { CallsToAction::SimpleComponent.new(kwargs) }
-  before { render_inline(component) }
+    let(:component) { CallsToAction::SimpleComponent.new(kwargs) }
+    before { render_inline(component) }
 
-  specify "renders the call to action" do
-    expect(page).to have_css(".call-to-action")
+    specify "renders the call to action" do
+      expect(page).to have_css(".call-to-action")
+    end
+
+    specify "the icon is present" do
+      image_element = page.find("img")
+      expect(image_element[:src]).to match(Regexp.new(icon))
+    end
+
+    specify "the title is present" do
+      expect(page).to have_css("h4", text: title)
+    end
+
+    specify "the text is present" do
+      expect(page).to have_css("p", text: text)
+    end
+
+    specify "the link is present" do
+      expect(page).to have_link(link_text, href: link_target)
+    end
   end
 
-  specify "the icon is present" do
-    image_element = page.find("img")
-    expect(image_element[:src]).to match(Regexp.new(icon))
-  end
+  describe "failing to render due to missing args" do
+    let(:kwargs) { { icon: icon, link_text: link_text, link_target: link_target } }
 
-  specify "the title is present" do
-    expect(page).to have_css("h4", text: title)
-  end
-
-  specify "the text is present" do
-    expect(page).to have_css("p", text: text)
-  end
-
-  specify "the link is present" do
-    expect(page).to have_link(link_text, href: link_target)
+    specify "raises an argument error when title and text aren't provided" do
+      expect { CallsToAction::SimpleComponent.new(**kwargs) }.to raise_error(ArgumentError, /title or text must be present/)
+    end
   end
 end


### PR DESCRIPTION
### Trello card

Related indirectly to this: https://trello.com/c/RvPMwUIc/593-content-create-campaign-landing-pages

### Context

Sometimes if the CTA has to contain a title it's a bit overbearing and repetitive.

### Changes proposed in this pull request

Allow the simple call to action to be rendered without a title

![Screenshot from 2020-12-10 11-18-56](https://user-images.githubusercontent.com/128088/101765871-d7eed580-3ad9-11eb-9883-5bcd978cfd71.png)


### Guidance to review

Look ok?
