### PR TITLE
Add COVID-19 link to footer

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -26,7 +26,7 @@
       </div>
       <div class="site-footer-top__links-container">
         <%= link_to("Home", page_path(page: :home)) %>
-        <% navigation_resources.each_with_index do |resource, index| %>
+        <% navigation_resources.each do |resource| %>
           <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
         <% end %>
         <%= link_to "Find an event near you", events_path %>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -31,6 +31,7 @@
         <% end %>
         <%= link_to "Find an event near you", events_path %>
         <%= link_to("Helping you become a teacher", page_path(page: "helping-you-become-a-teacher")) %>
+        <%= link_to("COVID-19", page_path(page: "covid-19")) %>
       </div>
     </div>
     <div class="site-footer-bottom">


### PR DESCRIPTION
### Trello card

https://trello.com/c/yt7r00D8/716-add-a-covid-19-link-to-the-footer

### Context

Once the COVID banner has been dismissed there's no way for users to find the link to it.

### Changes proposed in this pull request

Add a COVID-19 link to the end of the nav options in the footer.

Also remove unused indexing on the links loop.

### Guidance to review

![Screenshot from 2021-01-14 11-35-12](https://user-images.githubusercontent.com/128088/104586053-db3b2b00-565c-11eb-85e8-1b4207c3ca75.png)


