### PR TITLE
Added Grouped Cards component

### DIFF
--- a/app/components/grouped_cards/card_component.html.erb
+++ b/app/components/grouped_cards/card_component.html.erb
@@ -1,0 +1,22 @@
+<div class="events-featured__list__item">
+  <div class="event-box">
+    <div class="event-box__header">
+      <h4>
+        <%= header %>
+      </h4>
+    </div>
+
+    <hr class="event-box__divider event-box__divider--online-event" />
+
+    <div class="event-box__datetime">
+      <p>
+      <% for field, value in fields %>
+        <div>
+          <span><%= field.humanize %>:</span>
+          <span><%= linked_value(value) %></span>
+        </div>
+      <% end %>
+      <p>
+    </div>
+  </div>
+</div>

--- a/app/components/grouped_cards/card_component.rb
+++ b/app/components/grouped_cards/card_component.rb
@@ -1,0 +1,21 @@
+module GroupedCards
+  class CardComponent < ViewComponent::Base
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    def header
+      @data["header"]
+    end
+
+    def fields
+      @data.without("header")
+    end
+
+    def linked_value(value)
+      Rinku.auto_link(h(value)).html_safe
+    end
+  end
+end

--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -1,13 +1,13 @@
 <ul>
   <% for region in regions %>
   <li>
-    <%= link_to region, "#group--#{region_link_anchor(region)}" %>
+    <%= link_to region, "##{group_link_anchor(region)}" %>
   </li>
   <% end %>
 </ul>
 
 <% for region in regions %>
-<div class="events-featured" id="group--<%= region_link_anchor(region) %>">
+<div class="events-featured" id="<%= group_link_anchor(region) %>">
   <div class="events-featured__heading">
     <h3>
       <%= region %>

--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -1,0 +1,23 @@
+<ul>
+  <% for region in regions %>
+  <li>
+    <%= link_to region, "#group--#{region_link_anchor(region)}" %>
+  </li>
+  <% end %>
+</ul>
+
+<% for region in regions %>
+<div class="events-featured" id="group--<%= region_link_anchor(region) %>">
+  <div class="events-featured__heading">
+    <h3>
+      <%= region %>
+    </h3>
+  </div>
+
+  <div class="events-featured__list">
+  <% for provider in providers(region) %>
+    <%= render GroupedCards::CardComponent.new provider %>
+  <% end %>
+  </div>
+</div>
+<% end %>

--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -8,8 +8,8 @@ module GroupedCards
       @data.keys
     end
 
-    def region_link_anchor(region)
-      region.downcase.gsub %r{[^a-z0-9]+}, "-"
+    def group_link_anchor(group)
+      "group--" + group.parameterize
     end
 
     def providers(region)

--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -1,0 +1,19 @@
+module GroupedCards
+  class ListingComponent < ViewComponent::Base
+    def initialize(data)
+      @data = data
+    end
+
+    def regions
+      @data.keys
+    end
+
+    def region_link_anchor(region)
+      region.downcase.gsub %r{[^a-z0-9]+}, "-"
+    end
+
+    def providers(region)
+      @data[region]
+    end
+  end
+end

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -14,6 +14,7 @@
 
     <main class="semantic" role="main" id="main-content">
 
+      <% if @front_matter["fullwidth"].blank? %>
       <aside>
         <% if @front_matter["jump_links"].present? %>
           <div class="link-block link-block--jump">
@@ -41,8 +42,9 @@
 
         <%= render partial: "layouts/shared/narrow_call_to_action" %>
       </aside>
+      <% end %>
 
-      <article class="markdown overhang">
+      <article class="markdown overhang <%= "fullwidth" if @front_matter["fullwidth"] %> ">
         <% if !@front_matter["image"] %>
           <%= tag.h1(@front_matter["title"]) %>
         <% end %>

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -56,6 +56,10 @@
     &__datetime {
         margin-bottom: 4px;
         font-size: 0.8em;
+
+        span {
+          word-break: break-word;
+        }
     }
 
     &__divider {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -77,7 +77,7 @@ main.semantic {
     margin: 1em auto 4em;
   }
 
-  > article {
+  > article:not(.fullwidth) {
     flex: 0 1 65%;
   }
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -77,9 +77,12 @@ main.semantic {
     margin: 1em auto 4em;
   }
 
-  > article:not(.fullwidth) {
-    flex: 0 1 65%;
+  > article {
+    &.fullwidth {
+      flex: 1 0 100%;
+    }
   }
+
 
   > aside {
     flex: 0 0 calc(30%);

--- a/spec/components/grouped_cards/card_component_spec.rb
+++ b/spec/components/grouped_cards/card_component_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe GroupedCards::CardComponent, type: "component" do
+  subject { render_inline(instance) && page }
+
+  let(:instance) { described_class.new organisation }
+  let(:organisation) do
+    {
+      header: "First organisation",
+      name: "Joe Bloggs",
+      telephone: "01234 567890 (ext 123)",
+      email: "joe.bloggs@first.org",
+    }.with_indifferent_access
+  end
+
+  it { is_expected.to have_css "h4", text: "First organisation" }
+  it { is_expected.to have_css ".event-box__datetime span", text: "Name" }
+  it { is_expected.to have_css ".event-box__datetime span", text: "Joe Bloggs" }
+  it { is_expected.to have_link "joe.bloggs@first.org", href: "mailto:joe.bloggs@first.org" }
+end

--- a/spec/components/grouped_cards/listing_component_spec.rb
+++ b/spec/components/grouped_cards/listing_component_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe GroupedCards::ListingComponent, type: "component" do
+  subject { render_inline(instance) && page }
+
+  let(:instance) { described_class.new data }
+  let(:organisation) do
+    {
+      header: "First organisation",
+      name: "Joe Bloggs",
+      telephone: "01234567890",
+      email: "joe.bloggs@first.org",
+    }.with_indifferent_access
+  end
+  let :data do
+    {
+      "Region 1" => [organisation, organisation],
+      "Region 2" => [organisation],
+    }.with_indifferent_access
+  end
+
+  it { is_expected.to have_css "ul", count: 1 }
+  it { is_expected.to have_css "ul li a", count: 2 }
+  it { is_expected.to have_link "Region 1", href: "#group--region-1" }
+
+  it { is_expected.to have_css "h3", text: "Region 1" }
+  it { is_expected.to have_css "h3", text: "Region 2" }
+
+  it { is_expected.to have_css ".event-box", count: 3 }
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/xa8Eotqv

### Context

The website should provide an indexed list of assessment providers. For this we need a grouped cards listing of all assessment providers

### Changes proposed in this pull request

1. Allow full width markdown pages
2. Add a GroupedCards::Listing component
3. Add a GroupedCards::Card component
4. Small CSS tweak to allow breaking long words (eg email addresses) in the cards

### Guidance to review

1. The event-box CSS should probably be split out into something more general but I'll do that in a follow up PR rather than overcomplicate this one

### Preview

![Screenshot from 2021-01-18 16-32-21](https://user-images.githubusercontent.com/10818/104941313-d05cff00-59aa-11eb-9fcd-b252011e9ae6.png)


