### PR TITLE
Fixed link to Cookies page from privacy policy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,4 +94,10 @@ module ApplicationHelper
 
     referer.gsub(root_url, root_path)
   end
+
+  def replace_bau_cookies_link(html_content)
+    html_content&.gsub \
+      ' href="https://getintoteaching.education.gov.uk/how-we-use-your-information"',
+      " href=\"#{cookies_path}\""
+  end
 end

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
 <section class="event-info content container-1000" role="main" id="main-content">
   <div class="content__left">
     <h2>Privacy Policy</h2>
-    <%= safe_html_format @privacy_policy.text %>
+    <%= safe_html_format replace_bau_cookies_link @privacy_policy.text %>
   </div>
   <div class="content_right"></div>
 </section>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -174,4 +174,27 @@ describe ApplicationHelper do
       expect(helper).to receive(:fa_icon).once.with(icon_name, style: "fas")
     end
   end
+
+  describe "#replace_bau_cookies_link" do
+    subject { helper.replace_bau_cookies_link html }
+
+    context "when in href" do
+      let :html do
+        <<~HTML
+          <p>
+            <a href="/first">First</a>
+          </p>
+
+          </p>
+            <a href="https://getintoteaching.education.gov.uk/how-we-use-your-information">
+              Information
+            </a>
+          </p>
+        HTML
+      end
+
+      it { is_expected.to have_link "First", href: "/first" }
+      it { is_expected.to have_link "Information", href: cookies_path }
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/Bop3uAte/650-update-link-to-cookie-policy-in-the-privacy-policy-page

### Context

The HTML content for the cookies page in the CRM has a link to cookies which points to the BAU site.

This is held in the CRM so we need to fixup the html returned from the CRM.

### Changes proposed in this pull request

1. Add a view helper to swap out the link

### Guidance to review

1. Highly specific but I don't think this is a scenario we'll encounter elsewhere, it can be generalised at that point if it is

