### PR TITLE
Add a content spec that ensures no localhost links

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -48,6 +48,13 @@ RSpec.feature "content pages check", type: :feature, content: true do
           end
       end
 
+      scenario "there are no localhost links" do
+        document
+          .css("a")
+          .map { |fragment| fragment["href"] }
+          .each { |href| expect(href).not_to match(%r{https?://(localhost|127\.0\.0\.1)}) }
+      end
+
       scenario "the internal links reference existing pages" do
         document
           .css("a")


### PR DESCRIPTION
This is on the back of a release that included one; it was missed by the other tests as they omit any link that starts with http or https.

![Screenshot from 2020-12-16 09-51-34](https://user-images.githubusercontent.com/128088/102333083-d5322b80-3f84-11eb-9890-947643ec99cb.png)

