### PR TITLE
Add Fail2ban to Rack::Attack config

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -9,3 +9,4 @@ GOOGLE_TAG_MANAGER_ID=GTM-P2WKCWR
 BAM_ID=1
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.cloudapps.digital/"
+FAIL2BAN=3

--- a/.env.preprod
+++ b/.env.preprod
@@ -9,4 +9,5 @@ GOOGLE_TAG_MANAGER_ID=GTM-P2WKCWR
 BAM_ID=1
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.cloudapps.digital/"
+SKIP_REQ_LIMITS=true
 FAIL2BAN=3

--- a/.env.rolling
+++ b/.env.rolling
@@ -2,4 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 BAM_ID=1
 VWO_ID=524595
-FAIL2BAN=3
+FAIL2BAN=1

--- a/.env.rolling
+++ b/.env.rolling
@@ -2,3 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 BAM_ID=1
 VWO_ID=524595
+FAIL2BAN=3

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -5,6 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
-
-  Rack::Attack.enabled = false
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -5,6 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
-
-  Rack::Attack.enabled = false
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,15 @@
 module Rack
   class Attack
+    FAIL2BAN_LIST = %w[
+      /etc/passwd
+      wp-admin
+      wp-login
+      wp-includes
+      .php
+    ].freeze
+
+    FAIL2BAN_REGEX = Regexp.new(FAIL2BAN_LIST.map(&Regexp.method(:quote)).join("|")).freeze
+
     # Throttle /csp_reports requests by IP (5rpm)
     throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
       req.ip if req.path == "/csp_reports"
@@ -43,6 +53,17 @@ module Rack
       end
 
       req.ip if (req.patch? || req.put?) && path_performs_event_sign_up
+    end
+
+    if ENV["FAIL2BAN"].to_s.match? %r{\A\d+\z}
+      FAIL2BAN_TIME = ENV["FAIL2BAN"].to_s.to_i.minutes.freeze
+
+      blocklist("block hostile bots") do |req|
+        Fail2Ban.filter("hostile-bots-#{req.ip}", maxretry: 0, findtime: 1.second, bantime: FAIL2BAN_TIME) do
+          FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
+            FAIL2BAN_REGEX.match?(req.path)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

Bots poking around the site should be banned

### Changes proposed in this pull request

1. Added Fail2Ban configuration - this is configured with an environment variable `FAIL2BAN` which is an integer of the minutes to ban an ip for. The rule automatically bans any IP accessing a question able endpoint - ie wordpress or php files or etc/passwd
2. Enable FAIL2BAN for 1 minute in `rolling` for quick testing (eg the Review URLs
3. Enable FAIL2BAN for 3 minutes in `preprod` / aka staging
4. Enabled Rack::Attack in all environments, instead disabling only the req limits in `preprod` / aka staging - to allow for the cypress tests
5. Log to Sentry when an IP is blocked and for how long

### Guidance to review
This PR does not enable the checks in production yet
