### PR TITLE
Add FeatureTableComponent for Ways to Train redesign

### DIFF
--- a/app/components/content/feature_table_component.html.erb
+++ b/app/components/content/feature_table_component.html.erb
@@ -1,0 +1,11 @@
+<%= wrapper do %>
+  <%= heading %>
+  <%= table do %>
+    <tbody class="desktop">
+      <%= desktop_rows %>
+    </tbody>
+    <tbody class="mobile">
+      <%= mobile_rows %>
+    </tbody>
+  <% end %>
+<% end %>

--- a/app/components/content/feature_table_component.html.erb
+++ b/app/components/content/feature_table_component.html.erb
@@ -1,11 +1,25 @@
-<%= wrapper do %>
-  <%= heading %>
-  <%= table do %>
+<div class="<%= wrapper_class %>">
+  <% if title? %>
+    <h2 class="strapline strapline--blue"><%= title %></h2>
+  <% end %>
+  <table aria-label="<%= description %>">
     <tbody class="desktop">
-      <%= desktop_rows %>
+      <% data.map do |key, value| %>
+        <tr>
+          <th><%= key %></th>
+          <td><%= value %></td>
+        </tr>
+      <% end %>
     </tbody>
     <tbody class="mobile">
-      <%= mobile_rows %>
+      <% data.map do |key, value| %>
+        <tr>
+          <th><%= key %></th>
+        </tr>
+        <tr>
+          <td><%= value %></td>
+        </tr>
+      <% end %>
     </tbody>
-  <% end %>
-<% end %>
+  </table>
+</div>

--- a/app/components/content/feature_table_component.html.erb
+++ b/app/components/content/feature_table_component.html.erb
@@ -2,24 +2,10 @@
   <% if title? %>
     <h2 class="strapline strapline--blue"><%= title %></h2>
   <% end %>
-  <table aria-label="<%= description %>">
-    <tbody class="desktop">
-      <% data.map do |key, value| %>
-        <tr>
-          <th><%= key %></th>
-          <td><%= value %></td>
-        </tr>
-      <% end %>
-    </tbody>
-    <tbody class="mobile">
-      <% data.map do |key, value| %>
-        <tr>
-          <th><%= key %></th>
-        </tr>
-        <tr>
-          <td><%= value %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <dl>
+    <% data.map do |key, value| %>
+      <dt><%= key %></dt>
+      <dd><%= value %></dd>
+    <% end %>
+  </dl>
 </div>

--- a/app/components/content/feature_table_component.rb
+++ b/app/components/content/feature_table_component.rb
@@ -1,0 +1,59 @@
+module Content
+  class FeatureTableComponent < ViewComponent::Base
+    attr_reader :data, :title, :description
+
+    def initialize(data, description, title = nil)
+      @data = data
+      @description = description
+      @title = title
+
+      fail(ArgumentError, "data must be present") unless data?
+      fail(ArgumentError, "description must be present") if description.blank?
+    end
+
+    def wrapper
+      wrapper_class = %w[feature-table]
+      wrapper_class << "feature-table--with-title" if title
+      tag.div(class: wrapper_class.join(" ")) { yield }
+    end
+
+    def table
+      tag.table("aria-label": description) { yield }
+    end
+
+    def heading
+      return nil if title.blank?
+
+      tag.h2(title, class: "strapline strapline--blue")
+    end
+
+    def desktop_rows
+      safe_join(
+        data.map do |key, value|
+          tag.tr do
+            tag.th(key) + tag.td(value)
+          end
+        end,
+      )
+    end
+
+    def mobile_rows
+      safe_join(
+        data.map do |key, value|
+          tag.tr {
+            tag.th(key)
+          } +
+          tag.tr do
+            tag.td(value)
+          end
+        end,
+      )
+    end
+
+  private
+
+    def data?
+      @data&.present?
+    end
+  end
+end

--- a/app/components/content/feature_table_component.rb
+++ b/app/components/content/feature_table_component.rb
@@ -11,43 +11,14 @@ module Content
       fail(ArgumentError, "description must be present") if description.blank?
     end
 
