### PR TITLE
Added check that mobile nav has the same links as desktop nav

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
 
       let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
 
-      scenario "navigatable pages appear in desktop navbar" do
+      scenario "navigable pages appear in desktop navbar" do
         navigation_pages.each do |url, frontmatter|
           page.within "nav .navbar__desktop" do
             is_expected.to have_link frontmatter[:title], href: url
@@ -105,7 +105,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
         end
       end
 
-      scenario "navigatable pages appear in mobile navbar" do
+      scenario "navigable pages appear in mobile navbar" do
         navigation_pages.each do |url, frontmatter|
           page.within "nav .navbar__mobile" do
             is_expected.to have_link frontmatter[:title], href: url

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
     end
   end
 
-  content_urls.slice(0, 1).each do |first_url|
+  content_urls.first.tap do |first_url|
     describe "navbar" do
       subject { page }
 

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -27,11 +27,12 @@ RSpec.feature "content pages check", type: :feature, content: true do
     end
   end
 
+  let(:document) { Nokogiri.parse(page.body) }
+
   content_urls.each do |url|
     describe "visiting #{url}" do
       let(:url) { url }
       before { visit(url) }
-      let(:document) { Nokogiri.parse(page.body) }
 
       scenario "checking that #{url} responds with success" do
         expect(page).to have_http_status :success
@@ -84,6 +85,40 @@ RSpec.feature "content pages check", type: :feature, content: true do
               expect(page).to(have_css("#" + fragment), %(invalid link on #{url} - #{href}, (missing fragment #{fragment})))
             end
           end
+      end
+    end
+  end
+
+  content_urls.slice(0, 1).each do |first_url|
+    describe "navbar" do
+      subject { page }
+
+      before { visit first_url }
+
+      let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
+
+      scenario "navigatable pages appear in desktop navbar" do
+        navigation_pages.each do |url, frontmatter|
+          page.within "nav .navbar__desktop" do
+            is_expected.to have_link frontmatter[:title], href: url
+          end
+        end
+      end
+
+      scenario "navigatable pages appear in mobile navbar" do
+        navigation_pages.each do |url, frontmatter|
+          page.within "nav .navbar__mobile" do
+            is_expected.to have_link frontmatter[:title], href: url
+          end
+        end
+      end
+
+      scenario "mobile nav matches desktop nav" do
+        document.css("nav .navbar__desktop a").each do |desktop_link|
+          page.within "nav .navbar__mobile" do
+            is_expected.to have_link desktop_link.text, href: desktop_link["href"]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Trello card

https://trello.com/c/Z1iYnBtC

### Context

We nearly made a release which had incorrect navigation on the mobile pages

### Changes proposed in this pull request

1. Check that desktop nav includes links for all pages marked as `navigation:`
2. Check that mobile nav includes links for all pages marked as `navigation:`
3. Check that all the links on the desktop nav appear in the mobile nav

### Guidance to review

1. Do the content specs still pass
