### PR TITLE
Reduce font size number

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ yarn eslint <path to your file>
 
 ### CSS
 
-[StyleLint](https://stylelint.io/) is for CSS linting, it uses the [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds).
+[StyleLint](https://stylelint.io/) is used for CSS linting, it uses the [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds).
 
 To lint the `./app/webpacker/styles` directory:
 

--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -18,14 +18,14 @@
       .step-header__text {
         text-align: left;
         margin: 0;
-        font-size: $fs-28;
+        font-size: size("medium");
         flex-grow: 2;
         white-space: initial;
         padding: 0 2em 0 0;
         background: transparent;
 
         @include mq($from: tablet) {
-          font-size: $fs-36;
+          font-size: size("large");
         }
       }
 

--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -18,14 +18,14 @@
       .step-header__text {
         text-align: left;
         margin: 0;
-        font-size: $fs-24;
+        font-size: $fs-28;
         flex-grow: 2;
         white-space: initial;
         padding: 0 2em 0 0;
         background: transparent;
 
         @include mq($from: tablet) {
-          font-size: $fs-32;
+          font-size: $fs-36;
         }
       }
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -37,7 +37,7 @@
   }
 
   .call-to-action__heading {
-    font-size: $fs-28;
+    font-size: size("medium");
     font-weight: bold;
     margin-bottom: 1em;
   }
@@ -99,7 +99,7 @@
       align-items: center;
 
       .call-to-action__heading {
-        font-size: $fs-19;
+        font-size: size("small");
         margin: 0 .5em;
       }
     }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -37,7 +37,7 @@
   }
 
   .call-to-action__heading {
-    font-size: $fs-26;
+    font-size: $fs-28;
     font-weight: bold;
     margin-bottom: 1em;
   }

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -100,7 +100,7 @@
 .cards-with-headers {
   h2 {
     padding: 0 $indent-amount $indent-amount;
-    font-size: $fs-36;
+    font-size: size("large");
   }
 
   .card {

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -31,7 +31,7 @@
         margin: 3em auto auto -.2em;
 
         > span {
-          font-size: $fs-24;
+          font-size: 1.5rem;
           color: $white;
           background-color: $pink-dark-90;
           padding: .8em;
@@ -100,7 +100,7 @@
 .cards-with-headers {
   h2 {
     padding: 0 $indent-amount $indent-amount;
-    font-size: $fs-32;
+    font-size: $fs-36;
   }
 
   .card {

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -9,7 +9,7 @@
   h2 {
     margin-bottom: 5px;
     margin-top: 0;
-    font-size: $fs-28;
+    font-size: size("medium");
     background: transparent;
     color: $black;
   }

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -45,7 +45,7 @@
 
   &__datetime {
     margin-bottom: 4px;
-    font-size: $fs-16;
+    font-size: size("xsmall");
 
     span {
       word-break: break-word;
@@ -64,7 +64,7 @@
   }
 
   &__content p {
-    font-size: $fs-16;
+    font-size: size("xsmall");
     margin-bottom: 0;
   }
 
@@ -89,7 +89,7 @@
 
       &__meta {
         padding-left: .8em;
-        font-size: $fs-16;
+        font-size: size("xsmall");
         font-weight: 800;
       }
     }

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -45,7 +45,7 @@
 
   &__datetime {
     margin-bottom: 4px;
-    font-size: $fs-15;
+    font-size: $fs-16;
 
     span {
       word-break: break-word;
@@ -89,7 +89,7 @@
 
       &__meta {
         padding-left: .8em;
-        font-size: smaller;
+        font-size: $fs-16;
         font-weight: 800;
       }
     }

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -1,6 +1,6 @@
 .feature-table {
   dl {
-    font-size: $fs-19;
+    font-size: size("small");
     background-color: $grey;
     width: 100%;
     padding: $indent-amount;

--- a/app/webpacker/styles/components/link-block.scss
+++ b/app/webpacker/styles/components/link-block.scss
@@ -8,7 +8,7 @@
     background-color: $pink;
     color: #ffffff;
     font-weight: bold;
-    font-size: $fs-19;
+    font-size: size("small");
     padding: $indent-amount $indent-amount $indent-amount 50px;
     margin: 0;
     position: relative;
@@ -66,7 +66,7 @@
           display: block;
           background-image: url('../images/icon-down.svg');
           width: 21px;
-          height: $fs-19;
+          height: size("small");
           position: absolute;
           top: 6px;
           left: 15px;

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -59,7 +59,7 @@
     color: govuk-colour("black");
     cursor: pointer;
     display: none;
-    font-size: $fs-24;
+    font-size: $fs-28;
     height: 30px;
     position: absolute;
     right: 0;

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -59,7 +59,7 @@
     color: govuk-colour("black");
     cursor: pointer;
     display: none;
-    font-size: $fs-28;
+    font-size: size("medium");
     height: 30px;
     position: absolute;
     right: 0;

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -4,7 +4,7 @@
   margin-bottom: .2rem;
   padding: .4rem $indent-amount;
   background: $blue;
-  font-size: size("large");
+  font-size: size("medium");
   font-weight: 700;
   margin-right: 8rem;
   color: $white;

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -4,7 +4,7 @@
   margin-bottom: .2rem;
   padding: .4rem $indent-amount;
   background: $blue;
-  font-size: $fs-24;
+  font-size: $fs-36;
   font-weight: 700;
   margin-right: 8rem;
   color: $white;
@@ -26,7 +26,7 @@
   }
 
   @include mq($from: tablet) {
-    font-size: $fs-32;
+    font-size: $fs-36;
 
     &:not(.always-indent) {
       margin-right: 0;

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -4,7 +4,7 @@
   margin-bottom: .2rem;
   padding: .4rem $indent-amount;
   background: $blue;
-  font-size: $fs-36;
+  font-size: size("large");
   font-weight: 700;
   margin-right: 8rem;
   color: $white;
@@ -22,11 +22,11 @@
   }
 
   &.small {
-    font-size: $fs-19;
+    font-size: size("small");
   }
 
   @include mq($from: tablet) {
-    font-size: $fs-36;
+    font-size: size("large");
 
     &:not(.always-indent) {
       margin-right: 0;

--- a/app/webpacker/styles/components/type-description.scss
+++ b/app/webpacker/styles/components/type-description.scss
@@ -1,11 +1,11 @@
 .type-description {
   h5 {
     margin: 10px 0;
-    font-size: $fs-16;
+    font-size: size("xsmall");
   }
 
   p {
-    font-size: $fs-16;
+    font-size: size("xsmall");
     margin-top: 0;
   }
 }
@@ -18,7 +18,7 @@
   display: block;
   text-decoration: none;
   font-weight: bold;
-  font-size: $fs-16;
+  font-size: size("xsmall");
 
   &:hover {
     text-decoration: underline;

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -61,7 +61,7 @@
 
     h2,
     h3 {
-      font-size: $fs-32;
+      font-size: $fs-36;
     }
 
     h3 {
@@ -118,16 +118,15 @@
         float: none;
         margin-top: $indent-amount;
         margin-bottom: -20px;
-        font-size: $fs-24;
+        font-size: $fs-36;
       }
 
       p {
-        font-size: $fs-16;
         line-height: 1.25;
       }
 
       a {
-        font-size: $fs-16;
+        font-size: $fs-19;
         padding: 8px 12px;
 
         .git-link {

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -61,7 +61,7 @@
 
     h2,
     h3 {
-      font-size: $fs-36;
+      font-size: size("large");
     }
 
     h3 {
@@ -118,7 +118,7 @@
         float: none;
         margin-top: $indent-amount;
         margin-bottom: -20px;
-        font-size: $fs-36;
+        font-size: size("large");
       }
 
       p {
@@ -126,7 +126,7 @@
       }
 
       a {
-        font-size: $fs-19;
+        font-size: size("small");
         padding: 8px 12px;
 
         .git-link {

--- a/app/webpacker/styles/error.scss
+++ b/app/webpacker/styles/error.scss
@@ -6,7 +6,7 @@
 
   h1 {
     margin-top: 0;
-    font-size: $fs-42;
+    font-size: size("xlarge");
     font-weight: 900;
   }
 

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -1,13 +1,13 @@
 .event-info {
   h1 {
-    font-size: $fs-42;
+    font-size: size("xlarge");
     line-height: 1.25;
     margin: 1em 0 5px;
   }
 
   &__date {
     margin-top: 0;
-    font-size: $fs-28;
+    font-size: size("medium");
   }
 
   &__venue {

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -7,7 +7,7 @@
 
   &__date {
     margin-top: 0;
-    font-size: $fs-26;
+    font-size: $fs-28;
   }
 
   &__venue {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -214,14 +214,6 @@
 }
 
 @include mq($until: mobile) {
-  .events-featured {
-    &__heading {
-      > h3 {
-        font-size: $fs-24;
-      }
-    }
-  }
-
   .search-for-events-results {
     > a {
       width: 100%;

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -60,7 +60,7 @@
 
   &__heading {
     > h3 {
-      font-size: $fs-28;
+      font-size: size("medium");
       margin: 0 0 $indent-amount 0;
       line-height: 1.25;
     }
@@ -108,7 +108,7 @@
 
     @mixin pagination-item {
       font-weight: bold;
-      font-size: $fs-16;
+      font-size: size("xsmall");
       padding: .8em;
       text-decoration: none;
       margin: 1em 0;

--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -11,3 +11,19 @@ $fs-28: 1.75rem;
 $fs-36: 2.25rem;
 $fs-42: 2.625rem;
 $fs-54: 3.375rem;
+
+$sizes: (
+  "xsmall": $fs-16,
+  "small": $fs-19,
+  "medium": $fs-28,
+  "large": $fs-36,
+  "xlarge" : $fs-42,
+  "xxlarge": $fs-54
+);
+
+@function size($size) {
+  @if not map-has-key($sizes, $size) {
+    @error "Unknown font size `#{$size}`";
+  }
+  @return map-get($sizes, $size);
+}

--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -5,15 +5,9 @@ html {
 // Numbers refer to pixel size when the base font
 // size of the broswer is 16px (most broswers)
 
-$fs-15: .93rem;
 $fs-16: 1rem;
 $fs-19: 1.1875rem;
-$fs-22: 1.375rem;
-$fs-22-4: 1.4rem;
-$fs-24: 1.5rem;
-$fs-26: 1.625rem;
 $fs-28: 1.75rem;
-$fs-32: 2rem;
-$fs-40: 2.5rem;
+$fs-36: 2.25rem;
 $fs-42: 2.625rem;
-$fs-64: 4rem;
+$fs-54: 3.375rem;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -63,7 +63,7 @@ footer.site-footer {
         margin-right: $indent-amount;
 
         .icon {
-          font-size: $fs-32;
+          font-size: $fs-36;
         }
 
         &:hover {

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -63,7 +63,7 @@ footer.site-footer {
         margin-right: $indent-amount;
 
         .icon {
-          font-size: $fs-36;
+          font-size: size("large");
         }
 
         &:hover {
@@ -76,7 +76,7 @@ footer.site-footer {
       text-align: right;
       vertical-align: top;
       color: $grey-mid;
-      font-size: $fs-16;
+      font-size: size("xsmall");
       letter-spacing: 0;
       display: flex;
       justify-content: flex-end;
@@ -143,7 +143,7 @@ footer.site-footer {
       text-align: right;
       vertical-align: top;
       color: $grey-mid;
-      font-size: $fs-16;
+      font-size: size("xsmall");
       letter-spacing: 0;
       padding-left: 40px;
       display: flex;
@@ -267,7 +267,7 @@ footer.site-footer {
         padding-left: 0;
 
         &__license {
-          font-size: $fs-16;
+          font-size: size("xsmall");
           padding-right: 30px;
           padding-top: 20px;
 

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -1,6 +1,6 @@
 select,
 input {
-  font-size: $fs-19;
+  font-size: size("small");
   margin-left: $indent-amount;
   margin-right: $indent-amount;
   border: 2px solid $black;
@@ -25,7 +25,7 @@ form {
   .fieldlabel,
   .govuk-label,
   h3.govuk-fieldset__heading {
-    font-size: $fs-19;
+    font-size: size("small");
     color: $black;
     font-weight: bold;
   }

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -32,13 +32,13 @@
     li {
       padding: 8px 16px;
       @include font;
-      font-size: $fs-16;
+      font-size: size("xsmall");
       font-weight: bold;
       line-height: 1;
 
       a {
         @include font;
-        font-size: $fs-16;
+        font-size: size("xsmall");
         display: block;
         text-decoration: none;
         font-weight: bold;
@@ -125,12 +125,12 @@
     .icon-hamburger-label {
       color: $black;
       font-weight: bold;
-      font-size: $fs-16;
+      font-size: size("xsmall");
       letter-spacing: 0;
     }
 
     &__links {
-      font-size: $fs-16;
+      font-size: size("xsmall");
       padding: 1px;
       background-color: $grey;
       width: 100%;
@@ -228,7 +228,7 @@
 
 .covid {
   @include font;
-  font-size: $fs-16;
+  font-size: size("xsmall");
   line-height: 1.25;
   background-color: $black;
   color: $white;
@@ -238,7 +238,7 @@
   padding-right: 35px;
 
   p {
-    font-size: $fs-16;
+    font-size: size("xsmall");
     line-height: 1.25;
     margin: 0 0 10px;
 
@@ -249,7 +249,7 @@
 
   &__header {
     display: block;
-    font-size: $fs-19;
+    font-size: size("small");
     font-weight: bold;
   }
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -110,7 +110,7 @@
     font-weight: bold;
     word-break: break-all;
     text-decoration: none;
-    font-size: $fs-16;
+    font-size: size("xsmall");
     padding: .5em;
 
     &:hover {
@@ -192,7 +192,7 @@
   &__quote {
     margin: 0 0 $indent-amount;
     font-weight: bold;
-    font-size: $fs-28;
+    font-size: size("medium");
     line-height: 1.25;
     display: block;
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -258,6 +258,10 @@
       width: calc(100% - 80px);
       margin: 30px 30px 30px 50px;
     }
+
+    &__quote {
+      font-size: size("small");
+    }
   }
 }
 

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -5,7 +5,7 @@
   text-decoration: none;
   color: $fg;
   padding: 14px $indent-amount;
-  font-size: $fs-19;
+  font-size: size("small");
   white-space: nowrap;
   border: none;
 

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -76,7 +76,7 @@
     }
 
     tbody {
-      font-size: $fs-16;
+      font-size: size("xsmall");
     }
   }
 

--- a/app/webpacker/styles/page-helpful.scss
+++ b/app/webpacker/styles/page-helpful.scss
@@ -3,7 +3,7 @@
   margin: 2em 0 0;
   background: $grey;
   display: none;
-  font-size: $fs-19;
+  font-size: size("small");
   flex-direction: row;
   justify-content: space-between;
   align-items: center;

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -4,11 +4,11 @@
     margin: auto $indent-amount;
 
     h1 {
-      font-size: $fs-42;
+      font-size: size("xlarge");
     }
 
     h2 {
-      font-size: $fs-28;
+      font-size: size("medium");
     }
   }
 }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -176,7 +176,7 @@ $mobile-cutoff: 800px;
       }
 
       > span {
-        font-size: $fs-32;
+        font-size: $fs-36;
         border-bottom: 3px solid $black;
 
         &:after {
@@ -184,7 +184,7 @@ $mobile-cutoff: 800px;
         }
 
         @include mq($from: tablet) {
-          font-size: $fs-64;
+          font-size: $fs-54;
           border-bottom: 5px solid $black;
         }
       }
@@ -193,11 +193,11 @@ $mobile-cutoff: 800px;
 
   &__subtitle {
     div {
-      font-size: $fs-22-4;
+      font-size: $fs-19;
       font-weight: 700;
 
       @include mq($from: tablet) {
-        font-size: $fs-32;
+        font-size: $fs-28;
         font-weight: 700;
       }
     }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -176,7 +176,7 @@ $mobile-cutoff: 800px;
       }
 
       > span {
-        font-size: $fs-36;
+        font-size: size("large");
         border-bottom: 3px solid $black;
 
         &:after {
@@ -184,7 +184,7 @@ $mobile-cutoff: 800px;
         }
 
         @include mq($from: tablet) {
-          font-size: $fs-54;
+          font-size: size("xxlarge");
           border-bottom: 5px solid $black;
         }
       }
@@ -193,11 +193,11 @@ $mobile-cutoff: 800px;
 
   &__subtitle {
     div {
-      font-size: $fs-19;
+      font-size: size("small");
       font-weight: 700;
 
       @include mq($from: tablet) {
-        font-size: $fs-28;
+        font-size: size("medium");
         font-weight: 700;
       }
     }

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -39,7 +39,7 @@
         }
 
         &__heading {
-          font-size: $fs-26;
+          font-size: $fs-28;
           margin: .5em 0;
         }
       }

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -39,7 +39,7 @@
         }
 
         &__heading {
-          font-size: $fs-28;
+          font-size: size("medium");
           margin: .5em 0;
         }
       }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -15,7 +15,7 @@
 
   &__header {
     h2 {
-      font-size: $fs-36;
+      font-size: size("large");
     }
   }
 
@@ -57,11 +57,11 @@
     }
 
     h2 {
-      font-size: $fs-28;
+      font-size: size("medium");
     }
 
     .stories-feature__subheading {
-      font-size: $fs-19;
+      font-size: size("small");
       font-weight: bold;
     }
   }
@@ -73,7 +73,7 @@
 
 .story {
   h1 {
-    font-size: $fs-42;
+    font-size: size("xlarge");
   }
 
   .story__header {
@@ -92,7 +92,7 @@
 
     &__label {
       h2 {
-        font-size: $fs-36;
+        font-size: size("large");
         border-bottom: none;
         padding: 0 $indent-amount;
         margin: 0;
@@ -136,7 +136,7 @@
       &:before {
         @include quote-icon;
         position: absolute;
-        left: $fs-19;
+        left: size("small");
       }
 
       &:after {
@@ -207,7 +207,7 @@
         margin: 0;
 
         @include mq($until: desktop) {
-          font-size: $fs-16;
+          font-size: size("xsmall");
         }
       }
     }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -15,7 +15,7 @@
 
   &__header {
     h2 {
-      font-size: $fs-32;
+      font-size: $fs-36;
     }
   }
 
@@ -73,7 +73,7 @@
 
 .story {
   h1 {
-    font-size: $fs-40;
+    font-size: $fs-42;
   }
 
   .story__header {
@@ -92,7 +92,7 @@
 
     &__label {
       h2 {
-        font-size: $fs-26;
+        font-size: $fs-36;
         border-bottom: none;
         padding: 0 $indent-amount;
         margin: 0;
@@ -123,7 +123,6 @@
     p {
       padding: 15px 44px;
       font-weight: bold;
-      font-size: $fs-22;
 
       @mixin quote-icon {
         @include icon;
@@ -206,7 +205,10 @@
       > p {
         padding: 0 .6em;
         margin: 0;
-        font-size: $fs-16;
+
+        @include mq($until: desktop) {
+          font-size: $fs-16;
+        }
       }
     }
 

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -7,7 +7,7 @@ $git-font-family: sans-serif;
 
 h1 {
   @include font;
-  font-size: $fs-32;
+  font-size: $fs-36;
 }
 
 h2 {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -7,29 +7,29 @@ $git-font-family: sans-serif;
 
 h1 {
   @include font;
-  font-size: $fs-36;
+  font-size: size("large");
 }
 
 h2 {
   @include font;
-  font-size: $fs-19;
+  font-size: size("small");
   line-height: 1.25;
 }
 
 h3 {
   @include font;
-  font-size: $fs-19;
+  font-size: size("small");
   font-weight: bold;
 }
 
 h4 {
   @include font;
-  font-size: $fs-19;
+  font-size: size("small");
 }
 
 p {
   @include font;
-  font-size: $fs-19;
+  font-size: size("small");
   line-height: 1.5;
 }
 
@@ -50,7 +50,7 @@ a {
 .git-link {
   @include font;
   font-weight: bold;
-  font-size: $fs-19;
+  font-size: size("small");
   color: $black;
   text-decoration: none;
   display: inline-block;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "scripts": {
     "spec": "jest",
-    "scss-lint": "npx stylelint app/webpacker/styles",
-    "scss-lint --fix": "npx stylelint app/webpacker/styles"
+    "scss-lint": "npx stylelint app/webpacker/styles"
   }
 }


### PR DESCRIPTION
### Trello card
https://trello.com/c/IGJu2Apb
https://trello.com/c/Y63wZzfY

### Context
Reduce the number of font sizes and adhere more closely with the designs.
![image](https://user-images.githubusercontent.com/47089130/105875164-5e616700-5ff5-11eb-80db-50f565593f5a.png)

### Changes proposed in this pull request
- Update font sizes:
  - Remove font sizes: `15px`  `24px`  `26px`  `32px`  `40px`  `64px` 
  - Add font sizes: `36px`  `54px` 

- Add sass function for easier use of font sizes
- Update home quote to be smaller on mobile

### Guidance to review

