### PR TITLE
Transition home page to semantic layout

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -1,8 +1,8 @@
-<div class="pagewidth-bg pagewidth-bg--grey pagewidth-bg--with-title">
+<div class="colored-stripe colored-stripe--grey colored-stripe--with-title">
   <section class="container">
     <article class="markdown overhang fullwidth">
-      <h2 id="searchforevents" class="pagewidth-bg__title purple"><%= heading %></h2>
-      <div class="pagewidth-bg__content search-for-events">
+      <h2 id="searchforevents" class="colored-stripe__title purple"><%= heading %></h2>
+      <div class="colored-stripe__content search-for-events">
         <div class="search-for-events__content">
           <%= form_for search, method: :get, url: path do |f| %>
             <div class="search-for-events__content__inputs"

--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -1,53 +1,53 @@
-<section class="search-for-events">
+<div class="pagewidth-bg pagewidth-bg--grey pagewidth-bg--with-title">
   <section class="container">
-    <div class="search-for-events__wrapper">
-      <h2 id="searchforevents" class="strapline search-for-events__header"><%= heading %></h2>
+    <article class="markdown overhang fullwidth">
+      <h2 id="searchforevents" class="pagewidth-bg__title purple"><%= heading %></h2>
+      <div class="pagewidth-bg__content search-for-events">
+        <div class="search-for-events__content">
+          <%= form_for search, method: :get, url: path do |f| %>
+            <div class="search-for-events__content__inputs"
+                  data-controller="conditional-field"
+                  data-conditional-field-mode="hide"
+                  data-conditional-field-expected="">
 
-      <div class="search-for-events__content">
-        <%= form_for search, method: :get, url: path do |f| %>
-
-          <div class="search-for-events__content__inputs"
-                data-controller="conditional-field"
-                data-conditional-field-mode="hide"
-                data-conditional-field-expected="">
-
-            <% if include_type %>
-              <%= tag.div(class: input_field_classes(:type)) do %>
-                  <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
-                  <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
+              <% if include_type %>
+                <%= tag.div(class: input_field_classes(:type)) do %>
+                    <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
+                    <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
+                <% end %>
               <% end %>
-            <% end %>
 
-            <%= tag.div(class: input_field_classes(:distance)) do %>
-                <%= f.label :distance, "Location", class: "search-for-events__content__input__label" %>
-                <%= f.select :distance, search.class.available_distances, {},
-                      data: { action: "conditional-field#toggle", "conditional-field-target": "source" } %>
-            <% end %>
+              <%= tag.div(class: input_field_classes(:distance)) do %>
+                  <%= f.label :distance, "Location", class: "search-for-events__content__input__label" %>
+                  <%= f.select :distance, search.class.available_distances, {},
+                        data: { action: "conditional-field#toggle", "conditional-field-target": "source" } %>
+              <% end %>
 
-            <%= tag.div(class: input_field_classes(:postcode), data: { "conditional-field-target": "showhide" }) do %>
-              <%= f.label :postcode, "Postcode", class: "search-for-events__content__input__label" %>
-              <%= f.text_field :postcode %>
-            <% end %>
+              <%= tag.div(class: input_field_classes(:postcode), data: { "conditional-field-target": "showhide" }) do %>
+                <%= f.label :postcode, "Postcode", class: "search-for-events__content__input__label" %>
+                <%= f.text_field :postcode %>
+              <% end %>
 
-            <%= tag.div(class: input_field_classes(:month)) do %>
-                <%= f.label :month, "Month", class: "search-for-events__content__input__label" %>
-                <%= f.select :month, search.available_months, **month_args %>
-            <% end %>
-          </div>
-
-          <% if error_messages.any? %>
-            <div class="search-for-events__content__errors">
-              <% error_messages.each do |error_message| %>
-                <%= tag.div(error_message) %>
+              <%= tag.div(class: input_field_classes(:month)) do %>
+                  <%= f.label :month, "Month", class: "search-for-events__content__input__label" %>
+                  <%= f.select :month, search.available_months, **month_args %>
               <% end %>
             </div>
