### PR TITLE
Fix the style of explore get into teaching cards

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -40,7 +40,7 @@
 <section class="cards-with-headers">
   <h2>Explore Get Into Teaching</h2>
 
-  <div class="cards stories">
+  <div class="cards">
     <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
   </div>
 <section>

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -94,9 +94,15 @@
 }
 
 .cards-with-headers {
+
   h2 {
     padding: 0 20px 20px ;
     font-size: 36px ;
+  }
+
+  .card {
+    margin-left: 1em;
+    overflow: initial;
   }
 }
 


### PR DESCRIPTION
These were affected by the recent changes to the stories cards (#641) and it wasn't noticed as the explore-style cards haven't been enabled yet.

Removing the `stories` class stops them from picking up the grey background and introducing a little `margin-left` allows their
'floating' header to be rendered without overflowing the outer container.

![Screenshot from 2021-01-07 12-19-04](https://user-images.githubusercontent.com/128088/103892164-04027400-50e3-11eb-8dca-add9f4f75478.png)

