### PR TITLE
Replace occurrences of .container-1000 class

### DIFF
--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <% if show_mailing_list %>
-  <div class="container-1000">
+  <section class="container">
     <div class="hero__mailing-strip">
         <div class="hero__mailing-strip__text">
             <p>Sign up to receive information via email that could help you make your decision to get into teaching.</p>
@@ -28,5 +28,5 @@
           <% end %>
         </div>
     </div>
-  </div>
+  </section>
 <% end %>

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -1,25 +1,21 @@
 <section class="event-reg-main">
-    <div class="content container-1000">
-        <div class="content__left">
-            <p>
-              <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
-            </p>
+  <p>
+    <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
+  </p>
 
-            <h1>Sign up for this event:</h1>
-            <h2><%= event.name %></h2>
+  <h1>Sign up for this event:</h1>
+  <h2><%= event.name %></h2>
 
-            <%= govuk_form_for current_step, url: step_path do |f| %>
-              <%= f.govuk_error_summary %>
+  <%= govuk_form_for current_step, url: step_path do |f| %>
+    <%= f.govuk_error_summary %>
 
-              <%= render current_step.key, current_step: current_step, f: f %>
+    <%= render current_step.key, current_step: current_step, f: f %>
 
-              <% if wizard.can_proceed? %>
-                <%= f.button class: "call-to-action-button" do %>
-                  <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
-                  <span></span>
-                <% end %>
-              <% end %>
-            <% end %>
-        </div>
-    </div>
+    <% if wizard.can_proceed? %>
+      <%= f.button class: "call-to-action-button" do %>
+        <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
+        <span></span>
+      <% end %>
+    <% end %>
+  <% end %>
 </section>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -1,42 +1,35 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <section class="event-reg-main" role="main" id="main-content">
-    <div class="content container-1000">
-        <div class="content__left">
-            <h1 class="strapline">Sign up complete</h1>
-            <br/><br/>
-            <h3>You are signed up for the following event:</h3>
+  <h1 class="strapline">Sign up complete</h1>
+  <br/><br/>
+  <h3>You are signed up for the following event:</h3>
 
-            <b><%= @event.name %></b>
-            <p><%= format_event_date @event, stacked: false %></p>
+  <b><%= @event.name %></b>
+  <p><%= format_event_date @event, stacked: false %></p>
 
-            <%- if params[:subscribed].to_s == "1" -%>
-            <h3>You've also signed up for email updates</h3>
-            <p>
-                You're ready to receive email updates to help you get
-                into teaching.
-            </p>
-            <%- end -%>
+  <%- if params[:subscribed].to_s == "1" -%>
+  <h3>You've also signed up for email updates</h3>
+  <p>
+      You're ready to receive email updates to help you get
+      into teaching.
+  </p>
+  <%- end -%>
 
-            <h2>What happens next?</h2>
-            <p>
-                You will receive a confirmation email with details of the event. If there is an issue with the event we will contact you via phone.
-            </p>
+  <h3>What happens next?</h3>
+  <p>
+      You will receive a confirmation email with details of the event. If there is an issue with the event we will contact you via phone.
+  </p>
 
-            <span data-controller="pinterest"
-                data-pinterest-action="track"
-                data-pinterest-event="custom"></span>
+  <span data-controller="pinterest"
+      data-pinterest-action="track"
+      data-pinterest-event="custom"></span>
 
-            <span data-controller="snapchat"
-                data-pinterest-action="track"
-                data-pinterest-event="INVITE"></span>
+  <span data-controller="snapchat"
+      data-pinterest-action="track"
+      data-pinterest-event="INVITE"></span>
 
-            <span data-controller="facebook"
-                data-pinterest-action="track"
-                data-pinterest-event="Event_Registrations"></span>
-        </div>
-        <div class="content__right">
-
-        </div>
-    </div>
+  <span data-controller="facebook"
+      data-pinterest-action="track"
+      data-pinterest-event="Event_Registrations"></span>
 </section>

--- a/app/views/event_steps/show.html.erb
+++ b/app/views/event_steps/show.html.erb
@@ -1,3 +1,3 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <%= render "form", current_step: @current_step, wizard: @wizard, event: @event %>

--- a/app/views/event_steps/update.html.erb
+++ b/app/views/event_steps/update.html.erb
@@ -1,3 +1,3 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <%= render "form", current_step: @current_step, wizard: @wizard, event: @event %>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -1,25 +1,17 @@
 <section class="mailing-reg-main" role="main" id="main-content">
