### PR TITLE
Fix hero max-width

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -13,7 +13,7 @@ body {
 }
 
 main,
-main > header {
+.hero {
     @extend %content-width-limiter-shared;
 }
 


### PR DESCRIPTION
### Trello card

### Context
Currently, the home page hero sits inside the `<main>` section, so is subject to it's max-width; the hero on the other pages sits above `<main>` so is not. 

### Changes proposed in this pull request

### Guidance to review
Will this work as a quick fix until the home page is updated?
