### PR TITLE
Update capitalisation of events headers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,3 +132,7 @@ RSpec/SubjectStub:
 RSpec/VerifiedDoubles:
   Exclude:
     - spec/**/*.rb
+
+RSpec/NotToNot:
+  Exclude:
+    - spec/**/*.rb

--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -10,7 +10,7 @@
     <%= divider %>
 
     <footer class="event-box__footer">
-      <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] %>
+      <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] %>
         <div class="event-box__footer__item">
           <div class="event-box__footer__icon-wrapper">
             <%= event_type_icon %>

--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -48,7 +48,7 @@ module Events
     def online_text
       return "Event has moved online" if virtual?
 
-      "Online Event"
+      "Online event"
     end
 
   private

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,7 +26,7 @@ module EventsHelper
   end
 
   def can_sign_up_online?(event)
-    event.web_feed_id && event_status_open?(event) && !is_event_type?(event, "School or University Event")
+    event.web_feed_id && event_status_open?(event) && !is_event_type?(event, "School or University event")
   end
 
   def is_event_type?(event, type_name)
@@ -80,7 +80,7 @@ module EventsHelper
 
   def event_type_color(type_id)
     case type_id
-    when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
+    when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
       "purple"
     else
       "blue"

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -90,4 +90,12 @@ module EventsHelper
   def pluralised_category_name(type_id)
     t("event_types.#{type_id}.name.plural")
   end
+
+  def past_category_name(category_name)
+    if category_name.downcase.include? "online"
+      "Past online events"
+    else
+      "Past #{category_name}"
+    end
+  end
 end

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -1,5 +1,5 @@
-<% category_name = t("event_types.#{@type.id}.name.plural") %>
-<% category_name = "Past #{category_name}" if @period == :past %>
+<% category_name = pluralised_category_name(@type.id) %>
+<% category_name = past_category_name(category_name) if @period == :past %>
 
 <% @page_title = category_name %>
 
@@ -56,9 +56,9 @@
   <section class="event-content-cta">
     <div class="container-1000">
       <div class="content-cta content-cta--center">
-        <h2>Past <%= category_name %></h2>
+        <h2> <%= past_category_name(category_name) %> </h2>
         <p>
-          You can see past <%= category_name %>, including all questions and answers, <%= link_to("on this page", archive_event_category_path(pluralised_category_name(@type.id).parameterize)) %>
+          You can see <%= past_category_name(category_name).downcase %>, including all questions and answers, <%= link_to("on this page", archive_event_category_path(pluralised_category_name(@type.id).parameterize)) %>
         </p>
       </div>
     </div>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,5 +1,5 @@
 <% plural_category_name = pluralised_category_name(type_id) %>
-<% with_logo = type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] %>
+<% with_logo = type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
 
 <div class="events-featured <%= "events-featured--with-logo" if with_logo %>">
   <div class="events-featured__heading">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,7 +7,7 @@
 <section role="main" id="main-content">
     <section class="event-type-descriptions">
       <div class="container-1000">
-        <h2 class="strapline strapline--blue">Types of Events</h2>
+        <h2 class="strapline strapline--blue">Types of events</h2>
         <section class="event-type-descriptions__content">
           <% GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.each do |type_id| %>
             <%= render Events::TypeDescriptionComponent.new(type_id) %>
@@ -39,7 +39,7 @@
     <% if @events_by_type.any? %>
       <section class="content container-1000">
         <% unless @performed_search %>
-        <h2 class="strapline strapline--blue discover-events-strapline">Discover Events</h2>
+        <h2 class="strapline strapline--blue discover-events-strapline">Discover events</h2>
         <% end %>
         <% @group_presenter.sorted_events_by_type.each do |type_id, events| %>
           <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -72,7 +72,7 @@
                   Sign up for this <span>event</span>
               <% end %>
             </p>
-          <% elsif is_event_type?(@event, "School or University Event") %>
+          <% elsif is_event_type?(@event, "School or University event") %>
             <h2 class="strapline-article">How to attend</h2>
             <p>To register for this event, follow the instructions in the event information section.</p>
           <% elsif @event.provider_website_url %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,22 +64,22 @@ en:
   event_types:
     222750001:
       name:
-        singular: "Train to Teach Event"
-        plural: "Train to Teach Events"
+        singular: "Train to Teach event"
+        plural: "Train to Teach events"
       description: |-
         Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training 
         will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
     222750008:
       name:
-        singular: "Online Event"
-        plural: "Online Events"
+        singular: "Online event"
+        plural: "Online events"
       description: |-
         In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train. 
         Get fast answers to your questions so you can take the next step to becoming a teacher.
     222750009:
       name:
