### PR TITLE
Add paragraph on Christmas opening times to footer

### DIFF
--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -15,6 +15,7 @@
                         If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
                         Monday-Friday between 8.30am and 5pm.
                     </p>
+
                     <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
                         Chat <span>online</span>
                     </a>
@@ -36,6 +37,8 @@
                 <p>
                     If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm. You can also use this number to update or amend any of your details.
                 </p>
+
+                <p><strong>Our opening times may vary during the Christmas period.</strong></p>
             </div>
 
         </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/crRTvHva/684-add-christmas-opening-hours-content-to-talk-to-us-banner

### Context

There needs to be a disclaimer in the footer that the opening hours are variable over Christmas.

### Changes proposed in this pull request

Simply add some text to the footer for the Christmas period.

I thought about making this clever and adding an if statement around it so it will show automatically next year too, but in the end decided to just do it the simple way and as soon as this is merged I'll create a PR to reverse it that we can merge after the holidays.

### Guidance to review

It's a single paragraph.