### PR TITLE
Add a link to campaign page from the bottom nav

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -29,6 +29,7 @@
         <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
       <% end %>
       <%= link_to "Find an event near you", events_path %>
+      <%= link_to("Helping you become a teacher", page_path(page: "helping-you-become-a-teacher")) %>
     </div>
   </div>
   <div class="site-footer-bottom">


### PR DESCRIPTION
### Trello card

https://trello.com/c/Mqq5MhoU/677-create-link-in-web-app-footer-for-campaign-landing-page

### Context

The new 'helping you become a teacher' campaign page isn't linked to from anywhere.

### Changes proposed in this pull request

Add a link to the campaign page's nav section, only in the footer. When the campaign's dropped and the page removed this will cause a failure in the link checking specs so we have coverage.

### Guidance to review

![Screenshot from 2020-12-18 12-21-32](https://user-images.githubusercontent.com/128088/102614173-b02bed00-412b-11eb-94a9-39707427cc87.png)