-    def wrapper
-      wrapper_class = %w[feature-table]
-      wrapper_class << "feature-table--with-title" if title
-      tag.div(class: wrapper_class.join(" ")) { yield }
+    def wrapper_class
+      klass = %w[feature-table]
+      klass << "feature-table--with-title" if title
+      klass.join(" ")
     end
 
-    def table
-      tag.table("aria-label": description) { yield }
-    end
-
-    def heading
-      return nil if title.blank?
-
-      tag.h2(title, class: "strapline strapline--blue")
-    end
-
-    def desktop_rows
-      safe_join(
-        data.map do |key, value|
-          tag.tr do
-            tag.th(key) + tag.td(value)
-          end
-        end,
-      )
-    end
-
-    def mobile_rows
-      safe_join(
-        data.map do |key, value|
-          tag.tr {
-            tag.th(key)
-          } +
-          tag.tr do
-            tag.td(value)
-          end
-        end,
-      )
+    def title?
+      title.present?
     end
 
   private

--- a/app/components/content/feature_table_component.rb
+++ b/app/components/content/feature_table_component.rb
@@ -1,14 +1,12 @@
 module Content
   class FeatureTableComponent < ViewComponent::Base
-    attr_reader :data, :title, :description
+    attr_reader :data, :title
 
-    def initialize(data, description, title = nil)
+    def initialize(data, title = nil)
       @data = data
-      @description = description
       @title = title
 
       fail(ArgumentError, "data must be present") unless data?
-      fail(ArgumentError, "description must be present") if description.blank?
     end
 
     def wrapper_class

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <%= render "sections/head" %>
+  <body>
+  <%= yield %>
+  </body>
+</html>

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -1,0 +1,56 @@
+.feature-table {
+  margin: 0 -20px 30px -20px;
+
+  .strapline {
+    margin: 0 4em 0 0;
+
+    &:after {
+      content: '';
+    }
+  }
+
+  table {
+    background-color: $grey;
+    width: 100%;
+    text-align: left;
+    border-spacing: 20px 0.2em;
+    padding: 20px 0;
+
+    tbody {
+      &.mobile {
+        display: none;
+      }
+
+      th {
+        width: 1%;
+        white-space: nowrap;
+
+        &:after {
+          content: ':';
+        }
+      }
+    }
+  }
+
+  &--with-title table {
+    margin-top: -1.3em;
+    padding: 40px 0 20px 0;
+  }
+
+  @media only screen and (max-width: $mobile-wrap) {
+    .strapline {
+      margin-right: 1.2em;
+    }
+
+    table tbody
+    {
+      &.mobile {
+        display: table-row-group;;
+      }
+
+      &.desktop {
+        display: none;
+      }
+    }
+  }
+}

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -9,32 +9,38 @@
     }
   }
 
