### PR TITLE
Disable Turbolinks for all jump links

### DIFF
--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
         const links = this.contentTarget.querySelectorAll('a');
 
         links.forEach((l) => {
-            if (l.getAttribute('href')?.startsWith('#')) {
+            if (l.getAttribute('href')?.includes('#')) {
                 l.dataset.turbolinks = "false"
             }
         });

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -2,10 +2,11 @@ import { Application } from 'stimulus' ;
 import LinkController from 'link_controller.js' ;
 
 describe('LinkController', () => {
-  describe ("disabling turbolinks for links to anchors", () => {
+  describe ("disabling turbolinks for links containing anchors", () => {
     beforeEach(() => {
       document.body.innerHTML = `
       <div data-controller="link" data-link-target="content">
+        <a href="path/to#position">Jump Link</a>
         <div id="level-1" class="video-overlay" data-video-target="player" data-action="click->video#close">
           <a href="#level-3" />
           <div id="level-2">


### PR DESCRIPTION
### Trello card

[Trello-736](https://trello.com/c/2Ca7KZbI/736-fix-home-page-step-links-not-showing-the-correct-place-in-the-accordion)

### Context

We already disable Turbolinks for jump links pointing to the same page, but it seems jump links pointing to other pages in the website aren't consistently scrolling to the correct location (sometimes the page will scroll then an image or something further up will load and throw the scroll position off).

Its mainly the steps to become a teacher page that this effects (linked to from the home page).

### Changes proposed in this pull request

- Disable Turbolinks for all jump links

### Guidance to review

