### PR TITLE
Make the content page specs redirect-aware

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "content pages check", type: :feature, content: true do
   let(:document) { Nokogiri.parse(page.body) }
+  let(:statuses_deemed_successful) { Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently) }
 
   PageLister.content_urls.each do |url|
     describe "visiting #{url}" do
@@ -53,7 +54,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
           .each do |href|
             visit(href)
 
-            expect(page).to(have_http_status(:success), "invalid link on #{url} - #{href}")
+            expect(page.status_code).to be_in(statuses_deemed_successful)
 
             if (fragment = URI.parse(href).fragment)
               expect(page).to(have_css("#" + fragment), "invalid link on #{url} - #{href}, (missing fragment #{fragment})")


### PR DESCRIPTION
This is necessary because without it renaming content pages that are linked to from the app will result in failed builds (e.g., DFE-Digital/get-into-teaching-content/pull/253) .

Now the renaming process can be to:
1. update the content and create a new redirect rule
2. then update the app with the new path

This will result in a short period where the link text doesn't exactly match the target content page but the build will pass.

The alternative is to remove the link, update the content and re-add, which is a bit more of a faff.