### PR TITLE
Only apply width-limiter to the page's main header

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -12,13 +12,13 @@ body {
     }
 }
 
-main, 
-header {
-    @extend %content-width-limiter-shared; 
+main,
+main > header {
+    @extend %content-width-limiter-shared;
 }
 
 .limit-content-width {
-    @extend %content-width-limiter-shared; 
+    @extend %content-width-limiter-shared;
 }
 
 .no-hero {


### PR DESCRIPTION
### Context

The `<header>` element is used for both section headings and the main heading on the page.

Here the `%content-width-limiter-shared` style was being applied to all headers on the page instead of only the outermost one (which is a direct descendant of `<main>`), causing them to be rendered centrally rather than left-aligned.

### Changes proposed in this pull request

Change the `header` selector that applies the content with limiter so it only applies to headers that are direct descendent of `<main>`.

![Screenshot from 2021-01-18 12-47-11](https://user-images.githubusercontent.com/128088/104917444-52d5c680-598b-11eb-8f65-6b7c82b9e08b.png)
