### PR TITLE
Revert to using margin for spacing

### DIFF
--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -92,18 +92,10 @@
   &--narrow {
     header {
       display: flex;
+      align-items: center;
 
       .call-to-action__heading {
-        margin-left: 1em;
-        margin-bottom: 0;
-      }
-
-      @supports (gap: 1em) {
-        gap: 1em;
-
-        .call-to-action__heading {
-          margin-left: 0;
-        }
+        margin: 0 0 0 .5em;
       }
     }
   }


### PR DESCRIPTION
[Gap in flex is unsupported by Safari](https://caniuse.com/?search=gap), but Safari _does_ support the gap property in grid - causing the removed media query to be ineffective.

Replacing with a margin-left which will work everywhere but is less elegant.

**Note there's no content live yet that uses this CTA**

| Before | After |
| ----- | ------ |
| ![Screenshot from 2020-12-21 14-50-28](https://user-images.githubusercontent.com/128088/102789463-1c148c80-439c-11eb-9699-a06bd4f580df.png) | ![Screenshot from 2020-12-21 14-50-42](https://user-images.githubusercontent.com/128088/102789478-1fa81380-439c-11eb-9770-94642db3591e.png) |

