### PR TITLE
Custom campaign landing page hero

### DIFF
--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -8,6 +8,12 @@
       <%= tag.div(subtitle) %>
     </div>
   <% end %>
+
+  <% if content.present? %>
+    <div class="hero__content">
+      <%= content %>
+    </div>
+  <% end %>
 <% end %>
 
 <% if show_mailing_list %>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,7 @@ class PagesController < ApplicationController
     "layouts/stories/landing",
     "layouts/stories/list",
     "layouts/stories/story",
+    "layouts/campaigns/landing_page_with_hero_nav",
   ].freeze
 
   def privacy_policy

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+    <%= render "sections/head" %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
+    </div>
+
+    <%= render "sections/header" %>
+    <%= render Sections::HeroComponent.new(@front_matter) do %>
+      <% if @front_matter["hero_nav"].any? %>
+        <ol>
+          <% @front_matter["hero_nav"].each do |section, href| %>
+          <li><%= link_to(section, href) %></li>
+          <% end %>
+        </ol>
+      <% end %>
+    <% end %>
+
+    <main class="semantic" role="main" id="main-content">
+      <article class="markdown overhang">
+        <%= yield %>
+      </article>
+    </main>
+
+    <%= render "sections/footer" %>
+    <%= render "components/videoplayer" %>
+    <%= render "sections/cookie-acceptance" %>
+    <%= render "sections/feedback-bar" %>
+    <%= render "components/analytics" %>
+  <% end %>
+</html>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -12,7 +12,7 @@
     <%= render "sections/header" %>
     <%= render Sections::HeroComponent.new(@front_matter) do %>
       <% if @front_matter["hero_nav"].any? %>
-        <ol>
+        <ol class="hero-nav">
           <% @front_matter["hero_nav"].each do |section, href| %>
           <li><%= link_to(section, href) %></li>
           <% end %>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -12,7 +12,7 @@
     <%= render "sections/header" %>
     <%= render Sections::HeroComponent.new(@front_matter) do %>
       <% if @front_matter["hero_nav"].any? %>
-        <ol class="hero-nav">
+        <ol class="hero__nav">
           <% @front_matter["hero_nav"].each do |section, href| %>
           <li><%= link_to(section, href) %></li>
           <% end %>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -21,9 +21,11 @@
     <% end %>
 
     <main class="semantic" role="main" id="main-content">
-      <article class="markdown hero-nav">
-        <%= yield %>
-      </article>
+      <section class="container">
+        <article class="markdown hero-nav">
+          <%= yield %>
+        </article>
+      </section>
     </main>
 
     <%= render "sections/footer" %>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -21,7 +21,7 @@
     <% end %>
 
     <main class="semantic" role="main" id="main-content">
-      <article class="markdown overhang">
+      <article class="markdown hero-nav">
         <%= yield %>
       </article>
     </main>

--- a/app/webpacker/styles/breakpoints.scss
+++ b/app/webpacker/styles/breakpoints.scss
@@ -3,7 +3,7 @@ $mq-breakpoints: (
   mobile: 500px,
   tablet: 800px,
   desktop: 1200px,
-  wide: 2000px,
+  wide: 1500px,
 );
 $mq-static-breakpoint: desktop;
 

--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -11,12 +11,11 @@
     display: flex;
     align-items: center;
 
-
-    span.pink-rotated-number {
-      background-color: $pink;
+    .pink-rotated-number {
+      background-color: $pink-dark;
       @include rotated-block;
-      color: white;
-      padding: .8em;
+      color: $white;
+      padding: .5em .8em;
       font-weight: bold;
       margin-right: 1em;
     }

--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -28,7 +28,6 @@
       &:after {
         content: "";
       }
-      // background-color: red;
     }
   }
 }

--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -1,0 +1,35 @@
+// styles headings like the fancy links placed in
+// the hero, used on campaign landing pages
+.markdown.hero-nav {
+
+  p + .numbered-heading {
+    margin-top: 4em;
+  }
+
+  .numbered-heading {
+    margin-top: 2em;
+    display: flex;
+    align-items: center;
+
+
+    span.pink-rotated-number {
+      background-color: $pink;
+      @include rotated-block;
+      color: white;
+      padding: .8em;
+      font-weight: bold;
+      margin-right: 1em;
+    }
+
+    h2 {
+      margin: 0;
+      background: none;
+      color: $black;
+
+      &:after {
+        content: "";
+      }
+      // background-color: red;
+    }
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -34,6 +34,8 @@
 @import './components/events/no-results';
 @import './components/turbolinks-progress-bar';
 
+@import './campaigns/numbered-headings';
+
 @import 'home';
 @import 'event';
 @import 'events';

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -18,6 +18,7 @@
 @import 'accordion';
 
 @import './sections/hero';
+@import './sections/hero/content';
 @import './sections/talk-to-us';
 
 @import './components/mixins/cards-grid';

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -72,7 +72,7 @@ $mobile-cutoff: 800px;
     }
 
     &__subtitle,
-    &__content { grid-area: 4 / 1 / 5 / 4; }
+    &__content { grid-area: 4 / 1 / 5 / 5; }
 
     &__subtitle {
       align-items: center;
@@ -92,13 +92,14 @@ $mobile-cutoff: 800px;
       grid-template-columns: repeat(8, minmax(100px, 1fr));
       grid-template-rows: 2em repeat(5, minmax(5px, max-content)) 2em;
 
-      &__title { grid-area: 3 / 1 / 5 / 5; }
+      &__title { grid-area: 3 / 1 / 5 / 6; }
 
-      &__subtitle,
-      &__content { grid-area: 5 / 1 / 7 / 4; }
+      &__subtitle { grid-area: 5 / 1 / 7 / 4; }
+
+      &__content { grid-area: 5 / 2 / 7 / 5; }
 
       &__img {
-        grid-area: 2 / 4 / 8 / 9;
+        grid-area: 2 / 5 / 8 / 9;
       }
     }
   }
