### PR TITLE
Change attributes for featured story card

### DIFF
--- a/app/components/cards/featured_story_component.rb
+++ b/app/components/cards/featured_story_component.rb
@@ -50,8 +50,8 @@ module Cards
     end
 
     def featured_metadata
-      case featured_story.frontmatter.featured
-      when Hash then featured_story.frontmatter.featured
+      case featured_story.frontmatter.featured_story_card
+      when Hash then featured_story.frontmatter.featured_story_card
       else {}
       end
     end

--- a/app/components/cards/featured_story_component.rb
+++ b/app/components/cards/featured_story_component.rb
@@ -46,7 +46,7 @@ module Cards
     end
 
     def story_candidates_name
-      featured_story.frontmatter.story["name"]
+      featured_story.frontmatter.story["teacher"].to_s.strip.split(%r{\s}).first
     end
 
     def featured_metadata

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -14,7 +14,7 @@ module Pages
       end
 
       def featured
-        pages = Pages::Frontmatter.select(:featured)
+        pages = Pages::Frontmatter.select(:featured_story_card)
         return nil? if pages.empty?
         raise MultipleFeatured, pages.keys if pages.many?
 

--- a/spec/components/cards/featured_story_component_spec.rb
+++ b/spec/components/cards/featured_story_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
     {
       title: "Page title",
       image: "/test.jpg",
-      featured: true,
+      featured_story_card: true,
       story: { "name" => "Teacher" },
     }
   end
@@ -33,7 +33,9 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
   end
 
   context "With different title" do
-    let(:frontmatter) { original.deep_merge featured: { "title" => "Featured" } }
+    let(:frontmatter) do
+      original.deep_merge featured_story_card: { "title" => "Featured" }
+    end
 
     it { is_expected.to have_css ".card" }
     it { is_expected.to have_css ".card.card--no-border" }

--- a/spec/components/cards/featured_story_component_spec.rb
+++ b/spec/components/cards/featured_story_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
       title: "Page title",
       image: "/test.jpg",
       featured_story_card: true,
-      story: { "name" => "Teacher" },
+      story: { "teacher" => "  Teacher Jones" },
     }
   end
 

--- a/spec/fixtures/files/markdown_content/page1.md
+++ b/spec/fixtures/files/markdown_content/page1.md
@@ -1,6 +1,6 @@
 ---
 title: Hello World 1
-featured: yes
+featured_story_card: yes
 ---
 
 Some content


### PR DESCRIPTION
### Trello card

https://trello.com/c/xmUzKlT8

### Context

Minor tweaks to the featured story card

### Changes proposed in this pull request

1. Use a more specific frontmatter key to mark the story to be used by the cards - this it to avoid confusion
2. Use the "teacher" attribute on stories because this is more consistent, but extract just the firstname

### Guidance to review

Add the following frontmatter to an existing story

```
featured_story_card: yes
explore:
  - card_type: featured story
```

