### PR TITLE
Update chat to new theme

### DIFF
--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -13,8 +13,8 @@ export default class extends Controller {
     startChat(e) {
         e.preventDefault();
         var windowFeatures = "menubar=no,location=yes,resizable=yes,scrollbars=no,status=yes,width=340,height=480";
-        window.open("https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0",
-        "Get into teaching: Chat online",
-        windowFeatures);
+        window.open("https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a2&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0",
+            "Get into teaching: Chat online",
+            windowFeatures);
     }
 }

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -29,7 +29,7 @@ describe('TalkToUsController', () => {
         it("opens the chat session", () => {
             var startChat = document.getElementById("startChat");
             startChat.click();
-            const url = "https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a1&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0";
+            const url = "https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a2&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0";
             const target = "Get into teaching: Chat online";
             const features = "menubar=no,location=yes,resizable=yes,scrollbars=no,status=yes,width=340,height=480";
             expect(open).toBeCalledWith(url, target, features);


### PR DESCRIPTION
We have a new 'theme' available for the chat that updates the logo and questions asked; this updates the `klick2contact` url so we are using it.

<img width="452" alt="Screenshot 2020-12-11 at 08 33 35" src="https://user-images.githubusercontent.com/29867726/101881006-b9e1ad80-3b8b-11eb-9aa1-5ce483bf6592.png">