### PR TITLE
Fix left column taking up full width by default

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -77,6 +77,8 @@ main.semantic {
   }
 
   > article {
+    flex: 0 1 65%;
+
     &.fullwidth {
       flex: 1 0 100%;
     }


### PR DESCRIPTION
The flex weight of the article element was removed in a recent PR, I'm not sure if it was intentional or an accident but it looks like it then defaults to `flex: 1` and takes up all the width. This commit re-instates it, keeping the `fullwidth` class.

| Before      | After |
| ----------- | ----------- |
| <img width="1244" alt="Screenshot 2021-01-20 at 19 55 56" src="https://user-images.githubusercontent.com/29867726/105227785-9ed66600-5b59-11eb-8026-0a9024de68a3.png">        |   <img width="1314" alt="Screenshot 2021-01-20 at 19 55 50" src="https://user-images.githubusercontent.com/29867726/105227820-aac22800-5b59-11eb-920d-bf9d3ce5582e.png">  |