-          <% end %>
 
-          <div class="search-for-events__content__update">
-            <button class="request-button">Update results <%= helpers.fas_icon "sync" %></button>
-          </div>
-        <% end %>
+            <% if error_messages.any? %>
+              <div class="search-for-events__content__errors">
+                <% error_messages.each do |error_message| %>
+                  <%= tag.div(error_message) %>
+                <% end %>
+              </div>
+            <% end %>
+
+            <div class="search-for-events__content__update">
+              <button class="request-button">Update results <%= helpers.fas_icon "sync" %></button>
+            </div>
+          <% end %>
+        </div>
       </div>
-    </div>
+    </article>
   </section>
-</section>
+</div>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -1,33 +1,33 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
-    <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
-        <div id="skiplink-container">
-            <div>
-                <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
-            </div>
-        </div>
-        <%= render "sections/header" %>
-        <%= render Sections::HeroComponent.new(@front_matter) %>
-        <main role="main" id="main-content">
-            <section class="content content--<%= @front_matter["direction"] %> <%= @front_matter["fullwidth"] ? "" : "container-1000" %>">
-                <%= yield %>
-                <% @front_matter["content"]&.each do |partial| %>
-                    <%= render(partial) %>
-                <% end %>
-                <% unless @front_matter["hide_page_helpful_question"] %>
-                    <div class="container-1000">
-                        <%= render "sections/page_helpful" %>
-                    </div>
-                <% end %>
-            </section>
-        </main>
+  <%= render "sections/head" %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <div id="skiplink-container">
+      <div>
+        <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
+    </div>
 
-        <%= render "sections/footer" %>
-        <%= render "components/videoplayer" %>
-        <%= render "sections/cookie-acceptance" %>
-        <%= render "sections/feedback-bar" %>
-        <%= render "components/analytics" %>
-    <% end %>
+    <%= render "sections/header" %>
+
+    <%= render Sections::HeroComponent.new(@front_matter) %>
+
+    <main class="semantic" role="main" id="main-content">
+      <section class="container">
+        <article class="markdown overhang fullwidth">
+          <%= yield %>
+        </article>
+      </section>
+
+      <% @front_matter["content"]&.each do |partial| %>
+        <%= render(partial) %>
+      <% end %>
+    </main>
+
+    <%= render "sections/footer" %>
+    <%= render "components/videoplayer" %>
+    <%= render "sections/cookie-acceptance" %>
+    <%= render "sections/feedback-bar" %>
+    <%= render "components/analytics" %>
+  <% end %>
 </html>
-

