### PR TITLE
Featured story card

### DIFF
--- a/app/components/cards/featured_story_component.rb
+++ b/app/components/cards/featured_story_component.rb
@@ -10,7 +10,7 @@ module Cards
     end
 
     def link_text
-      "Read more"
+      @link_text || "Read #{story_name}'s story"
     end
 
     def border
@@ -18,22 +18,22 @@ module Cards
     end
 
     def image
-      @image ||= story.frontmatter.featured[:image] || story.image
+      @image ||= featured_metadata["image"] || story.image
     end
 
     def header
-      story.frontmatter.featured[:title] || story.title
+      @header ||= featured_metadata["title"] || "#{story_name}'s story"
     end
 
     def snippet
-      story.frontmatter.featured[:snippet] || raise(MissingSnippet, story.path)
+      @snippet ||= story.frontmatter.title || raise(MissingTitleOnFeatured, story.path)
     end
 
     class NoFeaturedStory < RuntimeError; end
 
-    class MissingSnippet < RuntimeError
+    class MissingTitleOnFeatured < RuntimeError
       def initialize(story_path)
-        super "Featured story is missing the 'snippet' - #{story_path}"
+        super "Featured story is missing a 'title' - #{story_path}"
       end
     end
 
@@ -41,6 +41,17 @@ module Cards
 
     def story
       @story ||= @page_data.featured_page || raise(NoFeaturedStory)
+    end
+
+    def story_name
+      story.frontmatter.story["name"]
+    end
+
+    def featured_metadata
+      case story.frontmatter.featured
+      when Hash then story.frontmatter.featured
+      else {}
+      end
     end
   end
 end

--- a/app/components/cards/featured_story_component.rb
+++ b/app/components/cards/featured_story_component.rb
@@ -1,0 +1,46 @@
+module Cards
+  class FeaturedStoryComponent < CardComponent
+    def initialize(card:, page_data:)
+      super(card: card)
+      @page_data = page_data
+    end
+
+    def link
+      story.path
+    end
+
+    def link_text
+      "Read more"
+    end
+
+    def border
+      false
+    end
+
+    def image
+      @image ||= story.frontmatter.featured[:image] || story.image
+    end
+
+    def header
+      story.frontmatter.featured[:title] || story.title
+    end
+
+    def snippet
+      story.frontmatter.featured[:snippet] || raise(MissingSnippet, story.path)
+    end
+
+    class NoFeaturedStory < RuntimeError; end
+
+    class MissingSnippet < RuntimeError
+      def initialize(story_path)
+        super "Featured story is missing the 'snippet' - #{story_path}"
+      end
+    end
+
+  private
+
+    def story
+      @story ||= @page_data.featured_page || raise(NoFeaturedStory)
+    end
+  end
+end

--- a/app/components/cards/featured_story_component.rb
+++ b/app/components/cards/featured_story_component.rb
@@ -6,11 +6,11 @@ module Cards
     end
 
     def link
-      story.path
+      featured_story.path
     end
 
     def link_text
-      @link_text || "Read #{story_name}'s story"
+      @link_text ||= "Read #{story_candidates_name}'s story"
     end
 
     def border
@@ -18,15 +18,17 @@ module Cards
     end
 
     def image
-      @image ||= featured_metadata["image"] || story.image
+      @image ||= featured_metadata["image"] || featured_story.image
     end
 
     def header
-      @header ||= featured_metadata["title"] || "#{story_name}'s story"
+      @header ||= featured_metadata["title"] || "#{story_candidates_name}'s story"
     end
 
     def snippet
-      @snippet ||= story.frontmatter.title || raise(MissingTitleOnFeatured, story.path)
+      @snippet ||=
+        featured_story.frontmatter.title ||
+        raise(MissingTitleOnFeatured, featured_story.path)
     end
 
     class NoFeaturedStory < RuntimeError; end
@@ -39,17 +41,17 @@ module Cards
 
   private
 
-    def story
-      @story ||= @page_data.featured_page || raise(NoFeaturedStory)
+    def featured_story
+      @featured_story ||= @page_data.featured_page || raise(NoFeaturedStory)
     end
 
-    def story_name
-      story.frontmatter.story["name"]
+    def story_candidates_name
+      featured_story.frontmatter.story["name"]
     end
 
     def featured_metadata
-      case story.frontmatter.featured
-      when Hash then story.frontmatter.featured
+      case featured_story.frontmatter.featured
+      when Hash then featured_story.frontmatter.featured
       else {}
       end
     end

--- a/app/models/pages/data.rb
+++ b/app/models/pages/data.rb
@@ -7,5 +7,9 @@ module Pages
     def latest_event_for_category(category)
       Events::Category.new(category).latest
     end
+
+    def featured_page
+      Page.featured
+    end
   end
 end

--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -31,15 +31,8 @@ module Pages
       end
     end
 
