### PR TITLE
Update heading styles

### DIFF
--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -5,7 +5,6 @@
     }
 
     &__date {
-      font-weight: bold;
       font-size: 1.4em;
     }
 

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -25,7 +25,8 @@
 
   h2 {
       font-size: 28px;
-      border: 0;
+      background: transparent;
+      color: $black;
   }
 
   .govuk-input, .govuk-select {


### PR DESCRIPTION
### Trello card

[Trello-610](https://trello.com/c/2h6RhdYC/610-development-revise-event-page-headings-remove-bold-from-time-and-date-line)

### Context

There is too much bold text going on in event titles and the date/time; only the event title needs to be bold.

### Changes proposed in this pull request

- Normal font weight for event date/time
- Remove blue background from event sign up sub-heading

This was introduced inadvertently when we moved all content `h2` tags to a new style that has a blue background and white text (dropping the previous `border`).

### Guidance to review

| Before      | After |
| ----------- | ----------- |
| <img width="742" alt="Screenshot 2020-12-16 at 16 10 40" src="https://user-images.githubusercontent.com/29867726/102376023-17765f80-3fbb-11eb-9779-1b23460f9081.png">    |  <img width="655" alt="Screenshot 2020-12-16 at 16 10 19" src="https://user-images.githubusercontent.com/29867726/102374638-7c30ba80-3fb9-11eb-92b9-94e09e57f39c.png">|
|   <img width="810" alt="Screenshot 2020-12-16 at 16 10 43" src="https://user-images.githubusercontent.com/29867726/102375859-e72ec100-3fba-11eb-9520-04f7a91aa9ed.png">    | <img width="723" alt="Screenshot 2020-12-16 at 16 10 28" src="https://user-images.githubusercontent.com/29867726/102374642-7dfa7e00-3fb9-11eb-895b-7952898f26dc.png">       |


