### PR TITLE
Tweak narrow component so icon is flush top left

### DIFF
--- a/app/components/calls_to_action/narrow_component.html.erb
+++ b/app/components/calls_to_action/narrow_component.html.erb
@@ -1,14 +1,14 @@
 <%= tag.div(class: %w[call-to-action call-to-action--narrow]) do %>
-  <div class="call-to-action__content">
-    <header>
-      <%= icon %>
-      <% if title.present? %>
-        <h4 class="call-to-action__heading">
-          <%= title %>
-        </h4>
-      <% end %>
-    </header>
+  <header>
+    <%= icon %>
+    <% if title.present? %>
+      <h4 class="call-to-action__heading">
+        <%= title %>
+      </h4>
+    <% end %>
+  </header>
 
+  <div class="call-to-action__content">
     <% if text.present? %>
       <p class="call-to-action__text">
         <%= text %>

--- a/app/webpacker/styles/call_to_action.scss
+++ b/app/webpacker/styles/call_to_action.scss
@@ -30,15 +30,15 @@
   &__content {
     padding: .5em 1em 1em;
 
-    .call-to-action__heading {
-      font-size: 140%;
-      margin-bottom: 1em;
-    }
-
     .call-to-action__heading,
     .call-to-action__text:first-child {
       margin-top: .6em;
     }
+  }
+
+  .call-to-action__heading {
+    font-size: 140%;
+    margin-bottom: 1em;
   }
 
   &__action {
@@ -90,6 +90,9 @@
   }
 
   &--narrow {
+    display: flex;
+    flex-direction: column;
+
     header {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Minor tweak to ensure the icon doesn't have any margin. Moving the header element outside of the content container and making
the narrow CTA a flex column has the desired effect.

| Before | After |
| ----- |------ |
| ![Screenshot from 2021-01-06 11-13-24](https://user-images.githubusercontent.com/128088/103762466-3e4f1100-5010-11eb-8ea8-ad87defe6fbd.png) | ![Screenshot from 2021-01-06 11-19-49](https://user-images.githubusercontent.com/128088/103763124-4ce9f800-5011-11eb-85be-90e50e00f7f1.png) |