-    def initialize(content_dir_or_data = nil)
-      case content_dir_or_data
-      when Hash
-        @frontmatter = content_dir_or_data
-      when NilClass
-        @content_dir = MARKDOWN_CONTENT_DIR
-      else
-        @content_dir = Pathname.new(content_dir_or_data)
-      end
+    def initialize(content_dir = nil)
+      @content_dir = content_dir ? Pathname.new(content_dir) : MARKDOWN_CONTENT_DIR
     end
 
     def find(template)
@@ -55,7 +48,7 @@ module Pages
     alias_method :to_h, :find
 
     def preload
-      Dir.glob(content_pattern, &method(:add)) unless preloaded?
+      Dir.glob(content_pattern, &method(:add))
 
       self
     end

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -12,6 +12,14 @@ module Pages
       rescue Pages::Frontmatter::NotMarkdownTemplate
         new path, {}
       end
+
+      def featured
+        pages = Pages::Frontmatter.select(:featured)
+        return nil? if pages.empty?
+        raise MultipleFeatured, pages.keys if pages.many?
+
+        new(*pages.first)
+      end
     end
 
     def initialize(path, frontmatter)
@@ -25,6 +33,12 @@ module Pages
 
     def data
       @data ||= Pages::Data.new
+    end
+
+    class MultipleFeatured < RuntimeError
+      def initialize(page_paths)
+        super "There are multiple featured pages: #{page_paths.join(', ')}"
+      end
     end
   end
 end

--- a/spec/components/cards/featured_story_component_spec.rb
+++ b/spec/components/cards/featured_story_component_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Cards::FeaturedStoryComponent, type: :component do
+  subject { render_inline(instance) && page }
+
+  let :original do
+    {
+      title: "Page title",
+      image: "/test.jpg",
+      featured: {
+        snippet: "This is a featured page",
+      },
+    }
+  end
+
+  let(:frontmatter) { original }
+  let(:featured_page) { Pages::Page.new "/stories/featured", frontmatter }
+  let(:page_data) { Pages::Data.new }
+  let(:instance) { described_class.new card: {}, page_data: page_data }
+
+  before { allow(Pages::Page).to receive(:featured).and_return featured_page }
+
+  it { is_expected.to have_css ".card" }
+  it { is_expected.to have_css ".card.card--no-border" }
+  it { is_expected.to have_css ".card header", text: "Page title" }
+  it { is_expected.to have_css 'img[src="/test.jpg"]' }
+  it { is_expected.to have_content "This is a featured page" }
+
+  it "includes the footer link" do
+    is_expected.to have_link \
+      "Read more",
+      href: "/stories/featured",
+      class: "git-link"
+  end
+
+  context "With different title" do
+    let(:frontmatter) { original.deep_merge featured: { title: "Featured" } }
+
+    it { is_expected.to have_css ".card" }
+    it { is_expected.to have_css ".card.card--no-border" }
+    it { is_expected.to have_css ".card header", text: "Featured" }
+    it { is_expected.to have_css "img" }
+    it { is_expected.to have_content "This is a featured page" }
+  end
+
+  context "Without snippet" do
+    let(:frontmatter) { original.merge featured: { title: "Featured" } }
+
+    it { expect { subject }.to raise_exception described_class::MissingSnippet }
+  end
+
+  context "Without featured story" do
+    let(:featured_page) { nil }
+
+    it { expect { subject }.to raise_exception described_class::NoFeaturedStory }
+  end
+end

--- a/spec/components/cards/featured_story_component_spec.rb
+++ b/spec/components/cards/featured_story_component_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
     {
       title: "Page title",
       image: "/test.jpg",
-      featured: {
-        snippet: "This is a featured page",
-      },
+      featured: true,
+      story: { "name" => "Teacher" },
     }
   end
 
@@ -22,31 +21,31 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
 
   it { is_expected.to have_css ".card" }
   it { is_expected.to have_css ".card.card--no-border" }
-  it { is_expected.to have_css ".card header", text: "Page title" }
+  it { is_expected.to have_css ".card header", text: "Teacher's story" }
   it { is_expected.to have_css 'img[src="/test.jpg"]' }
-  it { is_expected.to have_content "This is a featured page" }
+  it { is_expected.to have_content "Page title" }
 
   it "includes the footer link" do
     is_expected.to have_link \
-      "Read more",
+      "Read Teacher's story",
       href: "/stories/featured",
       class: "git-link"
   end
 
   context "With different title" do
-    let(:frontmatter) { original.deep_merge featured: { title: "Featured" } }
+    let(:frontmatter) { original.deep_merge featured: { "title" => "Featured" } }
 
     it { is_expected.to have_css ".card" }
     it { is_expected.to have_css ".card.card--no-border" }
     it { is_expected.to have_css ".card header", text: "Featured" }
     it { is_expected.to have_css "img" }
-    it { is_expected.to have_content "This is a featured page" }
+    it { is_expected.to have_content "Page title" }
   end
 
   context "Without snippet" do