-    <div class="content container-1000">
-        <div class="content__left">
-            <p>
-              <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
-            </p>
+  <p>
+    <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
+  </p>
 
-            <%= govuk_form_for current_step, url: step_path do |f| %>
-              <%= render current_step.key, current_step: current_step, f: f %>
+  <%= govuk_form_for current_step, url: step_path do |f| %>
+    <%= render current_step.key, current_step: current_step, f: f %>
 
-              <% if wizard.can_proceed? %>
-                <%= f.button class: "call-to-action-button" do %>
-                  <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
-                  <span></span>
-                <% end %>
-              <% end %>
-            <% end %>
-        </div>
-
-        <div class="content__right">
-
-        </div>
-    </div>
+    <% if wizard.can_proceed? %>
+      <%= f.button class: "call-to-action-button" do %>
+        <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
+        <span></span>
+      <% end %>
+    <% end %>
+  <% end %>
 </section>
 

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,50 +1,49 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <section class="mailing-reg-main">
-    <div class="content container-1000">
-        <div class="content__left">
-            <h1 class="strapline">You've signed up</h1>
-            <p>You’re ready to receive email updates to help you get into teaching.</p>
+    <h1 class="strapline">You've signed up</h1>
+    <p>You’re ready to receive email updates to help you get into teaching.</p>
 
-            <h2>What happens next?</h2>
+    <h2>What happens next?</h2>
 
-            <p>
-              You’ll receive an email to the address you gave us when you signed up.
-              You can unsubscribe if you change your mind. To find out how we
-              handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
-            </p>
+    <p>
+      You’ll receive an email to the address you gave us when you signed up.
+      You can unsubscribe if you change your mind. To find out how we
+      handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
+    </p>
 
-            <h2>Want to speak to us?</h2>
+    <h2>Want to speak to us?</h2>
 
-            <p>
-              If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm.
-            </p>
-            <p>
-              You can also use this number to update or amend any of your details.
-            </p>
-        </div>
-        <span data-controller="pinterest"
-                data-pinterest-action="track"
-                data-pinterest-event="lead"
-                data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
+    <p>
+      If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm.
+    </p>
+    <p>
+      You can also use this number to update or amend any of your details.
+    </p>
 
-            <span data-controller="snapchat"
-                data-snapchat-action="track"
-                data-snapchat-event="SUBSCRIBE"></span>
+    <h2>Explore Get Into Teaching</h2>
 
-            <span data-controller="facebook"
-                data-facebook-action="trackCustom"
-                data-facebook-event="Newsletter_Subscribers"></span>
+    <span data-controller="pinterest"
+        data-pinterest-action="track"
+        data-pinterest-event="lead"
+        data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
 
-            <span data-controller="bam" data-bam-action="track"></span>
+    <span data-controller="snapchat"
+        data-snapchat-action="track"
+        data-snapchat-event="SUBSCRIBE"></span>
 
-            <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
-    </div>
+    <span data-controller="facebook"
+        data-facebook-action="trackCustom"
+        data-facebook-event="Newsletter_Subscribers"></span>
+
+    <span data-controller="bam" data-bam-action="track"></span>
+
+    <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
+</section>
+
+<% content_for(:feature) do %>
     <div class="explore">
-        <div class="content container-1000 explore__header">
-            <h2>Explore Get Into Teaching</h2>
-        </div>
         <%= render "content/home/featured_content" %>
     </div>
-</section>
+<% end %>
 

--- a/app/views/mailing_list/steps/show.html.erb
+++ b/app/views/mailing_list/steps/show.html.erb
@@ -1,3 +1,3 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <%= render "form", current_step: @current_step, wizard: @wizard, event: @event %>

--- a/app/views/mailing_list/steps/update.html.erb
+++ b/app/views/mailing_list/steps/update.html.erb
@@ -1,3 +1,3 @@
-<% @no_hero = @fullwidth = @hide_page_helpful_question = true %>
+<% @skip_hero = @hide_page_helpful_question = true %>
 
 <%= render "form", current_step: @current_step, wizard: @wizard, event: @event %>

--- a/app/views/sections/_feedback-bar.erb
+++ b/app/views/sections/_feedback-bar.erb
@@ -1,5 +1,5 @@
 <div class="feedback-bar" data-controller="feedback" data-banner-name="Feedback">
