### PR TITLE
Rubocop Rspec Step 1 updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,10 +58,6 @@ RSpec/DescribeClass:
   Exclude:
     - spec/**/*.rb
 
-RSpec/DescribedClass:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/EmptyLineAfterFinalLet:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - db/schema.rb
     - bin/*
     - node_modules/**/*
+    - spec/models/wizard/**/* # Separate PR splits this out into gem
 
 Capybara/FeatureMethods:
   Enabled: false
@@ -99,10 +100,6 @@ RSpec/InstanceVariable:
     - spec/**/*.rb
 
 RSpec/LeadingSubject:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/LeakyConstantDeclaration:
   Exclude:
     - spec/**/*.rb
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,10 +130,6 @@ RSpec/NestedGroups:
   Exclude:
     - spec/**/*.rb
 
-RSpec/NotToNot:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ReceiveCounts:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,10 +123,6 @@ RSpec/ReceiveCounts:
   Exclude:
     - spec/**/*.rb
 
-RSpec/RepeatedDescription:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ReturnFromStub:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,10 +127,6 @@ RSpec/RepeatedDescription:
   Exclude:
     - spec/**/*.rb
 
-RSpec/RepeatedExampleGroupDescription:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ReturnFromStub:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,10 +44,6 @@ Style/SignalException:
 
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
-FactoryBot/FactoryClassName:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/BeEql:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,10 +143,6 @@ RSpec/ScatteredSetup:
   Exclude:
     - spec/**/*.rb
 
-RSpec/SharedContext:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/SubjectStub:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,10 +45,6 @@ Style/SignalException:
 
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
-RSpec/BeEql:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ContextMethod:
   Exclude:
     - spec/**/*.rb

--- a/spec/components/calls_to_action/chat_online_component_spec.rb
+++ b/spec/components/calls_to_action/chat_online_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CallsToAction::ChatOnlineComponent, type: :component do
-  let(:component) { CallsToAction::ChatOnlineComponent.new }
+  let(:component) { described_class.new }
   before { render_inline(component) }
 
   specify "renders a call to action" do

--- a/spec/components/calls_to_action/multiple_buttons_component_spec.rb
+++ b/spec/components/calls_to_action/multiple_buttons_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CallsToAction::MultipleButtonsComponent, type: :component do
     { "first button" => "/first/link", "second button" => "/second/link" }
   end
 
-  let(:component) { CallsToAction::MultipleButtonsComponent.new(icon: icon, title: title, links: links) }
+  let(:component) { described_class.new(icon: icon, title: title, links: links) }
 
   before { render_inline(component) }
 

--- a/spec/components/calls_to_action/narrow_component_spec.rb
+++ b/spec/components/calls_to_action/narrow_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CallsToAction::NarrowComponent, type: :component do
   subject do
-    CallsToAction::NarrowComponent.new(
+    described_class.new(
       icon: "icon-question",
       title: "title",
       text: "text",

--- a/spec/components/calls_to_action/next_steps_component_spec.rb
+++ b/spec/components/calls_to_action/next_steps_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CallsToAction::NextStepsComponent, type: :component do
-  let(:component) { CallsToAction::NextStepsComponent.new }
+  let(:component) { described_class.new }
   before { render_inline(component) }
 
   specify "renders the call to action" do

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
   describe "rendering the component" do
     let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target } }
 
-    let(:component) { CallsToAction::SimpleComponent.new(kwargs) }
+    let(:component) { described_class.new(kwargs) }
     before { render_inline(component) }
 
     specify "renders the call to action" do
@@ -55,7 +55,7 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
     let(:kwargs) { { icon: icon, link_text: link_text, link_target: link_target } }
 
     specify "raises an argument error when title and text aren't provided" do
-      expect { CallsToAction::SimpleComponent.new(**kwargs) }.to raise_error(ArgumentError, /title or text must be present/)
+      expect { described_class.new(**kwargs) }.to raise_error(ArgumentError, /title or text must be present/)
     end
   end
 end

--- a/spec/components/calls_to_action/story_component_spec.rb
+++ b/spec/components/calls_to_action/story_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CallsToAction::StoryComponent, type: :component do
 
   let(:args) { { name: name, heading: heading, image: image_path, link: link, text: text } }
 
-  let(:component) { CallsToAction::StoryComponent.new(args) }
+  let(:component) { described_class.new(args) }
   before { render_inline(component) }
 
   specify "renders the call to action" do

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -13,7 +13,7 @@ describe CardComponent, type: "component" do
   let(:card) { base }
 
   subject do
-    render_inline CardComponent.new(card: card)
+    render_inline described_class.new(card: card)
     page
   end
 

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -14,7 +14,7 @@ describe Content::AccordionComponent, type: "component" do
     end
 
     subject! do
-      render_inline(Content::AccordionComponent.new) do |accordion|
+      render_inline(described_class.new) do |accordion|
         steps.each do |title, content|
           accordion.slot(:step, title: title) { content }
         end
@@ -56,7 +56,7 @@ describe Content::AccordionComponent, type: "component" do
   describe "Calls to action" do
     describe "chat_online" do
       subject do