--- a/app/webpacker/styles/components/colored-stripe.scss
+++ b/app/webpacker/styles/components/colored-stripe.scss
@@ -1,4 +1,4 @@
-.pagewidth-bg {
+.colored-stripe {
   margin: 3em 0;
   position: relative;
 
@@ -15,7 +15,7 @@
   }
 
   &--with-title {
-    .pagewidth-bg__content {
+    .colored-stripe__content {
       margin-top: -1em;
       padding-top: 0;
     }

--- a/app/webpacker/styles/components/pagewidth-bg.scss
+++ b/app/webpacker/styles/components/pagewidth-bg.scss
@@ -1,0 +1,27 @@
+.pagewidth-bg {
+  margin: 3em 0;
+  position: relative;
+
+  &--grey {
+    background-color: $grey;
+  }
+
+  &--yellow {
+    background-color: $yellow;
+  }
+
+  &__content {
+    padding: 3em 0;
+  }
+
+  &--with-title {
+    .pagewidth-bg__content {
+      margin-top: -1em;
+      padding-top: 0;
+    }
+  }
+
+  &__title {
+    transform: translate(0, -50%);
+  }
+}

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -21,28 +21,16 @@
   margin: 70px 0 50px 0;
 }
 
+.search-for-events-heading {
+  background-color: $purple;
+}
+
 .search-for-events {
     text-align: left;
-    background-color: $grey;
-    padding-bottom: 60px;
-    margin-bottom: 50px;
-    margin-top: 3em;
-
-    &__wrapper {
-      width: 100%;
-    }
-
-    &__header {
-        background-color: $pink;
-        position: relative;
-        top: -60px;
-    }
 
     &__content {
-        margin-top: -50px;
-        padding-left: 20px;
-        padding-right: 20px;
         font-size: 19px;
+        padding-top: 2em;
 
         &__inputs {
             display: flex;

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -30,6 +30,7 @@
 @import './components/content-alert';
 @import './components/feature-table';
 @import './components/link-block';
+@import './components/pagewidth-bg';
 @import './components/type-description';
 @import './components/events/no-results';
 @import './components/turbolinks-progress-bar';

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -30,7 +30,7 @@
 @import './components/content-alert';
 @import './components/feature-table';
 @import './components/link-block';
-@import './components/pagewidth-bg';
+@import './components/colored-stripe';
 @import './components/type-description';
 @import './components/events/no-results';
 @import './components/turbolinks-progress-bar';

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -67,7 +67,7 @@
 }
 .cta-links {
     display: flex;
-    margin-bottom: 70px;
+    margin-bottom: 30px;
 }
 
 .cta-link {
@@ -270,6 +270,33 @@
   margin-top: 45px;
 }
 
+.home-quote-img,
+.home-find-event-img {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background-size: cover;
+  // Width calculated to be a third of the content column plus half of the viewport
+  left: calc( ((1000px / 3) * 2) + ((100vw - 934px) / 2));
+  width: calc((1000px / 3) + ((100vw - 1066px) / 2));
+  max-width: 720px;
+  background-position: 50% 15%;
+
+  @include mq($from: wide) {
+    left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
+  }
+
+  @include mq($until: tablet) {
+    position: static;
+    width: 100%;
+    height: 300px;
+  }
+}
+
+.home-find-event-img {
+  background-image: url('../images/home-events.jpg');
+}
+
 .home-find-event {
     background-color: $grey;
     position: relative;
@@ -332,7 +359,6 @@
 .home-inset-content {
     margin: 0 20px;
 }
-
 .home-quote {
     background: $yellow;
     position: relative;

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -27,6 +27,10 @@
       &:after {
         content: ".";
       }
+
+      &.purple {
+        background-color: $purple;
+      }
     }
 
     .call-to-action,
@@ -34,6 +38,7 @@
     .secondary-button,
     .types-of-event,
     .content-cta,
+    .featured-content,
     .event-pagination,
     .page-helpful {
       @include overhang;
@@ -56,7 +61,9 @@
   }
 
   // stop the external icon from appearing inside CTA 'button' style links
-  .call-to-action__action {
+  // and the home page featured content video thumbnail links
+  .call-to-action__action,
+  .featured-content__item {
     a {
       &[href*="//"] {
         &::after {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -132,7 +132,7 @@ a {
     text-decoration: none;
 }
 
-@include mq($until: tablet) {    
+@include mq($until: tablet) {
     .strapline {
         font-size: 24px;
         padding-top: 10px;


### PR DESCRIPTION
Enables the home page to migrate to a semantic layout, matching the other layouts by replacing `home` (leaving `home_old` as the old layout which is still in use for now).

Adds a new CSS component `pagewidth-bg` to display a page-wide grey/yellow background that is used on both the home page and search for events page (the event search page is updated in this PR).

A few additional CSS classes have been added so that the new changes can co-exist with the existing home page structure while this is rolled out. We should be able to clean a lot of it up when the old layout is removed.

Content PR to follow this with: https://github.com/DFE-Digital/get-into-teaching-content/pull/286

| Home Page (old layout still)      | Evens Page (search component updated) |
| ----------- | ----------- |
| ![screencapture-0-0-0-0-3000-2021-01-25-10_08_39](https://user-images.githubusercontent.com/29867726/105691634-6a65ff80-5ef5-11eb-8b53-eab2fdaa4b3e.png)   | ![screencapture-0-0-0-0-3000-events-2021-01-25-10_08_18](https://user-images.githubusercontent.com/29867726/105691748-89fd2800-5ef5-11eb-9bec-15ffeae7818b.png)       |




