### PR TITLE
Add a bit more space above level 2 headings

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,4 +1,8 @@
 .markdown {
+    h2:not(:first-of-type) {
+        margin-top: 1em;
+    }
+
     a {
         &[href*="//"] {
             &::after {


### PR DESCRIPTION
Very minor tweak, but adds a bit of space above `h2` tags so they aren't immediately below the preceding content.
