### PR TITLE
Add 15 minute cache headers to all static assets in /public

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,11 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=#{15.minutes.to_i}",
+    "Expires" => 15.minutes.from_now.to_formatted_s(:rfc822),
+  }
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/TpdEGvzU

### Context

We're seeing 404s on pack files after a deploy - there's a few seconds where the app may receive a html referring from the earlier release, but by the time it requests the pack file the server has removed its reference to the earlier pack file

This is complicated by the content media files which may actually change so need to remain updateable.

### Changes proposed in this pull request

Use a short (15 minute) cache lifetime

* This should allow assets to be served by the CDN, and continue to be available long enough to bridge the deploy window.
* It should be short enough that if the content assets do change in a user visible fashion (uncommon/unllikely), than the site will quickly show the new images
* It should allow the CDN to start serving media and pack files, capping load at a single request every 15 minutes for any given asset, potentially speeding up the site and definitely increasing scaleability.

### Guidance to review

Headers can be tested locally by booting into `rolling` environment and using `curl -I http://localhost:3000`

Due to the continuous deploy but no Review URLs for `-app` this cannot be tested prior to merge. Open to ideas here but simplest seems to be use the 10 minutes as the QA step happens to check the QA site, any issues abort the deploy?