### PR TITLE
Move event category actions into EventCategoriesController

### DIFF
--- a/app/components/events/type_description_component.rb
+++ b/app/components/events/type_description_component.rb
@@ -20,7 +20,7 @@ module Events
     end
 
     def read_more_href
-      event_category_events_path(type_name_plural.parameterize)
+      event_category_path(type_name_plural.parameterize)
     end
 
   private

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -1,0 +1,57 @@
+class EventCategoriesController < ApplicationController
+  before_action -> { @period = :past }, only: %i[show_archive]
+  before_action -> { @period = :future }, only: %i[show]
+  before_action :load_type, :load_events, only: %i[show show_archive]
+
+  EVENTS_PER_PAGE = 9
+  MAXIMUM_EVENTS_IN_CATEGORY = 1_000
+
+  def show
+    @show_archive_link = has_archive?(@type)
+  end
+
+  def show_archive
+    raise_not_found && return unless has_archive?(@type)
+
+    render :show
+  end
+
+private
+
+  def load_events
+    @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: @period))
+    events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
+    group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
+    events_of_type = group_presenter.sorted_events_of_type(@type.id)
+    @events = paginate(events_of_type)
+  end
+
+  def load_type
+    @type = GetIntoTeachingApiClient::PickListItemsApi.new.get_teaching_event_types.find do |type|
+      I18n.t("event_types.#{type.id}.name.plural").parameterize == params[:id]
+    end
+
+    raise_not_found && return if @type.nil?
+  end
+
+  def paginate(events)
+    return [] if events.blank?
+
+    Kaminari
+      .paginate_array(events, total_count: events&.size)
+      .page(params[:page])
+      .per(EVENTS_PER_PAGE)
+  end
+
+  def has_archive?(type)
+    GetIntoTeachingApiClient::Constants::EVENT_TYPES_WITH_ARCHIVE.values.include?(type.id)
+  end
+
+  # filtering is like searching but limited to a single event type. A custom
+  # type isn't required and a month isn't enforced
+  def event_filter_params
+    return {} unless (event_params = params[Events::Search.model_name.param_key])
+
+    event_params.permit(:distance, :postcode, :month)
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,9 +3,7 @@ class EventsController < ApplicationController
   before_action :search_events, only: %i[search]
   before_action :load_upcoming_events, only: %i[index]
 
-  MAXIMUM_EVENTS_IN_CATEGORY = 1_000
   UPCOMING_EVENTS_PER_TYPE = 3
-  EVENTS_PER_PAGE = 9
 
   def index
     @page_title = "Find an event near you"
@@ -21,42 +19,7 @@ class EventsController < ApplicationController
     @page_title = @event.name
   end
 
-  def show_category
-    @type = GetIntoTeachingApiClient::PickListItemsApi.new.get_teaching_event_types.find do |type|
-      I18n.t("event_types.#{type.id}.name.plural").parameterize == params[:category]
-    end
-
-    raise_not_found && return if @type.nil?
-
-    @is_archive = params[:archive]
-    has_archive = has_archive?(@type)
-
-    raise_not_found && return if @is_archive && !has_archive
-
-    period = @is_archive ? :past : :future
-    @show_archive_link = !@is_archive && has_archive
-
-    @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: period))
-    events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
-    group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
-    events_of_type = group_presenter.sorted_events_by_type.first { |v| v.first == @type.id }&.last
-    @events = paginate(events_of_type)
-  end
-
 private
-
-  def paginate(events)
-    return [] if events.blank?
-
-    Kaminari
-      .paginate_array(events, total_count: events&.size)
-      .page(params[:page])
-      .per(EVENTS_PER_PAGE)
-  end
-
-  def has_archive?(type)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES_WITH_ARCHIVE.values.include?(type.id)
-  end
 
   def load_upcoming_events
     api = GetIntoTeachingApiClient::TeachingEventsApi.new
@@ -83,13 +46,5 @@ private
 
     (params[Events::Search.model_name.param_key] || defaults)
       .permit(:type, :distance, :postcode, :month)
