### PR TITLE
Clean up the page helpful partial

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -93,5 +93,7 @@
         <div data-controller="scribble" data-scribble-id="<%= @event.scribble_id %>"></div>
       <% end %>
 
-      <%= render "sections/page_question" %>
+    <div class="content__left">
+      <%= render "sections/page_helpful" %>
+    </div>
 </section>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -43,11 +43,11 @@
                   ) %>
                 <% end %>
               <% end %>
-
+              
+              <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
             </article>
         </main>
 
-        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -44,7 +44,7 @@
                 <% end %>
               <% end %>
               
-              <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
+              <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
             </article>
         </main>
 

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -58,10 +58,11 @@
         <% @front_matter["content"]&.each do |partial| %>
           <%= render(partial) %>
         <% end %>
+
+        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
       </article>
     </main>
 
-        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -59,7 +59,7 @@
           <%= render(partial) %>
         <% end %>
 
-        <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
+        <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
       </article>
     </main>
 

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -17,7 +17,7 @@
                 <% end %>
                 <% unless @front_matter["hide_page_helpful_question"] %>
                     <div class="container-1000">
-                        <%= render "sections/page_question" %>
+                        <%= render "sections/page_helpful" %>
                     </div>
                 <% end %>
             </section>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -15,7 +15,11 @@
                 <% @front_matter["content"]&.each do |partial| %>
                     <%= render(partial) %>
                 <% end %>
-                <%= render "sections/page_question" unless @front_matter["hide_page_helpful_question"] %>
+                <% unless @front_matter["hide_page_helpful_question"] %>
+                    <div class="container-1000">
+                        <%= render "sections/page_question" %>
+                    </div>
+                <% end %>
             </section>
         </main>
 

--- a/app/views/sections/_page_helpful.html.erb
+++ b/app/views/sections/_page_helpful.html.erb
@@ -1,0 +1,9 @@
+<div class="page-helpful" data-controller="page-helpful">
+    <div>
+        <strong data-page-helpful-target="text">Is this page helpful?</strong>
+    </div>
+    <div>
+        <a href="javascript:void(0)" class="page-question__answer" data-page-helpful-target="link" data-action="page-helpful#answer">Yes</a>
+        <a href="javascript:void(0)" class="page-question__answer" data-page-helpful-target="link" data-action="page-helpful#answer">No</a>
+    </div>
+</div>

--- a/app/views/sections/_page_question.html.erb
+++ b/app/views/sections/_page_question.html.erb
@@ -1,11 +1,9 @@
-<div class="page-question-wrapper" data-controller="page-helpful">
-    <div class="page-question">
-        <div class="page-question__left">
-            <strong data-page-helpful-target="text">Is this page helpful?</strong>
-        </div>
-        <div class="page-question__right">
-            <a href="javascript:void(0)" class="page-question__answer" data-page-helpful-target="link" data-action="page-helpful#answer">Yes</a>
-            <a href="javascript:void(0)" class="page-question__answer" data-page-helpful-target="link" data-action="page-helpful#answer">No</a>
-        </div>
+<div class="page-question" data-controller="page-helpful">
+    <div>
+        <strong data-page-helpful-target="text">Is this page helpful?</strong>
+    </div>
+    <div>
+        <a href="javascript:void(0)" data-page-helpful-target="link" data-action="page-helpful#answer">Yes</a>
+        <a href="javascript:void(0)" data-page-helpful-target="link" data-action="page-helpful#answer">No</a>
     </div>
 </div>

--- a/app/views/sections/_page_question.html.erb
+++ b/app/views/sections/_page_question.html.erb
@@ -1,9 +1,0 @@
-<div class="page-question" data-controller="page-helpful">
-    <div>
-        <strong data-page-helpful-target="text">Is this page helpful?</strong>
-    </div>
-    <div>
-        <a href="javascript:void(0)" data-page-helpful-target="link" data-action="page-helpful#answer">Yes</a>
-        <a href="javascript:void(0)" data-page-helpful-target="link" data-action="page-helpful#answer">No</a>
-    </div>
-</div>

--- a/app/webpacker/controllers/page_helpful_controller.js
+++ b/app/webpacker/controllers/page_helpful_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ['text', 'link']
 
   connect() {
-    this.element.style.display = 'block';
+    this.element.classList.add('visible');
   }
 
   answer() {
@@ -18,6 +18,6 @@ export default class extends Controller {
   }
 
   hideLinks() {
-    this.linkTargets.forEach((target) => target.style.display = 'none');
+    this.linkTargets.forEach((target) => target.classList.add('hidden'));
   }
 }

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -4,6 +4,10 @@
         margin: 1em 0 5px 0
     }
 