-        singular: "School or University Event"
-        plural: "School and University Events"
+        singular: "School or University event"
+        plural: "School and University events"
       description: |-
         These events, run by schools and universities, are a great way to and find out more about a particular training provider. 
         Find out what they have to offer and help make your decision on where to apply.

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -9,7 +9,7 @@ module GetIntoTeachingApiClient
 
     EVENT_TYPES_WITH_ARCHIVE =
       {
-        "Online Event" => 222_750_008,
+        "Online event" => 222_750_008,
       }.freeze
 
     # This is not a complete list.

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -2,9 +2,9 @@ module GetIntoTeachingApiClient
   module Constants
     EVENT_TYPES =
       {
-        "Train to Teach Event" => 222_750_001,
-        "Online Event" => 222_750_008,
-        "School or University Event" => 222_750_009,
+        "Train to Teach event" => 222_750_001,
+        "Online event" => 222_750_008,
+        "School or University event" => 222_750_009,
       }.freeze
 
     EVENT_TYPES_WITH_ARCHIVE =

--- a/spec/components/cards/renderer_component_spec.rb
+++ b/spec/components/cards/renderer_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Cards::RendererComponent, type: :component do
   end
 
   context "with card type specified" do
-    let(:card) { { category: "Train to Teach Event", card_type: "latest_event" }.with_indifferent_access }
+    let(:card) { { category: "Train to Teach event", card_type: "latest_event" }.with_indifferent_access }
     let(:event) { build(:event_api, name: "Test event") }
     let(:page_data) { double Pages::Data, latest_event_for_category: event }
 

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -21,7 +21,7 @@ describe Events::EventBoxComponent, type: "component" do
   end
 
   describe "online/offline" do
-    let(:online_heading) { "Online Event" }
+    let(:online_heading) { "Online event" }
     let(:moved_online_heading) { "Event has moved online" }
 
     context "when the event is an online event type" do
