### PR TITLE
Fix slanting hero from blocking top nav

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -11,6 +11,7 @@
         display: flex;
         position: relative;
         box-sizing: border-box;
+        overflow: hidden;
 
         height: 500px;
 


### PR DESCRIPTION
Setting the overflow to `hidden` will make any part of the heading contents that falls outside of the container hidden. This is needed because if the window is made wide enough it'll eventually overlap with the top nav.

![Screenshot from 2020-12-17 14-23-31](https://user-images.githubusercontent.com/128088/102500115-dd1cc900-4073-11eb-95e2-68956f445d78.png)

