### PR TITLE
Render section footer on home layout

### DIFF
--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -19,6 +19,8 @@
         <% @front_matter["content"]&.each do |partial| %>
           <%= render(partial) %>
         <% end %>
+
+        <%= render "sections/footer" %>
     <% end %>
 </html>
 


### PR DESCRIPTION
I missed this from the original `home-old` layout (which is still the one used in prod).