### PR TITLE
Add test to check internal images

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -55,6 +55,18 @@ RSpec.feature "content pages check", type: :feature, content: true do
           .each { |href| expect(href).not_to match(%r{https?://(localhost|127\.0\.0\.1)}) }
       end
 
+      scenario "the internal images exist" do
+        document
+          .css("img")
+          .map { |img| img["src"] }
+          .reject { |src| src.start_with?("http") }
+          .uniq
+          .each do |src|
+            visit(src)
+            expect(page).to have_http_status(:success), %(invalid image src on #{url} - #{src})
+          end
+      end
+
       scenario "the internal links reference existing pages" do
         document
           .css("a")


### PR DESCRIPTION
### Trello card

[Trello-599](https://trello.com/c/MRt1mo8u/599-development-add-checking-for-missing-images-to-the-content-checks)

### Context

At the moment it is possible to incorrectly reference an internal image, resulting in a broken image being pushed live.

We want to add a test to verify all internal images can be successfully requested.

### Changes proposed in this pull request

- Add test to check internal images

### Guidance to review

I've limited this to internal images; arguably we may want to also have a test case to catch any links to external images, I can't think of a reason we wouldn't vendor an image?