### PR TITLE
Added a varient of Call to action button which excludes the chevron

### DIFF
--- a/app/webpacker/styles/links_and_buttons.scss
+++ b/app/webpacker/styles/links_and_buttons.scss
@@ -66,6 +66,11 @@ a.content-link-secondary:hover {
     display: inline-block;
 }
 
+.call-to-action-icon-button {
+    @include button;
+    display: inline-block;
+}
+
 .secondary-button {
     @include button($bg: $grey-light, $fg: black);
 }


### PR DESCRIPTION
### Trello card

https://trello.com/c/cmJ1aEdI

### Context

We require a page providing access to the slides from presentations. That page is in `-content` but requires a tweak to the CSS style

### Changes proposed in this pull request

1. Add varient of call-to-action button which doesn't include the chevron