-    let(:frontmatter) { original.merge featured: { title: "Featured" } }
+    let(:frontmatter) { original.without :title }
 
-    it { expect { subject }.to raise_exception described_class::MissingSnippet }
+    it { expect { subject }.to raise_exception described_class::MissingTitleOnFeatured }
   end
 
   context "Without featured story" do

--- a/spec/fixtures/files/markdown_content/first.md
+++ b/spec/fixtures/files/markdown_content/first.md
@@ -1,0 +1,7 @@
+---
+title: First
+priority: 10
+section: stories
+---
+
+First page

--- a/spec/fixtures/files/markdown_content/page1.md
+++ b/spec/fixtures/files/markdown_content/page1.md
@@ -1,5 +1,6 @@
 ---
 title: Hello World 1
+featured: yes
 ---
 
 Some content

--- a/spec/fixtures/files/markdown_content/second.md
+++ b/spec/fixtures/files/markdown_content/second.md
@@ -1,0 +1,6 @@
+---
+title: Second
+priority: 20
+---
+
+Second page

--- a/spec/fixtures/files/markdown_content/third.md
+++ b/spec/fixtures/files/markdown_content/third.md
@@ -1,0 +1,7 @@
+---
+title: Third
+priority: 30
+section: stories
+---
+
+Third page

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe Pages::Data do
   include_context "use fixture markdown pages"
 
-  let(:md_files) { { "/page1" => { title: "Page 1", featured: true } } }
-
   let(:instance) { described_class.new }
 
   describe "#find_page" do

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Pages::Data do
+  include_context "use fixture markdown pages"
+
+  let(:md_files) { { "/page1" => { title: "Page 1", featured: true } } }
+
   let(:instance) { described_class.new }
 
   describe "#find_page" do
@@ -29,5 +33,13 @@ RSpec.describe Pages::Data do
       it { is_expected.to be_kind_of GetIntoTeachingApiClient::TeachingEvent }
       it { is_expected.to have_attributes type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[category] }
     end
+  end
+
+  describe "#featured_page" do
+    subject { instance.featured_page }
+
+    before { expect(Pages::Page).to receive(:featured).and_call_original }
+
+    it { is_expected.to be_kind_of Pages::Page }
   end
 end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -27,11 +27,9 @@ RSpec.describe Pages::Frontmatter do
   end
 
   shared_examples "a listing of all pages" do
-    it "includes all pages" do
-      expect(subject.keys).to match_array(%w[/page1 /subfolder/page2])
-    end
-
-    it { is_expected.to include "/page1" => { title: "Hello World 1" } }
+    it { expect(subject.keys).to include "/page1" }
+    it { expect(subject.keys).to include "/subfolder/page2" }
+    it { expect(subject["/page1"]).to include title: "Hello World 1" }
   end
 
   describe ".perform_caching" do
@@ -103,14 +101,6 @@ RSpec.describe Pages::Frontmatter do
   end
 
   describe "#select" do
-    let :content_dir do
-      {
-        "/first" => { priority: 10, section: "stories", first: "First" },
-        "/second" => { priority: 20 },
-        "/third" => { priority: 30, section: "stories" },
-      }
-    end
-
     context "stories with matching key" do
       subject { instance.select :section }
 

--- a/spec/models/pages/page_spec.rb
+++ b/spec/models/pages/page_spec.rb
@@ -28,20 +28,11 @@ RSpec.describe Pages::Page do
   describe ".featured" do
     subject { described_class.featured }
 
-    let(:pages) do
-      {
-        "/stories/featured" => { featured: true, title: "Featured page" },
-        "/stories/second" => { title: "Second page" },
-      }
-    end
-
-    let(:frontmatter) { Pages::Frontmatter.new pages }
-
-    before { expect(Pages::Frontmatter).to receive(:instance).and_return frontmatter }
-
-    it_behaves_like "a page", "Featured page", "/stories/featured", "content/stories/featured"
+    it_behaves_like "a page", "Hello World 1", "/page1", "content/page1"
 
     context "#with multiple featured stories" do
+      before { allow(Pages::Frontmatter).to receive(:select).and_return pages }
+
       let(:pages) do
         {
           "/stories/featured" => { featured: true, title: "Featured page" },


### PR DESCRIPTION
### Trello card

https://trello.com/c/xmUzKlT8

### Context

Plan has changed somewhat and the idea is now to mark a story as featured, and any page with this card on will show details from that page.

Where possible it tries to mirror the behaviour of the existing Stories::CardComponent whilst just delegating whats shown to the story being linked to - eg links, snippet text, images

### Changes proposed in this pull request

1. Add a simple query mechanism for the pages list in Pages::Frontmatter
2. Allow Pages::Page to look up the featured page using (1)
3. Added a FeaturedStory component to render the featured page as a card

### Guidance to review

1. Add `featured: yes` to the metadata for a story
2. Add the following snippet to another stories metadata

```yaml
explore:
  card_type: featured story
```