@@ -60,14 +60,14 @@ describe Events::EventBoxComponent, type: "component" do
 
   [
     OpenStruct.new(
-      name: "Train to Teach Event",
+      name: "Train to Teach event",
       trait: :train_to_teach_event,
       expected_colour: "purple",
       is_online: false,
       is_virtual: false,
     ),
     OpenStruct.new(
-      name: "Online Event",
+      name: "Online event",
       trait: :online_event,
       expected_colour: "blue",
       is_online: true,
@@ -80,9 +80,9 @@ describe Events::EventBoxComponent, type: "component" do
       is_online: false,
       is_virtual: false,
     ),
-    # a 'Train to Teach Event' that also happens to be online
+    # a 'Train to Teach event' that also happens to be online
     OpenStruct.new(
-      name: "Train to Teach Event",
+      name: "Train to Teach event",
       trait: :train_to_teach_event,
       expected_colour: "purple",
       is_online: true,

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -100,8 +100,8 @@ describe Events::EventBoxComponent, type: "component" do
 
       if event_type.is_online && event_type.trait == :online_event
         context "when is_online and an 'online_event'" do
-          specify %(the event should also be described as an 'Online Event') do
-            expect(page).to have_content("Online Event")
+          specify %(the event should also be described as an 'Online event') do
+            expect(page).to have_content("Online event")
           end
 
           specify %(the online icon should be #{event_type.expected_colour}) do

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Events::TypeDescriptionComponent, type: "component" do
-  let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+  let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
 
   subject! { render_inline(described_class.new(type)) }
 
@@ -14,7 +14,7 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has a heading" do
-    expect(page).to have_css("h5", text: "Online Events")
+    expect(page).to have_css("h5", text: "Online events")
   end
 
   it "has a description" do

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
 
     trait :online_event do
       online
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
     end
 
     trait :school_or_university_event do

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :event_api, class: "GetIntoTeachingApiClient::TeachingEvent" do
     id { SecureRandom.uuid }
     sequence(:readable_id, &:to_s)
-    type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
     web_feed_id { "123" }
     status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
@@ -28,7 +28,7 @@ FactoryBot.define do
     end
 
     trait :train_to_teach_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
     end
 
     trait :virtual do
@@ -48,7 +48,7 @@ FactoryBot.define do
     end
 
     trait :school_or_university_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"] }
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] }
     end
 
     trait :no_event_type do

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Finding an event", type: :feature do
     visit events_path
 
     expect(page).to have_text "Search for events"
-    expect(page).to have_css "h3", text: "Train to Teach Events"
+    expect(page).to have_css "h3", text: "Train to Teach events"
 
     click_on(event.name)
 
@@ -36,7 +36,7 @@ RSpec.feature "Finding an event", type: :feature do
 
     expect(page).to have_text "Search for events"
 
-    select "Train to Teach Event"
+    select "Train to Teach event"
     click_on "Update results"
 
     expect(page).not_to have_css "h2", text: "Organized by Get into Teaching"
@@ -51,7 +51,7 @@ RSpec.feature "Finding an event", type: :feature do
   scenario "Navigating events by page" do
     visit event_category_path(event_category_slug)
 
-    expect(page).to have_css("h2", text: "Search for Train to Teach Events")
+    expect(page).to have_css("h2", text: "Search for Train to Teach events")
 
     expect(page).to have_link("2", href: event_category_path(event_category_slug, page: 2))
     expect(page).to have_link("Next ›", href: event_category_path(event_category_slug, page: 2))

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -182,4 +182,14 @@ describe EventsHelper, type: "helper" do
       end
     end
   end
+
+  describe "#past_category_name" do
+    it "returns 'Past online events' if the category name contains 'online'" do
+      expect(past_category_name("Online events")).to eql("Past online events")
+    end
+
+    it "returns the category name with 'Past' prepended if the category name does not contain 'online'" do
+      expect(past_category_name("Train to Teach events")).to eql("Past Train to Teach events")
+    end
+  end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -173,7 +173,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#pluralised_category_name" do
     {
-      222_750_001 => "Train to Teach Events",
+      222_750_001 => "Train to Teach events",
       222_750_008 => "Online events",
       222_750_009 => "School and University events",
     }.each do |type_id, name|

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -98,8 +98,8 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#is_event_type?" do
-    let(:matching_type) { "School or University Event" }
-    let(:non_matching_type) { "Online Event" }
+    let(:matching_type) { "School or University event" }
+    let(:non_matching_type) { "Online event" }
     let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
 
     it "should be truthy when the type matches" do
@@ -113,12 +113,12 @@ describe EventsHelper, type: "helper" do
 
   describe "#event_type_color" do
     it "returns purple for train to teach events" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
       expect(event_type_color(type_id)).to eq("purple")
     end
 
     it "returns blue for non-train to teach events" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
       expect(event_type_color(type_id)).to eq("blue")
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University Events"]
       expect(event_type_color(type_id)).to eq("blue")
@@ -174,8 +174,8 @@ describe EventsHelper, type: "helper" do
   describe "#pluralised_category_name" do
     {
       222_750_001 => "Train to Teach Events",
-      222_750_008 => "Online Events",
-      222_750_009 => "School and University Events",
+      222_750_008 => "Online events",
+      222_750_009 => "School and University events",
     }.each do |type_id, name|
       specify "#{type_id} => #{name}" do
         expect(pluralised_category_name(type_id)).to eql(name)

--- a/spec/models/events/category_spec.rb
+++ b/spec/models/events/category_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Events::Category do
   include_context "stub types api"
 
-  let(:category_name) { "Train to Teach Event" }
+  let(:category_name) { "Train to Teach event" }
   let(:type_id) do
     GetIntoTeachingApiClient::Constants::EVENT_TYPES[category_name]
   end
@@ -53,7 +53,7 @@ RSpec.describe Events::Category do
     it { is_expected.to have_attributes type_id: type_id }
 
     context "with no events for category id" do
-      let(:category_name) { "Online Event" }
+      let(:category_name) { "Online event" }
       it { is_expected.to be_nil }
     end
   end

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Pages::Data do
     end
 
     context "with category name" do
-      let(:category) { "Train to Teach Event" }
+      let(:category) { "Train to Teach event" }
 
       it { is_expected.to be_kind_of GetIntoTeachingApiClient::TeachingEvent }
       it { is_expected.to have_attributes type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[category] }

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -12,7 +12,7 @@ describe Events::GroupPresenter do
 
   describe "#sorted_events_by_type" do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
-    let(:online_event_type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+    let(:online_event_type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
 
     it "returns events_by_type as an array of [type_id, events] tuples" do
       expect(subject.sorted_events_by_type).to eq([
@@ -47,7 +47,7 @@ describe Events::GroupPresenter do
       let(:early) { build(:event_api, :online_event, start_at: 1.week.from_now) }
       let(:middle) { build(:event_api, :online_event, start_at: 2.weeks.from_now) }
       let(:late) { build(:event_api, :online_event, start_at: 3.weeks.from_now) }
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
       let(:unsorted_events) { [middle, late, early] }
       let(:ascending) { true }
 

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -16,9 +16,9 @@ describe Events::GroupPresenter do
 
     it "returns events_by_type as an array of [type_id, events] tuples" do
       expect(subject.sorted_events_by_type).to eq([
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"], train_to_teach_events],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"], online_events],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"], school_and_university_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"], online_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events],
       ])
     end
 

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -29,7 +29,7 @@ describe "View events by category" do
     subject { response }
 
     it { is_expected.to have_http_status :success }
-    it { expect(response.body).to include "Past Online events" }
+    it { expect(response.body).to include "Past online events" }
 
     it "displays all events in the category, ordered by date descending" do
       expect(response.body.scan(/Event \d/)).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -29,7 +29,7 @@ describe "View events by category" do
     subject { response }
 
     it { is_expected.to have_http_status :success }
-    it { expect(response.body).to include "Past Online Events" }
+    it { expect(response.body).to include "Past Online events" }
 
     it "displays all events in the category, ordered by date descending" do
       expect(response.body.scan(/Event \d/)).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -76,7 +76,7 @@ describe "View events by category" do
     let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_after, start_before: start_before, type_id: nil } }
 
     it "queries events for the correct category" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_id: type_id, quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events")
