### PR TITLE
Reflect merge commit message through to `-content` repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
   update_content_repo:
     name: Update the base image used in the Content repo
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     needs: build
     steps:
       - name: Check out the repo
@@ -188,19 +188,19 @@ jobs:
           cd content
           git show HEAD
 
-      # - name: Push the commit
-      #   run: |-
-      #     cd content
-      #     git push origin master
+      - name: Push the commit
+        run: |-
+          cd content
+          git push origin master
 
-      # - name: Slack Notification
-      #   if: failure()
-      #   uses: rtCamp/action-slack-notify@master
-      #   env:
-      #     SLACK_CHANNEL: getintoteaching_tech
-      #     SLACK_COLOR: '#3278BD'
-      #     SLACK_ICON: https://github.com/rtCamp.png?size=48
-      #     SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure :disappointed_relieved:'
-      #     SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: getintoteaching_tech
+          SLACK_COLOR: '#3278BD'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure :disappointed_relieved:'
+          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
   CONTENT_REPOSITORY: DFE-Digital/get-into-teaching-content
 jobs:
   build:
-    name: Build and Deploy 
+    name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -128,9 +128,12 @@ jobs:
   update_content_repo:
     name: Update the base image used in the Content repo
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     needs: build
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
       - name: Set short sha
         id: sha
         run: echo ::set-output name=short::$(echo "${{ github.sha }}" | cut -c -7)
@@ -143,6 +146,11 @@ jobs:
       - name: Print discovered docker-image variable
         run: |-
           echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
+
+      - name: Extract latest commit message
+        id: latest-commit
+        run: |-
+          echo ::set-output name=message::$(git show -s --format=%B HEAD)
 
       - name: Check out the Content
         uses: actions/checkout@v2
@@ -169,26 +177,30 @@ jobs:
           git add Dockerfile
           git commit -m "Updated base image to ${{ steps.sha.outputs.short}}
 
-          ${{ steps.docker-image.outputs.image }}"
+          ${{ steps.docker-image.outputs.image }}
+
+          -----
+
+          ${{ steps.latest-commit.outputs.message }}"
 
       - name: Show last commit
         run: |-
           cd content
           git show HEAD
 
-      - name: Push the commit
-        run: |-
-          cd content
-          git push origin master
+      # - name: Push the commit
+      #   run: |-
+      #     cd content
+      #     git push origin master
 
-      - name: Slack Notification
-        if: failure()
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_CHANNEL: getintoteaching_tech
-          SLACK_COLOR: '#3278BD'
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure :disappointed_relieved:'
-          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      # - name: Slack Notification
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@master
+      #   env:
+      #     SLACK_CHANNEL: getintoteaching_tech
+      #     SLACK_COLOR: '#3278BD'
+      #     SLACK_ICON: https://github.com/rtCamp.png?size=48
+      #     SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure :disappointed_relieved:'
+      #     SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
### Trello card

N/a

### Context

Currently we just note the changed sha in the commits we create into the `-content` repo. If these are to be included in release notes than it would help to include further information about what was changed in the `-app` repo.

### Changes proposed in this pull request

Copy the latest commit message in `-app` to the commit being created in `-content`.

### Guidance to review

This is on a branch at the moment - so I've disabled the push to `-content` and the check for `-master`.

Once reviewed I'll re-enable both of those, it'll require re-approval because its changed but than it can be merged
