### PR TITLE
Transition to search_teaching_events_grouped_by_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,6 @@
 GIT
-  remote: https://github.com/waiting-for-dev/front_matter_parser.git
-  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
-  specs:
-    front_matter_parser (0.2.1)
-
-PATH
-  remote: ../get-into-teaching-api-ruby-client
+  remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
+  revision: abbc59ebe7c7a76866aefc9914eb7c515ef5454d
   specs:
     get_into_teaching_api_client (1.1.8)
       json (~> 2.1, >= 2.1.0)
@@ -17,6 +12,12 @@ PATH
       faraday-http-cache
       faraday_middleware
       get_into_teaching_api_client
+
+GIT
+  remote: https://github.com/waiting-for-dev/front_matter_parser.git
+  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
+  specs:
+    front_matter_parser (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,22 @@
 GIT
-  remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: f04da90eb269eb537a614248596536926f20f97b
+  remote: https://github.com/waiting-for-dev/front_matter_parser.git
+  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
   specs:
-    get_into_teaching_api_client (1.1.7)
+    front_matter_parser (0.2.1)
+
+PATH
+  remote: ../get-into-teaching-api-ruby-client
+  specs:
+    get_into_teaching_api_client (1.1.8)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.10)
+    get_into_teaching_api_client_faraday (0.1.11)
       activesupport
       faraday
       faraday-encoding
       faraday-http-cache
       faraday_middleware
       get_into_teaching_api_client
-
-GIT
-  remote: https://github.com/waiting-for-dev/front_matter_parser.git
-  revision: 71d1d61c4feeb2c73de7d986a7f97e9ab931917e
-  specs:
-    front_matter_parser (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,7 +60,10 @@ private
 
   def load_upcoming_events
     api = GetIntoTeachingApiClient::TeachingEventsApi.new
-    @events_by_type = api.upcoming_teaching_events_indexed_by_type(quantity_per_type: UPCOMING_EVENTS_PER_TYPE)
+    @events_by_type = api.search_teaching_events_grouped_by_type(
+      quantity_per_type: UPCOMING_EVENTS_PER_TYPE,
+      start_after: DateTime.now.utc.beginning_of_day,
+    )
     @group_presenter = Events::GroupPresenter.new(@events_by_type)
   end
 

--- a/app/models/events/category.rb
+++ b/app/models/events/category.rb
@@ -45,8 +45,12 @@ module Events
 
     def query_events(limit)
       events_api
-        .upcoming_teaching_events_indexed_by_type(quantity_per_type: limit)
-        .transform_keys { |k| k.to_s.to_i }
+        .search_teaching_events_grouped_by_type(
+          quantity_per_type: limit,
+          start_after: DateTime.now.utc.beginning_of_day,
+        )
+        .index_by(&:type_id)
+        .transform_values(&:teaching_events)
     end
 
     def normalize_name(name)

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -88,7 +88,7 @@ module Events
     end
 
     def query_events_api(limit)
-      GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_indexed_by_type(
+      GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events_grouped_by_type(
         type_id: type,
         radius: distance,
         postcode: postcode&.strip,

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -3,9 +3,9 @@ module Events
     def initialize(events_by_type, display_empty_types = false, ascending = true)
       @display_empty_types = display_empty_types
       @events_by_type = events_by_type
-        .transform_keys { |k| k.to_s.to_i }
+        .index_by(&:type_id)
         .transform_values do |v|
-          events = v.sort_by { |e| [e.start_at] }
+          events = v.teaching_events.sort_by { |e| [e.start_at] }
           events.reverse! unless ascending
           events
         end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -9,14 +9,12 @@ RSpec.feature "Finding an event", type: :feature do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
-  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
+  let(:events_by_type) { group_events_by_type(events) }
   let(:event) { events.last }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:upcoming_teaching_events_indexed_by_type) { events_by_type }
-    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_indexed_by_type) { events_by_type }
+      receive(:search_teaching_events_grouped_by_type) { events_by_type }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { event }
   end

--- a/spec/models/events/category_spec.rb
+++ b/spec/models/events/category_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Events::Category do
   end
 
   describe "#latest" do
-    include_context "stub events by category api", 1
+    include_context "stub upcoming events by category api", 1
 
     subject { instance.latest }
 

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -158,7 +158,7 @@ describe Events::Search do
 
       it "calls the API" do
         expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-          receive(:search_teaching_events_indexed_by_type).with(**expected_attributes)
+          receive(:search_teaching_events_grouped_by_type).with(**expected_attributes)
       end
 
       context "when there's whitespace around a provided postcode" do
@@ -166,7 +166,7 @@ describe Events::Search do
 
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-            receive(:search_teaching_events_indexed_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
+            receive(:search_teaching_events_grouped_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
         end
       end
 
@@ -179,7 +179,7 @@ describe Events::Search do
 
           it "searches from the beginning of today to the end of the next 5 months" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: travel_date.beginning_of_day, start_before: DateTime.new(2020, 6, 30).end_of_day))
           end
         end
@@ -190,7 +190,7 @@ describe Events::Search do
 
           it "searches from the beginning of today to the end of the current month" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: date.beginning_of_day, start_before: date.end_of_month))
           end
         end
