### PR TITLE
Add page title to event/mailing list completion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Lint/AmbiguousOperator:
 Style/SignalException:
   Enabled: false
 
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/**/*steps_controller.rb'

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -1,9 +1,12 @@
 class EventStepsController < ApplicationController
   before_action :load_event
-  before_action :redirect_closed_events, only: %i[show update] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   include WizardSteps
   self.wizard_class = Events::Wizard
+
+  before_action :redirect_closed_events, only: %i[show update]
+  before_action :set_step_page_title, only: [:show]
+  before_action :set_completed_page_title, only: [:completed]
 
 private
 
@@ -39,10 +42,14 @@ private
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:event_id])
   end
 
-  def set_page_title
+  def set_step_page_title
     @page_title = "Sign up for #{@event.name}"
     unless @current_step.nil?
       @page_title += ", #{@current_step.title.downcase} step"
     end
+  end
+
+  def set_completed_page_title
+    @page_title = "Sign up complete"
   end
 end

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -3,7 +3,8 @@ module MailingList
     include WizardSteps
     self.wizard_class = MailingList::Wizard
 
-    before_action :set_page_title, only: [:show] # rubocop:disable Rails/LexicallyScopedActionFilter
+    before_action :set_step_page_title, only: [:show]
+    before_action :set_completed_page_title, only: [:completed]
 
   private
 
@@ -20,11 +21,15 @@ module MailingList
       session[:mailinglist] ||= {}
     end
 
-    def set_page_title
+    def set_step_page_title
       @page_title = "Sign up for email updates"
       unless @current_step.nil?
         @page_title += ", #{@current_step.title.downcase} step"
       end
+    end
+
+    def set_completed_page_title
+      @page_title = "You've signed up"
     end
   end
 end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     visit event_steps_path(event_id: event_readable_id)
 
+    expect(page).to have_title("Get into teaching: Sign up for #{event.name}, personal details step")
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
@@ -50,6 +51,7 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personalised_updates
     click_on "Complete sign up"
 
+    expect(page).to have_title("Get into teaching: Sign up complete")
     expect(page).to have_text "What happens next"
     expect(page).to have_text "signed up for email updates"
   end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -50,6 +50,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
+    expect(page).to have_title("Get into teaching: Sign up for email updates, name step")
+
     expect(page).to have_text "Sign up for email updates"
     fill_in_name_step
     click_on "Next Step"
@@ -79,6 +81,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
+    expect(page).to have_title("Get into teaching: You've signed up")
     expect(page).to have_text "You've signed up"
     expect(page).to have_text "What happens next"
   end


### PR DESCRIPTION
### Trello card

[Trello-550](https://trello.com/c/9vh9fdOf/550-mailing-list-event-sign-up-completion-pages-dont-have-a-custom-page-title)

### Context

The event/mailing list sign up completion pages do not have titles set.

The event sign up wizard titles are also not working, though the logic is in place the `before_action` had been removed.

### Changes proposed in this pull request

- Add page title to event/mailing list completion

Also adds tests to cover the page title behaviour of both wizards.

### Guidance to review

