### PR TITLE
Make hero nav links encapsulate arrows

### DIFF
--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -14,7 +14,7 @@
       <% if @front_matter["hero_nav"].any? %>
         <ol class="hero__nav">
           <% @front_matter["hero_nav"].each do |section, href| %>
-          <li><%= link_to(section, href) %></li>
+          <li><%= link_to(tag.span(section), href) %></li>
           <% end %>
         </ol>
       <% end %>

--- a/app/webpacker/styles/sections/hero/content.scss
+++ b/app/webpacker/styles/sections/hero/content.scss
@@ -23,26 +23,29 @@
           margin: 1em;
         }
 
-        &:after {
-          flex-shrink: 0;
-          flex-basis: 2em;
-          height: 2em;
-          min-width: 4em;
-          content: "   ";
-          background-image: url('../images/icon-down.svg');
-          background-repeat: no-repeat;
-          background-position: center;
-        }
-
         a {
+          display: flex;
+          flex-grow: 1;
           color: $black;
           text-decoration: none;
-          flex-shrink: 1;
-          flex-grow: 1;
-          max-width: 30em;
 
           &:hover {
             text-decoration: underline;
+          }
+
+          span {
+            flex-grow: 1;
+          }
+
+          &:after {
+            flex-basis: 2em;
+            align-self: center;
+            height: 2em;
+            min-width: 4em;
+            content: "   ";
+            background-image: url('../images/icon-down.svg');
+            background-repeat: no-repeat;
+            background-position: center;
           }
         }
       }


### PR DESCRIPTION
Minor CSS tweak to make the link include the down-pointing arrows.

This should make the link targets bigger and more intuitive for mobile users.

![Screenshot from 2021-01-22 13-57-39](https://user-images.githubusercontent.com/128088/105499810-e5db6d00-5cb9-11eb-9e0d-d577f0f69207.png)
