### PR TITLE
Fix the pink play icon on homepage video content

### DIFF
--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -22,7 +22,16 @@
         position: relative;
         overflow: auto;
         .more-stories__thumbs__thumb__play {
-            top: 80px;
+            @include rotated-block(-3deg, $blur: 4px);
+            background-color: $pink-dark-90;
+            padding: 1em 1em 1em 1.5em;
+            position: absolute;
+            top: 120px;
+            margin-left: -.6em;
+
+            &:hover {
+              background-color: $pink;
+            }
         }
     }
 


### PR DESCRIPTION
This is caused by the homepage and stories having overlapping but not
exact markup. This temporary fix solves the problem for the time being
but it really should be reworked.

![Screenshot from 2020-12-22 17-49-39](https://user-images.githubusercontent.com/128088/102918023-1db68100-447e-11eb-9d14-55c0c2e42df1.png)
