### PR TITLE
Add calls to action to right column

### DIFF
--- a/app/components/calls_to_action/narrow_component.html.erb
+++ b/app/components/calls_to_action/narrow_component.html.erb
@@ -1,0 +1,22 @@
+<%= tag.div(class: %w[call-to-action call-to-action--narrow]) do %>
+  <div class="call-to-action__content">
+    <header>
+      <%= icon %>
+      <% if title.present? %>
+        <h4 class="call-to-action__heading">
+          <%= title %>
+        </h4>
+      <% end %>
+    </header>
+
+    <% if text.present? %>
+      <p class="call-to-action__text">
+        <%= text %>
+      </p>
+    <% end %>
+
+    <div class="call-to-action__action">
+      <%= link %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/calls_to_action/narrow_component.rb
+++ b/app/components/calls_to_action/narrow_component.rb
@@ -1,0 +1,5 @@
+module CallsToAction
+  # A SimpleComponent-like box that's strucutred so it will
+  # work better in a narrow column (to the side of main content)
+  class NarrowComponent < CallsToAction::SimpleComponent; end
+end

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -11,6 +11,9 @@
         <main role="main" id="main-content">
             <%= render Sections::HeroComponent.new(@front_matter) %>
             <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
+
+                <%= render partial: "layouts/shared/narrow_call_to_action" %>
+
                 <div class="content__left">
                   <% if @front_matter["alert"].present? %>
                     <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -39,13 +39,7 @@
                   </div>
                 <% end %>
 
-                <% if @front_matter.dig("right_column", "ctas").present? %>
-                  <div class="content__right">
-                    <% @front_matter.dig("right_column", "ctas").each do |cta| %>
-                      <%= render CallsToAction::NarrowComponent.new(**cta.symbolize_keys) %>
-                    <% end %>
-                  </div>
-                <% end %>
+                <%= render partial: "layouts/shared/narrow_call_to_action" %>
 
                 <% if @front_matter["fullwidth"] %>
                   <%= yield %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -39,6 +39,14 @@
                   </div>
                 <% end %>
 
+                <% if @front_matter.dig("right_column", "ctas").present? %>
+                  <div class="content__right">
+                    <% @front_matter.dig("right_column", "ctas").each do |cta| %>
+                      <%= render CallsToAction::NarrowComponent.new(**cta.symbolize_keys) %>
+                    <% end %>
+                  </div>
+                <% end %>
+
                 <% if @front_matter["fullwidth"] %>
                   <%= yield %>
                 <% else %>

--- a/app/views/layouts/shared/_narrow_call_to_action.html.erb
+++ b/app/views/layouts/shared/_narrow_call_to_action.html.erb
@@ -1,0 +1,7 @@
+<% if @front_matter.dig("right_column", "ctas").present? %>
+  <div class="content__right">
+    <% @front_matter.dig("right_column", "ctas").each do |cta| %>
+      <%= render CallsToAction::NarrowComponent.new(**cta.symbolize_keys) %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -88,4 +88,23 @@
   .call-to-action__action + .call-to-action__action {
     margin-top: 2em;
   }
+
+  &--narrow {
+    header {
+      display: flex;
+
+      .call-to-action__heading {
+        margin-left: 1em;
+        margin-bottom: 0;
+      }
+
+      @supports (gap: 1em) {
+        gap: 1em;
+
+        .call-to-action__heading {
+          margin-left: 0;
+        }
+      }
+    }
+  }
 }

--- a/spec/components/calls_to_action/narrow_component_spec.rb
+++ b/spec/components/calls_to_action/narrow_component_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe CallsToAction::NarrowComponent, type: :component do
+  subject do
+    CallsToAction::NarrowComponent.new(
+      icon: "icon-question",
+      title: "title",
+      text: "text",
+      link_text: "link_text",
+      link_target: "/link_target",
+    )
+  end
+
+  it { is_expected.to be_a_kind_of(CallsToAction::SimpleComponent) }
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/RmC3uEST/537-content-check-journeys-and-ctas-from-returners-funding-salaries-internationals-taac-as-key-entry-points-and-align-sense-check-on

### Context

Calls to action are wanted on the international candidates page but the intention is to make use of the right column rather than placing them among the content.


### Changes proposed in this pull request

Add a 'Narrow' CTA component and allow it to be initialised and automatically added to pages when the relevant frontmatter is present.

![Screenshot from 2020-12-14 12-12-25](https://user-images.githubusercontent.com/128088/102082722-56b17e80-3e0a-11eb-96d5-d301f4feb0ec.png)

![Screenshot from 2020-12-14 12-37-26](https://user-images.githubusercontent.com/128088/102082815-82346900-3e0a-11eb-87e3-000345345cbc.png)

#### Final page

![ways-to-train-with-right-cta](https://user-images.githubusercontent.com/128088/102210426-11548600-3eca-11eb-9bb1-b4670540b84c.png)


### Guidance to review

Also see https://github.com/DFE-Digital/get-into-teaching-content/pull/213 which is related
