### PR TITLE
Make h2/strapline font size consistent

### DIFF
--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -97,7 +97,7 @@
 
   h2 {
     padding: 0 20px 20px ;
-    font-size: 36px ;
+    font-size: 24pt;
   }
 
   .card {

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -1,5 +1,5 @@
 @mixin content-heading {
-    font-size: 36px;
+    font-size: 24pt;
     font-weight: bold;
     color: $white;
     background-color: $blue;

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -60,8 +60,8 @@
       }
 
       h2, h3 {
-          font-size: 36px;
-      }
+        font-size: 24pt;
+    }
 
       h3 {
           margin-top: 0;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -280,7 +280,7 @@
         padding-top: 20px;
     }
     h2 {
-        font-size: 36px;
+        font-size: 24pt;
         margin: 0 0 10px;
         @media (max-width: 800px) {
             font-size: 28px;

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -49,7 +49,7 @@ a {
 .strapline-image {
     @include font;
     color: $white;
-    font-size: 36px;
+    font-size: 24pt;
     background-color: $purple;
     display: inline-block;
     padding: 12px 20px 8px;
@@ -62,7 +62,7 @@ a {
     @include font;
     color: $white;
     font-weight: bold;
-    font-size: 36px;
+    font-size: 24pt;
     background-color: $purple;
     display: inline-block;
     padding: 10px 20px;
@@ -91,7 +91,7 @@ a {
 .strapline-article {
     @include font;
     color: $black;
-    font-size: 36px;
+    font-size: 24pt;
     background-color: transparent;
     padding-bottom: 5px;
 }


### PR DESCRIPTION
### Trello card

[Trello-729](https://trello.com/c/Oq1fyS9J/729-make-strapline-font-sizes-consistent)

### Context

We seem to have slight variations in the font size of straplines; a strapline is 36px but often overriden by the `h2` tag style to 34px/24pt. I think it looks better at 24pt so I've tweaked them all to be consistent.

Going forward it would be nice to have a set of variables for the different font sizes, but that's a different kettle of fish/left to a separate PR.

### Changes proposed in this pull request

- Make h2/strapline font size consistent

### Guidance to review

I've had a decent click about and everything looks fine as far as I can tell. The change isn't big enough that it would case an earth shattering issue if something doesn't look quite right at the smaller font size.
