### PR TITLE
Add IE-specific fix to keep footer below content

### DIFF
--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -1,6 +1,8 @@
 footer.site-footer {
     background-color: $black;
 
+    clear: both; // IE-specific fix to make sure footer stays below main content
+
     .site-footer-top {
         width: 100%;
         padding-left: 40px;
@@ -11,7 +13,7 @@ footer.site-footer {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        
+
         a {
             text-decoration: none;
         }


### PR DESCRIPTION

### Trello card

(to be added)

### Context

When `clear: both` isn't present the 'grey' footer section begins near
the top of the page and both affects the page visually and prevents
links within the overlap from being clicked - rendering the page
unuseable.


### Changes proposed in this pull request

Force the footer to be below the content by specifying `clear: both`. This works in modern browsers without having to be quite so explicit.

### Guidance to review

| Before | After |
| ------- | ------ |
| ![Screenshot from 2021-01-11 14-13-00](https://user-images.githubusercontent.com/128088/104194280-fb7aa800-5418-11eb-8ac6-ca4473849cec.png) | ![Screenshot from 2021-01-11 14-24-21](https://user-images.githubusercontent.com/128088/104194311-08979700-5419-11eb-8e6f-7d4f85782f58.png) |
