### PR TITLE
Adjust the hero grid proportions a bit

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -60,11 +60,13 @@ $mobile-cutoff: 800px;
 
 // grid-specific
 .hero {
+  $title-overlap-img: 4em;
+
   @supports (display: grid) {
     display: grid;
 
     grid-template-columns: 3em repeat(3, 1fr);
-    grid-template-rows: repeat(4, minmax(1em, max-content));
+    grid-template-rows: max-content $title-overlap-img repeat(2, minmax(1em, max-content));
 
     &__title {
       grid-area: 2 / 1 / 4 / 4;
@@ -85,22 +87,21 @@ $mobile-cutoff: 800px;
 
     &__img {
       min-height: 10em;
-      grid-area: 1 / 2 / 3 / 5;
+      grid-area: -5 / -4 / -3 / -1;
     }
 
     @include mq($from: tablet) {
-      grid-template-columns: repeat(8, minmax(100px, 1fr));
+
+      grid-template-columns: repeat(3, minmax(100px, 1fr)) $title-overlap-img repeat(4, minmax(100px, 1fr));
       grid-template-rows: 2em repeat(5, minmax(5px, max-content)) 2em;
 
-      &__title { grid-area: 3 / 1 / 5 / 6; }
+      &__title { grid-area: 3 / 1 / 5 / 5; }
 
       &__subtitle { grid-area: 5 / 1 / 7 / 4; }
 
       &__content { grid-area: 5 / 1 / 7 / 5; }
 
-      &__img {
-        grid-area: 2 / 5 / 8 / 9;
-      }
+      &__img { grid-area: -6 / -6 / -1 / -1; }
     }
 
     @include mq($from: wide) {


### PR DESCRIPTION
The title was overhanging the hero image a little too much. This change introduces a variable `$title-overlap-img` that's set to `4em`. This value will be set to the 'overlap' column/row (depending on whether we're on desktop or mobile) that the image and title both occupy.

![Screenshot from 2021-01-26 16-09-27](https://user-images.githubusercontent.com/128088/105872038-d88fec80-5ff1-11eb-81b7-d84775ff749e.png)


Resize preview:


https://user-images.githubusercontent.com/128088/105872150-fa896f00-5ff1-11eb-967e-bad6fd4e245b.mp4


Also, for ease, change the image over to using negative coordinates as it's right aligned (meaning if we introduce more columns or rows the image will stay at the right/bottom).