+    .page-helpful {
+        margin: 0 -20px 20px -20px;
+    }
+
     &__date {
       font-size: 1.4em;
     }

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -13,7 +13,7 @@
 @import 'footer';
 @import 'dialog';
 @import 'feedback-bar';
-@import 'page-question';
+@import 'page_helpful';
 @import 'call_to_action';
 @import 'accordion';
 

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -36,6 +36,10 @@
     .feature-table {
       @include overhang;
     }
+
+    .page-question {
+      @include overhang;
+    }
   }
 
   h2:not(:first-of-type) {

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -37,7 +37,7 @@
       @include overhang;
     }
 
-    .page-question {
+    .page-helpful {
       @include overhang;
     }
   }

--- a/app/webpacker/styles/page-question.scss
+++ b/app/webpacker/styles/page-question.scss
@@ -1,40 +1,31 @@
-.page-question-wrapper {
-    display: block;
-    margin: 2em auto 4em;
-    max-width: 1000px;
-}
-
 .page-question {
-    width: 66.6666%;
     padding: 20px;
     background: $grey;
-    display: flex;
+    display: none;
+    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     box-sizing: border-box;
+
+    &.visible {
+        display: flex;
+    }
+
     a {
         color: $blue-dark;
         font-weight: bold;
         display: inline-block;
+
         &:last-child {
             margin-left: 20px;
         }
+        
         &:hover {
             text-decoration: none;
         }
-    }
-}
-@include mq($until: desktop) {
-    .page-question-wrapper {
-        padding: 20px 20px 50px;
-    }
-}
 
-@include mq($until: tablet) {
-    .page-question-wrapper {
-        padding: 20px 0px 50px;
-    }
-    .page-question {
-        width: 100%;
+        &.hidden {
+            display: none;
+        }
     }
 }

--- a/app/webpacker/styles/page_helpful.scss
+++ b/app/webpacker/styles/page_helpful.scss
@@ -1,11 +1,12 @@
-.page-question {
+.page-helpful {
     padding: 20px;
+    margin: 2em 0 0 0;
     background: $grey;
     display: none;
+    font-size: 19px;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    box-sizing: border-box;
 
     &.visible {
         display: flex;

--- a/spec/javascript/controllers/page_helpful_controller_spec.js
+++ b/spec/javascript/controllers/page_helpful_controller_spec.js
@@ -16,14 +16,14 @@ describe('PageHelpfulController', () => {
   describe("on connect", () => {
     it("displays the page helpful HTML", () => {
       const pageHelpful = document.getElementById("pageHelpful");
-      expect(pageHelpful.style.display).toContain('block');
+      expect(pageHelpful.classList).toContain('visible');
     });
   });
 
   describe("submitting an answer", () => {
     it("hides the links", () => {
       answerButton.click();
-      expect(answerButton.style.display).toContain('none');
+      expect(answerButton.classList).toContain('hidden');
     });
 
     it("displays a thank you message", () => {

--- a/spec/views/sections/_page_helpful.html.erb_spec.rb
+++ b/spec/views/sections/_page_helpful.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-describe "sections/_page_question.html.erb", type: :view do
-  before { render partial: "sections/page_question" }
+describe "sections/_page_helpful.html.erb", type: :view do
+  before { render partial: "sections/page_helpful" }
   subject { rendered }
 
   # Targetted by GTM event.


### PR DESCRIPTION
### Trello card

[Trello-739](https://trello.com/c/LiFR6iZk/739-clean-up-page-question-css)

### Context

The "Is this page helpful?" section that appears at the bottom of most pages is showing a bit misaligned. In addition the CSS could be simplified and the component itself renamed to be clearer.

The `page_question__answer` class needs to remain as-is given GTM targets this.

### Changes proposed in this pull request

- Clean up page_helpful component
- Rename page_question to page_helpful

### Guidance to review

I've manually tested this in each of the different layouts its used in.

| Before      | After       |
| ----------- | ----------- |
| <img width="852" alt="Screenshot 2021-01-19 at 15 28 59" src="https://user-images.githubusercontent.com/29867726/105055640-2ee9b200-5a6b-11eb-8b50-8e94a48d21e3.png">      |    <img width="757" alt="Screenshot 2021-01-19 at 15 28 48" src="https://user-images.githubusercontent.com/29867726/105055608-27c2a400-5a6b-11eb-8c02-bea20d085f8f.png">   |