### PR TITLE
Change teacher training step to radio buttons

### DIFF
--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -75,7 +75,7 @@ private
   end
 
   def step_params
-    params.require(step_param_key).permit @current_step.attributes.keys
+    params.fetch(step_param_key, {}).permit @current_step.attributes.keys
   end
 
   def step_param_key

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -7,7 +7,7 @@ module MailingList
                 inclusion: { in: :consideration_journey_stage_ids }
 
       def consideration_journey_stages
-        @consideration_journey_stages ||= [OpenStruct.new(id: nil, value: "Please select")] + query_consideration_journey_stages
+        @consideration_journey_stages ||= query_consideration_journey_stages
       end
 
       def consideration_journey_stage_ids

--- a/app/views/mailing_list/steps/_teacher_training.html.erb
+++ b/app/views/mailing_list/steps/_teacher_training.html.erb
@@ -7,7 +7,9 @@
 
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_collection_select :consideration_journey_stage_id,
-      f.object.consideration_journey_stages,
-      :id,
-      :value %>
+<%= f.govuk_collection_radio_buttons :consideration_journey_stage_id,
+  f.object.consideration_journey_stages,
+  :id,
+  :value,
+  legend: { text: t('helpers.label.mailing_list_steps_teacher_training.consideration_journey_stage_id') }
+%>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
-    select "I’m not sure and finding out more"
+    choose "I’m not sure and finding out more"
     click_on "Next Step"
 
     expect(page).to have_text "Which subject do you want to teach"
@@ -102,7 +102,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
-    select "I’m not sure and finding out more"
+    choose "I’m not sure and finding out more"
     click_on "Next Step"
 
     expect(page).to have_text "Which subject do you want to teach"
@@ -156,9 +156,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "How close are you to applying"
-    expect(page).to have_select(
-      "How close are you to applying for teacher training?",
-      selected: GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.key(response.consideration_journey_stage_id),
+    expect(find("[name=\"mailing_list_steps_teacher_training[consideration_journey_stage_id]\"][checked]").value).to eq(
+      response.consideration_journey_stage_id.to_s,
     )
     click_on "Next Step"
 

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -77,6 +77,11 @@ describe EventStepsController do
       it { is_expected.to have_http_status :success }
     end
 
+    context "with no data" do
+      let(:details_params) { {} }
+      it { is_expected.to have_http_status :success }
+    end
+
     context "for last step" do
       context "when all valid" do
         before do

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -51,6 +51,11 @@ describe MailingList::StepsController do
       it { is_expected.to have_http_status :success }
     end
 
+    context "with no data" do
+      let(:details_params) { {} }
+      it { is_expected.to have_http_status :success }
+    end
+
     context "for last step" do
       let(:steps) { MailingList::Wizard.steps }
       let(:model) { steps.last }


### PR DESCRIPTION
### Trello card

[Trello-682](https://trello.com/c/AVp3XQcs/682-development-change-we-need-some-more-details-from-drop-down-to-radio-buttons-on-mailing-list)

### Context

Switch the teacher training step answers from a drop down to radio buttons.

### Changes proposed in this pull request

- Change teacher training step to radio buttons

Also updates `WizardSteps` to handle posting no data (which happens if no radio values are checked). Rails form builder has supported this natively with a hidden field for a while, but the GOV.UK form builder doesn't seem to.

### Guidance to review

<img width="749" alt="Screenshot 2020-12-18 at 09 02 23" src="https://user-images.githubusercontent.com/29867726/102595590-bf9d3d00-410f-11eb-9263-babe43b1a740.png">
