### PR TITLE
Wide display styling

### DIFF
--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -1,6 +1,8 @@
-<div class="navbar">
-    <div class="logo">
-        <%= render "components/logo" %>
+<div class="navbar limit-content-width">
+    <div class="logo-wrapper">
+        <div class="logo">
+            <%= render "components/logo" %>
+        </div>
     </div>
     <div class="navbar__desktop">
         <ul>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,48 +1,50 @@
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
-  <div class="site-footer-top">
-    <div class="site-footer-top__social">
-      <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fab_icon("facebook-f", "icon") %>
-        <span class="visually-hidden">Facebook - opens in a new tab</span>
-      </a>
-      <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fab_icon("instagram", "icon") %>
-        <span class="visually-hidden">Instagram - opens in a new tab</span>
-      </a>
-      <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fab_icon("linkedin-in", "icon") %>
-        <span class="visually-hidden">LinkedIn - opens in a new tab</span>
-      </a>
-      <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fab_icon("twitter", "icon") %>
-        <span class="visually-hidden">Twitter - opens in a new tab</span>
-      </a>
-      <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
-        <%= fab_icon("youtube", "icon") %>
-        <span class="visually-hidden">Youtube - opens in a new tab</span>
-      </a>
+  <div class="footer-wrapper limit-content-width">
+    <div class="site-footer-top">
+      <div class="site-footer-top__social">
+        <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+          <%= fab_icon("facebook-f", "icon") %>
+          <span class="visually-hidden">Facebook - opens in a new tab</span>
+        </a>
+        <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+          <%= fab_icon("instagram", "icon") %>
+          <span class="visually-hidden">Instagram - opens in a new tab</span>
+        </a>
+        <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+          <%= fab_icon("linkedin-in", "icon") %>
+          <span class="visually-hidden">LinkedIn - opens in a new tab</span>
+        </a>
+        <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+          <%= fab_icon("twitter", "icon") %>
+          <span class="visually-hidden">Twitter - opens in a new tab</span>
+        </a>
+        <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+          <%= fab_icon("youtube", "icon") %>
+          <span class="visually-hidden">Youtube - opens in a new tab</span>
+        </a>
+      </div>
+      <div class="site-footer-top__links-container">
+        <%= link_to("Home", page_path(page: :home)) %>
+        <% navigation_resources.each_with_index do |resource, index| %>
+          <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
+        <% end %>
+        <%= link_to "Find an event near you", events_path %>
+        <%= link_to("Helping you become a teacher", page_path(page: "helping-you-become-a-teacher")) %>
+      </div>
     </div>
-    <div class="site-footer-top__links-container">
-      <%= link_to("Home", page_path(page: :home)) %>
-      <% navigation_resources.each_with_index do |resource, index| %>
-        <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
-      <% end %>
-      <%= link_to "Find an event near you", events_path %>
-      <%= link_to("Helping you become a teacher", page_path(page: "helping-you-become-a-teacher")) %>
-    </div>
-  </div>
-  <div class="site-footer-bottom">
-    <div class="site-footer-bottom__logo-container">
-      <%= image_pack_tag 'media/images/dfelogo.png', alt: "Department for Education" %>
-    </div>
-    <div class="site-footer-bottom__links-container">
-      <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSfIBfaYUk07Fb6dxUKAokiPoGGL73ZYVGHM1mSNyA-K-6QRbA/viewform">Feedback</a>
-      <%= link_to "Cookies", cookies_path %>
-      <%= link_to "Privacy notice", privacy_policy_path %>
-      <%= link_to("Accessibility", page_path(page: :accessibility)) %>
-      <a target="_blank" rel="noopener noreferrer" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
-      <div class="site-footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated</div>
+    <div class="site-footer-bottom">
+      <div class="site-footer-bottom__logo-container">
+        <%= image_pack_tag 'media/images/dfelogo.png', alt: "Department for Education" %>
+      </div>
+      <div class="site-footer-bottom__links-container">
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSfIBfaYUk07Fb6dxUKAokiPoGGL73ZYVGHM1mSNyA-K-6QRbA/viewform">Feedback</a>
+        <%= link_to "Cookies", cookies_path %>
+        <%= link_to "Privacy notice", privacy_policy_path %>
+        <%= link_to("Accessibility", page_path(page: :accessibility)) %>
+        <a target="_blank" rel="noopener noreferrer" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
+        <div class="site-footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated</div>
+      </div>
     </div>
   </div>
 </footer>