@@ -201,7 +201,7 @@ describe Events::Search do
 
           it "searches from the start of the next month to the end" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: date.beginning_of_month, start_before: date.end_of_month))
           end
         end
@@ -217,7 +217,7 @@ describe Events::Search do
 
           it "searches from the start of 4 months ago to the end of yesterday" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: DateTime.new(2019, 10, 1).beginning_of_day, start_before: day_before_travel_date.end_of_day))
           end
         end
@@ -228,7 +228,7 @@ describe Events::Search do
 
           it "searches from the beginning of the month to the end of yesterday" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: date.beginning_of_month, start_before: day_before_travel_date.end_of_day))
           end
         end
@@ -239,7 +239,7 @@ describe Events::Search do
 
           it "searches from the start of the previous month to the end" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-              receive(:search_teaching_events_indexed_by_type)
+              receive(:search_teaching_events_grouped_by_type)
                 .with(**expected_attributes.merge(start_after: date.beginning_of_month, start_before: date.end_of_month))
           end
         end
@@ -251,7 +251,7 @@ describe Events::Search do
 
       it "does not call the API" do
         expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).not_to \
-          receive(:search_teaching_events_indexed_by_type)
+          receive(:search_teaching_events_grouped_by_type)
         subject.query_events
       end
     end

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Pages::Data do
 
   describe "#latest_event_for_category" do
     include_context "stub types api"
-    include_context "stub events by category api", 1
+    include_context "stub upcoming events by category api", 1
 
     subject { instance.latest_event_for_category category }
 

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -5,7 +5,7 @@ describe Events::GroupPresenter do
   let(:online_events) { build_list(:event_api, 3, :online_event) }
   let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
   let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
-  let(:events_by_type) { all_events.group_by(&:type_id) }
+  let(:events_by_type) { group_events_by_type(all_events) }
   let(:display_empty_types) { false }
 
   subject { described_class.new(events_by_type, display_empty_types) }
@@ -14,8 +14,12 @@ describe Events::GroupPresenter do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
     let(:online_event_type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
 
-    it "returns events_by_type wrapped in an array by default" do
-      expect(subject.sorted_events_by_type.to_h).to eq(events_by_type)
+    it "returns events_by_type as an array of [type_id, events] tuples" do
+      expect(subject.sorted_events_by_type).to eq([
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"], train_to_teach_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"], online_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"], school_and_university_events],
+      ])
     end
 
     it "sorts event types according to GetIntoTeachingApiClient::Constants::EVENT_TYPES" do
@@ -47,7 +51,7 @@ describe Events::GroupPresenter do
       let(:unsorted_events) { [middle, late, early] }
       let(:ascending) { true }
 
-      subject { described_class.new({ type_id => unsorted_events }, false, ascending) }
+      subject { described_class.new(group_events_by_type(unsorted_events), false, ascending) }
 
       it "sorts events of the same type by date, ascending" do
         expect(subject.sorted_events_by_type.to_h[type_id]).to eql([early, middle, late])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
   config.include ActiveSupport::Testing::TimeHelpers
-  config.include Helpers::Events
+  config.include SpecHelpers::Events
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include Helpers::Events
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -11,18 +11,18 @@ describe "View events by category" do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
-  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
+  let(:events_by_type) { group_events_by_type(events) }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_indexed_by_type) { events_by_type }
+      receive(:search_teaching_events_grouped_by_type) { events_by_type }
   end
 
   context "when viewing a category archive" do
     let(:category) { "online-events" }
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+        receive(:search_teaching_events_grouped_by_type) { events_by_type }
       get event_category_archive_events_path(category)
     end
 
@@ -45,7 +45,7 @@ describe "View events by category" do
   context "when viewing a category" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+        receive(:search_teaching_events_grouped_by_type) { events_by_type }
       get event_category_events_path("train-to-teach-events")
     end
 
@@ -78,7 +78,7 @@ describe "View events by category" do
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type).with(blank_search.merge(type_id: type_id, quantity_per_type: expected_limit))
+        receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_id: type_id, quantity_per_type: expected_limit))
       get event_category_events_path("school-and-university-events")
     end
   end
@@ -93,7 +93,7 @@ describe "View events by category" do
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type).with(filter.merge(type_id: type_id, quantity_per_type: expected_limit))
+        receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_id: type_id, quantity_per_type: expected_limit))
       get event_category_events_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })
     end
   end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -4,7 +4,7 @@ describe EventsController do
   include_context "stub types api"
 
   describe "#index" do
-    include_context "stub events by category api", EventsController::UPCOMING_EVENTS_PER_TYPE
+    include_context "stub upcoming events by category api", EventsController::UPCOMING_EVENTS_PER_TYPE
     let(:parsed_response) { Nokogiri.parse(response.body) }
 
     subject! do
