### PR TITLE
Remove temp code to render /index story lists

### DIFF
--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -68,26 +68,6 @@ describe PagesController do
     end
   end
 
-  describe "rendering a page that has a .../index template" do
-    include_context "prepend fake views"
-
-    it "returns the template at <template>/index if the request is just for <template>" do
-      get "/test"
-      expect(response).to have_http_status(:success)
-      expect(response.body).to include("Index Page Test")
-    end
-
-    it "returns 404 if <template>/index is requested directly" do
-      get "/test/index"
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "returns 404 if there is no <template>/index and the request is just for <template>" do
-      get "/stories"
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
   describe "redirect to TTA site" do
     include_context "stub env vars", "TTA_SERVICE_URL" => "https://tta-service/"
     subject { response }

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -5,12 +5,6 @@ class PageLister
     /index
     /steps-to-become-a-teacher/v2-index
     /privacy-policy
-    /my-story-into-teaching/career-changers/index
-    /my-story-into-teaching/career-progression/index
-    /my-story-into-teaching/international-career-changers/index
-    /my-story-into-teaching/making-a-difference/index
-    /my-story-into-teaching/returners/index
-    /my-story-into-teaching/teacher-training-stories/index
   ].freeze
 
   class << self


### PR DESCRIPTION
This code was added so that we could render the story list content at the `/section` path when it exists at both `/section.md` and `/section/index.md`. The story list content has now all been moved to be in the `/section.md` format, so this code is no longer required.