### PR TITLE
Set active accordion step from data attr

### DIFF
--- a/app/components/content/accordion_component.html.erb
+++ b/app/components/content/accordion_component.html.erb
@@ -10,7 +10,7 @@
   </div>
 <% end %>
 
-<div class="accordions" data-controller="accordion">
+<%= tag.div(class: "accordions", data: data_attributes) do %>
   <% steps.each.with_index(1) do |step, i| %>
     <%= tag.section(id: "step-#{i}", class: "step", data: { id: i }) do %>
 
@@ -31,7 +31,7 @@
 
     <% end %>
   <% end %>
-</div>
+<% end %>
 
 <% if content_after_accordion %>
   <div class="content_after_accordion">

--- a/app/components/content/accordion_component.rb
+++ b/app/components/content/accordion_component.rb
@@ -7,8 +7,9 @@ module Content
 
     attr_reader :numbered
 
-    def initialize(numbered: false)
-      @numbered = numbered
+    def initialize(numbered: false, active_step: nil)
+      @numbered    = numbered
+      @active_step = active_step
     end
 
     def render?
@@ -23,6 +24,10 @@ module Content
       if numbered?
         %(#{number}.)
       end
+    end
+
+    def data_attributes
+      { controller: "accordion", accordion_active_step_value: @active_step }.compact
     end
 
     class ComposableSlot < ViewComponent::Slot

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -22,7 +22,7 @@
                   <%= yield %>
 
                   <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
-                    <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered")) do |accordion| %>
+                    <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered"), active_step: accordion_fm.dig("active_step")) do |accordion| %>
                       <%= accordion.slot(
                         :content_before_accordion,
                         partial: accordion_fm.dig("content_before_accordion", "partial"),

--- a/app/webpacker/controllers/accordion_controller.js
+++ b/app/webpacker/controllers/accordion_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "stimulus"
 export default class extends Controller {
 
     static targets = ["header", "content"]
+    static values = {
+      activeStep: Number
+    }
 
     connect() {
         this.setup();
@@ -44,19 +47,34 @@ export default class extends Controller {
     }
 
     setup() {
-        // disable all the steps except the nominated one or the first
-        const stepMatcher = /step-([\d])/;
-        const stepFromHash = window.location.hash.match(stepMatcher);
-
-        let activeStep = "step-1";
-
-        if (stepFromHash) {
-            activeStep = stepFromHash[0];
-        }
+        const selector = this.stepFromURI() || this.stepFromAttr() || ".step";
 
         document
-            .querySelectorAll(`.step:not(#${activeStep})`)
+            .querySelectorAll(selector)
             .forEach(step => this.deactivate(step));
+    }
+
+    stepFromURI() {
+        const stepMatcher = /step-([\d])/;
+        const uriFragment = window.location.hash.match(stepMatcher);
+
+        if (uriFragment) {
+          const stepFromHashId = uriFragment[0];
+
+          return `.step:not(#${stepFromHashId})`;
+        }
+
+        return false;
+    }
+
+    stepFromAttr() {
+        if (this.activeStepValue) {
+          const stepFromDataAttr = `step-${this.activeStepValue}`;
+
+          return `.step:not(#${stepFromDataAttr})`;
+        }
+
+      return false;
     }
 
     allStepElements() {

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -120,6 +120,18 @@ describe Content::AccordionComponent, type: "component" do
     end
   end
 
+  describe "Numbered steps" do
+    subject! do
+      render_inline(Content::AccordionComponent.new(numbered: true)) do |accordion|
+        accordion.slot(:step, title: title) { text }
+      end
+    end
+
+    specify "the step is prefixed by a number" do
+      expect(page).to have_css("h2.step-header__text", text: %r{1. #{title}})
+    end
+  end
+
   describe "Setting the active step via a data attribute" do
     let(:active_step) { 3 }
 

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 describe Content::AccordionComponent, type: "component" do
+  let(:title) { "some title" }
+  let(:text) { "some text" }
+
   describe "Rending the accordion" do
     let(:steps) do
       {
@@ -51,9 +54,6 @@ describe Content::AccordionComponent, type: "component" do
   end
 
   describe "Calls to action" do
-    let(:title) { "some title" }
-    let(:text) { "some text" }
-
     describe "chat_online" do
       subject do
         render_inline(Content::AccordionComponent.new) do |accordion|
@@ -117,6 +117,22 @@ describe Content::AccordionComponent, type: "component" do
           expect(page).to have_content(name)
         end
       end
+    end
+  end
+
+  describe "Setting the active step via a data attribute" do
+    let(:active_step) { 3 }
+
+    subject! do
+      render_inline(Content::AccordionComponent.new(active_step: active_step)) do |accordion|
+        1.upto(3).each do |i|
+          accordion.slot(:step, title: "title #{i}") { "text #{i}" }
+        end
+      end
+    end
+
+    specify "the active step data attribute is set" do
+      expect(page).to have_css(%(.accordions[data-accordion-active-step-value="#{active_step}"]))
     end
   end
 end

--- a/spec/javascript/controllers/accordion_controller_spec.js
+++ b/spec/javascript/controllers/accordion_controller_spec.js
@@ -2,9 +2,8 @@ import { Application } from 'stimulus' ;
 import AccordionController from 'accordion_controller.js' ;
 
 describe('AccordionController', () => {
-
     document.body.innerHTML = `
-    <div data-controller="accordion">
+    <div data-controller="accordion" data-accordion-active-step-value="2">
         <section id="step-1" class="step" data-id="1">
             <button id="button-1" class="step-header" data-action="click->accordion#toggle" data-accordion-target="header">
               Button 1
@@ -32,38 +31,37 @@ describe('AccordionController', () => {
             </div>
         </section>
     </div>
-    ` ;
+    `;
 
     const application = Application.start() ;
     application.register('accordion', AccordionController) ;
 
-    describe("when first loaded", () => {
+    describe("when first loaded with 'active' step set to '2'", () => {
         it("only first step should be opened", () => {
-          expect(document.getElementById("step-1").classList).not.toContain("inactive");
+          expect(document.getElementById("step-2").classList).not.toContain("inactive");
 
-          expect(document.getElementById("step-2").classList).toContain("inactive");
+          expect(document.getElementById("step-1").classList).toContain("inactive");
           expect(document.getElementById("step-3").classList).toContain("inactive");
         });
     })
 
     describe("when open header is toggled", () => {
         it("should close", () => {
-          expect(document.getElementById("step-1").classList).not.toContain("inactive");
+          expect(document.getElementById("step-2").classList).not.toContain("inactive");
 
-          document.getElementById("button-1").click();
+          document.getElementById("button-2").click();
 
-          expect(document.getElementById("step-1").classList).toContain("inactive");
+          expect(document.getElementById("step-2").classList).toContain("inactive");
         });
     });
 
     describe("when closed header is toggled", () => {
         it("should open", () => {
-          expect(document.getElementById("step-2").classList).toContain("inactive");
+          expect(document.getElementById("step-3").classList).toContain("inactive");
 
-          document.getElementById("button-2").click();
+          document.getElementById("button-3").click();
 
-          expect(document.getElementById("step-2").classList).not.toContain("inactive");
+          expect(document.getElementById("step-3").classList).not.toContain("inactive");
         });
     });
 });
-


### PR DESCRIPTION
This will allow accordions to have a step open automatically based on what's specified in the `data-accordion-active-step-value` attribute. It's so we can open the first 'Steps to become a teacher' step by default and leave the 'Ways to train' one fully closed.

Also see https://github.com/DFE-Digital/get-into-teaching-content/pull/215