### PR TITLE
Whitelist usage of home_old layout

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,7 @@ class PagesController < ApplicationController
 
   PAGE_LAYOUTS = [
     "layouts/home",
+    "layouts/home_old",
     "layouts/accordion",
     "layouts/stories/landing",
     "layouts/stories/list",


### PR DESCRIPTION
This layout was added in an earlier PR so that we can transition the home page to a new semantic layout, but I forgot to whitelist it (its not being used yet).