-  end
-
-  # filtering is like searching but limited to a single event type. A custom
-  # type isn't required and a month isn't enforced
-  def event_filter_params
-    return {} unless (event_params = params[Events::Search.model_name.param_key])
-
-    event_params.permit(:distance, :postcode, :month)
   end
 end

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -15,6 +15,10 @@ module Events
       populate_events_by_type.sort_by { |k, _| event_type_ids.index(k) }
     end
 
+    def sorted_events_of_type(type_id)
+      sorted_events_by_type.first { |v| v.first == type_id }&.last
+    end
+
   private
 
     def populate_events_by_type

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -1,5 +1,5 @@
 <% category_name = t("event_types.#{@type.id}.name.plural") %>
-<% category_name = "Past #{category_name}" if @is_archive %>
+<% category_name = "Past #{category_name}" if @period == :past %>
 
 <% @page_title = category_name %>
 
@@ -34,7 +34,7 @@
 <section class="types-of-event content container-1000">
   <div class="events-featured">
     <div class="events-featured__list">
-      <%= render partial: "event", collection: @events %>
+      <%= render partial: "events/event", collection: @events %>
     </div>
   </div>
 </section>
@@ -58,7 +58,7 @@
       <div class="content-cta content-cta--center">
         <h2>Past <%= category_name %></h2>
         <p>
-          You can see past <%= category_name %>, including all questions and answers, <%= link_to("on this page", event_category_archive_events_path(pluralised_category_name(@type.id).parameterize)) %>
+          You can see past <%= category_name %>, including all questions and answers, <%= link_to("on this page", archive_event_category_path(pluralised_category_name(@type.id).parameterize)) %>
         </p>
       </div>
     </div>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -25,7 +25,7 @@
   <% show_see_all_events ||= false %>
 
   <% if show_see_all_events %>
-    <%= link_to(event_category_events_path(plural_category_name.parameterize), class: "call-to-action-button") do %>
+    <%= link_to(event_category_path(plural_category_name.parameterize), class: "call-to-action-button") do %>
       Explore <span><%= plural_category_name %></span>
     <% end %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,6 @@ Rails.application.routes.draw do
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"
-      get "category/:category", to: "events#show_category", as: :event_category
-      get "category/:category/archive", to: "events#show_category", as: :event_category_archive, archive: true
     end
     resources "steps",
               path: "/apply",
@@ -40,6 +38,16 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  resources :event_categories, only: %i[show] do
+    member do
+      get "archive", to: "event_categories#show_archive"
+    end
+  end
+  # The event category pages used to exist here - once we're sure no traffic is
+  # coming to these paths we can safely remove these redirects.
+  get "events/category/:id/", to: redirect("/event_categories/%{id}/")
+  get "events/category/:id/archive", to: redirect("/event_categories/%{id}/archive")
 
   namespace :mailing_list, path: "/mailinglist" do
     resources :steps,

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -22,6 +22,6 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has a read more link" do
-    expect(page).to have_link("Read more", href: "/events/category/online-events", class: "type-description__link")
+    expect(page).to have_link("Read more", href: "/event_categories/online-events", class: "type-description__link")
   end
 end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -49,18 +49,18 @@ RSpec.feature "Finding an event", type: :feature do
 
   let(:event_category_slug) { "train-to-teach-events" }
   scenario "Navigating events by page" do
-    visit event_category_events_path(event_category_slug)
+    visit event_category_path(event_category_slug)
 
     expect(page).to have_css("h2", text: "Search for Train to Teach Events")
 
-    expect(page).to have_link("2", href: event_category_events_path(event_category_slug, page: 2))
-    expect(page).to have_link("Next ›", href: event_category_events_path(event_category_slug, page: 2))
+    expect(page).to have_link("2", href: event_category_path(event_category_slug, page: 2))
+    expect(page).to have_link("Next ›", href: event_category_path(event_category_slug, page: 2))
 
     # there are 11 events and 9 per page
     expect(page).to have_css(".event-box", count: 9)
 
     click_on("2")
     expect(page).to have_css(".event-box", count: 2)
-    expect(page).to have_link("‹ Prev", href: event_category_events_path(event_category_slug))
+    expect(page).to have_link("‹ Prev", href: event_category_path(event_category_slug))
   end
 end

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -65,4 +65,12 @@ describe Events::GroupPresenter do
       end
     end
   end
