### PR TITLE
Update API client to remove types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: afef61cf2553e754a7447ba3ac5a98215780f5ff
+  revision: fc55a73e7192f95199f4c3d2e9c04c3e7eb6ada3
   specs:
-    get_into_teaching_api_client (1.1.6)
+    get_into_teaching_api_client (1.1.7)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.8)
+    get_into_teaching_api_client_faraday (0.1.9)
       activesupport
       faraday
       faraday-encoding
@@ -137,7 +137,7 @@ GEM
     htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (2.4.0)
+    json (2.4.1)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -320,7 +320,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     view_component (2.23.1)

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -30,7 +30,7 @@ module Events
     class << self
       def available_event_types
         @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES.map do |key, value|
-          GetIntoTeachingApiClient::TypeEntity.new(id: value, value: key)
+          GetIntoTeachingApiClient::PickListItem.new(id: value, value: key)
         end
       end
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -3,25 +3,25 @@ require "rails_helper"
 RSpec.feature "Mailing list wizard", type: :feature do
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 
   let(:consideration_journey_stage_types) do
     GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 
   let(:teaching_subject_types) do
     GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -73,7 +73,7 @@ describe Events::Steps::PersonalisedUpdates do
       subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
         GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
       )
-      subjects.map { |k, v| GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k }) }
+      subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
     end
 
     before do

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -6,7 +6,7 @@ describe MailingList::Steps::DegreeStatus do
 
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -6,7 +6,7 @@ describe MailingList::Steps::Name do
 
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -6,7 +6,7 @@ describe MailingList::Steps::Subject do
 
   let(:teaching_subject_types) do
     GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k })
     end
   end
 
@@ -31,7 +31,7 @@ describe MailingList::Steps::Subject do
       subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
         GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
       )
-      subjects.map { |k, v| GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k }) }
+      subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
     end
 
     subject { instance.teaching_subject_ids }

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -6,7 +6,7 @@ describe MailingList::Steps::TeacherTraining do
 
   let(:consideration_journey_stage_types) do
     GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
-      GetIntoTeachingApiClient::TypeEntity.new({ id: v, value: k })
+      GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
 


### PR DESCRIPTION
The types are being deprecated and support has been removed from the API client. This updates the client in the app to ensure nobody accidentally references the old type methods going forward (they will be deleted from the API shortly).
