### PR TITLE
CSS layout refactoring

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -1,47 +1,46 @@
-<div class="content-wrapper">
-  <div class="content__left">
-    <article class="story">
-      <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
+<article class="story markdown">
+  <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
 
-      <%= tag.h1(title) %>
+  <%= tag.h1(title) %>
 
-      <header class="story__header">
-        <% if image.present? %>
-          <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
-        <% end %>
-        <div class="story__header__label">
-          <%= helpers.story_heading(teacher, position) %>
-        </div>
-      </header>
+  <header class="story__header">
+    <% if image.present? %>
+      <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
+    <% end %>
+    <div class="story__header__label">
+      <%= helpers.story_heading(teacher, position) %>
+    </div>
+  </header>
 
-      <% if show_video? %>
-        <%= helpers.youtube(video) %>
-      <% end %>
+  <% if show_video? %>
+    <%= helpers.youtube(video) %>
+  <% end %>
 
-      <%= content %>
+  <%= content %>
 
-      <% if show_more_information? %>
-        <%= link_to(more_information_link, class: "git-link") do %>
-          <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
-        <% end %>
-      <% end %>
-    </article>
-  </div>
-</div>
+  <% if show_more_information? %>
+    <%= link_to(more_information_link, class: "git-link") do %>
+      <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
+    <% end %>
+  <% end %>
 
-<% if show_more_stories? %>
-  <h2 class="strapline">More stories</h2>
-  <div class="cards stories">
-    <%= render Cards::RendererComponent.with_collection(more_stories) %>
-  </div>
-<% end %>
+</article>
 
-<% if show_explore? %>
-<section class="cards-with-headers">
-  <h2>Explore Get Into Teaching</h2>
+<section class="feature">
+  <% if show_more_stories? %>
+    <h2 class="strapline">More stories</h2>
+    <div class="cards stories">
+      <%= render Cards::RendererComponent.with_collection(more_stories) %>
+    </div>
+  <% end %>
 
-  <div class="cards">
-    <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
-  </div>
-<section>
-<% end %>
+  <% if show_explore? %>
+    <section class="cards-with-headers">
+      <h2>Explore Get Into Teaching</h2>
+
+      <div class="cards">
+        <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
+      </div>
+      <section>
+  <% end %>
+</section>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -8,9 +8,10 @@
         </div>
     </div>
         <%= render "sections/header" %>
-        <main role="main" id="main-content">
-            <%= render Sections::HeroComponent.new(@front_matter) %>
-            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
+        <%= render Sections::HeroComponent.new(@front_matter) %>
+
+        <main class="semantic" role="main" id="main-content">
+            <section class="feature">
 
                 <%= render partial: "layouts/shared/narrow_call_to_action" %>
 
@@ -44,10 +45,10 @@
                   <% end %>
                 </div>
 
-                <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
             </section>
         </main>
 
+        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -11,41 +11,40 @@
         <%= render Sections::HeroComponent.new(@front_matter) %>
 
         <main class="semantic" role="main" id="main-content">
-            <section class="feature">
+            <aside>
+              <%= render partial: "layouts/shared/narrow_call_to_action" %>
+            </aside>
 
-                <%= render partial: "layouts/shared/narrow_call_to_action" %>
+            <article>
+              <% if @front_matter["alert"].present? %>
+                <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
+              <% end %>
 
-                <div class="content__left">
-                  <% if @front_matter["alert"].present? %>
-                    <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
-                  <% end %>
+              <%= yield %>
 
-                  <%= yield %>
+              <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
+                <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered"), active_step: accordion_fm.dig("active_step")) do |accordion| %>
+                  <%= accordion.slot(
+                    :content_before_accordion,
+                    partial: accordion_fm.dig("content_before_accordion", "partial"),
+                    call_to_action: accordion_fm.dig("content_before_accordion", "cta")
+                  ) %>
 
