### PR TITLE
Update events moved online copy

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,7 +30,7 @@
         </div>
         <div>
           <h4>Some events have moved online</h4>
-          <p>Until it is safe to see you in person, the Train to Teach and School and University events are online.</p>
+          <p>Until it is safe to see you in person, the Train to Teach and most of School and University events are online.</p>
         </div>
       </p>
     </section>


### PR DESCRIPTION
### Trello card

[Trello-629](https://trello.com/c/cRXXry4w/629-development-amend-some-events-have-moved-online-component-to-reflect-that-some-school-and-uni-events-are-still-in-person)

### Context

We want to clarify that _most_ but not all School and University events are online.

### Changes proposed in this pull request

- Update events moved online copy

### Guidance to review

<img width="842" alt="Screenshot 2020-12-16 at 08 22 00" src="https://user-images.githubusercontent.com/29867726/102322968-c8f3a180-3f77-11eb-92aa-1e6c5e9e837c.png">