-  <div class="container-1000">
+  <section class="container">
       <div class="feedback-bar__inner">
           <div class="feedback-bar__left">
               <span class="feedback-bar__label">FEEDBACK</span>
@@ -7,5 +7,5 @@
           </div>
           <a href="" class="feedback-bar__close" id="hide-feedback-bar" data-action="click->feedback#dismiss">Hide</a>
       </div>
-  </div>
+  </section>
 </div>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
-  <div class="footer-wrapper limit-content-width">
+  <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">
         <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,5 +1,5 @@
 <section id="talk-to-us" class="talk-to-us">
-    <div class="container-1000">
+    <section class="container">
         <div class="talk-to-us__inner">
 
             <h2 class="strapline">Talk to us</h2>

--- a/app/webpacker/styles/feedback-bar.scss
+++ b/app/webpacker/styles/feedback-bar.scss
@@ -7,15 +7,16 @@
     bottom: 0;
     left: 0;
     z-index: 100;
-    .container-1000 {
+    .container {
         width: 100%;
-        text-align: left;
     }
     &__inner {
+      box-sizing: border-box;
         background-color: white;
         padding: 20px;
         border: 1px solid $grey;
         border-width: 1px 1px 0 1px;
+        width: 100%;
         display: flex;
         justify-content: space-between;
     }
@@ -59,10 +60,10 @@
 
 @include mq($until: tablet) {
     .feedback-bar {
-        width: 100%;
-        .container-1000 {
-            padding: 0;
+        section.container {
+          margin: 0;
         }
+
         &__left {
             flex-direction: column;
             margin-top: -38px;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -1,7 +1,9 @@
 footer.site-footer {
-    background-color: $black;
-
     clear: both; // IE-specific fix to make sure footer stays below main content
+
+    .site-footer__wrapper {
+      background-color: $black;
+    }
 
     .site-footer-top {
         width: 100%;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -64,55 +64,55 @@ main.semantic {
   @include mq($from: tablet) {
     margin-bottom: 4em;
   }
+}
 
-  section.container {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: column;
+section.container {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
 
-    max-width: $content-max-width;
-    margin: 1em .8em 0;
+  max-width: $content-max-width;
+  margin: 1em .8em 0;
 
+  @include mq($from: tablet) {
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+    margin: 1em auto 0;
+  }
+
+  > article {
+    flex: 0 1 65%;
+
+    &.fullwidth {
+      flex: 1 0 100%;
+    }
+
+    &.no-hero {
+      margin-top: 2em;
+    }
+  }
+
+
+  > aside {
+    flex: 0 0 calc(30%);
+
+    // note we're not using `gap: 1em` even though it works for flex in
+    // Firefox/Chrome as Safari is lagging behind a bit. Instead knock a
+    // bit off the basis and add some margin when wider than tablet
     @include mq($from: tablet) {
-      flex-direction: row-reverse;
-      justify-content: flex-end;
-      margin: 1em auto 0;
+      flex: 0 0 calc(30% - 1em);
+      margin-left: 1em;
     }
+  }
 
-    > article {
-      flex: 0 1 65%;
+  // feature: content that's not a regular text document, like a list of items on an index
+  // supplementary: content that's not directly related to the main article but might be of interest
+  > .feature,
+  > .supplementary {
+    flex: 0 0 100%;
+  }
 
-      &.fullwidth {
-        flex: 1 0 100%;
-      }
-
-      &.no-hero {
-        margin-top: 2em;
-      }
-    }
-
-
-    > aside {
-      flex: 0 0 calc(30%);
-
-      // note we're not using `gap: 1em` even though it works for flex in
-      // Firefox/Chrome as Safari is lagging behind a bit. Instead knock a
-      // bit off the basis and add some margin when wider than tablet
-      @include mq($from: tablet) {
-        flex: 0 0 calc(30% - 1em);
-        margin-left: 1em;
-      }
-    }
-
-    // feature: content that's not a regular text document, like a list of items on an index
-    // supplementary: content that's not directly related to the main article but might be of interest
-    > .feature,
-    > .supplementary {
-      flex: 0 0 100%;
-    }
-
-    >.page-helpful {
-      flex: 0 1 65%;
-    }
+  >.page-helpful {
+    flex: 0 1 65%;
   }
 }

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -1,5 +1,7 @@
 .event-reg-main,
 .mailing-reg-main {
+  margin-bottom: 1em;
+
   .govuk-checkboxes__item, .govuk-form-group
   {
       margin-bottom: 10px;
@@ -12,6 +14,7 @@
   h1 {
       font-size: $fs-42;
       margin: 0;
+      line-height: 1.25;
 
       &.strapline {
         margin-bottom: 30px;
@@ -20,9 +23,19 @@
   }
 
   h2 {
+      @include content-heading;
+      margin-bottom: 0;
       font-size: $fs-28;
       background: transparent;
       color: $black;
+  }
+
+  h3 {
+    font-size: $fs-28;
+    margin: 0;
+    padding: 0;
+    margin-top: 20px;
+    margin-bottom: 10px;
   }
 
   .govuk-input, .govuk-select {
@@ -40,22 +53,25 @@
 @include mq($until: tablet) {
   .event-reg-main,
   .mailing-reg-main {
+      h1 {
+        &.strapline {
+          margin-left: 0;
+        }
+    }
 
-      &__content {
+    &__content {
 
-          display: block;
+        display: block;
 
-          &__left {
-              display: block;
-              margin-right: 40px;
-          }
+        &__left {
+            display: block;
+            margin-right: 40px;
+        }
 
-          &__right {
-              display: block;
-              margin-top: 40px;
-          }
-
-      }
-
+        &__right {
+            display: block;
+            margin-top: 40px;
+        }
+    }
   }
 }

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -9,14 +9,13 @@
       margin-left: 0px;
   }
 
-  .content__left {
-      h1 {
-          font-size: $fs-42;
-          margin: 0;
-          &.strapline {
-            margin-bottom: 30px;
-            margin-left: -20px;
-          }
+  h1 {
+      font-size: $fs-42;
+      margin: 0;
+
+      &.strapline {
+        margin-bottom: 30px;
+        margin-left: -20px;
       }
   }
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -185,13 +185,12 @@ $mobile-cutoff: 800px;
   display: flex;
   align-items: center;
   background-color: $green;
-  margin-top: 50px;
+  margin-top: 1em;
 
   @include mq($until: tablet) {
     flex-direction: column;
     align-items: flex-start;
-    margin: 0 -20px;
-    margin-top: 30px;
+    margin: 1.5em 0;
   }
 
   &__text {

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -3,10 +3,6 @@
     background-color: $grey;
     padding-bottom: 1px;
 
-    .container-1000 {
-        text-align: left;
-    }
-
     &__inner {
         position: relative;
         top: -65px;
@@ -35,12 +31,12 @@
 
                 a{
                     text-decoration: none;
-                }  
+                }
             }
 
             &__column:first-child {
                 display: none;
-            
+
                 &.visible {
                     display: inline-block;
                 }
@@ -61,11 +57,10 @@
 
 @include mq($until: tablet) {
     .talk-to-us {
-        padding: 0;
-        
         &__inner {
-            top: -50px;
-            
+            padding: 0 20px;
+            top: -45px;
+
             .strapline {
                 font-size: $fs-24;
             }
@@ -73,7 +68,7 @@
             &__label {
                 margin: 0;
             }
-    
+
             &__table {
                 flex-direction: column;
                 &__column {
@@ -89,6 +84,6 @@
                 padding-right: 0px;
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
### Trello card

[Trello-757](https://trello.com/c/SbZOdKxq/757-remove-unused-css-content)

### Context

We still use the `.container-1000` class in a few places, which is associated with the old `.content` layout. We want to replace these with the new layout `section.container` so that we can kill off all the old `.content` related CSS.

The `section.container` class has been moved outside of the `main.markdown` class so that we can use it in the hero component and footer sections. We probably need to go one step further and decouple `.markdown` from `main` so that we can utilise the `.overhang` CSS in these areas as well, but I've not done that yet in an attempt to keep this PR manageable.

A few CSS selectors from the `.content` class had to be shifted into the event/mailing list component CSS as we seem to use custom margins and font sizes here for headings. We should look to clean this up further going forward. 

### Changes proposed in this pull request

- Remove section.container outwith main.semantic
- Replace container-1000 in mailing list CTA
- Replace container-1000 in feedback-bar
- Replace container-1000 in talk-to-us section
- Replace container-1000 in mailing list sign up
- Replace container-1000 in event sign up

### Guidance to review

This PR will be followed up by another that removes the now unused CSS.

Pages/components effected:

- Mailing list CTA (home page)
- Feedback bar
- Talk to us section
- Mailing list sign up
- Event sign up