### PR TITLE
Added support for optional preview views folder

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 # Add public visible environment variables here for the Developemnt environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
+PREVIEW_PAGES=1

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 GIT_API_TOKEN=test
 GIT_API_ENDPOINT=https://host.api/endpoint
 TTA_SERVICE_URL=http://tta-service.test
+PREVIEW_PAGES=1

--- a/app/preview_pages/content/home.md
+++ b/app/preview_pages/content/home.md
@@ -1,0 +1,20 @@
+---
+title: "Demo home page"
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis 
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+## Second heading
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu 
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in 
+culpa qui officia deserunt mollit anim id est laborum.
+
+
+### Third heading
+
+Bullets and Links:
+
+* [home page](/)

--- a/config/initializers/preview_pages.rb
+++ b/config/initializers/preview_pages.rb
@@ -1,0 +1,3 @@
+if ENV["PREVIEW_PAGES"].to_s.in? %w[yes true 1]
+  ActionController::Base.append_view_path Rails.root.join("app/preview_pages")
+end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Breadcrumbs", type: :feature do
-  include_context "prepend fake views"
   include_context "stub types api"
 
   let(:event) { GetIntoTeachingApiClient::TeachingEvent.new(statusId: 1) }

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -42,8 +42,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
       receive(:add_mailing_list_member)
   end
 
-  include_context "prepend fake views"
-
   scenario "Full journey as a new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe "ensuring frontmatter from content pages is rendered" do
-  include_context "prepend fake views"
-
   context "with an accordion layout" do
     before { get "/content-page" }
     subject { response.body }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe "LID tracking pixels" do
-  include_context "prepend fake views"
-
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type) { {} }

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe "rendering pages with a custom layout" do
-  include_context "prepend fake views"
-
   context "with a home page layout" do
     before { get "/home-page" }
     subject { response.body }

--- a/spec/support/fake_views.rb
+++ b/spec/support/fake_views.rb
@@ -1,5 +1,2 @@
-shared_context "prepend fake views" do
-  before do
-    ApplicationController.prepend_view_path Rails.root + "spec/support/views"
-  end
-end
+# Include our templates used for testing
+ApplicationController.append_view_path Rails.root.join("spec/support/views")


### PR DESCRIPTION
### Trello card

https://trello.com/c/pdn3qdOK

### Context

The docker images built from this repo should be verifiable on a basic level without adding in the `-content` repo. This is already possible from the `Rails.env.test?` because it adds a custom view path with additional templates to use.

We should add one with page templates for visual testing

### Changes proposed in this pull request

1. Add an additional `app/preview_pages` folder for templates - this can be enabled with the environment variable `PREVIEW_PAGES=1`. This is set by default in the rails environments `development`, `test`
2. This can be disabled locally if using symlinks to `-content` by setting `PREVIEW_PAGES=0` in `.env.local`
3. Add a test home page - the templates can be expanded later as needed
4. `Pages::Frontmatter` has been taught to handle multiple content directories, and by default will use all view_paths originating within the `Rails.root` rather than just the first one
5. The "prepend fake views" rspec support code now always includes the folder of templates from the rspec folder - previously with was being repeatedly added causing a performance regression on tests when `Frontmatter` started using all paths

