### PR TITLE
Adding alt attributes for accessibility

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -6,14 +6,15 @@ class CardComponent < ViewComponent::Base
   def initialize(card:)
     @card = card
 
-    @snippet   = card["snippet"]
-    @link      = card["link"]
-    @link_text = card["link_text"].presence || card["linktext"]
-    @image     = card["image"]
-    @video     = card["video"]
-    @header    = card["header"]
-    @title     = card["title"]
-    @border    = card["border"] != false
+    @snippet           = card["snippet"]
+    @link              = card["link"]
+    @link_text         = card["link_text"].presence || card["linktext"]
+    @image             = card["image"]
+    @image_description = card["image_description"]
+    @video             = card["video"]
+    @header            = card["header"]
+    @title             = card["title"]
+    @border            = card["border"] != false
   end
 
   def media_link
@@ -35,7 +36,13 @@ private
   end
 
   def thumbnail_image_tag
-    helpers.image_tag(image, data: { "object-fit" => "cover" })
+    helpers.image_tag(image, data: { "object-fit" => "cover" }, **thumbnail_image_alt_attribute)
+  end
+
+  def thumbnail_image_alt_attribute
+    return {} if @image_description.blank?
+
+    { alt: @image_description }
   end
 
   def video_link

--- a/app/views/components/_videoplayer.html.erb
+++ b/app/views/components/_videoplayer.html.erb
@@ -7,6 +7,7 @@
                 width="800"
                 height="450"
                 src=""
+                alt="Watch a video for more information about becoming a teacher"
                 frameborder="0"
                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                 allowfullscreen

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -7,6 +7,7 @@ describe CardComponent, type: "component" do
       link: "/another/page",
       link_text: "Link to another page",
       image: "/images/card_thumb.jpg",
+      image_description: "A thorough description of the image",
     }.with_indifferent_access
   end
 
@@ -25,6 +26,10 @@ describe CardComponent, type: "component" do
     is_expected.to have_link(href: card[:link]) do |anchor|
       expect(anchor).to have_css(%(img[src='#{card[:image]}']))
     end
+  end
+
+  specify "sets the image's alt text" do
+    is_expected.to have_css(%(img[alt='#{card[:image_description]}']))
   end
 
   specify "includes the snippet" do

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -113,4 +113,12 @@ describe CardComponent, type: "component" do
       is_expected.to have_link("shortened linktext", href: card[:link], class: "git-link")
     end
   end
+
+  context "when no image_description is provided" do
+    let(:card) { base.merge(image_description: nil).with_indifferent_access }
+
+    it "has no image description attribute" do
+      expect(subject.find("img")["alt"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Context

The recent accessibility report showed that we're missing alt attributes in a few places.

### Changes proposed in this pull request

Add a generic alt tag to the video player and allow story card photo thumbnails to have their alt tags set via the new frontmatter key `image_description`.

### Guidance to review

Does this look ok and make sense? We could make this nicer in the future by getting rid of the list of card attrs in the index pages and using the global frontmatter and auto-generating the descriptions from their name/position. Some more work (ie to disable/unpublish without deleting) would need to be done to support that though.
