### PR TITLE
Revert "Update Event::Search to explicitly search future events only"

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -76,7 +76,7 @@ module Events
     end
 
     def start_of_month
-      return DateTime.now.utc.beginning_of_day if month.blank?
+      return nil if month.blank?
 
       DateTime.parse("#{month}-01 00:00:00").beginning_of_month
     end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -123,17 +123,6 @@ describe Events::Search do
             receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
         end
       end
-
-      context "when the month is nil" do
-        subject { build(:events_search, month: nil).tap(&:validate) }
-
-        it "searches all future events" do
-          start_of_today = DateTime.now.utc.beginning_of_day
-          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-            receive(:search_teaching_events_indexed_by_type)
-              .with(**expected_attributes.merge(start_before: nil, start_after: start_of_today))
-        end
-      end
     end
 
     context "when invalid" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -47,8 +47,7 @@ describe "View events by category" do
   end
 
   context "when viewing the schools and university events category" do
-    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
-    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_of_today, start_before: nil, type_id: nil } }
+    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: nil, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
@@ -61,8 +60,7 @@ describe "View events by category" do
   describe "filtering the results" do
     let(:postcode) { "TE57 1NG" }
     let(:radius) { 30 }
-    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
-    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_of_today, start_before: nil, type_id: nil } }
+    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]


### PR DESCRIPTION
Reverts DFE-Digital/get-into-teaching-app#727 - causing a 500 error on event category search.