+
+  describe "#sorted_events_of_type" do
+    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+
+    it "returns the events of the given type" do
+      expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events)
+    end
+  end
 end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "View events by category" do
   include_context "stub types api"
 
-  let(:expected_limit) { EventsController::MAXIMUM_EVENTS_IN_CATEGORY }
+  let(:expected_limit) { EventCategoriesController::MAXIMUM_EVENTS_IN_CATEGORY }
 
   let(:events) do
     5.times.collect do |index|
@@ -23,7 +23,7 @@ describe "View events by category" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
-      get event_category_archive_events_path(category)
+      get archive_event_category_path(category)
     end
 
     subject { response }
@@ -46,7 +46,7 @@ describe "View events by category" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
-      get event_category_events_path("train-to-teach-events")
+      get event_category_path("train-to-teach-events")
     end
 
     subject { response }
@@ -79,7 +79,7 @@ describe "View events by category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_id: type_id, quantity_per_type: expected_limit))
-      get event_category_events_path("school-and-university-events")
+      get event_category_path("school-and-university-events")
     end
   end
 
@@ -94,19 +94,19 @@ describe "View events by category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University Event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_id: type_id, quantity_per_type: expected_limit))
-      get event_category_events_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })
+      get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })
     end
   end
 
   describe "pagination" do
     before { get(path) }
 
-    let(:events_per_page) { EventsController::EVENTS_PER_PAGE }
+    let(:events_per_page) { EventCategoriesController::EVENTS_PER_PAGE }
     let(:parsed_response) { Nokogiri.parse(response.body) }
 
     context "when there are more than one page's worth of events" do
       let(:extra_events) { 3 }
-      let(:path) { event_category_events_path("train-to-teach-events") }
+      let(:path) { event_category_path("train-to-teach-events") }
       let(:events) { build_list(:event_api, events_per_page + extra_events) }
 
       describe "pagination links" do
@@ -129,7 +129,7 @@ describe "View events by category" do
       end
 
       describe "accessing later pages" do
-        let(:path) { event_category_events_path("train-to-teach-events", page: 2) }
+        let(:path) { event_category_path("train-to-teach-events", page: 2) }
 
         specify "only the first page of events is shown" do
           expect(parsed_response.css(".event-box")).to have_attributes(size: extra_events)
@@ -138,7 +138,7 @@ describe "View events by category" do
     end
 
     context "when there are fewer than one page's worth of events" do
-      let(:path) { event_category_events_path("train-to-teach-events") }
+      let(:path) { event_category_path("train-to-teach-events") }
       let(:events) { build_list(:event_api, events_per_page - 3) }
 
       specify "no pagination links are shown" do
@@ -147,7 +147,7 @@ describe "View events by category" do
     end
 
     context "when there are no results" do
-      let(:path) { event_category_events_path("train-to-teach-events") }
+      let(:path) { event_category_path("train-to-teach-events") }
       let(:events) { [] }
 
       subject { parsed_response.css(".no-results").first }
@@ -159,7 +159,7 @@ describe "View events by category" do
 
   context "when a category does not exist" do
     before do
-      get event_category_events_path("non-existant")
+      get event_category_path("non-existant")
     end
 
     subject { response }


### PR DESCRIPTION
### Trello card

[Trello-706](https://trello.com/c/qwTLpPgS/706-split-category-action-out-into-eventcategoriescontroller-and-tidy-up)

### Context

Currently we have one, reasonably complex action in the `EventsController` that deals with showing an event category and its associated archive.

This commit pulls that action out and splits it into two new actions; `show` and `show_archive` in a new `EventCategoriesController`.

The routes have also been updated to better match what you would expect from a Rails app, so:

```
/event_categories/:id
/event_categories/:id/archive
```

Redirects are in place to ensure any old/bookmarked traffic gets redirected, though we can probably remove the redirects in a few days if we observe no traffic going to the old endpoints.

### Changes proposed in this pull request

- Move event category actions into EventCategoriesController

### Guidance to review

