### PR TITLE
Update links to point at current landing page

### DIFF
--- a/app/components/cards/chat_online_component.html.erb
+++ b/app/components/cards/chat_online_component.html.erb
@@ -3,7 +3,7 @@
     <%= truncated_header %>
   </header>
 
-  <a href="/helping-you-become-a-teacher" data-controller="talk-to-us" data-action="talk-to-us#startChat" class="card__thumb">
+  <a href="/three-things-to-help-you-get-into-teaching" data-controller="talk-to-us" data-action="talk-to-us#startChat" class="card__thumb">
     <%= thumbnail_image_tag %>
   </a>
 
@@ -16,7 +16,7 @@
       <%= link_text %> <%= helpers.fas_icon("chevron-right") %>
     </a>
 
-    <a href="/helping-you-become-a-teacher" class="git-link no-js-fallback">
+    <a href="/three-things-to-help-you-get-into-teaching" class="git-link no-js-fallback">
       Chat to us <%= helpers.fas_icon("chevron-right") %>
     </a>
   </footer>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -30,7 +30,7 @@
           <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
         <% end %>
         <%= link_to "Find an event near you", events_path %>
-        <%= link_to("Helping you become a teacher", page_path(page: "helping-you-become-a-teacher")) %>
+        <%= link_to("Helping you become a teacher", page_path(page: "three-things-to-help-you-get-into-teaching")) %>
         <%= link_to("COVID-19", page_path(page: "covid-19")) %>
       </div>
     </div>


### PR DESCRIPTION
The 'helping you become a teacher' one was renamed to 'three things to help you get into teaching'.