-        render_inline(Content::AccordionComponent.new) do |accordion|
+        render_inline(described_class.new) do |accordion|
           accordion.slot(:step, title: title, call_to_action: call_to_action) do
             text
           end
@@ -88,7 +88,7 @@ describe Content::AccordionComponent, type: "component" do
 
     describe "story" do
       subject do
-        render_inline(Content::AccordionComponent.new) do |accordion|
+        render_inline(described_class.new) do |accordion|
           accordion.slot(:step, title: title, call_to_action: call_to_action)
         end
       end
@@ -122,7 +122,7 @@ describe Content::AccordionComponent, type: "component" do
 
   describe "Numbered steps" do
     subject! do
-      render_inline(Content::AccordionComponent.new(numbered: true)) do |accordion|
+      render_inline(described_class.new(numbered: true)) do |accordion|
         accordion.slot(:step, title: title) { text }
       end
     end
@@ -136,7 +136,7 @@ describe Content::AccordionComponent, type: "component" do
     let(:active_step) { 3 }
 
     subject! do
-      render_inline(Content::AccordionComponent.new(active_step: active_step)) do |accordion|
+      render_inline(described_class.new(active_step: active_step)) do |accordion|
         1.upto(3).each do |i|
           accordion.slot(:step, title: "title #{i}") { "text #{i}" }
         end

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -5,7 +5,7 @@ describe Events::EventBoxComponent, type: "component" do
   let(:event) { build(:event_api) }
   let(:condensed) { false }
 
-  subject! { render_inline(Events::EventBoxComponent.new(event, condensed: condensed)) }
+  subject! { render_inline(described_class.new(event, condensed: condensed)) }
 
   specify "renders an event box" do
     expect(page).to have_css(".event-box")

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -96,22 +96,26 @@ describe Events::EventBoxComponent, type: "component" do
       end
 
       if event_type.is_online && event_type.trait == :online_event
-        specify %(the event should also be described as an 'Online Event') do
-          expect(page).to have_content("Online Event")
-        end
+        context "when is_online and an 'online_event'" do
+          specify %(the event should also be described as an 'Online Event') do
+            expect(page).to have_content("Online Event")
+          end
 
