### PR TITLE
Fix max-width on main element

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,5 +1,5 @@
 %content-width-limiter-shared {
-    max-width: wide;
+    max-width: 2000px;
     margin: auto;
 }
 


### PR DESCRIPTION
On refactoring the media queries I changed this to be the value of the 'wide' breakpoint, but the variable is not being set correctly and remains as `max-width: wide`. Changing back to be the value explicitly.