### PR TITLE
Show Turbolinks progress indicator

### DIFF
--- a/app/webpacker/styles/components/turbolinks-progress-bar.scss
+++ b/app/webpacker/styles/components/turbolinks-progress-bar.scss
@@ -1,0 +1,4 @@
+.turbolinks-progress-bar {
+  height: 5px;
+  background-color: $blue-dark;
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -31,6 +31,7 @@
 @import './components/link-block';
 @import './components/type-description';
 @import './components/events/no-results';
+@import './components/turbolinks-progress-bar';
 
 @import 'home';
 @import 'event';


### PR DESCRIPTION
### Trello card

[Trello-724](https://trello.com/c/SDLkj67Z/724-add-css-for-the-turbolinks-progress-bar)

### Context

Add CSS to style the Turbolinks progress indicator, using the GiT blue for the background colour.

### Changes proposed in this pull request

- Show Turbolinks progress indicator

### Guidance to review

<img width="1312" alt="Screenshot 2021-01-19 at 09 02 28" src="https://user-images.githubusercontent.com/29867726/105011722-2f675600-5a35-11eb-9555-dedd93dc02ed.png">
