### PR TITLE
Update Event::Search to explicitly search future events only

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -76,7 +76,7 @@ module Events
     end
 
     def start_of_month
-      return nil if month.blank?
+      return DateTime.now.utc.beginning_of_day if month.blank?
 
       DateTime.parse("#{month}-01 00:00:00").beginning_of_month
     end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -123,6 +123,17 @@ describe Events::Search do
             receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
         end
       end
+
+      context "when the month is nil" do
+        subject { build(:events_search, month: nil).tap(&:validate) }
+
+        it "searches all future events" do
+          start_of_today = DateTime.now.utc.beginning_of_day
+          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+            receive(:search_teaching_events_indexed_by_type)
+              .with(**expected_attributes.merge(start_before: nil, start_after: start_of_today))
+        end
+      end
     end
 
     context "when invalid" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -47,7 +47,8 @@ describe "View events by category" do
   end
 
   context "when viewing the schools and university events category" do
-    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: nil, start_before: nil, type_id: nil } }
+    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
+    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_of_today, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
@@ -60,7 +61,8 @@ describe "View events by category" do
   context "filtering the results" do
     let(:postcode) { "TE57 1NG" }
     let(:radius) { 30 }
-    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
+    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
+    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_of_today, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]


### PR DESCRIPTION
### Trello card

[Trello-672](https://trello.com/c/Mx2EzMU4/672-development-create-an-archive-repository-for-online-events-which-are-3-4-months-old)

### Context

Currently the `Event::Search` class relies on the API only returning future-dated events (as we only cache upcoming events from the CRM).

Going forward that will change as we're displaying archived/past events in the website. Before this change happens in the API we need to explicitly search future events _only_ in the application.

This commit ensures that when no month is selected we are only going to search for events after the start of the current day.

Going forward it may be worth deprecating the `upcoming_events_indexed_by_type` and just relying on the search endpoint, which can do this anyway when given today as the `start_after` parameter.

### Changes proposed in this pull request

- Update Event::Search to explicitly search future events only

### Guidance to review

Upcoming API PR: https://github.com/DFE-Digital/get-into-teaching-api/pull/434