-  table {
+  dl {
+    font-size: 19px;
     background-color: $grey;
     width: 100%;
-    text-align: left;
-    border-spacing: 20px 0.2em;
-    padding: 20px 0;
+    padding: 20px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 
-    tbody {
-      &.mobile {
-        display: none;
+    dt, dd {
+      padding: 0.15em 0;
+    }
+
+    dt {
+      font-weight: bold;
+      flex-basis: 38%;
+
+      &:after {
+        content: ':';
       }
+    }
 
-      th {
-        width: 1%;
-        white-space: nowrap;
-
-        &:after {
-          content: ':';
-        }
-      }
+    dd {
+      flex-basis: 62%;
+      margin: 0;
     }
   }
 
-  &--with-title table {
+  &--with-title dl {
     margin-top: -1.3em;
-    padding: 40px 0 20px 0;
+    padding-top: 40px;
   }
 
   @media only screen and (max-width: $mobile-wrap) {
@@ -42,14 +48,9 @@
       margin-right: 1.2em;
     }
 
-    table tbody
-    {
-      &.mobile {
-        display: table-row-group;;
-      }
-
-      &.desktop {
-        display: none;
+    dl {
+      dt, dd {
+        flex-basis: 100%;
       }
     }
   }

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -27,6 +27,7 @@
 @import './components/content-nav';
 @import './components/content-cta';
 @import './components/content-alert';
+@import './components/feature-table';
 @import './components/link-block';
 @import './components/type-description';
 @import './components/events/no-results';

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,9 @@ module GovukRailsBoilerplate
     # the framework and any gems in your application.
 
     config.exceptions_app = routes
+
+    # View component previews
+    config.view_component.preview_paths << Rails.root.join("spec/components/previews")
+    config.view_component.default_preview_layout = "component_preview"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,5 +74,5 @@ Rails.application.routes.draw do
   get "/ways-to-train", to: "ways_to_train#show"
 
   get "/guidance/*page", to: "guidance#show"
-  get "*page", to: "pages#show", as: :page
+  get "*page", to: "pages#show", as: :page, constraints: ->(request) { !request.path.start_with?("/rails/") }
 end

--- a/spec/components/content/feature_table_component_spec.rb
+++ b/spec/components/content/feature_table_component_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe Content::FeatureTableComponent, type: "component" do
   let(:title) { "Features" }
-  let(:description) { "A description of the data" }
   let(:data) do
     {
       "Feature 1" => "Value 1",
@@ -12,42 +11,30 @@ describe Content::FeatureTableComponent, type: "component" do
   end
 
   subject! do
-    render_inline(described_class.new(data, description, title))
+    render_inline(described_class.new(data, title))
     page
   end
 
   it { is_expected.to have_css(".feature-table") }
   it { is_expected.to have_css("h2", text: title) }
-  it { expect(page.find("table")["aria-label"]).to eq(description) }
-  it { is_expected.to have_css("tbody.mobile") }
-  it { is_expected.to have_css("tbody.desktop") }
+  it { is_expected.to have_css("dl") }
 
-  describe "within the body of the table" do
-    it "displays table headings" do
-      data.keys.each { |heading| expect(page).to have_css("tbody.mobile th", text: heading) }
-      data.keys.each { |heading| expect(page).to have_css("tbody.desktop th", text: heading) }
+  describe "within the definition list" do
+    it "displays headings" do
+      data.keys.each { |heading| expect(page).to have_css("dl dt", text: heading) }
     end
 
-    it "displays table data" do
-      data.values.each { |heading| expect(page).to have_css("tbody.mobile td", text: heading) }
-      data.values.each { |heading| expect(page).to have_css("tbody.desktop td", text: heading) }
+    it "displays values" do
+      data.values.each { |value| expect(page).to have_css("dl dd", text: value) }
     end
   end
 
   it "raises an error when data is nil" do
-    expect { described_class.new(nil, description) }.to raise_error(ArgumentError, /data must be present/)
+    expect { described_class.new(nil) }.to raise_error(ArgumentError, /data must be present/)
   end
 
   it "raises an error when data is an empty hash" do
-    expect { described_class.new({}, description) }.to raise_error(ArgumentError, /data must be present/)
-  end
-
-  it "raises an error when description is nil" do
-    expect { described_class.new(data, nil) }.to raise_error(ArgumentError, /description must be present/)
-  end
-
-  it "raises an error when description is empty" do
-    expect { described_class.new(data, " ") }.to raise_error(ArgumentError, /description must be present/)
+    expect { described_class.new({}) }.to raise_error(ArgumentError, /data must be present/)
   end
 
   context "when title is nil" do

--- a/spec/components/content/feature_table_component_spec.rb
+++ b/spec/components/content/feature_table_component_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe Content::FeatureTableComponent, type: "component" do
+  let(:title) { "Features" }
+  let(:description) { "A description of the data" }
+  let(:data) do
+    {
+      "Feature 1" => "Value 1",
+      "Feature 2" => "Value 2",
+      "Feature 3" => "Value 3",
+    }
+  end
+
+  subject! do
+    render_inline(described_class.new(data, description, title))
+    page
+  end
+
+  it { is_expected.to have_css(".feature-table") }
+  it { is_expected.to have_css("h2", text: title) }
+  it { expect(page.find("table")["aria-label"]).to eq(description) }
+  it { is_expected.to have_css("tbody.mobile") }
+  it { is_expected.to have_css("tbody.desktop") }
+
+  describe "within the body of the table" do
+    it "displays table headings" do
+      data.keys.each { |heading| expect(page).to have_css("tbody.mobile th", text: heading) }
+      data.keys.each { |heading| expect(page).to have_css("tbody.desktop th", text: heading) }
+    end
+
+    it "displays table data" do
+      data.values.each { |heading| expect(page).to have_css("tbody.mobile td", text: heading) }
+      data.values.each { |heading| expect(page).to have_css("tbody.desktop td", text: heading) }
+    end
+  end
+
+  it "raises an error when data is nil" do
+    expect { described_class.new(nil, description) }.to raise_error(ArgumentError, /data must be present/)
+  end
+
+  it "raises an error when data is an empty hash" do
+    expect { described_class.new({}, description) }.to raise_error(ArgumentError, /data must be present/)
+  end
+
+  it "raises an error when description is nil" do
+    expect { described_class.new(data, nil) }.to raise_error(ArgumentError, /description must be present/)
+  end
+
+  it "raises an error when description is empty" do
+    expect { described_class.new(data, " ") }.to raise_error(ArgumentError, /description must be present/)
+  end
+
+  context "when title is nil" do
+    let(:title) { nil }
+
+    it { is_expected.not_to have_css("h2") }
+  end
+
+  context "when title is empty" do
+    let(:title) { " " }
+
+    it { is_expected.not_to have_css("h2") }
+  end
+end

--- a/spec/components/previews/content/feature_table_component_preview.rb
+++ b/spec/components/previews/content/feature_table_component_preview.rb
@@ -1,10 +1,10 @@
 class Content::FeatureComponentPreview < ViewComponent::Preview
   def with_title_and_data
-    render(Content::FeatureTableComponent.new(data, "Description of the data", "Features"))
+    render(Content::FeatureTableComponent.new(data, "Features"))
   end
 
   def with_data
-    render(Content::FeatureTableComponent.new(data, "Description of the data"))
+    render(Content::FeatureTableComponent.new(data))
   end
 
 private

--- a/spec/components/previews/content/feature_table_component_preview.rb
+++ b/spec/components/previews/content/feature_table_component_preview.rb
@@ -1,0 +1,19 @@
+class Content::FeatureComponentPreview < ViewComponent::Preview
+  def with_title_and_data
+    render(Content::FeatureTableComponent.new(data, "Description of the data", "Features"))
+  end
+
+  def with_data
+    render(Content::FeatureTableComponent.new(data, "Description of the data"))
+  end
+
+private
+
+  def data
+    {
+      "Feature 1" => "Value 1",
+      "Feature 2" => "Value 2",
+      "Feature 3" => "Value 3",
+    }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-708](https://trello.com/c/1lP8Kcde/708-development-ways-to-train-table-style-layout)

### Context

We are implementing a redesign of the Ways to Train layout, which replaces the current accordion design with a series of 'feature tables'.

This PR introduces the `FeatureTableViewComponent` that will be used in the redesigned content.

### Changes proposed in this pull request

- Exclude /rails from default content route

Currently the main content route will try and map `/rails` to a content page. This excludes it so that we can access the in-built
Rails routes in development (for ViewComponent previews). 

- Add FeatureTableComponent

This is a table component that will be used in the new Ways to Train page. It consists of a strapline heading and two column table in desktop, with the first column being the heading and the second column the associated value. In mobile this changes to a single column layout, alternating headings and values.

- Enable ViewComponent previews

Configures `ViewComponent` previews that can be accessed at:

```
/rails/view_components
```

Adds a basic view component layout and the `FeatureTableComponentPreview`.

- Switch table to definition list

Uses a definition list instead of a table, which simplifies the HTML. Currently the first column of the list in desktop mode is fixed-width as trying to implement a variable width first column is not going to be straight forward -- this will be picked up in a follow up PR if/when we have another use case for this table.

### Guidance to review

The CSS isn't too pretty due to the overlap of the strap-line and the need to be flush with the page width on mobile; open to any suggestions if it can be improved. 

| Desktop      | Mobile |
| ----------- | ----------- |
| <img width="750" alt="Screenshot 2021-01-14 at 10 49 11" src="https://user-images.githubusercontent.com/29867726/104582499-de7fe800-5657-11eb-89b6-a1bf97b8dab5.png">      | <img width="518" alt="Screenshot 2021-01-14 at 11 02 23" src="https://user-images.githubusercontent.com/29867726/104582591-fce5e380-5657-11eb-82b4-3a2d530d286f.png">       |

