### PR TITLE
Bump API client version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: abbc59ebe7c7a76866aefc9914eb7c515ef5454d
+  revision: 61152b6255ba9ea824d28c5db3c0dce75658dd2e
   specs:
-    get_into_teaching_api_client (1.1.8)
+    get_into_teaching_api_client (1.1.9)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.11)
+    get_into_teaching_api_client_faraday (0.1.12)
       activesupport
       faraday
       faraday-encoding


### PR DESCRIPTION
Removes the `x_teaching_events_indexed_by_type` methods, which are no longer used in the app 