### PR TITLE
Use inherit instead of unset to fix IE-specific styling problem

### DIFF
--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -11,7 +11,7 @@
         h2 {
             @include content-heading;
             color: $black;
-            background-color: unset;
+            background-color: inherit;
             size: 110%;
             margin-bottom: 0;
         }


### PR DESCRIPTION
Unset[0] and its friend initial[1] aren't supported by IE. Using inherit
here fixes the issue at hand in a less-elegant but more-fragile manner.

![screenshot_from_2021-01-11_15-42-17](https://user-images.githubusercontent.com/128088/104204926-b1e48a00-5425-11eb-8fca-bc1b2855cedb.png)


[0] https://developer.mozilla.org/en-US/docs/Web/CSS/unset
[1] https://developer.mozilla.org/en-US/docs/Web/CSS/initial
