### PR TITLE
Automatic authentication using long-lived access tokens

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,4 @@
 # Add public visible environment variables here for the Developemnt environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
+GIT_API_TOKEN="abc123"
+GIT_API_ENDPOINT="https://localhost:5001/api"

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "prometheus-client"
 
 gem "sentry-raven"
 
-gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
+gem "get_into_teaching_api_client_faraday", path: "../get-into-teaching-api-ruby-client", require: "api/client"
 gem "redis"
 
 gem "kaminari", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 PATH
   remote: ../get-into-teaching-api-ruby-client
   specs:
-    get_into_teaching_api_client (1.1.8)
+    get_into_teaching_api_client (1.1.9)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.91)
+    get_into_teaching_api_client_faraday (0.1.12)
       activesupport
       faraday
       faraday-encoding

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,22 @@
 GIT
-  remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 61152b6255ba9ea824d28c5db3c0dce75658dd2e
+  remote: https://github.com/waiting-for-dev/front_matter_parser.git
+  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
   specs:
-    get_into_teaching_api_client (1.1.9)
+    front_matter_parser (0.2.1)
+
+PATH
+  remote: ../get-into-teaching-api-ruby-client
+  specs:
+    get_into_teaching_api_client (1.1.8)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.12)
+    get_into_teaching_api_client_faraday (0.1.91)
       activesupport
       faraday
       faraday-encoding
       faraday-http-cache
       faraday_middleware
       get_into_teaching_api_client
-
-GIT
-  remote: https://github.com/waiting-for-dev/front_matter_parser.git
-  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
-  specs:
-    front_matter_parser (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -36,3 +36,4 @@ module MailingList
     end
   end
 end
+

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -22,6 +22,11 @@ module MailingList
       end
     end
 
+    def perform_auth_request(candidate_id, token)
+      api = GetIntoTeachingApiClient::MailingListApi.new
+      api.get_pre_filled_mailing_list_add_member_long_lived(candidate_id, token)
+    end
+
   private
 
     def add_member_to_mailing_list

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -78,7 +78,8 @@ module Wizard
     def authenticate(candidate_id, token)
       response = perform_auth_request(candidate_id, token)
       prepopulate_store(response)
-      @store["authenticate"] = false
+      @store["timed_one_time_password"] = "000000"
+      @store["authenticate"] = true
       @store["authenticated"] = true
     end
 

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -78,6 +78,7 @@ module Wizard
     def authenticate(candidate_id, token)
       response = perform_auth_request(candidate_id, token)
       prepopulate_store(response)
+      @store["authenticate"] = false
       @store["authenticated"] = true
     end
 

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -24,7 +24,7 @@ module Wizard
   private
 
     def previously_authenticated?
-      @store["authenticate"]
+      @store["authenticated"]
     end
 
     def request_attributes

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,3 +50,5 @@ module GovukRailsBoilerplate
     config.view_component.default_preview_layout = "component_preview"
   end
 end
+
+OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE

--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -9,7 +9,7 @@ GetIntoTeachingApiClient.configure do |config|
   if endpoint
     parsed = URI.parse(endpoint)
 
-    config.host = parsed.hostname
+    config.host = "#{parsed.hostname}:#{parsed.port}"
     config.base_path = parsed.path.gsub(%r{\A/api}, "")
   end
 

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -18,6 +18,21 @@ describe MailingList::Wizard do
     end
   end
 
+  describe "#perform_auth_request" do
+    let(:wizardstore) { Wizard::Store.new({}) }
+    let(:wizard) { described_class.new wizardstore, "name" }
+    let(:candidate_id) { "abc" }
+    let(:token) { "def" }
+    let(:stub_response) { GetIntoTeachingApiClient::MailingListAddMember.new(candidateId: candidate_id) }
+
+    it "authenticates with the API" do
+      expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+        receive(:get_pre_filled_mailing_list_add_member_long_lived).with(candidate_id, token) { stub_response }
+      response = wizard.perform_auth_request(candidate_id, token)
+      expect(response).to eq(stub_response)
+    end
+  end
+
   describe "#complete!" do
     let(:uuid) { SecureRandom.uuid }
     let(:store) do

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -31,6 +31,20 @@ describe MailingList::StepsController do
 
       it { is_expected.to have_http_status :not_found }
     end
+
+    context "when auth parameters are provided" do
+      let(:candidate_id) { "abc" }
+      let(:token) { "def" }
+
+      before do
+        expect_any_instance_of(MailingList::Wizard).to \
+          receive(:authenticate).with(candidate_id, token)
+        get mailing_list_steps_path(:name, { candidate_id: "abc", token: "def" })
+        follow_redirect!
+      end
+
+      it { is_expected.to redirect_to(mailing_list_step_path(:degree_status)) }
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
### Trello card

[Trello-661](https://trello.com/c/ebrz8S9V/661-development-work-with-crm-team-on-developing-approach-to-migrating-past-registrants-on-to-mailing-list-subscription)

### Context

We are adding API endpoints that can generate 'long lived' access tokens against candidate records in the CRM. The idea being the CRM will call this endpoint to generate a token for a candidate then send that candidate an email containing the mailing list sign up 'magic link' link, including their candidate id and token:

```
/mailinglist/signup?candidate_id=f4488e35-8fd5-4884-af9f-ca98f76e0432&token=3097d0cb-5b9d-450f-8b4a-1c5f6dbeb6a2
```

When a candidate opens their 'magic link' the application can use the `candidate_id` and `token` to authenticate the candidate and retrieve their details from the API, pre-filling the mailing list form and taking them to the first step _after_ the `Authenticate` step (so skipping entering their name/email and verification code).

### Changes proposed in this pull request

- [Temp] Point app at local API instance (for testing)
- Authenticate using long-lived access tokens

### Guidance to review

I think this needs more restructuring; we currently 'authenticate' and 'prefill' within the `Wizard` class and the `Authenticate` step; I think this could/should probably be consolidated so the logic is in the `Wizard` alone.

I need to gracefully handle when an authentication fails still; this is TBC.