### PR TITLE
Only render simple cta text and title if present

### DIFF
--- a/app/components/calls_to_action/simple_component.html.erb
+++ b/app/components/calls_to_action/simple_component.html.erb
@@ -2,13 +2,18 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-    <h4 class="call-to-action__heading">
-      <%= title %>
-    </h4>
 
-    <p class="call-to-action__text">
-      <%= text %>
-    </p>
+    <% if title.present? %>
+      <h4 class="call-to-action__heading">
+        <%= title %>
+      </h4>
+    <% end %>
+
+    <% if text.present? %>
+      <p class="call-to-action__text">
+        <%= text %>
+      </p>
+    <% end %>
 
     <div class="call-to-action__action">
       <%= link %>

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -34,6 +34,11 @@
       font-size: 140%;
       margin-bottom: 1em;
     }
+
+    .call-to-action__heading,
+    .call-to-action__text:first-child {
+      margin-top: .6em;
+    }
   }
 
   &__action {

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -1,90 +1,86 @@
 .call-to-action {
-    background-color: $grey;
-    padding: 0;
-    margin-bottom: 2em;
+  background-color: $grey;
+  padding: 0;
+  margin-bottom: 2em;
+  display: flex;
+
+  @media only screen and (max-width: 800px) {
+    flex-direction: column;
+  }
+
+  &__icon {
+    background-color: $yellow;
+    padding: 1em;
+  }
+
+  &__photo {
+    > img {
+      width: 8em;
+    }
+  }
+
+  &--chat-online {
+    display: none;
+  }
+
+  &.visible {
+    display: flex;
+  }
+
+  &__content {
+    padding: .5em 1em 1em;
+
+    .call-to-action__heading {
+      font-size: 140%;
+      margin-bottom: 1em;
+    }
+  }
+
+  &__action {
+    margin: .5em 0;
+
+    button,
+    a {
+      @include button;
+      @include chevron;
+      white-space: initial;
+
+      display: inline-block;
+    }
+
+    .call-to-action__text {
+      margin-bottom: .4em;
+    }
+  }
+
+  &__button-row {
     display: flex;
 
-    @media only screen and (max-width: 800px) {
-        flex-direction: column;
-    }
-
-    &__icon {
-        background-color: $yellow;
-        padding: 1em;
-    }
-
-    &__photo {
-        > img {
-            width: 8em;
-        }
-    }
-
-    &--chat-online {
-        display: none;
-    }
-
-    &.visible {
-        display: flex;
-    }
-
-    &__content {
-        padding: .5em 1em 1em;
-
-        .call-to-action__heading {
-            font-size: 140%;
-            margin-bottom: 1em;
-        }
-    }
-
-
-    &__content {
-    }
-
     &__action {
-        margin: .5em 0;
-        button,
-        a {
-            @include button;
-            @include chevron;
-            white-space: initial;
-
-            display: inline-block;
-        }
-
-        .call-to-action__text {
-            margin-bottom: .4em;
-        }
+      a {
+        @include button;
+        @include chevron;
+        white-space: initial;
+      }
     }
 
-    &__button-row {
-        display: flex;
-
-        &__action {
-            a {
-                @include button;
-                @include chevron;
-                white-space: initial;
-            }
-        }
-
-        .call-to-action__button-row__action + .call-to-action__button-row__action {
-            margin-top: 0;
-            margin-left: 1em;
-        }
-
-        @media only screen and (max-width: 800px) {
-            flex-direction: column;
-
-            .call-to-action__button-row__action + .call-to-action__button-row__action {
-                margin-top: 1em;
-                margin-left: 0;
-            }
-        }
+    .call-to-action__button-row__action + .call-to-action__button-row__action {
+      margin-top: 0;
+      margin-left: 1em;
     }
 
+    @media only screen and (max-width: 800px) {
+      flex-direction: column;
 
-    // add some extra space between multiple actions
-    .call-to-action__action + .call-to-action__action {
-        margin-top: 2em;
+      .call-to-action__button-row__action + .call-to-action__button-row__action {
+        margin-top: 1em;
+        margin-left: 0;
+      }
     }
+  }
+
+  // add some extra space between multiple actions
+  .call-to-action__action + .call-to-action__action {
+    margin-top: 2em;
+  }
 }

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
     specify "the link is present" do
       expect(page).to have_link(link_text, href: link_target)
     end
+
+    context "when no title is present" do
+      let(:kwargs) { { icon: icon, text: text, link_text: link_text, link_target: link_target } }
+
+      specify "no paragraph tag should be rendered" do
+        expect(page).not_to have_css("h4", class: "call-to-action__heading")
+      end
+    end
+
+    context "when no text is present" do
+      let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target } }
+
+      specify "no paragraph tag should be rendered" do
+        expect(page).not_to have_css("p", class: "call-to-action__text")
+      end
+    end
   end
 
   describe "failing to render due to missing args" do


### PR DESCRIPTION
### Trello card

N/A

### Context

The simple component was rendering empty elements if no content was provided

### Changes proposed in this pull request

Only render the relevant elements when content is present and standardise the margins at the top

![Screenshot from 2020-12-10 16-23-05](https://user-images.githubusercontent.com/128088/101799685-5c564e00-3b04-11eb-90ab-24aba8c80ec9.png)

### Guidance to review

Sense check. 