### PR TITLE
Remove /my-story-into-teaching/section/index content specs

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -5,6 +5,12 @@ class PageLister
     /index
     /steps-to-become-a-teacher/v2-index
     /privacy-policy
+    /my-story-into-teaching/career-changers/index
+    /my-story-into-teaching/career-progression/index
+    /my-story-into-teaching/international-career-changers/index
+    /my-story-into-teaching/making-a-difference/index
+    /my-story-into-teaching/returners/index
+    /my-story-into-teaching/teacher-training-stories/index
   ].freeze
 
   class << self


### PR DESCRIPTION
The  my story into teaching list pages are in the content repo at `/my-story-into-eaching/section/index.md`, however we have Rails routes for these that render them at `my-story-into-teaching/section`. It turns out you could access the pages at both `/section` and `/section/index` though with the latter route they display a broken/partial listing page.

Going forward this won't be the case as we're moving the pages to be at `/section.md` instead of `/section/index.md` and scrapping the Rails routes. The routes have been scrapped but the content specs are still expecting a page at `/section/index` which is no longer the case (without the routes we are _only_ rendering them at `/section` now, which is correct), so this PR excludes these from the content specs until we can move the pages into the content repo.

