### PR TITLE
Fix the story list layout

### DIFF
--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -4,8 +4,8 @@
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
-      <main role="main" id="main-content">
-        <section class="semantic">
+      <main role="main" class="semantic" id="main-content">
+        <section class="container">
           <section class="feature">
             <%= back_link "/my-story-into-teaching", text: "All stories" %>
             <%= yield %>
@@ -14,7 +14,7 @@
               <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
             </div>
           </section>
-        </section>
+        </div>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>


### PR DESCRIPTION
This was missing the `container` section and the `semantic` class in the `main` element.

| Desktop      | Mobile |
| ----------- | ----------- |
| ![screencapture-0-0-0-0-3000-my-story-into-teaching-returners-2021-01-26-14_40_31](https://user-images.githubusercontent.com/29867726/105859712-c196cd80-5fe4-11eb-9d9f-c0fcabef10d0.png) | ![screencapture-0-0-0-0-3000-my-story-into-teaching-returners-2021-01-26-14_40_16](https://user-images.githubusercontent.com/29867726/105859650-b17eee00-5fe4-11eb-9b16-fbc894d61063.png) |





