### PR TITLE
Link to privacy policy on mailing list completion page

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -9,7 +9,7 @@
             <p>
               You’ll receive an email to the address you gave us when you signed up.
               You can unsubscribe if you change your mind. To find out how we
-              handle your personal data, you can read our privacy policy.
+              handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
             </p>
 
             <h2>Want to speak to us?</h2>


### PR DESCRIPTION
Updates the "privacy policy" text to link through to our privacy policy.


