### PR TITLE
Don't show the external link icon in CTA buttons

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -9,4 +9,16 @@
             }
         }
     }
+
+    // stop the external icon from appearing inside CTA 'button' style links
+    .call-to-action__action {
+      a {
+        &[href*="//"] {
+            &::after {
+              content: none;
+              margin-left: unset;
+            }
+        }
+      }
+    }
 }


### PR DESCRIPTION
Now we're displaying CTA's amongst Markdown content we need to suppress the addition of the external link icons for CTA buttons.

| Before | After |
| ------ | ------ |
| ![Screenshot from 2020-12-15 13-58-35](https://user-images.githubusercontent.com/128088/102224543-ff7cde00-3edd-11eb-8a21-8c5b56adf9a9.png) | ![Screenshot from 2020-12-15 13-58-53](https://user-images.githubusercontent.com/128088/102224549-0277ce80-3ede-11eb-89fb-ef403496da74.png) |