-        specify %(the online icon should be #{event_type.expected_colour}) do
-          expect(page).to have_css(%(.icon-online-event--#{event_type.expected_colour}))
+          specify %(the online icon should be #{event_type.expected_colour}) do
+            expect(page).to have_css(%(.icon-online-event--#{event_type.expected_colour}))
+          end
         end
       end
 
       if event_type.is_online && event_type.trait != :online_event
-        specify %(the event should also be described as a 'Event has moved online') do
-          expect(page).to have_content("Event has moved online")
-        end
+        context "when is_online but not 'online_event'" do
+          specify %(the event should also be described as a 'Event has moved online') do
+            expect(page).to have_content("Event has moved online")
+          end
 
-        specify %(the online icon should be #{event_type.expected_colour}) do
-          expect(page).to have_css(%(.icon-moved-online-event--#{event_type.expected_colour}))
+          specify %(the online icon should be #{event_type.expected_colour}) do
+            expect(page).to have_css(%(.icon-moved-online-event--#{event_type.expected_colour}))
+          end
         end
       end
 

--- a/spec/components/events/no_results_component_spec.rb
+++ b/spec/components/events/no_results_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Events::NoResultsComponent, type: "component" do
   let(:message) { "no results message" }
-  let(:component) { Events::NoResultsComponent.new }
+  let(:component) { described_class.new }
 
   subject do
     render_inline(component) { message }

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -4,7 +4,7 @@ describe Events::SearchComponent, type: "component" do
   let(:search) { build(:events_search, :invalid) }
   let(:path) { "/some/path" }
 
-  let(:component) { Events::SearchComponent.new(search, path) }
+  let(:component) { described_class.new(search, path) }
   subject! { render_inline(component) }
 
   specify "builds a search form" do
@@ -20,7 +20,7 @@ describe Events::SearchComponent, type: "component" do
 
     context "when overridden" do
       let(:new_heading) { "Search for Awesome events" }
-      subject! { render_inline(Events::SearchComponent.new(search, path, heading: new_heading)) }
+      subject! { render_inline(described_class.new(search, path, heading: new_heading)) }
 
       specify %(the title is overridden) do
         expect(page).to have_css("h2", text: new_heading)
@@ -56,10 +56,10 @@ describe Events::SearchComponent, type: "component" do
     end
 
     describe "optionally-blank month field" do
-      subject! { render_inline(Events::SearchComponent.new(search, path, allow_blank_month: true)) }
+      subject! { render_inline(described_class.new(search, path, allow_blank_month: true)) }
 
-      specify "there should be a blank option with the text '#{Events::SearchComponent::BLANK_MONTH_TEXT}'" do
-        expect(page).to have_css("option[value='']", text: Events::SearchComponent::BLANK_MONTH_TEXT)
+      specify "there should be a blank option with the text '#{described_class::BLANK_MONTH_TEXT}'" do
+        expect(page).to have_css("option[value='']", text: described_class::BLANK_MONTH_TEXT)
       end
     end
   end

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Events::TypeDescriptionComponent, type: "component" do
   let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
 
-  subject! { render_inline(Events::TypeDescriptionComponent.new(type)) }
+  subject! { render_inline(described_class.new(type)) }
 
   it "has a containing div" do
     expect(page).to have_css("div.type-description")

--- a/spec/components/navbar/navbar_component_spec.rb
+++ b/spec/components/navbar/navbar_component_spec.rb
@@ -9,7 +9,7 @@ describe Navbar::NavbarComponent, type: "component" do
     allow(Pages::Frontmatter).to receive(:list).and_return all_frontmatter
   end
 
-  subject! { render_inline(Navbar::NavbarComponent.new) }
+  subject! { render_inline(described_class.new) }
 
   describe "Desktop navbar component" do
     context "when rendered" do

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -12,7 +12,7 @@ describe Sections::HeroComponent, type: "component" do
       backlink: "/",
     }.with_indifferent_access
   end
-  let(:component) { Sections::HeroComponent.new(front_matter) }
+  let(:component) { described_class.new(front_matter) }
   subject! { render_inline(component) }
 
   describe "rendering a hero section" do
@@ -28,7 +28,7 @@ describe Sections::HeroComponent, type: "component" do
 
     describe "images" do
       context "when no image is present" do
-        let(:component) { Sections::HeroComponent.new(front_matter.merge(image: nil)) }
+        let(:component) { described_class.new(front_matter.merge(image: nil)) }
 
         specify "nothing is rendered" do
           expect(rendered_component).to be_empty
@@ -43,7 +43,7 @@ describe Sections::HeroComponent, type: "component" do
       end
 
       describe "responsive images" do
-        let(:component) { Sections::HeroComponent.new(front_matter.merge(mobileimage: "media/images/events-hero-mob.jpg")) }
+        let(:component) { described_class.new(front_matter.merge(mobileimage: "media/images/events-hero-mob.jpg")) }
 
         specify "the image's srcset should contain desktop and mobile" do
           img_tag = page.find(".hero__img > img")
@@ -55,7 +55,7 @@ describe Sections::HeroComponent, type: "component" do
 
     describe "mailing list cta" do
       context "when mailinglist: true" do
-        let(:component) { Sections::HeroComponent.new(front_matter.merge(deepheader: true)) }
+        let(:component) { described_class.new(front_matter.merge(deepheader: true)) }
 
         specify "renders a mailing list strip beneath the header" do
           expect(page).to have_css(".hero__mailing-strip")

--- a/spec/components/stories/card_component_spec.rb
+++ b/spec/components/stories/card_component_spec.rb
@@ -11,7 +11,7 @@ describe Stories::CardComponent, type: "component" do
   end
 
   subject do
-    render_inline(Stories::CardComponent.new(card: story))
+    render_inline(described_class.new(card: story))
     page
   end
 
@@ -42,7 +42,7 @@ describe Stories::CardComponent, type: "component" do
     let(:video_story) { story.merge(video: video).with_indifferent_access }
 
     subject do
-      render_inline(Stories::CardComponent.new(card: video_story))
+      render_inline(described_class.new(card: video_story))
       page
     end
 

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -39,7 +39,7 @@ describe Stories::StoryComponent, type: "component" do
   let(:front_matter) { default_front_matter }
 
   subject do
-    render_inline(Stories::StoryComponent.new(front_matter))
+    render_inline(described_class.new(front_matter))
     page
   end
 
@@ -94,7 +94,7 @@ describe Stories::StoryComponent, type: "component" do
   describe "content" do
     let(:content) { "The quick brown fox" }
     subject do
-      render_inline(Stories::StoryComponent.new(front_matter)) do
+      render_inline(described_class.new(front_matter)) do
         content
       end
 

--- a/spec/controllers/concerns/static_pages_spec.rb
+++ b/spec/controllers/concerns/static_pages_spec.rb
@@ -1,32 +1,34 @@
 require "rails_helper"
 
 describe StaticPages do
-  class StaticPageTester
-    include StaticPages
-    attr_reader :cacheable_static_page
+  let(:testing_class) do
+    Class.new do
+      include StaticPages
+      attr_reader :cacheable_static_page
 
-    def render
-      cache_static_page { fetch_content }
-    end
+      def render
+        cache_static_page { fetch_content }
+      end
 
-    def fetch_content
-      true
-    end
+      def fetch_content
+        true
+      end
 
-    def stale?(*_args)
-      true
-    end
+      def stale?(*_args)
+        true
+      end
 
-    def expires_in(*_args)
-      true
-    end
+      def expires_in(*_args)
+        true
+      end
 
-    def params
-      {}
+      def params
+        {}
+      end
     end
   end
 
-  let(:tester) { StaticPageTester.new }
+  let(:tester) { testing_class.new }
 
   let(:config) { Rails.application.config.x.static_pages }
   let(:etag) { "12345" }

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :event_api, class: GetIntoTeachingApiClient::TeachingEvent do
+  factory :event_api, class: "GetIntoTeachingApiClient::TeachingEvent" do
     id { SecureRandom.uuid }
     sequence(:readable_id, &:to_s)
     type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :event_building_api, class: GetIntoTeachingApiClient::TeachingEventBuilding do
+  factory :event_building_api, class: "GetIntoTeachingApiClient::TeachingEventBuilding" do
     id { SecureRandom.uuid }
     venue { "Albert Hall" }
     address_line1 { "Line 1" }

--- a/spec/factories/events/further_details_factory.rb
+++ b/spec/factories/events/further_details_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :events_further_details, class: Events::Steps::FurtherDetails do
+  factory :events_further_details, class: "Events::Steps::FurtherDetails" do
     event_id { "abc123" }
     privacy_policy { true }
     subscribe_to_mailing_list { true }

--- a/spec/factories/events/personal_details_factory.rb
+++ b/spec/factories/events/personal_details_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :events_personal_details, class: Events::Steps::PersonalDetails do
+  factory :events_personal_details, class: "Events::Steps::PersonalDetails" do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
     sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :events_personalised_updates, class: Events::Steps::PersonalisedUpdates do
+  factory :events_personalised_updates, class: "Events::Steps::PersonalisedUpdates" do
     degree_status_id do
       GetIntoTeachingApiClient::PickListItemsApi.new
         .get_qualification_degree_status.first.id

--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :events_search, class: Events::Search do
+  factory :events_search, class: "Events::Search" do
     type { Events::Search.available_event_types.first.id }
     distance { Events::Search.available_distances.first[0] }
     postcode { "TE57 1NG" }

--- a/spec/factories/mailing_list/degree_status_factory.rb
+++ b/spec/factories/mailing_list/degree_status_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_degree_status, class: MailingList::Steps::DegreeStatus do
+  factory :mailing_list_degree_status, class: "MailingList::Steps::DegreeStatus" do
     degree_status_id { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["First year"] }
   end
 end

--- a/spec/factories/mailing_list/name_factory.rb
+++ b/spec/factories/mailing_list/name_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_name, class: MailingList::Steps::Name do
+  factory :mailing_list_name, class: "MailingList::Steps::Name" do
     first_name { "Test" }
     sequence(:last_name) { |n| "User #{n}" }
     sequence(:email) { |n| "testuser#{n}@testing.education.gov.uk" }

--- a/spec/factories/mailing_list/postcode_factory.rb
+++ b/spec/factories/mailing_list/postcode_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_postcode, class: MailingList::Steps::Postcode do
+  factory :mailing_list_postcode, class: "MailingList::Steps::Postcode" do
     address_postcode { "TE571NG" }
   end
 end

--- a/spec/factories/mailing_list/privacy_policy_factory.rb
+++ b/spec/factories/mailing_list/privacy_policy_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_privacy_policy, class: MailingList::Steps::PrivacyPolicy do
+  factory :mailing_list_privacy_policy, class: "MailingList::Steps::PrivacyPolicy" do
     accept_privacy_policy { "1" }
   end
 end

--- a/spec/factories/mailing_list/subject_factory.rb
+++ b/spec/factories/mailing_list/subject_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_subject, class: MailingList::Steps::Subject do
+  factory :mailing_list_subject, class: "MailingList::Steps::Subject" do
     preferred_teaching_subject_id { GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS["Physics"] }
   end
 end

--- a/spec/factories/mailing_list/teacher_training_factory.rb
+++ b/spec/factories/mailing_list/teacher_training_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :mailing_list_teacher_training, class: MailingList::Steps::TeacherTraining do
+  factory :mailing_list_teacher_training, class: "MailingList::Steps::TeacherTraining" do
     consideration_journey_stage_id { GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES["It’s just an idea"] }
   end
 end

--- a/spec/factories/wizard/authenticate_factory.rb
+++ b/spec/factories/wizard/authenticate_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :authenticate, class: Events::Steps::Authenticate do
+  factory :authenticate, class: "Events::Steps::Authenticate" do
     timed_one_time_password { "012345" }
   end
 end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,43 +1,9 @@
 require "rails_helper"
 
 RSpec.feature "content pages check", type: :feature, content: true do
-  IGNORE = %w[
-    /test
-    /guidance_archive
-    /index
-    /steps-to-become-a-teacher/v2-index
-    /privacy-policy
-  ].freeze
-
-  class << self
-    def md_files
-      Dir["app/views/content/**/[^_]*.md"]
-    end
-
-    def html_files
-      Dir["app/views/content/**/[^_]*.html.erb"]
-    end
-
-    def files
-      html_files + md_files
-    end
-
-    def remove_folders(filename)
-      filename.gsub "app/views/content", ""
-    end
-
-    def remove_extension(filename)
-      filename.gsub %r{(\.[a-zA-Z0-9]+)+\z}, ""
-    end
-
-    def content_urls
-      files.map(&method(:remove_folders)).map(&method(:remove_extension)) - IGNORE
-    end
-  end
-
   let(:document) { Nokogiri.parse(page.body) }
 
-  content_urls.each do |url|
+  PageLister.content_urls.each do |url|
     describe "visiting #{url}" do
       let(:url) { url }
       before { visit(url) }
@@ -97,7 +63,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
     end
   end
 
-  content_urls.first.tap do |first_url|
+  PageLister.content_urls.first.tap do |first_url|
     describe "navbar" do
       subject { page }
 

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -193,12 +193,12 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text("Are you over 16 and do you agree")
-    expect(page).to_not have_text("Would you like to receive email updates")
+    expect(page).not_to have_text("Would you like to receive email updates")
     click_on "Complete sign up"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
-    expect(page).to_not have_text "Choose yes or no"
+    expect(page).not_to have_text "Choose yes or no"
 
     within_fieldset "Are you over 16 and do you agree" do
       check "Yes"
@@ -235,12 +235,12 @@ RSpec.feature "Event wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text("Are you over 16 and do you agree")
-    expect(page).to_not have_text("Would you like to receive email updates")
+    expect(page).not_to have_text("Would you like to receive email updates")
     click_on "Complete sign up"
 
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Accept the privacy policy to continue"
-    expect(page).to_not have_text "Choose yes or no"
+    expect(page).not_to have_text "Choose yes or no"
 
     within_fieldset "Are you over 16 and do you agree" do
       check "Yes"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -237,7 +237,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "You’ve already signed up"
-    expect(page).to_not have_button("Next Step")
+    expect(page).not_to have_button("Next Step")
   end
 
   scenario "Full journey as an existing candidate that has already subscribed to a teacher training adviser" do
@@ -261,7 +261,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next Step"
 
     expect(page).to have_text "You have already signed up to an adviser"
-    expect(page).to_not have_button("Next Step")
+    expect(page).not_to have_button("Next Step")
   end
 
   scenario "Start as an existing candidate then switch to new candidate" do

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -137,7 +137,7 @@ describe EventsHelper, type: "helper" do
     end
 
     it "returns the address, comma separated with line breaks between parts" do
-      expect(event.building).to_not be_nil
+      expect(event.building).not_to be_nil
       expect(event_address(event)).to eq("Line 1,\nLine 2,\nManchester,\nMA1 1AM")
     end
   end

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -8,7 +8,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of requests") }
-    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
   end
 
   describe "app_csp_violations_total" do
@@ -16,7 +16,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of CSP violations") }
-    it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.not_to raise_error }
   end
 
   describe "app_request_duration_ms" do
@@ -24,7 +24,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
-    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
   end
 
   describe "app_request_view_runtime_ms" do
@@ -32,7 +32,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
-    it { expect { subject.get(labels: %i[path method status]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
   end
 
   describe "app_render_view_ms" do
@@ -40,7 +40,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
-    it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
   end
 
   describe "app_render_partial_ms" do
@@ -48,7 +48,7 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
-    it { expect { subject.get(labels: %i[identifier]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
   end
 
   describe "app_cache_read_total" do
@@ -56,6 +56,6 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of cache reads") }
-    it { expect { subject.get(labels: %i[key hit]) }.to_not raise_error }
+    it { expect { subject.get(labels: %i[key hit]) }.not_to raise_error }
   end
 end

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -43,12 +43,12 @@ describe Events::Steps::FurtherDetails do
     context "when invalid" do
       before do
         subject.privacy_policy = nil
-        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to_not \
+        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).not_to \
           receive(:get_latest_privacy_policy)
       end
 
       it "does not update the store" do
-        expect(subject).to_not be_valid
+        expect(subject).not_to be_valid
         subject.save
         expect(wizardstore["subscribe_to_mailing_list"]).to be_nil
       end

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -18,11 +18,11 @@ describe Events::Steps::PersonalDetails do
   end
 
   context "first_name" do
-    it { is_expected.to_not allow_value("a" * 257).for :first_name }
+    it { is_expected.not_to allow_value("a" * 257).for :first_name }
   end
 
   context "last_name" do
-    it { is_expected.to_not allow_value("a" * 257).for :last_name }
+    it { is_expected.not_to allow_value("a" * 257).for :last_name }
   end
 
   context "email address" do

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -21,7 +21,7 @@ describe Healthcheck do
           allow(File).to receive(:read).with(shafile).and_raise Errno::ENOENT
         end
 
-        it { is_expected.to eql nil }
+        it { is_expected.to be_nil }
       end
     end
   end

--- a/spec/models/mailing_list/steps/already_subscribed_spec.rb
+++ b/spec/models/mailing_list/steps/already_subscribed_spec.rb
@@ -4,7 +4,7 @@ describe MailingList::Steps::AlreadySubscribed do
   include_context "wizard step"
   it_behaves_like "a wizard step"
 
-  it { is_expected.to_not be_can_proceed }
+  it { is_expected.not_to be_can_proceed }
 
   describe "#skipped?" do
     it "returns true if already_subscribed_to_mailing_list is false/nil/undefined" do
@@ -25,12 +25,12 @@ describe MailingList::Steps::AlreadySubscribed do
 
     it "returns false if already_subscribed_to_mailing_list is true" do
       wizardstore["already_subscribed_to_mailing_list"] = true
-      expect(subject).to_not be_skipped
+      expect(subject).not_to be_skipped
     end
 
     it "returns false if already_subscribed_to_teacher_training_adviser is true" do
       wizardstore["already_subscribed_to_teacher_training_adviser"] = true
-      expect(subject).to_not be_skipped
+      expect(subject).not_to be_skipped
     end
   end
 end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -27,11 +27,11 @@ describe MailingList::Steps::Name do
   end
 
   context "first_name" do
-    it { is_expected.to_not allow_value("a" * 257).for :first_name }
+    it { is_expected.not_to allow_value("a" * 257).for :first_name }
   end
 
   context "last_name" do
-    it { is_expected.to_not allow_value("a" * 257).for :last_name }
+    it { is_expected.not_to allow_value("a" * 257).for :last_name }
   end
 
   context "email address" do
@@ -44,7 +44,7 @@ describe MailingList::Steps::Name do
     let(:options) { channels.map(&:id) }
     it { is_expected.to allow_values(options).for :channel_id }
     it { is_expected.to allow_value(nil, "").for :channel_id }
-    it { is_expected.to_not allow_value(12_345).for :channel_id }
+    it { is_expected.not_to allow_value(12_345).for :channel_id }
   end
 
   context "when the step is valid" do

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Pages::Frontmatter do
 
     context "when caching" do
       before do
-        allow(Pages::Frontmatter).to receive(:instance) { instance.preload }
+        allow(described_class).to receive(:instance) { instance.preload }
         expect(instance).to receive(:find_from_preloaded).and_call_original
       end
 

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -30,7 +30,7 @@ describe Wizard::Steps::Authenticate do
 
     it "returns false if authenticate is true" do
       wizardstore["authenticate"] = true
-      expect(subject).to_not be_skipped
+      expect(subject).not_to be_skipped
     end
   end
 
@@ -72,7 +72,7 @@ describe Wizard::Steps::Authenticate do
       it "does not attempt to call the API" do
         subject.timed_one_time_password = nil
         subject.save
-        expect { subject.save }.to_not raise_error
+        expect { subject.save }.not_to raise_error
       end
 
       it "does not set authenticated to true" do
@@ -93,7 +93,7 @@ describe Wizard::Steps::Authenticate do
       end
 
       it "does not call the API on validation if already authenticated" do
-        expect(subject).to_not receive(:perform_existing_candidate_request)
+        expect(subject).not_to receive(:perform_existing_candidate_request)
         wizardstore["authenticated"] = true
         subject.timed_one_time_password = "123456"
         subject.valid?

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -9,7 +9,7 @@ describe Wizard::Store do
 
   describe ".new" do
     context "with valid source data" do
-      it { is_expected.to be_instance_of(Wizard::Store) }
+      it { is_expected.to be_instance_of(described_class) }
       it { is_expected.to have_attributes data: backingstore }
       it { is_expected.to respond_to :[] }
       it { is_expected.to respond_to :[]= }

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -8,7 +8,7 @@ describe Events::GroupPresenter do
   let(:events_by_type) { all_events.group_by(&:type_id) }
   let(:display_empty_types) { false }
 
-  subject { Events::GroupPresenter.new(events_by_type, display_empty_types) }
+  subject { described_class.new(events_by_type, display_empty_types) }
 
   context "#sorted_events_by_type" do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
@@ -46,7 +46,7 @@ describe Events::GroupPresenter do
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
       let(:unsorted_events) { [middle, late, early] }
 
-      subject { Events::GroupPresenter.new({ type_id => unsorted_events }) }
+      subject { described_class.new({ type_id => unsorted_events }) }
 
       it "sorts events of the same type by date" do
         expect(subject.sorted_events_by_type.to_h[type_id]).to eql([early, middle, late])

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -19,15 +19,15 @@ describe "CSP violation reporting" do
     let(:params) { { other: "payload" } }
 
     it { is_expected.to have_http_status(:success) }
-    it { expect(Rails.logger).to_not have_received(:error) }
-    it { expect(self).to_not have_recorded_csp_violation }
+    it { expect(Rails.logger).not_to have_received(:error) }
+    it { expect(self).not_to have_recorded_csp_violation }
   end
 
   describe "when the csp-report contains keys not in our whitelist" do
     let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js", "random" => "information" } } }
     let(:expected_report) { params["csp-report"].slice("blocked-uri") }
 
-    it { expect(Rails.logger).to_not have_received(:error).with(params) }
+    it { expect(Rails.logger).not_to have_received(:error).with(params) }
     it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => expected_report }).once }
     it { expect(self).to have_recorded_csp_violation(expected_report) }
   end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -124,7 +124,7 @@ describe "View events by category" do
 
       subject { parsed_response.css(".no-results").first }
 
-      it { is_expected.to_not be_nil }
+      it { is_expected.not_to be_nil }
       it { expect(subject.text).to include("Sorry your search has not found any events") }
     end
   end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -141,7 +141,7 @@ describe EventsController do
         context "when the event is closed" do
           let(:event) { build(:event_api, :closed, web_feed_id: "123", readable_id: event_readable_id) }
 
-          it { is_expected.to_not match(/How to attend/) }
+          it { is_expected.not_to match(/How to attend/) }
           it { is_expected.to match(/This event is now closed/) }
         end
 
@@ -155,10 +155,10 @@ describe EventsController do
         context "when the event is online" do
           let(:event) { build(:event_api, is_online: true) }
 
-          it { is_expected.to_not match(/#{event.building.venue}/) }
-          it { is_expected.to_not match(/#{event.building.address_line1}/) }
-          it { is_expected.to_not match(/#{event.building.address_line2}/) }
-          it { is_expected.to_not match(/#{event.building.address_postcode}/) }
+          it { is_expected.not_to match(/#{event.building.venue}/) }
+          it { is_expected.not_to match(/#{event.building.address_line1}/) }
+          it { is_expected.not_to match(/#{event.building.address_line2}/) }
+          it { is_expected.not_to match(/#{event.building.address_postcode}/) }
         end
 
         context %(when the event is a 'School or University Event') do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -136,11 +136,11 @@ describe "Find an event near you" do
     end
 
     it "does not display the events moved online notice" do
-      expect(response.body).to_not include("Some events have moved online")
+      expect(response.body).not_to include("Some events have moved online")
     end
 
     it "does not display the discover events heading" do
-      expect(response.body).to_not include("Discover Events")
+      expect(response.body).not_to include("Discover Events")
     end
 
     it "categorises the results" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Find an event near you" do
   include_context "stub types api"
 
-  NO_EVENTS_REGEX = /Sorry your search has not found any events/.freeze
+  let(:no_events_regex) { /Sorry your search has not found any events/ }
 
   let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
@@ -61,7 +61,7 @@ describe "Find an event near you" do
       let(:events) { [] }
 
       it "displays a single no results message" do
-        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        no_results_messages = response.body.scan(no_events_regex).flatten
         expect(no_results_messages.count).to eq(1)
       end
     end
@@ -112,7 +112,7 @@ describe "Find an event near you" do
       let(:events) { [] }
 
       it "displays a single no results message" do
-        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        no_results_messages = response.body.scan(no_events_regex).flatten
         expect(no_results_messages.count).to eq(1)
       end
 
@@ -156,7 +156,7 @@ describe "Find an event near you" do
       let(:events) { [] }
 
       it "displays a single no results message" do
-        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        no_results_messages = response.body.scan(no_events_regex).flatten
         expect(no_results_messages.count).to eq(1)
       end
     end
@@ -167,7 +167,7 @@ describe "Find an event near you" do
 
       it "displays the no results message per category" do
         headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
-        no_results_messages = response.body.scan(NO_EVENTS_REGEX).flatten
+        no_results_messages = response.body.scan(no_events_regex).flatten
         expect(headings.count).to eq(Events::Search.available_event_types.count)
         expect(headings.count - 1).to eq(no_results_messages.count)
       end

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -11,14 +11,14 @@ describe "GET /privacy-policy" do
 
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-        receive(:get_latest_privacy_policy).and_return(policy)
+        receive(:get_latest_privacy_policy).with(no_args).and_return(policy)
     end
 
     it { is_expected.to have_http_status :success }
     it { expect(subject.body).to include(policy.text) }
   end
 
-  context "when viewing the latest privacy policy" do
+  context "when viewing a privacy policy by id" do
     subject do
       get(privacy_policy_path(id: policy.id))
       response

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -5,7 +5,7 @@ describe "Redirects" do
 
   redirects.each do |from, to|
     specify "'#{from}' redirects to '#{to}'" do
-      expect(get(from)).to eql(301)
+      expect(get(from)).to be 301
       expect(response).to redirect_to(to)
     end
   end

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -80,7 +80,7 @@ shared_context "stub events by category api" do |results_per_type|
   end
 end
 
-shared_examples "api support" do
+shared_context "api support" do
   let(:token) { "test123" }
   let(:endpoint) { "http://my.api/api" }
   let(:response_headers) { { "Content-Type" => "application/json" } }

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -1,0 +1,35 @@
+class PageLister
+  IGNORE = %w[
+    /test
+    /guidance_archive
+    /index
+    /steps-to-become-a-teacher/v2-index
+    /privacy-policy
+  ].freeze
+
+  class << self
+    def md_files
+      Dir["app/views/content/**/[^_]*.md"]
+    end
+
+    def html_files
+      Dir["app/views/content/**/[^_]*.html.erb"]
+    end
+
+    def files
+      html_files + md_files
+    end
+
+    def remove_folders(filename)
+      filename.gsub "app/views/content", ""
+    end
+
+    def remove_extension(filename)
+      filename.gsub %r{(\.[a-zA-Z0-9]+)+\z}, ""
+    end
+
+    def content_urls
+      files.map(&method(:remove_folders)).map(&method(:remove_extension)) - IGNORE
+    end
+  end
+end

--- a/spec/support/rate_limiting_support.rb
+++ b/spec/support/rate_limiting_support.rb
@@ -12,7 +12,7 @@ shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
     context "when fewer than rate limit" do
       let(:request_count) { limit - 1 }
 
-      it { is_expected.to_not eq(429) }
+      it { is_expected.not_to eq(429) }
     end
 
     context "when more than rate limit" do
@@ -24,7 +24,7 @@ shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
         it "allows another request" do
           travel period + 1.second
           perform_request
-          expect(response.status).to_not eq(429)
+          expect(response.status).not_to eq(429)
         end
       end
     end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -35,7 +35,7 @@ shared_examples "an issue verification code wizard step" do
       it "does not call the API" do
         subject.email = nil
         subject.save
-        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to_not receive(:create_candidate_access_token)
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).not_to receive(:create_candidate_access_token)
       end
     end
 

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,10 +1,16 @@
 require "rails_helper"
 
 describe EmailFormatValidator do
-  class TestModel
-    include ActiveModel::Model
-    attr_accessor :email
-    validates :email, email_format: true
+  let :test_model do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :email
+      validates :email, email_format: true
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "test")
+      end
+    end
   end
 
   before { instance.valid? }
@@ -12,7 +18,7 @@ describe EmailFormatValidator do
 
   context "invalid addresses" do
     %w[test.com test@@test.com test@test test@test.].each do |email|
-      let(:instance) { TestModel.new(email: email) }
+      let(:instance) { test_model.new(email: email) }
 
       it "#{email} should not be valid" do
         is_expected.to include email: "is invalid"
@@ -20,7 +26,7 @@ describe EmailFormatValidator do
     end
 
     context "when over 100 characters" do
-      let(:instance) { TestModel.new(email: "#{'a' * 100}@test.com") }
+      let(:instance) { test_model.new(email: "#{'a' * 100}@test.com") }
 
       it "is not be valid" do
         is_expected.to include email: "is invalid"
@@ -31,7 +37,7 @@ describe EmailFormatValidator do
   context "valid addresses" do
     %w[test@example.com testymctest@gmail.com test%.mctest@domain.co.uk]
       .each do |email|
-      let(:instance) { TestModel.new(email: email) }
+      let(:instance) { test_model.new(email: email) }
 
       it "#{email} should be valid" do
         is_expected.not_to include :email

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,10 +1,16 @@
 require "rails_helper"
 
 describe PostcodeValidator do
-  class TestModel
-    include ActiveModel::Model
-    attr_accessor :postcode, :accept_partial_postcode
-    validates :postcode, postcode: { accept_partial_postcode: :accept_partial_postcode }
+  let(:test_model) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :postcode, :accept_partial_postcode
+      validates :postcode, postcode: { accept_partial_postcode: :accept_partial_postcode }
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "test")
+      end
+    end
   end
 
   before { instance.valid? }
@@ -13,7 +19,7 @@ describe PostcodeValidator do
   context "with invalid full postcodes" do
     ["F00BAR", "123ABC", "TE57 ING"].each do |postcode|
       context "checking '#{postcode}'" do
-        let(:instance) { TestModel.new(postcode: postcode) }
+        let(:instance) { test_model.new(postcode: postcode) }
         it { is_expected.to include postcode: "is invalid" }
       end
     end
@@ -22,7 +28,7 @@ describe PostcodeValidator do
   context "with valid full postcodes" do
     ["M1 2WD", "TE57 1NG", ""].each do |postcode|
       context "checking '#{postcode}'" do
-        let(:instance) { TestModel.new(postcode: postcode) }
+        let(:instance) { test_model.new(postcode: postcode) }
         it { is_expected.not_to include :postcode }
       end
     end
@@ -31,7 +37,7 @@ describe PostcodeValidator do
   context "with valid outward only postcodes" do
     %w[ST6 M1 TE57].each do |postcode|
       context "checking '#{postcode}'" do
-        let(:instance) { TestModel.new(postcode: postcode, accept_partial_postcode: true) }
+        let(:instance) { test_model.new(postcode: postcode, accept_partial_postcode: true) }
         it { is_expected.not_to include :postcode }
       end
     end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -1,10 +1,17 @@
 require "rails_helper"
 
 describe TelephoneValidator do
-  class TelephoneTestModel
-    include ActiveModel::Model
-    attr_accessor :telephone
-    validates :telephone, telephone: true
+  let :test_model do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :telephone
+      validates :telephone, telephone: true
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "test_model")
+      end
+    end
   end
 
   before { instance.valid? }
@@ -12,14 +19,14 @@ describe TelephoneValidator do
 
   %w[1234 123456789123456789123 1feg313153gewg1 random].each do |number|
     context "checking '#{number}'" do
-      let(:instance) { TelephoneTestModel.new(telephone: number) }
+      let(:instance) { test_model.new(telephone: number) }
       it { is_expected.to include telephone: "is invalid" }
     end
   end
 
   %w[01234567890 07123456789 +448574837584 555.3442.3516 (5835)533-6326-3525].each do |number|
     context "checking '#{number}'" do
-      let(:instance) { TelephoneTestModel.new(telephone: number) }
+      let(:instance) { test_model.new(telephone: number) }
       it { is_expected.not_to include :telephone }
     end
   end


### PR DESCRIPTION
### Trello card

https://trello.com/c/D6sNREFU

### Context

We are using RSpec-rubocop to enforce a consistent set of rules for specs, currently with a lot of checks disabled.

### Changes proposed in this pull request

1. Enabled various rules which can be enabled without invasive changes to specs.

### Guidance to review

I don't think any of the rules being enabled should be controversial.
