### PR TITLE
Add full stops to titles with a colour bg via CSS

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -23,6 +23,9 @@
       font-size: 24pt;
       font-weight: 700;
       color: $white;
+      &:after {
+        content: ".";
+      }
     }
 
     .call-to-action {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -82,6 +82,9 @@
                             border-bottom: 4px solid $black;
                             padding-bottom: 4px;
                         }
+                        &:after {
+                            content: ".";
+                        }
                     }
                 }
             }


### PR DESCRIPTION
To match branding, adding full stops to titles in colour bgs.

