### PR TITLE
Replace TypeEntity with PickListItem/LookupItem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 07e01cd14642a60d84bad0977a72b66c8a13a8e4
+  revision: afef61cf2553e754a7447ba3ac5a98215780f5ff
   specs:
-    get_into_teaching_api_client (1.1.5)
+    get_into_teaching_api_client (1.1.6)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.7)
+    get_into_teaching_api_client_faraday (0.1.8)
       activesupport
       faraday
       faraday-encoding
@@ -137,7 +137,7 @@ GEM
     htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (2.3.1)
+    json (2.4.0)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
   end
 
   def show_category
-    @type = GetIntoTeachingApiClient::TypesApi.new.get_teaching_event_types.find do |type|
+    @type = GetIntoTeachingApiClient::PickListItemsApi.new.get_teaching_event_types.find do |type|
       I18n.t("event_types.#{type.id}.name.plural").parameterize == params[:category]
     end
 
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
 
     @event_search = Events::Search.new(event_filter_params.merge(type: @type.id))
     all_results = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
-    @events = paginate(all_results[@type.id.to_sym])
+    @events = paginate(all_results[@type.id.to_s.to_sym])
   end
 
 private

--- a/app/models/events/category.rb
+++ b/app/models/events/category.rb
@@ -18,12 +18,12 @@ module Events
 
   private
 
-    def types_api
-      GetIntoTeachingApiClient::TypesApi.new
+    def pick_list_items_api
+      GetIntoTeachingApiClient::PickListItemsApi.new
     end
 
     def event_types
-      @event_types = types_api.get_teaching_event_types
+      @event_types = pick_list_items_api.get_teaching_event_types
     end
 
     def events_api

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -21,7 +21,7 @@ module Events
 
       def degree_status_options
         @degree_status_options ||=
-          GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
+          GetIntoTeachingApiClient::PickListItemsApi.new.get_qualification_degree_status
       end
 
       def degree_status_option_ids
@@ -30,7 +30,7 @@ module Events
 
       def journey_stage_options
         @journey_stage_options ||=
-          GetIntoTeachingApiClient::TypesApi.new.get_candidate_journey_stages
+          GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_journey_stages
       end
 
       def journey_stage_option_ids
@@ -39,7 +39,7 @@ module Events
 
       def teaching_subject_options
         @teaching_subject_options ||=
-          GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.reject do |type|
+          GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
             GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
           end
       end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -10,7 +10,7 @@ class Healthcheck
   end
 
   def test_api
-    GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects
+    GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects
     true
   rescue Faraday::Error, GetIntoTeachingApiClient::ApiError
     false

--- a/app/models/mailing_list/steps/degree_status.rb
+++ b/app/models/mailing_list/steps/degree_status.rb
@@ -18,7 +18,7 @@ module MailingList
     private
 
       def query_degree_status
-        GetIntoTeachingApiClient::TypesApi.new.get_qualification_degree_status
+        GetIntoTeachingApiClient::PickListItemsApi.new.get_qualification_degree_status
       end
     end
   end

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -32,7 +32,7 @@ module MailingList
     private
 
       def query_channels
-        @query_channels ||= GetIntoTeachingApiClient::TypesApi.new.get_candidate_mailing_list_subscription_channels
+        @query_channels ||= GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_mailing_list_subscription_channels
       end
     end
   end

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -17,7 +17,7 @@ module MailingList
     private
 
       def query_teaching_subjects
-        GetIntoTeachingApiClient::TypesApi.new.get_teaching_subjects.reject do |type|
+        GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
           GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
         end
       end

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -17,7 +17,7 @@ module MailingList
     private
 
       def query_consideration_journey_stages
-        GetIntoTeachingApiClient::TypesApi.new.get_candidate_journey_stages
+        GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_journey_stages
       end
     end
   end

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -1,19 +1,19 @@
 FactoryBot.define do
   factory :events_personalised_updates, class: Events::Steps::PersonalisedUpdates do
     degree_status_id do
-      GetIntoTeachingApiClient::TypesApi.new
+      GetIntoTeachingApiClient::PickListItemsApi.new
         .get_qualification_degree_status.first.id
     end
 
     consideration_journey_stage_id do
-      GetIntoTeachingApiClient::TypesApi.new
+      GetIntoTeachingApiClient::PickListItemsApi.new
         .get_candidate_journey_stages.first.id
     end
 
     address_postcode { "TE57 1NG" }
 
     preferred_teaching_subject_id do