-                  <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
-                    <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered"), active_step: accordion_fm.dig("active_step")) do |accordion| %>
-                      <%= accordion.slot(
-                        :content_before_accordion,
-                        partial: accordion_fm.dig("content_before_accordion", "partial"),
-                        call_to_action: accordion_fm.dig("content_before_accordion", "cta")
-                      ) %>
-
-                      <% accordion_fm["steps"]&.each do |title, contents| %>
-                        <%= accordion.slot(:step, title: title, call_to_action: contents["cta"]) do %>
-                          <%= render(partial: contents["partial"]) %>
-                        <% end %>
-                      <% end %>
-
-                      <%= accordion.slot(
-                        :content_after_accordion,
-                        partial: accordion_fm.dig("content_after_accordion", "partial"),
-                        call_to_action: accordion_fm.dig("content_after_accordion", "cta")
-                      ) %>
+                  <% accordion_fm["steps"]&.each do |title, contents| %>
+                    <%= accordion.slot(:step, title: title, call_to_action: contents["cta"]) do %>
+                      <%= render(partial: contents["partial"]) %>
                     <% end %>
                   <% end %>
-                </div>
 
-            </section>
+                  <%= accordion.slot(
+                    :content_after_accordion,
+                    partial: accordion_fm.dig("content_after_accordion", "partial"),
+                    call_to_action: accordion_fm.dig("content_after_accordion", "cta")
+                  ) %>
+                <% end %>
+              <% end %>
+
+            </article>
         </main>
 
         <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>

--- a/app/views/layouts/shared/_narrow_call_to_action.html.erb
+++ b/app/views/layouts/shared/_narrow_call_to_action.html.erb
@@ -1,7 +1,5 @@
 <% if @front_matter.dig("right_column", "ctas").present? %>
-  <div class="content__right">
-    <% @front_matter.dig("right_column", "ctas").each do |cta| %>
-      <%= render CallsToAction::NarrowComponent.new(**cta.symbolize_keys) %>
-    <% end %>
-  </div>
+  <% @front_matter.dig("right_column", "ctas").each do |cta| %>
+    <%= render CallsToAction::NarrowComponent.new(**cta.symbolize_keys) %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -5,38 +5,40 @@
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
 
-
-      <main class="content container-1000 story-landing" role="main" id="main-content">
-        <div class="stories-feature">
-          <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
-          <div class="stories-feature__content">
-            <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
-            <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
-            <%= tag.p(@front_matter.dig("featured_story", "text")) %>
-            <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
-              Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
-            <% end %>
+      <main class="semantic story-landing" role="main" id="main-content">
+        <section class="feature">
+          <div class="stories-feature">
+            <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
+            <div class="stories-feature__content">
+              <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
+              <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
+              <%= tag.p(@front_matter.dig("featured_story", "text")) %>
+              <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
+                Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
+              <% end %>
+            </div>
           </div>
-        </div>
-        <% @front_matter["sections"]&.each do |name, section| %>
-          <section>
-            <header>
-              <%= tag.h2(name) %>
-              <%= tag.p(section["text"]) %>
-            </header>
-            <% if section["stories"].present? %>
-              <div class="cards stories">
-                <%= render Cards::RendererComponent.with_collection(section["stories"]) %>
-              </div>
 
