### PR TITLE
Update Event::Search to explicitly search future events only (take #2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: fc55a73e7192f95199f4c3d2e9c04c3e7eb6ada3
+  revision: f04da90eb269eb537a614248596536926f20f97b
   specs:
     get_into_teaching_api_client (1.1.7)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.9)
+    get_into_teaching_api_client_faraday (0.1.10)
       activesupport
       faraday
       faraday-encoding
@@ -116,16 +116,18 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-encoding (0.0.5)
       faraday
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
+    faraday-net_http (1.0.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -135,9 +137,9 @@ GEM
       activesupport (>= 5.2)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
-    json (2.4.1)
+    json (2.5.1)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -166,7 +168,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.2)
+    minitest (5.14.3)
     msgpack (1.3.3)
     multipart-post (2.1.1)
     nio4r (2.5.4)

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -76,9 +76,13 @@ module Events
     end
 
     def start_of_month
-      return nil if month.blank?
+      start_of_today = DateTime.now.utc.beginning_of_day
+      return start_of_today if month.blank?
 
-      DateTime.parse("#{month}-01 00:00:00").beginning_of_month
+      date = DateTime.parse("#{month}-01 00:00:00")
+      return start_of_today if date.month == start_of_today.month
+
+      date.beginning_of_month
     end
 
     def end_of_month

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -123,6 +123,31 @@ describe Events::Search do
             receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
         end
       end
+
+      context "when the month is nil" do
+        subject { build(:events_search, month: nil).tap(&:validate) }
+
+        it "searches all future events" do
+          start_of_today = DateTime.now.utc.beginning_of_day
+          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+            receive(:search_teaching_events_indexed_by_type)
+              .with(**expected_attributes.merge(start_before: nil, start_after: start_of_today))
+        end
+      end
+
+      context "when the month is the current month" do
+        let(:month) { DateTime.now.utc.to_formatted_s(:humanmonthyear) }
+        subject { build(:events_search, month: month).tap(&:validate) }
+
+        it "searches only the remainder of the month" do
+          start_of_today = DateTime.now.utc.beginning_of_day
+          end_of_month = DateTime.now.utc.end_of_month
+
+          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+            receive(:search_teaching_events_indexed_by_type)
+              .with(**expected_attributes.merge(start_before: end_of_month, start_after: start_of_today))
+        end
+      end
     end
 
     context "when invalid" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -47,7 +47,8 @@ describe "View events by category" do
   end
 
   context "when viewing the schools and university events category" do
-    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: nil, start_before: nil, type_id: nil } }
+    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
+    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_of_today, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
@@ -60,7 +61,8 @@ describe "View events by category" do
   describe "filtering the results" do
     let(:postcode) { "TE57 1NG" }
     let(:radius) { 30 }
-    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: nil, start_before: nil, type_id: nil } }
+    let(:start_of_today) { DateTime.now.utc.beginning_of_day }
+    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_of_today, start_before: nil, type_id: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -29,7 +29,7 @@ describe EventsController do
     let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
     let(:search_key) { Events::Search.model_name.param_key }
     let(:search_path) { search_events_path(search_key => search_params) }
-    let(:date) { 1.week.from_now }
+    let(:date) { DateTime.now.utc }
     let(:search_month) { date.strftime("%Y-%m") }
     let(:parsed_response) { Nokogiri.parse(response.body) }
 
@@ -60,7 +60,7 @@ describe EventsController do
           postcode: nil,
           quantity_per_type: results_per_type,
           radius: nil,
-          start_after: date.beginning_of_month,
+          start_after: date.beginning_of_day,
           start_before: date.end_of_month,
           type_id: event_type,
         }


### PR DESCRIPTION
Re-instates https://github.com/DFE-Digital/get-into-teaching-app/pull/727 (reverted due to a bug resulting in a 500 error).

The fix is pulled in as part of the updated ApiClient lib: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/28