### PR TITLE
Allow the hero subtitle to be a hyperlink

### DIFF
--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -3,7 +3,7 @@
   <div class="hero__title">
     <h1><%= tag.span(title) %></h1>
   </div>
-  <% if subtitle.present? %>
+  <% if show_subtitle? %>
     <div class="hero__subtitle">
       <%= tag.div(subtitle) %>
     </div>

--- a/app/components/sections/hero_component.rb
+++ b/app/components/sections/hero_component.rb
@@ -1,11 +1,12 @@
 module Sections
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :image, :mobile_image, :subtitle, :show_mailing_list
+    attr_accessor :title, :image, :mobile_image, :show_mailing_list
 
     def initialize(front_matter)
       front_matter.with_indifferent_access.tap do |fm|
         @title             = fm["title"]
         @subtitle          = fm["subtitle"]
+        @subtitle_link     = fm["subtitle_link"]
         @image             = fm["image"]
         @mobile_image      = fm["mobileimage"]
         @show_mailing_list = fm["mailinglist"]
@@ -25,6 +26,18 @@ module Sections
       image_sizes << %(#{mobile_image_path} 600w) if mobile_image.present?
 
       image_tag(image_path, class: "hero__img", srcset: image_sizes.join(", "), alt: "Student in a classroom")
+    end
+
+    def subtitle
+      if @subtitle_link.present?
+        link_to(@subtitle, @subtitle_link)
+      else
+        @subtitle
+      end
+    end
+
+    def show_subtitle?
+      @subtitle.present?
     end
 
   private

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -38,6 +38,15 @@ $mobile-cutoff: 800px;
       margin: initial;
       width: initial;
     }
+
+    a {
+      color: $black;
+      text-decoration: none;
+
+      &:hover {
+        border-bottom: 2px solid $black;
+      }
+    }
   }
 
   &__img {

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -24,6 +24,25 @@ describe Sections::HeroComponent, type: "component" do
       specify "renders the subtitle" do
         expect(page).to have_css(".hero__subtitle > div", text: front_matter[:subtitle])
       end
+
+      context "when the subtitle is a link" do
+        let(:front_matter) do
+          {
+            title: "Teaching, it's pretty awesome",
+            subtitle: "Teach all the subjects!",
+            subtitle_link: "https://foo.com",
+            image: "media/images/hero-home-dt.jpg",
+          }
+        end
+
+        subject! { render_inline(component) }
+
+        specify "renders the subtitle" do
+          expect(page).to have_css(".hero__subtitle > div") do |div|
+            expect(div).to have_link(front_matter[:subtitle], href: front_matter[:subtitle_link])
+          end
+        end
+      end
     end
 
     describe "images" do


### PR DESCRIPTION
This was one of the ideas to increase engagement with the mailing list signup. When a `subtitle_link` key is present in the front matter the subtitle text is a link rather than regular text. It remains unstyled
except that on hover it's underlined (via a border to match the title above).

When no subtitle is present the text will be displayed without any changes.

A corresponding change will need to be made in the content repo for this to be visible.

