### PR TITLE
Fix home quote styling between 1500-2000px

### DIFF
--- a/app/webpacker/styles/breakpoints.scss
+++ b/app/webpacker/styles/breakpoints.scss
@@ -6,6 +6,6 @@ $mq-breakpoints: (
   wide: 1500px,
 );
 $mq-static-breakpoint: desktop;
+$max-content-width: 2000px;
 
 @import 'sass-mq';
-

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -211,6 +211,24 @@
     &__citation {
         font-weight: bold;
     }
+
+    &__img {
+        position: absolute;
+        top: 0;
+        // Width calculated to be a third of the content column plus half of the viewport
+        left: calc( ((1000px / 3) * 2) + ((100vw - 934px) / 2));
+        width: calc((1000px / 3) + ((100vw - 1066px) / 2));
+        max-width: 720px;
+        height: 100%;
+        background-position: 50% 15%;
+        background-size: cover;
+    }
+
+    @include mq($from: wide) {
+        &__img {
+            left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
+        }
+    }
 }
 
 @include mq($until: tablet) {

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -141,6 +141,10 @@
   margin-top: 45px;
 }
 
+@function img-left($view-width) {
+    @return calc( ((1000px / 3) * 2) + ((#{$view-width} - 934px) / 2));
+}
+
 .home-quote-img,
 .home-find-event-img {
   position: absolute;
@@ -148,7 +152,7 @@
   height: 100%;
   background-size: cover;
   // Width calculated to be a third of the content column plus half of the viewport
-  left: calc( ((1000px / 3) * 2) + ((100vw - 934px) / 2));
+  left: img-left(100vw);
   width: calc((1000px / 3) + ((100vw - 1066px) / 2));
   max-width: 720px;
   background-position: 50% 15%;
@@ -157,6 +161,10 @@
     position: static;
     width: 100%;
     height: 300px;
+  }
+
+  @include mq($from: $max-content-width) {
+    left: img-left($max-content-width);
   }
 }
 
@@ -206,24 +214,6 @@
 
     &__citation {
         font-weight: bold;
-    }
-
-    &__img {
-        position: absolute;
-        top: 0;
-        // Width calculated to be a third of the content column plus half of the viewport
-        left: calc( ((1000px / 3) * 2) + ((100vw - 934px) / 2));
-        width: calc((1000px / 3) + ((100vw - 1066px) / 2));
-        max-width: 720px;
-        height: 100%;
-        background-position: 50% 15%;
-        background-size: cover;
-    }
-
-    @include mq($from: wide) {
-        &__img {
-            left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
-        }
     }
 }
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -153,10 +153,6 @@
   max-width: 720px;
   background-position: 50% 15%;
 
-  @include mq($from: wide) {
-    left: calc( ((1000px / 3) * 2) + ((2000px - 934px) / 2));
-  }
-
   @include mq($until: tablet) {
     position: static;
     width: 100%;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,5 +1,5 @@
 %content-width-limiter-shared {
-    max-width: 2000px;
+    max-width: $max-content-width;
     margin: auto;
 }
 


### PR DESCRIPTION
### Trello card
N/A

### Context
The styling of `home-quote` and `home-find-event` is making the rest of the content squashed between 1500-2000px

![image](https://user-images.githubusercontent.com/47089130/105714398-32ba8000-5f14-11eb-9b18-fd5a09a1f9fd.png)

### Changes proposed in this pull request
- Fix home quote styling between 1500-2000px
- Introduce constant for 2000px to remove confusion between `wide` and the max-width of the site.
- Remove media query that (I think) doesn't do anything

### Guidance to review

