### PR TITLE
Add support for Online Train to Teach Events

### DIFF
--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -61,8 +61,12 @@ module Events
 
   private
 
+    def has_building?
+      @event.building.present?
+    end
+
     def moved_online?
-      online? && !online_event_type?
+      online? && has_building?
     end
 
     def online_event_type?

--- a/app/webpacker/images/icon-online-purple.svg
+++ b/app/webpacker/images/icon-online-purple.svg
@@ -1,0 +1,5 @@
+<svg id="online_icon" data-name="online icon" xmlns="http://www.w3.org/2000/svg" width="38.323" height="25.353" viewBox="0 0 38.323 25.353">
+  <g id="Group_777" data-name="Group 777">
+    <path id="Path_1329" data-name="Path 1329" d="M1188.545,591.264h24.631l2.076,4.034H1186.1Zm.574-15.945h23.439V588.57h-23.439Zm26.118,14.1v-16.8h-28.8v16.917l-5.094,8.436h38.323Z" transform="translate(-1181.345 -572.625)" fill="#8967aa"/>
+  </g>
+</svg>

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -33,6 +33,10 @@
   background-image: url("../images/icon-online-blue.svg");
   width: 34px;
   height: 34px;
+
+  &--purple {
+    background-image: url("../images/icon-online-purple.svg");
+  }
 }
 
 .icon-moved-online-event {

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -41,7 +41,15 @@ describe Events::EventBoxComponent, type: "component" do
       end
     end
 
-    context "when the event has moved online" do
+    context "when the event is online, with no associated building (not virtual)" do
+      let(:event) { build(:event_api, :online_train_to_teach_event) }
+
+      specify "it's marked as being online" do
+        expect(page).to have_css(".event-box__footer__meta", text: online_heading)
+      end
+    end
+
+    context "when the event has moved online (virtual)" do
       let(:event) { build(:event_api, :virtual_train_to_teach_event) }
 
       specify "it's marked as being moved online" do

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -30,6 +30,12 @@ FactoryBot.define do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     end
 
+    trait :online_train_to_teach_event do
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+      is_online { true }
+      building { nil }
+    end
+
     trait :virtual_train_to_teach_event do
       train_to_teach_event
       is_online { true }
@@ -38,6 +44,7 @@ FactoryBot.define do
     trait :online_event do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
       is_online { true }
+      building { nil }
     end
 
     trait :school_or_university_event do


### PR DESCRIPTION
### Trello card

[Trello-660](https://trello.com/c/npt5sr4O/660-add-functionality-within-the-api-to-show-non-postcode-tagged-virtual-ttt-events-in-all-postcode-searches)

### Context

At the moment we have events that have the Online Event type and other events that are marked as being `is_online` but have an associated `building` - these are "virtual" events that have moved online.

A new event type is being added, which is a Train to Teach type event that `is_online` but has no `building`. These are to be displayed the same as regular Train to Teach type events, except instead of having "Event has moved online" we will show them as "Online event" (with a purple icon instead of the current blue used for Online Event type events).

### Changes proposed in this pull request

- Add support for Online Train to Teach Events

### Guidance to review

There are a couple of online TTT events on the dev instance just now.

| Before      | After  |
| ----------- | ----------- |
|   <img width="317" alt="Screenshot 2021-01-05 at 09 27 14" src="https://user-images.githubusercontent.com/29867726/103630036-05903880-4f39-11eb-86aa-d4967905378b.png">    |   <img width="318" alt="Screenshot 2021-01-05 at 09 25 39" src="https://user-images.githubusercontent.com/29867726/103630018-fe692a80-4f38-11eb-8926-ee8981df925e.png">     |