@@ -155,9 +156,6 @@ $mobile-cutoff: 800px;
     }
   }
 
-  &__content {
-    background-color: lightblue;
-  }
 
   &__img {
     height: 100%;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -96,12 +96,17 @@ $mobile-cutoff: 800px;
 
       &__subtitle { grid-area: 5 / 1 / 7 / 4; }
 
-      &__content { grid-area: 5 / 2 / 7 / 5; }
+      &__content { grid-area: 5 / 1 / 7 / 5; }
 
       &__img {
         grid-area: 2 / 5 / 8 / 9;
       }
     }
+
+    @include mq($from: wide) {
+      &__content { grid-area: 5 / 2 / 7 / 5; }
+    }
+
   }
 }
 

--- a/app/webpacker/styles/sections/hero/content.scss
+++ b/app/webpacker/styles/sections/hero/content.scss
@@ -1,0 +1,47 @@
+// campaign-specific hero styles
+.hero {
+  &__content {
+    ol {
+      font-weight: bold;
+      counter-reset: item;
+      list-style-type: none;
+      padding-left: 0;
+
+      li {
+        counter-increment: item;
+        display: flex;
+        align-items: center;
+
+        &:before {
+          content: counter(item);
+          flex: 0 0 1.5em;
+          @include rotated-block;
+          background-color: $pink-dark;
+          text-align: center;
+          color: $white;
+          padding: .4em;
+          margin: 1em;
+        }
+
+        &:after {
+          flex-shrink: 0;
+          flex-basis: 2em;
+          height: 2em;
+          min-width: 4em;
+          content: "   ";
+          background-image: url('../images/icon-down.svg');
+          background-repeat: no-repeat;
+          background-position: center;
+        }
+
+        a {
+          color: $black;
+          text-decoration: none;
+          flex-shrink: 1;
+          flex-grow: 1;
+          max-width: 30em;
+        }
+      }
+    }
+  }
+}

--- a/app/webpacker/styles/sections/hero/content.scss
+++ b/app/webpacker/styles/sections/hero/content.scss
@@ -1,7 +1,7 @@
 // campaign-specific hero styles
 .hero {
   &__content {
-    ol {
+    .hero-nav {
       font-weight: bold;
       counter-reset: item;
       list-style-type: none;

--- a/app/webpacker/styles/sections/hero/content.scss
+++ b/app/webpacker/styles/sections/hero/content.scss
@@ -1,7 +1,7 @@
 // campaign-specific hero styles
 .hero {
   &__content {
-    .hero-nav {
+    .hero__nav {
       font-weight: bold;
       counter-reset: item;
       list-style-type: none;
@@ -40,6 +40,10 @@
           flex-shrink: 1;
           flex-grow: 1;
           max-width: 30em;
+
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
     }

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -67,5 +67,20 @@ describe Sections::HeroComponent, type: "component" do
         end
       end
     end
+
+    describe "rendering block content" do
+      let(:sample) { "some content" }
+      let(:component) do
+        described_class.new(front_matter)
+      end
+
+      subject! do
+        render_inline(component) { sample }
+      end
+
+      specify "the block content should be rendered by the component" do
+        expect(page).to have_css(".hero__content", text: sample)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/TKmHrvze/696-development-mock-up-potential-modifications-to-the-campaign-landing-page-based-on-heat-maps-eg-upfront-info-and-ctas-for-mobile

### Context

The design for the campaign pages calls for a list of navigation links under the hero title and for headings to be styled with a numeric prefix in the pink slanted style.

### Changes proposed in this pull request

Add the functionality and styling to support the above.

![Screenshot from 2021-01-21 16-30-27](https://user-images.githubusercontent.com/128088/105381080-883a1880-5c06-11eb-9d46-1f715ad45ce9.png)

![Screenshot from 2021-01-21 16-30-20](https://user-images.githubusercontent.com/128088/105381098-8bcd9f80-5c06-11eb-8c4f-330eb193bc18.png)


https://user-images.githubusercontent.com/128088/105381218-ae5fb880-5c06-11eb-9344-b02a0f648cde.mp4




### Guidance to review

Does it look ok? There's a corresponding branch to test with in the content repo

