### PR TITLE
Content layout refactoring

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,70 +2,64 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+
     <div id="skiplink-container">
-        <div>
-            <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
-        </div>
+      <div>
+        <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
     </div>
-        <%= render "sections/header" %>
-        <main role="main" id="main-content">
-            <%= render Sections::HeroComponent.new(@front_matter) %>
-            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
-                <% if @front_matter["jump_links"].present? %>
-                  <div class="content__right">
-                    <div class="link-block link-block--jump">
-                      <h2 class="link-block__header">On this page:</h2>
-                      <ul class="link-block__list">
-                        <% @front_matter["jump_links"].each do |item, anchor| %>
-                          <%= link_to(item, anchor) %>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </div>
+
+    <%= render "sections/header" %>
+    <%= render Sections::HeroComponent.new(@front_matter) %>
+
+    <main class="semantic" role="main" id="main-content">
+
+      <aside>
+        <% if @front_matter["jump_links"].present? %>
+          <div class="link-block link-block--jump">
+            <h2 class="link-block__header">On this page:</h2>
+            <ul class="link-block__list">
+              <% @front_matter["jump_links"].each do |item, anchor| %>
+                <%= link_to(item, anchor) %>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <% if @front_matter["related_content"].present? %>
+          <div class="link-block link-block--related">
+            <h2 class="link-block__header">Related Content:</h2>
+            <ul class="link-block__list">
+              <ul class="link-block__list">
+                <% @front_matter["related_content"].each do |item, anchor| %>
+                  <%= link_to(item, anchor) %>
                 <% end %>
+              </ul>
+            </ul>
+          </div>
+        <% end %>
 
-                <% if @front_matter["related_content"].present? %>
-                  <div class="content__right">
-                    <div class="link-block link-block--related">
-                      <h2 class="link-block__header">Related Content:</h2>
-                      <ul class="link-block__list">
-                        <ul class="link-block__list">
-                          <% @front_matter["related_content"].each do |item, anchor| %>
-                            <%= link_to(item, anchor) %>
-                          <% end %>
-                        </ul>
-                      </ul>
-                    </div>
-                  </div>
-                <% end %>
+        <%= render partial: "layouts/shared/narrow_call_to_action" %>
+      </aside>
 
-                <%= render partial: "layouts/shared/narrow_call_to_action" %>
+      <article class="markdown overhang">
+        <% if !@front_matter["image"] %>
+          <%= tag.h1(@front_matter["title"]) %>
+        <% end %>
 
-                <% if @front_matter["fullwidth"] %>
-                  <%= yield %>
-                <% else %>
-                  <div class="content__left">
-                    <% if !@front_matter["image"] %>
-                      <%= tag.h1(@front_matter["title"]) %>
-                    <% end %>
+        <% if @front_matter["alert"].present? %>
+          <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
+        <% end %>
 
-                    <% if @front_matter["alert"].present? %>
-                      <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
-                    <% end %>
+        <%= yield %>
 
-                    <article class="markdown">
-                      <%= yield %>
+        <% @front_matter["content"]&.each do |partial| %>
+          <%= render(partial) %>
+        <% end %>
+      </article>
+    </main>
 
-                      <% @front_matter["content"]&.each do |partial| %>
-                        <%= render(partial) %>
-                      <% end %>
-                    </article>
-                  </div>
-                <% end %>
-                <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
-            </section>
-        </main>
-
+        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -48,7 +48,6 @@ body {
 
 $content-max-width: 1000px;
 $mobile-wrap: 800px;
-$gap: 1em;
 
 main.semantic {
   display: flex;
@@ -71,7 +70,7 @@ main.semantic {
   > aside {
     flex: 0 0 calc(30%);
 
-    // note we're not using `gap: $gap` even though it works for flex in
+    // note we're not using `gap: 1em` even though it works for flex in
     // Firefox/Chrome as Safari is lagging behind a bit. Instead knock a
     // bit off the basis and add some margin when wider than mobile
     @media only screen and (min-width: $mobile-wrap) {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -59,7 +59,6 @@ main.semantic {
   margin: 1em .8em 3em;
 
   @media only screen and (min-width: $mobile-wrap) {
-    gap: $gap;
     flex-direction: row-reverse;
     justify-content: flex-end;
     margin: 1em auto 4em;
@@ -72,6 +71,9 @@ main.semantic {
   > aside {
     flex: 0 0 calc(30%);
 
+    // note we're not using `gap: $gap` even though it works for flex in
+    // Firefox/Chrome as Safari is lagging behind a bit. Instead knock a
+    // bit off the basis and add some margin when wider than mobile
     @media only screen and (min-width: $mobile-wrap) {
       flex: 0 0 calc(30% - 1em);
       margin-left: 1em;

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,33 +1,64 @@
 .markdown {
-    h2:not(:first-of-type) {
-        margin-top: 1em;
+
+  // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
+  &.overhang {
+    $indent-amount: 1.5rem;
+
+    @media only screen and (min-width: $mobile-wrap) {
+      > * {
+        margin-left: $indent-amount;
+      }
     }
 
+    @mixin overhang { margin-left: auto; }
+
+    > h2 {
+      @include overhang;
+
+      display: inline-block;
+      margin-top: 0;
+      margin-bottom: .2rem;
+      padding: .4rem $indent-amount;
+      background: $blue;
+      font-size: 24pt;
+      font-weight: 700;
+      color: $white;
+    }
+
+    .call-to-action {
+      @include overhang;
+    }
+  }
+
+  h2:not(:first-of-type) {
+    margin-top: 1em;
+  }
+
+  a {
+    &[href*="//"] {
+      &::after {
+        content: url('../images/icon-external.svg');
+        margin-left: 0.2em;
+        display: inline-block;
+        background-repeat: no-repeat;
+      }
+    }
+  }
+
+  // stop the external icon from appearing inside CTA 'button' style links
+  .call-to-action__action {
     a {
-        &[href*="//"] {
-            &::after {
-                content: url('../images/icon-external.svg');
-                margin-left: 0.2em;
-                display: inline-block;
-                background-repeat: no-repeat;
-            }
-        }
-    }
-
-    // stop the external icon from appearing inside CTA 'button' style links
-    .call-to-action__action {
-      a {
-        &[href*="//"] {
-            &::after {
-              content: none;
-              margin-left: unset;
-            }
+      &[href*="//"] {
+        &::after {
+          content: none;
+          margin-left: unset;
         }
       }
     }
 
     // this is added by Kramdown when using the ToC (table of contents) plugin
     #markdown-toc {
-        margin-bottom: 3em;
+      margin-bottom: 3em;
     }
+  }
 }


### PR DESCRIPTION
**This follows on from #728**

### Trello card

[444](https://trello.com/c/IinPwbxD/444-consistency-of-naming-in-css-ideally-removing-naming-and-relying-on-element-names-where-possible)

### Context

This continues the work started in #728 but applies the layout to the 'content' pages. These are pages with markdown content that aren't stories (eg 'teaching as a career', 'salaries and benefits').

### Changes proposed in this pull request

Update the content layout so that it's based on the new semantic structure and implements the custom `h2` 'overhang' styling.

![Screenshot from 2021-01-06 15-01-39](https://user-images.githubusercontent.com/128088/103786808-c47d4e80-5034-11eb-9442-233360762044.png)

Also update the flexbox ordering so `aside` content is rendered above the `article`.

### Guidance to review

Does it look good?


Much of this is whitespace, I'd recommend switching to the branch locally and doing a `git diff master.. -w`