### PR TITLE
Support home page as markdown

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,7 @@ class PagesController < ApplicationController
   rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
   PAGE_LAYOUTS = [
+    "layouts/home",
     "layouts/accordion",
     "layouts/stories/landing",
     "layouts/stories/list",
@@ -53,7 +54,7 @@ private
     layout = @page.frontmatter[:layout]
     return layout if PAGE_LAYOUTS.include?(layout)
 
-    request.path == root_path ? "layouts/home" : "layouts/content"
+    request.path == root_path ? "layouts/home-old" : "layouts/content"
   end
 
   def content_template

--- a/app/views/layouts/home-old.html.erb
+++ b/app/views/layouts/home-old.html.erb
@@ -16,9 +16,11 @@
             </section>
         </main>
 
-        <% @front_matter["content"]&.each do |partial| %>
-          <%= render(partial) %>
-        <% end %>
+        <%= render "sections/footer" %>
+        <%= render "components/videoplayer" %>
+        <%= render "sections/cookie-acceptance" %>
+        <%= render "sections/feedback-bar" %>
+        <%= render "components/analytics" %>
     <% end %>
 </html>
 

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -3,6 +3,17 @@ require "rails_helper"
 describe "rendering pages with a custom layout" do
   include_context "prepend fake views"
 
+  context "with a home page layout" do
+    before { get "/home-page" }
+    subject { response.body }
+
+    it { expect(response).to have_http_status(200) }
+    it { is_expected.to include("Home Page Test") }
+
+    it { is_expected.to include("Discover the steps to become a teacher") }
+    it { is_expected.to include("Check your qualifications") }
+  end
+
   context "with an accordion layout" do
     before { get "/accordion-page" }
     subject { response.body }

--- a/spec/support/views/content/home-page.md
+++ b/spec/support/views/content/home-page.md
@@ -1,0 +1,14 @@
+---
+  layout: "layouts/home"
+  title: "Home Page Test"
+  deepheader: true
+  mailinglist: true
+  fullwidth: true
+  hide_page_helpful_question: true
+  lid_pixel_event: "Homepage"
+  subtitle: "Get information and support to help you become a teacher"
+  image: "media/images/hero-home-dt.jpg"
+  backlink: "/"
+  content:
+    - content/home/test_content
+---

--- a/spec/support/views/content/home/_test_content.erb
+++ b/spec/support/views/content/home/_test_content.erb
@@ -1,0 +1,18 @@
+<div class="steps-home">
+    <div class="container-1000">
+        <div class="strapline strapline--small strapline--blue">Steps</div>
+
+        <div class="home-inset-content">
+          <h1>Discover the steps to become a teacher.</h1>
+
+          <div class="steps__wrapper">
+            <div class="steps__step">
+                <div class="steps__number"><span>1</span></div>
+                <a href="/steps-to-become-a-teacher" class="steps__link">
+                    <span>Check your qualifications</span>
+                </a>
+            </div>
+          </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Trello card

[Trello-730](https://trello.com/c/rIrXR9Qa/730-define-home-page-layout-in-the-frontmatter)

### Context

Currently the home page is an ERB that relies on the `PagesController` applying the correct layout.

This moves the current home template to `home-old` (to be removed in an following PR) and adds a new `home` template that supports a markdown version of the home page, which will specify the content and layout as frontmatter.

### Changes proposed in this pull request

- Support home page as markdown

### Guidance to review

Follow up PR: https://github.com/DFE-Digital/get-into-teaching-content/pull/272