-              <footer>
-                <%= link_to section["link"] do %>
-                  <span>Read all stories about <%= name.downcase %></span>
-                <% end %>
-              </footer>
-            <% end %>
-          </section>
-        <% end %>
+          <% @front_matter["sections"]&.each do |name, section| %>
+            <section>
+              <header>
+                <%= tag.h2(name) %>
+                <%= tag.p(section["text"]) %>
+              </header>
+              <% if section["stories"].present? %>
+                <div class="cards stories">
+                  <%= render Cards::RendererComponent.with_collection(section["stories"]) %>
+                </div>
+
+                <footer>
+                  <%= link_to section["link"] do %>
+                    <span>Read all stories about <%= name.downcase %></span>
+                  <% end %>
+                </footer>
+              <% end %>
+            </section>
+          <% end %>
+        </section>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -4,12 +4,16 @@
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
-      <main class="content container-1000" role="main" id="main-content">
-        <%= back_link "/my-story-into-teaching", text: "All stories" %>
-        <%= yield %>
-        <div class="cards stories">
-          <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
-        </div>
+      <main class="semantic" role="main" id="main-content">
+
+        <section class="feature">
+          <%= back_link "/my-story-into-teaching", text: "All stories" %>
+          <%= yield %>
+
+          <div class="cards stories">
+            <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
+          </div>
+        </section>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -3,12 +3,10 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
-      <main class="content container-1000" role="main" id="main-content">
-        <article class="markdown">
-          <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
-            <%= yield %>
-          <% end %>
-        </article>
+      <main role="main" id="main-content" class="semantic">
+        <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
+          <%= yield %>
+        <% end %>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -41,3 +41,39 @@ body {
 .hidden {
     display: none;
 }
+
+
+
+// new layouts, intended to remove the reliance on float and instead use semantic markup and flexbox:
+
+$content-max-width: 1000px;
+$mobile-wrap: 800px;
+
+main.semantic {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+
+  max-width: $content-max-width;
+  margin: 1em .8em 3em;
+
+  @media only screen and (min-width: $mobile-wrap) {
+    flex-direction: row;
+    margin: 1em auto 4em;
+  }
+
+  > article {
+    flex: 0 0 70%;
+  }
+
+  > aside {
+    flex: 0 0 30%;
+  }
+
+  // feature: content that's not a regular text document, like a list of items on an index
+  // supplementary: content that's not directly related to the main article but might be of interest
+  > .feature,
+  > .supplementary {
+    flex: 0 0 100%;
+  }
+}

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -48,6 +48,7 @@ body {
 
 $content-max-width: 1000px;
 $mobile-wrap: 800px;
+$gap: 1em;
 
 main.semantic {
   display: flex;
@@ -58,16 +59,23 @@ main.semantic {
   margin: 1em .8em 3em;
 
   @media only screen and (min-width: $mobile-wrap) {
-    flex-direction: row;
+    gap: $gap;
+    flex-direction: row-reverse;
+    justify-content: flex-end;
     margin: 1em auto 4em;
   }
 
   > article {
-    flex: 0 0 70%;
+    flex: 0 1 65%;
   }
 
   > aside {
-    flex: 0 0 30%;
+    flex: 0 0 calc(30%);
+
+    @media only screen and (min-width: $mobile-wrap) {
+      flex: 0 0 calc(30% - 1em);
+      margin-left: 1em;
+    }
   }
 
   // feature: content that's not a regular text document, like a list of items on an index

--- a/app/webpacker/styles/page-question.scss
+++ b/app/webpacker/styles/page-question.scss
@@ -1,9 +1,7 @@
 .page-question-wrapper {
-    width: 100%;
-    float: left;
-    clear: both;
-    padding: 20px 0 50px;
-    box-sizing: border-box;
+    display: block;
+    margin: 2em auto 4em;
+    max-width: 1000px;
 }
 
 .page-question {

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -17,7 +17,7 @@
         }
     }
 
-    > section {
+    .feature > section {
         margin-bottom: 3em;
 
         > footer {


### PR DESCRIPTION
### Trello card

[444](https://trello.com/c/IinPwbxD/444-consistency-of-naming-in-css-ideally-removing-naming-and-relying-on-element-names-where-possible)

### Context

This is a tentative first step towards reorganising our layouts. The previous attempt, #711, was closed as it became a can of worms. Here we'll introduce the changes tested in #711 bit by bit.

Once the transition is complete the old styles can be removed and the remaining ones tidied up.

### Changes proposed in this pull request

This is the first part of a migration away from the `content` and `content-1000` float-based layouts and towards a simpler flexbox model.

Here we introduce the `semantic` class; this is a stopgap to target only the pages we're transitioning while the migration is in flow. Once the old layouts are removed we can drop the class and simplify further.

The intent is to structure the contents of `main` based on the direct child elements. Currently there are two; `article` with `aside` and a 70/30 split and `.feature` - intended for things like index pages and lists of events - which is full-width.

#### Some screenshots (with borders to show the layout boundaries)

##### With aside content:
![Screenshot from 2021-01-05 10-56-55](https://user-images.githubusercontent.com/128088/103650658-4a779780-4f58-11eb-898c-44cf7c8b9c17.png)

##### Without aside content:
![Screenshot from 2021-01-05 10-57-30](https://user-images.githubusercontent.com/128088/103650717-667b3900-4f58-11eb-9f0a-9c704c645954.png)

###### Mobile

![Screenshot from 2021-01-05 11-07-36](https://user-images.githubusercontent.com/128088/103650795-7d219000-4f58-11eb-8a90-4a29aacb4f2c.png)


###### Resizing the page


https://user-images.githubusercontent.com/128088/103881953-0c52b300-50d3-11eb-83cd-20bfd54a0e5d.mp4



### Guidance to review

Does it look ok?