### PR TITLE
Clean up online/offline/virtual logic

### DIFF
--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -1,13 +1,11 @@
 <div class="event-box">
     <header class="event-box__header">
-      <h4><%= heading %></h4>
+      <h4><%= title %></h4>
     </header>
 
-    <% unless condensed? %>
-      <div class="event-box__datetime">
-        <%= datetime %>
-      </div>
-    <% end %>
+    <div class="event-box__datetime">
+      <%= datetime %>
+    </div>
 
     <%= divider %>
 

--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -1,17 +1,17 @@
 module Events
   class EventBoxComponent < ViewComponent::Base
-    attr_reader :title, :event, :type, :online, :condensed
+    attr_reader :title, :event, :type, :online, :virtual
 
     delegate :format_event_date, :name_of_event_type, :event_type_color, :safe_format, to: :helpers
+    alias_method :online?, :online
+    alias_method :virtual?, :virtual
 
-    alias_method :condensed?, :condensed
-
-    def initialize(event, condensed: false)
+    def initialize(event)
       @event       = event
       @title       = event.name
       @type        = event.type_id
       @online      = event.is_online
-      @condensed   = condensed
+      @virtual     = event.is_virtual
     end
 
     def datetime
@@ -24,14 +24,6 @@ module Events
 
     def type_color
       event_type_color(type)
-    end
-
-    def online?
-      online
-    end
-
-    def heading
-      condensed ? datetime : title
     end
 
     def divider
@@ -47,31 +39,19 @@ module Events
     end
 
     def online_icon
-      icon_class = moved_online? ? "icon-moved-online-event" : "icon-online-event"
+      icon_class = virtual? ? "icon-moved-online-event" : "icon-online-event"
       colour_class = "#{icon_class}--#{type_color}"
 
       tag.div(class: [event_box_footer_icon_class, icon_class, colour_class])
     end
 
     def online_text
-      return "Event has moved online" if moved_online?
+      return "Event has moved online" if virtual?
 
       "Online Event"
     end
 
   private
-
-    def has_building?
-      @event.building.present?
-    end
-
-    def moved_online?
-      online? && has_building?
-    end
-
-    def online_event_type?
-      @type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"]
-    end
 
     def event_box_footer_icon_class
       "event-box__footer__icon"

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     sequence(:start_at) { |i| i.weeks.from_now }
     end_at { start_at + 2.hours }
     is_online { false }
+    is_virtual { false }
     building { build :event_building_api }
 
     trait :closed do
@@ -30,21 +31,20 @@ FactoryBot.define do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
     end
 
-    trait :online_train_to_teach_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    trait :virtual do
       is_online { true }
-      building { nil }
+      is_virtual { true }
     end
 
-    trait :virtual_train_to_teach_event do
-      train_to_teach_event
+    trait :online do
       is_online { true }
+      is_virtual { false }
+      building { nil }
     end
 
     trait :online_event do
+      online
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online Event"] }
-      is_online { true }
-      building { nil }
     end
 
     trait :school_or_university_event do


### PR DESCRIPTION
### Trello card

[Trello-695](https://trello.com/c/ON3HS3MN/695-clean-up-online-moved-online-virtual-naming-and-references)

### Context

An event can have three different 'states':

- Offline (in person)
- Online (fully online with no building)
- Virtual (online, but has an associated building - aka moved online)

The API client has been updated with an `is_virtual` attribute that enables the app to determine these states more succinctly.

### Changes proposed in this pull request

- Clean up event online/offline/virtual checks

Also removes `condensed` as an option from `EventBoxComponent` as this is no longer used anywhere.

### Guidance to review