-      GetIntoTeachingApiClient::TypesApi.new
+      GetIntoTeachingApiClient::LookupItemsApi.new
         .get_teaching_subjects.first.id
     end
   end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Event wizard", type: :feature do
       receive(:get_latest_privacy_policy).and_return(latest_privacy_policy)
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:add_teaching_event_attendee)
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_teaching_event_types) { [] }
   end
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature "Mailing list wizard", type: :feature do
   let(:latest_privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
 
   before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
       receive(:get_teaching_subjects).and_return(teaching_subject_types)
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
     allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
       receive(:get_latest_privacy_policy).and_return(latest_privacy_policy)

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -77,7 +77,7 @@ describe Events::Steps::PersonalisedUpdates do
     end
 
     before do
-      allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+      allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
         receive(:get_teaching_subjects).and_return(teaching_subject_types)
     end
 

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -30,7 +30,7 @@ describe Healthcheck do
   include_examples "reading git shas", "content_sha", "/etc/get-into-teaching-content-sha"
 
   before do
-    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_subjects")
+    stub_request(:get, "#{git_api_endpoint}/api/lookup_items/teaching_subjects")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
@@ -46,7 +46,7 @@ describe Healthcheck do
 
     context "with broken connection" do
       before do
-        stub_request(:get, "#{git_api_endpoint}/api/types/teaching_subjects")
+        stub_request(:get, "#{git_api_endpoint}/api/lookup_items/teaching_subjects")
           .to_timeout
           .then.to_timeout
           .then.to_timeout
@@ -57,7 +57,7 @@ describe Healthcheck do
 
     context "with an API error" do
       before do
-        expect_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+        expect_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
           receive(:get_teaching_subjects).and_raise(GetIntoTeachingApiClient::ApiError)
       end
 

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -11,7 +11,7 @@ describe MailingList::Steps::DegreeStatus do
   end
 
   before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
   end
 

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -11,7 +11,7 @@ describe MailingList::Steps::Name do
   end
 
   before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
   end
 

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -11,7 +11,7 @@ describe MailingList::Steps::Subject do
   end
 
   before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
       receive(:get_teaching_subjects).and_return(teaching_subject_types)
   end
 

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -11,7 +11,7 @@ describe MailingList::Steps::TeacherTraining do
   end
 
   before do
-    allow_any_instance_of(GetIntoTeachingApiClient::TypesApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
       receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
   end
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -3,31 +3,31 @@ shared_context "stub types api" do
   let(:stub_types) { [{ "id" => 1, "value" => "First type" }] }
 
   before do
-    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_event/types")
+    stub_request(:get, "#{git_api_endpoint}/api/pick_list_items/teaching_event/types")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: stub_types.to_json
 
-    stub_request(:get, "#{git_api_endpoint}/api/types/qualification/degree_status")
+    stub_request(:get, "#{git_api_endpoint}/api/pick_list_items/qualification/degree_status")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map { |k, v| { id: v, value: k } }.to_json
 
-    stub_request(:get, "#{git_api_endpoint}/api/types/candidate/consideration_journey_stages")
+    stub_request(:get, "#{git_api_endpoint}/api/pick_list_items/candidate/consideration_journey_stages")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map { |k, v| { id: v, value: k } }.to_json
 
-    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_event/types")
+    stub_request(:get, "#{git_api_endpoint}/api/pick_list_items/teaching_event/types")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApiClient::Constants::EVENT_TYPES.map { |k, v| { id: v, value: k } }.to_json
 
-    stub_request(:get, "#{git_api_endpoint}/api/types/teaching_subjects")
+    stub_request(:get, "#{git_api_endpoint}/api/lookup_items/teaching_subjects")
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },


### PR DESCRIPTION
### Trello card

[Trello-358](https://trello.com/c/K6lPR3ev/358-return-types-with-integer-ids-as-integer-rather-than-string)

### Context

The /types endpoints are being deprecated and have been split up into two new endpoints:

/lookup_items (types with a string id)
/pick_list_items (types with an integer id)

We need to replace all calls to the `TypesApi` with the replacement APIs.

### Changes proposed in this pull request

- Replace TypeEntity with PickListItem/LookupItem

### Guidance to review

I've given this a decent amount of manual testing and I've also ran the integration tests against it, all coming back green.