### PR TITLE
Fix jump when dismissing feedback banner

### DIFF
--- a/app/webpacker/controllers/feedback_controller.js
+++ b/app/webpacker/controllers/feedback_controller.js
@@ -22,7 +22,8 @@ export default class extends Controller {
     this.element.style.display = 'none';
   }
 
-  dismiss() {
+  dismiss(event) {
+    if (event) event.preventDefault();
     this.dismissFeedback();
     this.hide();
   }


### PR DESCRIPTION
### Trello card
https://trello.com/c/9pusruce

### Context
When dismissing the feedback banner, the page jumps to the top. This PR prevents that.

### Changes proposed in this pull request
- Fix jump when dismissing feedback banner

### Guidance to review

