### PR TITLE
Updated GroupedCards component to link title if links supplied

### DIFF
--- a/app/components/grouped_cards/card_component.html.erb
+++ b/app/components/grouped_cards/card_component.html.erb
@@ -1,9 +1,7 @@
-<div class="events-featured__list__item">
+<div class="events-featured__list__item grouped-cards">
   <div class="event-box">
-    <div class="event-box__header">
-      <h4>
-        <%= header %>
-      </h4>
+    <div class="event-box__header grouped-cards__header">
+      <%= linked_header %>
     </div>
 
     <hr class="event-box__divider event-box__divider--online-event" />
@@ -11,12 +9,12 @@
     <div class="event-box__datetime">
       <p>
       <% for field, value in fields %>
-        <div>
+        <div class="grouped-cards__fields">
           <span><%= field.humanize %>:</span>
           <span><%= linked_value(value) %></span>
         </div>
       <% end %>
-      <p>
+      </p>
     </div>
   </div>
 </div>

--- a/app/components/grouped_cards/card_component.rb
+++ b/app/components/grouped_cards/card_component.rb
@@ -10,12 +10,24 @@ module GroupedCards
       @data["header"]
     end
 
+    def linked_header
+      if link
+        link_to tag.h4(header), link
+      else
+        tag.h4 header
+      end
+    end
+
     def fields
-      @data.without("header")
+      @data.without("header", "link")
     end
 
     def linked_value(value)
       Rinku.auto_link(h(value)).html_safe
+    end
+
+    def link
+      @data["link"]
     end
   end
 end

--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -1,22 +1,22 @@
 <ul>
-  <% for region in regions %>
+  <% for group in groups %>
   <li>
-    <%= link_to region, "##{group_link_anchor(region)}" %>
+    <%= link_to group, "##{group_link_anchor(group)}" %>
   </li>
   <% end %>
 </ul>
 
-<% for region in regions %>
-<div class="events-featured" id="<%= group_link_anchor(region) %>">
+<% for group in groups %>
+<div class="events-featured" id="<%= group_link_anchor(group) %>">
   <div class="events-featured__heading">
     <h3>
-      <%= region %>
+      <%= group %>
     </h3>
   </div>
 
   <div class="events-featured__list">
-  <% for provider in providers(region) %>
-    <%= render GroupedCards::CardComponent.new provider %>
+  <% for item in items(group) %>
+    <%= render GroupedCards::CardComponent.new item %>
   <% end %>
   </div>
 </div>

--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -4,7 +4,7 @@ module GroupedCards
       @data = data
     end
 
-    def regions
+    def groups
       @data.keys
     end
 
@@ -12,8 +12,8 @@ module GroupedCards
       "group--" + group.parameterize
     end
 
-    def providers(region)
-      @data[region]
+    def items(group)
+      @data[group]
     end
   end
 end

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -1,0 +1,14 @@
+.grouped-cards {
+  &__header a[href*="//"] {
+    display: block;
+
+    &::after {
+      display: none;
+      content: "";
+    }
+  }
+
+  .grouped-cards__fields + .grouped-cards__fields {
+    margin-top: 0.5em ;
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -32,6 +32,7 @@
 @import './components/type-description';
 @import './components/events/no-results';
 @import './components/turbolinks-progress-bar';
+@import './components/grouped-cards';
 
 @import 'home';
 @import 'event';

--- a/spec/components/grouped_cards/card_component_spec.rb
+++ b/spec/components/grouped_cards/card_component_spec.rb
@@ -17,4 +17,21 @@ describe GroupedCards::CardComponent, type: "component" do
   it { is_expected.to have_css ".event-box__datetime span", text: "Name" }
   it { is_expected.to have_css ".event-box__datetime span", text: "Joe Bloggs" }
   it { is_expected.to have_link "joe.bloggs@first.org", href: "mailto:joe.bloggs@first.org" }
+
+  it { is_expected.not_to have_css "a h4" }
+
+  context "with link" do
+    let(:organisation) do
+      {
+        header: "First organisation",
+        link: "https://education.gov.uk",
+        name: "Joe Bloggs",
+        email: "joe.bloggs@first.org",
+      }.with_indifferent_access
+    end
+
+    it { is_expected.to have_link href: "https://education.gov.uk" }
+    it { is_expected.to have_css "a h4", text: "First organisation" }
+    it { is_expected.to have_link "joe.bloggs@first.org", href: "mailto:joe.bloggs@first.org" }
+  end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/xa8Eotqv

### Context

Headers in the cards should link to the appropriate websites

### Changes proposed in this pull request

1. Tweaked generation of cards - h4's are now linked where appropriate - the links are round the entire headers to increase the tap target on mobile.
2. Removed references to regions from the now generalised grouped-cards component.

