### PR TITLE
Enable rubocop-rspec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Lint Ruby
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -e RAILS_ENV=test ${{steps.docker.outputs.DOCKER_IMAGE}} \
-            rubocop app config db lib spec Gemfile --format json --out=/app/out/rubocop-result.json
+            rubocop --format json --out=/app/out/rubocop-result.json
 
       - name:  Keep Rubocop output
         uses: actions/upload-artifact@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,14 +3,14 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-Rails/UnknownEnv:
-  Environments:
-    - development
-    - test
-    - rolling
-    - preprod
-    - userresearch
-    - production
+AllCops:
+  Exclude:
+    - Rakefile
+    - config.ru
+    - db/schema.rb
+    - bin/*
+    - node_modules/**/*
+
 
 Lint/AmbiguousOperator:
   Enabled: false
@@ -21,3 +21,12 @@ Style/SignalException:
 Rails/LexicallyScopedActionFilter:
   Exclude:
     - 'app/controllers/**/*steps_controller.rb'
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - rolling
+    - preprod
+    - userresearch
+    - production

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+require:
+  - rubocop-rspec
+
 AllCops:
   Exclude:
     - Rakefile
@@ -10,7 +13,6 @@ AllCops:
     - db/schema.rb
     - bin/*
     - node_modules/**/*
-
 
 Lint/AmbiguousOperator:
   Enabled: false
@@ -30,3 +32,9 @@ Rails/UnknownEnv:
     - preprod
     - userresearch
     - production
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ImplicitSubject:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,10 @@ AllCops:
     - bin/*
     - node_modules/**/*
 
-Lint/AmbiguousOperator:
+Capybara/FeatureMethods:
   Enabled: false
 
-Style/SignalException:
+Lint/AmbiguousOperator:
   Enabled: false
 
 Rails/LexicallyScopedActionFilter:
@@ -38,3 +38,138 @@ RSpec/AnyInstance:
 
 RSpec/ImplicitSubject:
   Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
+
+FactoryBot/FactoryClassName:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/BeEql:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ContextMethod:
+  Exclude:
+    - spec/**/*.rb
+RSpec/ContextWording:
+  Exclude:
+    - spec/**/*.rb
+RSpec/DescribeClass:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/DescribedClass:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/EmptyLineAfterFinalLet:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/EmptyLineAfterHook:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/EmptyLineAfterSubject:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ExampleLength:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ExampleWording:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ExpectInHook:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/FilePath:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/HookArgument:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/HooksBeforeExamples:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/InstanceVariable:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/LeadingSubject:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/LetBeforeExamples:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/MessageSpies:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/NamedSubject:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/NestedGroups:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/NotToNot:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ReceiveCounts:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/RepeatedDescription:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/RepeatedExampleGroupDescription:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ReturnFromStub:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ScatteredLet:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ScatteredSetup:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/SharedContext:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/SubjectStub:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/VerifiedDoubles:
+  Exclude:
+    - spec/**/*.rb


### PR DESCRIPTION
### Trello card

https://trello.com/c/D6sNREFU

### Context

Consistency and clarity in specs is desirable, we use rubocop to apply a default set of rules to the codebase so apply the rspec specific rules to the specs

### Changes proposed in this pull request

1. Enable the rubocop-rspec rules
2. Add exclusions for rules which don't currently pass

### Guidance to review

I've a series of commits to bring the code base inline but its going to turn into a mega PR, instead I've excluded failures for now and will send through subsequent PRs removing those exclusions