@@ -26,7 +26,7 @@ describe EventsController do
   describe "#search" do
     let(:results_per_type) { Events::Search::RESULTS_PER_TYPE }
     let(:events) { [build(:event_api, name: "First"), build(:event_api, name: "Second")] }
-    let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
+    let(:events_by_type) { group_events_by_type(events) }
     let(:search_key) { Events::Search.model_name.param_key }
     let(:search_path) { search_events_path(search_key => search_params) }
     let(:date) { DateTime.now.utc }
@@ -35,7 +35,7 @@ describe EventsController do
 
     before do
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type)
+        receive(:search_teaching_events_grouped_by_type)
         .with(a_hash_including(expected_request_attributes)) { events_by_type }
     end
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -13,14 +13,16 @@ describe "Find an event near you" do
       build(:event_api, name: "Event #{index + 1}", start_at: start_at, type_id: type_id)
     end
   end
-  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
+  let(:events_by_type) { group_events_by_type(events) }
 
   subject { response }
 
   context "when landing on the page initially" do
+    let(:expected_request_attributes) { { start_after: DateTime.now.utc.beginning_of_day } }
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:upcoming_teaching_events_indexed_by_type) { events_by_type }
+        receive(:search_teaching_events_grouped_by_type)
+        .with(a_hash_including(expected_request_attributes)) { events_by_type }
     end
 
     before { get events_path }
@@ -92,7 +94,7 @@ describe "Find an event near you" do
 
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+        receive(:search_teaching_events_grouped_by_type) { events_by_type }
     end
 
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
@@ -126,7 +128,7 @@ describe "Find an event near you" do
   context "when searching for an event" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_indexed_by_type) { events_by_type }
+        receive(:search_teaching_events_grouped_by_type) { events_by_type }
     end
 
     before { get search_events_path(events_search: { month: "2020-07" }) }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -5,7 +5,7 @@ describe "LID tracking pixels" do
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:upcoming_teaching_events_indexed_by_type) { {} }
+      receive(:search_teaching_events_grouped_by_type) { {} }
   end
 
   before { get path }

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -68,14 +68,20 @@ shared_context "stub mailing list add member api" do
   end
 end
 
-shared_context "stub events by category api" do |results_per_type|
+shared_context "stub upcoming events by category api" do |results_per_type|
   let(:events) { [build(:event_api, name: "First"), build(:event_api, name: "Second")] }
-  let(:events_by_type) { events.group_by { |event| event.type_id.to_s.to_sym } }
-  let(:expected_request_attributes) { { quantity_per_type: results_per_type } }
+  let(:events_by_type) { group_events_by_type(events) }
+  let(:expected_request_attributes) do
+    {
+      quantity_per_type: results_per_type,
+      start_after: DateTime.now.utc.beginning_of_day,
+    }
+  end
+  before { travel_to(DateTime.new(2020, 11, 1, 10)) }
 
   before do
     expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:upcoming_teaching_events_indexed_by_type)
+      receive(:search_teaching_events_grouped_by_type)
       .with(a_hash_including(expected_request_attributes)) { events_by_type }
   end
 end

--- a/spec/support/helpers/events.rb
+++ b/spec/support/helpers/events.rb
@@ -1,0 +1,9 @@
+module Helpers
+  module Events
+    def group_events_by_type(events)
+      events.group_by(&:type_id).map do |type_id, events_of_type|
+        GetIntoTeachingApiClient::TeachingEventsByType.new(typeId: type_id, teachingEvents: events_of_type)
+      end
+    end
+  end
+end

--- a/spec/support/spec_helpers/events.rb
+++ b/spec/support/spec_helpers/events.rb
@@ -1,4 +1,4 @@
-module Helpers
+module SpecHelpers
   module Events
     def group_events_by_type(events)
       events.group_by(&:type_id).map do |type_id, events_of_type|


### PR DESCRIPTION
### Trello card

[Trello-649](https://trello.com/c/yBEK1KXr/649-dev-refactor-search-indexed-by-endpoints-to-have-a-better-response)

### Context

We currently use the `search_teaching_events_indexed_by_type` and `upcoming_teaching_events_indexed_by_type` queries, which return in the format:

```
{
  "<type_id>": [... events ...],
  ...
}
```

Instead, the API now has a new `search_teaching_events_grouped_by_type` endpoint that returns results in a more rest-ful format:

```
[
  { "typeId": <type_id>, "teachingEvents": [... events ...] },
   ...
]
```

Note the upcoming endpoint has not been udpated, and instead we are removing it completely as it can be achieved by passing a `startAfter` parameter to the search method.

All occurances of calls to `..._indexed_by_..` have been updated.

### Changes proposed in this pull request

- Transition to search_teaching_events_grouped_by_type

- Bump ApiClient version

Pulls in the new `search_teaching_events_grouped_by_type` method.

### Guidance to review

I've given this a decent test locally to ensure all the event searching etc works as expected.