### PR TITLE
Add a bottom margin on the Kramdown ToC

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -25,4 +25,9 @@
         }
       }
     }
+
+    // this is added by Kramdown when using the ToC (table of contents) plugin
+    #markdown-toc {
+        margin-bottom: 3em;
+    }
 }


### PR DESCRIPTION
Add more space at the bottom of the ToC so it looks like this:

![Screenshot from 2021-01-08 15-39-12](https://user-images.githubusercontent.com/128088/104033779-e78c3780-51c7-11eb-880d-890e97400eed.png)