@@ -91,7 +91,7 @@ describe "View events by category" do
     let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_id: nil } }
 
     it "queries events for the correct category" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_id: type_id, quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -45,7 +45,7 @@ describe EventsController do
     end
 
     context "with valid search params" do
-      let(:event_type_name) { "Train to Teach Event" }
+      let(:event_type_name) { "Train to Teach event" }
       let(:event_type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES[event_type_name] }
       let(:search_params) do
         attributes_for(
@@ -159,8 +159,8 @@ describe EventsController do
           it { is_expected.not_to match(/#{event.building.address_postcode}/) }
         end
 
-        context %(when the event is a 'School or University Event') do
-          let(:event) { build(:event_api, web_feed_id: nil, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]) }
+        context %(when the event is a 'School or University event') do
+          let(:event) { build(:event_api, web_feed_id: nil, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]) }
 
           it { is_expected.to match(%r{To register for this event, follow the instructions in the event information section}) }
           it { is_expected.not_to match(%r{Sign up for this}) }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -78,9 +78,9 @@ describe "Find an event near you" do
       it "presents the types in the correct order" do
         headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
         expected_headings = [
-          "Train to Teach Events",
-          "Online Events",
-          "School and University Events",
+          "Train to Teach events",
+          "Online events",
+          "School and University events",
         ]
 
         expect(headings & expected_headings).to eq(expected_headings)
@@ -89,7 +89,7 @@ describe "Find an event near you" do
   end
 
   context "when searching for an event by type" do
-    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
     let(:events) { [build(:event_api, type_id: type_id)] }
 
     before do
@@ -101,7 +101,7 @@ describe "Find an event near you" do
 
     it "displays only the category filtered to" do
       headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
-      expected_headings = ["Train to Teach Events"]
+      expected_headings = ["Train to Teach events"]
 
       expect(headings).to eq(expected_headings)
     end
@@ -148,7 +148,7 @@ describe "Find an event near you" do
     it "categorises the results" do
       headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
       expected_headings = [
-        "Train to Teach Events",
+        "Train to Teach events",
       ]
 
       expect(headings & expected_headings).to eq(expected_headings)
@@ -164,7 +164,7 @@ describe "Find an event near you" do
     end
 
     context "when there are results for a subset of categories" do
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
       let(:events) { [build(:event_api, type_id: type_id)] }
 
       it "displays the no results message per category" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -38,11 +38,11 @@ describe "Find an event near you" do
     end
 
     it "displays the discover events heading" do
-      expect(response.body).to include("Discover Events")
+      expect(response.body).to include("Discover events")
     end
 
     it "displays event types" do
-      expect(response.body).to include("Types of Events")
+      expect(response.body).to include("Types of events")
       event_types = GetIntoTeachingApiClient::Constants::EVENT_TYPES.values
 
       event_types.each do |type|
@@ -142,7 +142,7 @@ describe "Find an event near you" do
     end
 
     it "does not display the discover events heading" do
-      expect(response.body).not_to include("Discover Events")
+      expect(response.body).to_not include("Discover events")
     end
 
     it "categorises the results" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/CEw8IFIy

### Context
Stylistic change based on a request by the events team.

### Changes proposed in this pull request
- Update headers
    - Train to Teach Events => Train to Teach events
    - Online Events => Online events
    - Schools and University Events => Schools and University events
 - Update additional headers
     - Types of Events => Types of events
     - Discover Events => Discover events
 - Update past online events
     - Past Online Events => Past online events

### Guidance to review
Changes in below image weren't requested specifically, but updated to match. Can revert if not wanted
![image](https://user-images.githubusercontent.com/47089130/102993942-05924080-4516-11eb-9efa-e137cfd5fc76.png)


