### PR TITLE
Allow partials list in frontmatter to be rendered

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -55,6 +55,10 @@
 
                     <article class="markdown">
                       <%= yield %>
+
+                      <% @front_matter["content"]&.each do |partial| %>
+                        <%= render(partial) %>
+                      <% end %>
                     </article>
                   </div>
                 <% end %>


### PR DESCRIPTION
### Context

The previous approach to allowing pages that are a mix of Markdown and regular HTML - mainly used where we need calls to action mid way down a page - was to rename the page from `.md` to `.html.erb`, and then to render markdown pages alongside HTML. At the top of these files a `@front_matter` instance variable is declared and set with the appropriate metadata.

This was a flawed approach because it means that the functionality that builds the sitemap and navigation doesn't pick up pages. 

### Solution

This solves the problem by reverting all templates back to markdown and allowing the writer to create a list of partials under the `content:` key, that will be rendered on the page. The partials can be either `.md` or `.html.erb`, so we have complete control of the page contents.

The disadvantage of this approach is that it's more complex than a single HTML file and we end up with a file per section plus a file per CTA. On the plus side the syntax is straightforward and it works in a simple manner, and the sections are very easy to reorder.

[This content example](https://github.com/DFE-Digital/get-into-teaching-content/pull/200/commits/c3037957f3b7506dba3ae0538d48c2ce49a5ccba) shows how the frontmatter will look when set up in this manner, here's an except:

```markdown
---
  title: Helping you become a teacher
  image: /assets/images/international-dt.jpg
  jump_links:
    Personal teacher training advisers: "#personal-teacher-training-advisers"
    Events: "#events"
    Email updates: "#email-updates"
  content:
    - content/helping-you-become-a-teacher/tta
    - content/helping-you-become-a-teacher/tta-cta
    - content/helping-you-become-a-teacher/events
    - content/helping-you-become-a-teacher/events-cta
    - content/helping-you-become-a-teacher/email-updates
    - content/helping-you-become-a-teacher/email-updates-cta
---
```

When there is also markdown content in the file it will be rendered **above the partials**.

I'm not 100% convinced by the key name `content:`, I thought it's more descriptive than `partials:` so went with it. Open to suggestions.