### PR TITLE
Fix JS error on guidance pages

### DIFF
--- a/app/views/layouts/guidance.html.erb
+++ b/app/views/layouts/guidance.html.erb
@@ -675,8 +675,6 @@
 
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 
-        <script src="https://www.gov.uk/assets/static/header-footer-only-b40a2139e794b00c053ad6f4ade31cedd5e091d679a259f0042664549a66d3bb.js"></script>
-
         <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
         <script src="https://www.gov.uk/assets/government-frontend/application-e6e189e655c0c3d1835298a128f8f68fa8b56785858230797bba7b8c5acfdfbf.js"></script>
 


### PR DESCRIPTION
### Trello card

[Trello-668](https://trello.com/c/FLC0rHxk/668-bug-going-back-from-ways-to-train-updates-the-address-bar-but-not-the-page-content)

### Context

We ran into a bug with Turbolinks imploding once you visit the a guidance page (so the browser back button failed to work). This was caused by a JS exception on the guidance pages, originating from some include JS. Removing the offending JS fixes the issues.

### Changes proposed in this pull request

- Fix JS error on guidance pages

### Guidance to review

I gave the guidance page a good click about and nothing appears to be effected by removing this. We're also going to be removing/restyling these pages in the near future.