--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -1,12 +1,14 @@
 <nav role="navigation" aria-label="main">
     <section class="covid" data-controller="banner" data-banner-name="Covid">
-        <span class="covid__header">Coronavirus (COVID-19)</span>
-        <p>
-            Whether you're currently training to be a teacher, ready to apply for teacher training or exploring teaching as a potential career, you may have questions about the impact of COVID-19. <a href="/covid-19">Please check here for updates</a>
-        </p>
-        <p>
-            <a href="#" data-action="click->banner#hide">Hide this message</a>
-        </p>
+        <div class="limit-content-width">
+            <span class="covid__header">Coronavirus (COVID-19)</span>
+            <p>
+                Whether you're currently training to be a teacher, ready to apply for teacher training or exploring teaching as a potential career, you may have questions about the impact of COVID-19. <a href="/covid-19">Please check here for updates</a>
+            </p>
+            <p>
+                <a href="#" data-action="click->banner#hide">Hide this message</a>
+            </p>
+        </div>
     </section>
     <%= render(Navbar::NavbarComponent.new) %>
 </nav>

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -347,5 +347,18 @@
     }
 }
 
+// Account for the extra height added by the logo skew
+@media only screen and (min-width: 2000px) {
+    .logo-wrapper {
+        height: calc(100% + 40px);
+        overflow: hidden;
+
+    }
+
+    .logo {
+        top: 18px;
+    }
+}    
+
 
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -315,6 +315,12 @@
         padding-bottom: 12px;
         width: 70%;
     }
+
+    @media only screen and (min-width: 2000px) {
+        &__img {
+            left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
+        }
+    }
 }
 
 .steps-home {
@@ -385,6 +391,12 @@
         height: 100%;
         background-position: 50% 15%;
         background-size: cover;
+    }
+
+    @media only screen and (min-width: 2000px) {
+        &__img {
+            left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
+        }
     }
 }
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,3 +1,8 @@
+%content-width-limiter-shared {
+    max-width: 2000px;
+    margin: auto;
+}
+
 body {
     font-family: $git-font-family;
 
@@ -5,6 +10,14 @@ body {
         margin: 0;
         padding: 0;
     }
+}
+
+main {
+    @extend %content-width-limiter-shared; 
+}
+
+.limit-content-width {
+    @extend %content-width-limiter-shared; 
 }
 
 .no-hero {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -12,7 +12,8 @@ body {
     }
 }
 
-main {
+main, 
+header {
     @extend %content-width-limiter-shared; 
 }
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -26,11 +26,6 @@
             height: auto;
         }
 
-        @media only screen and (min-width: 1500px) {
-            min-height: 500px;
-            height: 33vw;
-        }
-
         .hero__titles {
             display: flex;
             flex-direction: column;
@@ -69,9 +64,6 @@
                         width: calc(100% - 50px);
                         max-width: 400px;
                         min-width: 0;
-                    }
-                    @media only screen and (min-width: 1500px) {
-                        font-size: 3.6vw;
                     }
 
                     span {


### PR DESCRIPTION
### Trello card
https://trello.com/c/bBRBK28x

### Context
Update the styling to scale better on large displays

### Changes proposed in this pull request
- Limit width of main content and update hero to match
- Limit width of footer contents
- Limit width of header contents
- Move hero into `<main>` element in "My story into teaching" and "Find an event near you"

### Guidance to review
## **Before**
### 6000 width
![image](https://user-images.githubusercontent.com/47089130/103783780-0dcb9f00-5031-11eb-84b6-a4429bb6dbbc.png)

## **After**
### 6000 width
![image](https://user-images.githubusercontent.com/47089130/103783932-3e133d80-5031-11eb-91c8-39fd81f7d201.png)

### 3000 width
![image](https://user-images.githubusercontent.com/47089130/103784895-694a5c80-5032-11eb-9840-9d67cd02fa40.png)

### header
![image](https://user-images.githubusercontent.com/47089130/103784942-8121e080-5032-11eb-9efe-aaf3d4e1cf2c.png)

