### PR TITLE
Extracted no 'latest event' behaviour into separate component

### DIFF
--- a/app/components/cards/find_events_component.rb
+++ b/app/components/cards/find_events_component.rb
@@ -1,0 +1,40 @@
+module Cards
+  class FindEventsComponent < CardComponent
+    HEADER = "Find a Teacher Training Event".freeze
+    SNIPPET = <<~SNIPPET.freeze
+      Find an event to speak to real teachers and get your questions answered
+      by our expert advisers. You can also find out what it is like to train
+      and be in the classroom.
+    SNIPPET
+
+    def initialize(card:, page_data: nil)
+      super card: card
+      @page_data = page_data
+    end
+
+    def border
+      false
+    end
+
+    def header
+      HEADER
+    end
+
+    def snippet
+      SNIPPET
+    end
+
+    def link_text
+      "View events"
+    end
+
+    def link
+      events_path
+    end
+
+    def image
+      # FIXME: change to image_pack_path once theres a new webpacker release
+      @image ||= resolve_path_to_image("latest-event-card.jpg")
+    end
+  end
+end

--- a/app/components/cards/latest_event_component.rb
+++ b/app/components/cards/latest_event_component.rb
@@ -1,18 +1,12 @@
 module Cards
   class LatestEventComponent < CardComponent
-    ALL_EVENTS_HEADER = "Find a Teacher Training Event".freeze
-    ALL_EVENTS_SNIPPET = <<~SNIPPET.freeze
-      Find an event to speak to real teachers and get your questions answered
-      by our expert advisers. You can also find out what it is like to train
-      and be in the classroom.
-    SNIPPET
-
     attr_reader :page_data, :category, :event
 
     def initialize(card:, page_data: nil)
       super card: card
 
       @category = card["category"].to_s
+      @card = card
       @page_data = page_data
 
       fetch_event
@@ -23,28 +17,28 @@ module Cards
     end
 
     def header
-      event ? "Event: #{event.name}" : ALL_EVENTS_HEADER
+      "Event: #{event.name}"
     end
 
     def snippet
-      event ? event.summary : ALL_EVENTS_SNIPPET
+      event.summary
     end
 
     def link_text
-      event ? "View event" : "View events"
+      "View event"
     end
 
     def link
-      if event
-        event_path event.readable_id
-      else
-        events_path
-      end
+      event_path event.readable_id
     end
 
     def image
       # FIXME: change to image_pack_path once theres a new webpacker release
       @image ||= resolve_path_to_image("latest-event-card.jpg")
+    end
+
+    def call
+      event ? super : render(find_events_component)
     end
 
   private
@@ -54,6 +48,10 @@ module Cards
     rescue Events::Category::UnknownEventCategory => e
       Raven.capture_exception(e)
       @event = nil
+    end
+
+    def find_events_component
+      FindEventsComponent.new(card: @card)
     end
   end
 end

--- a/spec/components/cards/find_events_component_spec.rb
+++ b/spec/components/cards/find_events_component_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Cards::FindEventsComponent, type: :component do
+  subject { render_inline(instance) && page }
+
+  let(:page_data) { Pages::Data.new }
+  let(:url_helpers) { Rails.application.routes.url_helpers }
+  let(:event) { build(:event_api, name: "Test event") }
+  let(:card) { {}.with_indifferent_access }
+  let(:instance) { described_class.new card: card, page_data: page_data }
+
+  it { is_expected.to have_css ".card" }
+  it { is_expected.to have_css ".card.card--no-border" }
+  it { is_expected.to have_css ".card header", text: described_class::HEADER }
+  it { is_expected.to have_css "img" }
+  it { is_expected.to have_content described_class::SNIPPET }
+
+  it "includes the footer link" do
+    is_expected.to have_link \
+      "View events",
+      href: url_helpers.events_path,
+      class: "git-link"
+  end
+end

--- a/spec/components/cards/latest_event_component_spec.rb
+++ b/spec/components/cards/latest_event_component_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
   let(:event) { build(:event_api, name: "Test event") }
   let(:instance) { described_class.new card: card, page_data: page_data }
   let(:card) { { category: "train to teach event" }.with_indifferent_access }
-
-  let(:generic_header) { described_class::ALL_EVENTS_HEADER }
-  let(:generic_snippet) { described_class::ALL_EVENTS_SNIPPET }
+  let(:find_events_header) { Cards::FindEventsComponent::HEADER }
 
   context "with category" do
     before do
@@ -37,11 +35,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
     context "with no events" do
       let(:event) { nil }
 
-      it { is_expected.to have_css ".card" }
-      it { is_expected.to have_css ".card.card--no-border" }
-      it { is_expected.to have_css ".card header", text: generic_header }
-      it { is_expected.to have_css "img" }
-      it { is_expected.to have_content generic_snippet }
+      it { is_expected.to have_css ".card header", text: find_events_header }
       it { is_expected.to have_link "View events", href: url_helpers.events_path }
     end
   end
@@ -53,7 +47,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     before { expect(Raven).to receive(:capture_exception).and_call_original }
 
-    it { is_expected.to have_css ".card header", text: generic_header }
+    it { is_expected.to have_css ".card header", text: find_events_header }
   end
 
   context "with no category" do
@@ -63,6 +57,6 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     before { expect(Raven).to receive(:capture_exception).and_call_original }
 
-    it { is_expected.to have_css ".card header", text: generic_header }
+    it { is_expected.to have_css ".card header", text: find_events_header }
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/xmUzKlT8

### Context

There's now a need to render a generic 'find an event card'.

### Changes proposed in this pull request

1. Extract the 'fallback' behaviour out of the LatestEvent into a new FindEventsComponent
2. LatestEvent now chains to FindEvents if it can't find the event


