### PR TITLE
Add no results message to event category results

### DIFF
--- a/app/components/events/no_results_component.html.erb
+++ b/app/components/events/no_results_component.html.erb
@@ -1,0 +1,3 @@
+ <div class="no-results">
+  <%= content %>
+</div>

--- a/app/components/events/no_results_component.rb
+++ b/app/components/events/no_results_component.rb
@@ -1,0 +1,4 @@
+module Events
+  class NoResultsComponent < ViewComponent::Base
+  end
+end

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -17,9 +17,9 @@
       <%= render partial: "event", collection: events %>
     </div>
   <% else %>
-    <div class="search-for-events-no-results search-for-events-no-results--by-type">
+    <%= render(Events::NoResultsComponent.new) do %>
       Sorry your search has not found any events of this type, try a different location or month.
-    </div>
+    <% end %>
   <% end %>
 
   <% show_see_all_events ||= false %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -48,9 +48,9 @@
     <% else %>
       <section class="content container-1000">
         <div class="content__left">
-          <div class="search-for-events-no-results">
+          <%= render(Events::NoResultsComponent.new) do %>
             Sorry your search has not found any events, try a different type, location or month.
-          </div>
+          <% end %>
         </div>
       </section>
     <% end %>

--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -44,9 +44,9 @@
 <% else %>
 <section class="content container-1000">
   <div class="content__left">
-    <div class="search-for-events-no-results">
+    <%= render(Events::NoResultsComponent.new) do %>
       Sorry your search has not found any events, try a different location or month. <%= link_to("Search for another event type", events_path) %></a>.
-    </div>
+    <% end %>
   </div>
 </section>
 <% end %>

--- a/app/views/events/show_category.html.erb
+++ b/app/views/events/show_category.html.erb
@@ -29,6 +29,7 @@
   </div>
 </section>
 
+<% if @events.any? %>
 <section class="types-of-event content container-1000">
   <div class="events-featured">
     <div class="events-featured__list">
@@ -37,8 +38,15 @@
   </div>
 </section>
 
-<% if @events.any? %>
-  <div class="event-pagination content container-1000">
-    <%= paginate @events %>
+<div class="event-pagination content container-1000">
+  <%= paginate @events %>
+</div>
+<% else %>
+<section class="content container-1000">
+  <div class="content__left">
+    <div class="search-for-events-no-results">
+      Sorry your search has not found any events, try a different location or month. <%= link_to("Search for another event type", events_path) %></a>.
+    </div>
   </div>
+</section>
 <% end %>

--- a/app/webpacker/styles/components/events/no-results.scss
+++ b/app/webpacker/styles/components/events/no-results.scss
@@ -1,0 +1,12 @@
+.no-results {
+  background: $purple;
+  color: $white;
+  padding: 1em;
+  font-weight: bold;
+  box-sizing: border-box;
+  margin: 0 0 1.5em 0;
+
+  a {
+    color: $white;
+  }
+}

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -214,6 +214,10 @@
   font-weight: bold;
   margin-bottom: 80px;
 
+  a {
+    color: $white;
+  }
+
   &--by-type {
     box-sizing: border-box;
     margin: 0 0 30px 0;

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -103,6 +103,14 @@
         margin-top: 30px;
     }
 
+    .no-results {
+      width: 66.6%;
+
+      @media only screen and (max-width: 800px) {
+        width: 100%;
+      }
+    }
+
     &--with-logo {
       margin-top: 90px;
     }
@@ -207,31 +215,9 @@
   margin-bottom: -20px;
 }
 
-.search-for-events-no-results {
-  background: $purple;
-  color: $white;
-  padding: 20px;
-  font-weight: bold;
-  margin-bottom: 80px;
-
-  a {
-    color: $white;
-  }
-
-  &--by-type {
-    box-sizing: border-box;
-    margin: 0 0 30px 0;
-    width: 66.6%;
-  }
-}
-
 @media only screen and (max-width: 800px) {
     .event-type-descriptions {
       padding-bottom: 0px;
-    }
-
-    .search-for-events-no-results--by-type {
-      width: 100%;
     }
 
     .types-of-event {

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -29,6 +29,7 @@
 @import './components/content-alert';
 @import './components/link-block';
 @import './components/type-description';
+@import './components/events/no-results';
 
 @import 'home';
 @import 'event';

--- a/spec/components/events/no_results_component_spec.rb
+++ b/spec/components/events/no_results_component_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Events::NoResultsComponent, type: "component" do
+  let(:message) { "no results message" }
+  let(:component) { Events::NoResultsComponent.new }
+
+  subject do
+    render_inline(component) { message }
+    page
+  end
+
+  it { is_expected.to have_css(".no-results") }
+  it { is_expected.to have_text(message) }
+end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -117,6 +117,16 @@ describe "View events by category" do
         expect(parsed_response.css("nav.pagination")).to be_empty
       end
     end
+
+    context "when there are no results" do
+      let(:path) { event_category_events_path("train-to-teach-events") }
+      let(:events) { [] }
+
+      subject { parsed_response.css(".search-for-events-no-results").first }
+
+      it { is_expected.to_not be_nil }
+      it { expect(subject.text).to include("Sorry your search has not found any events") }
+    end
   end
 
   context "when a category does not exist" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -122,7 +122,7 @@ describe "View events by category" do
       let(:path) { event_category_events_path("train-to-teach-events") }
       let(:events) { [] }
 
-      subject { parsed_response.css(".search-for-events-no-results").first }
+      subject { parsed_response.css(".no-results").first }
 
       it { is_expected.to_not be_nil }
       it { expect(subject.text).to include("Sorry your search has not found any events") }


### PR DESCRIPTION
### Trello card

[Trello-663](https://trello.com/c/N45f2PjE/663-add-no-results-message-to-event-category-page)

### Context

Currently if a user clicks the 'explore' button on an event category that has no results we are displaying an empty events container, which looks a bit broken. Instead, we want to display a no results message and direct the user back to the main search page so that they can try searching with a different type.

### Changes proposed in this pull request

- Add no results message to event category
- Move no results HTML in to ViewComponent

### Guidance to review

<img width="1404" alt="Screenshot 2020-12-16 at 11 22 33" src="https://user-images.githubusercontent.com/29867726/102342328-ff89e600-3f90-11eb-94b1-226932db6430.png">
