### PR TITLE
Fix responsiveness/margins/sizes throughout

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -1,46 +1,49 @@
-<article class="story markdown">
-  <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
 
-  <%= tag.h1(title) %>
+<section class="container">
+  <article class="markdown overhang no-hero">
+    <article class="story markdown">
+      <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
 
-  <header class="story__header">
-    <% if image.present? %>
-      <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
-    <% end %>
-    <div class="story__header__label">
-      <%= helpers.story_heading(teacher, position) %>
-    </div>
-  </header>
+      <%= tag.h1(title) %>
 
-  <% if show_video? %>
-    <%= helpers.youtube(video) %>
-  <% end %>
+      <header class="story__header">
+        <% if image.present? %>
+          <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
+        <% end %>
+        <div class="story__header__label">
+          <%= helpers.story_heading(teacher, position) %>
+        </div>
+      </header>
 
-  <%= content %>
+      <% if show_video? %>
+        <%= helpers.youtube(video) %>
+      <% end %>
 
-  <% if show_more_information? %>
-    <%= link_to(more_information_link, class: "git-link") do %>
-      <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
-    <% end %>
-  <% end %>
+      <%= content %>
 
-</article>
-
-<section class="feature">
-  <% if show_more_stories? %>
-    <h2 class="strapline">More stories</h2>
-    <div class="cards stories">
-      <%= render Cards::RendererComponent.with_collection(more_stories) %>
-    </div>
-  <% end %>
-
-  <% if show_explore? %>
-    <section class="cards-with-headers">
-      <h2>Explore Get Into Teaching</h2>
-
-      <div class="cards">
-        <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
+      <% if show_more_information? %>
+        <%= link_to(more_information_link, class: "git-link") do %>
+          <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
+        <% end %>
+      <% end %>
+    </article>
+  </article>
+  <section class="feature">
+    <% if show_more_stories? %>
+      <h2 class="strapline">More stories</h2>
+      <div class="cards stories stories--with-padding">
+        <%= render Cards::RendererComponent.with_collection(more_stories) %>
       </div>
+    <% end %>
+
+    <% if show_explore? %>
+      <section class="cards-with-headers">
+        <h2>Explore Get Into Teaching</h2>
+
+        <div class="cards">
+          <%= render Cards::RendererComponent.with_collection(explore, page_data: page_data) %>
+        </div>
       <section>
-  <% end %>
+    <% end %>
+  </section>
 </section>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -1,8 +1,8 @@
 <% @skip_hero = @hide_page_helpful_question = true %>
 
+<h2 class="green">Sign up complete</h2>
+
 <section class="event-reg-main" role="main" id="main-content">
-  <h1 class="strapline">Sign up complete</h1>
-  <br/><br/>
   <h3>You are signed up for the following event:</h3>
 
   <b><%= @event.name %></b>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -26,7 +26,7 @@
 
 
 <% unless @performed_search %>
-  <div class="content-alert">
+  <div class="content-alert content-alert--left">
     <div class="content-alert__icon">
       <%= image_pack_tag "media/images/icon-moved-online-purple.svg", alt: "" %>
     </div>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -16,7 +16,7 @@
               <%= render partial: "layouts/shared/narrow_call_to_action" %>
             </aside>
 
-            <article>
+            <article class="markdown overhang">
               <% if @front_matter["alert"].present? %>
                 <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
               <% end %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -26,7 +26,6 @@
           <%= yield %>
         </article>
       </section>
-      </section>
     </main>
 
     <%= render "sections/footer" %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -7,7 +7,7 @@
 
       <main class="semantic story-landing" role="main" id="main-content">
         <section class="container">
-          <section class="feature">
+          <article class="markdown overhang fullwidth no-hero">
             <div class="stories-feature">
               <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
               <div class="stories-feature__content">
@@ -21,26 +21,26 @@
             </div>
 
             <% @front_matter["sections"]&.each do |name, section| %>
-              <section>
-                <header>
-                  <%= tag.h2(name) %>
-                  <%= tag.p(section["text"]) %>
-                </header>
-                <% if section["stories"].present? %>
-                  <div class="cards stories">
+              <div class="story-landing__header">
+                <%= tag.h2(name) %>
+                <%= tag.p(section["text"]) %>
+              </div>
+              <% if section["stories"].present? %>
+                <div class="story-landing__stories">
+                  <div class="story-landing__cards cards stories">
                     <%= render Cards::RendererComponent.with_collection(section["stories"]) %>
                   </div>
 
-                  <footer>
+                  <div class="story-landing__footer">
                     <%= link_to section["link"] do %>
                       <span>Read all stories about <%= name.downcase %></span>
                     <% end %>
-                  </footer>
-                <% end %>
-              </section>
+                  </div>
+                </div>
+              <% end %>
             <% end %>
           </section>
-        </section>
+        </article>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -6,15 +6,15 @@
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <main role="main" class="semantic" id="main-content">
         <section class="container">
-          <section class="feature">
+          <article class="markdown overhang fullwidth">
             <%= back_link "/my-story-into-teaching", text: "All stories" %>
             <%= yield %>
 
             <div class="cards stories">
               <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
             </div>
-          </section>
-        </div>
+          </article>
+        </section>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -4,11 +4,9 @@
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <main class="semantic" role="main" id="main-content">
-        <section class="container">
-          <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
-            <%= yield %>
-          <% end %>
-        </section>
+        <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
+          <%= yield %>
+        <% end %>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,10 +1,11 @@
 <% @skip_hero = @hide_page_helpful_question = true %>
 
+<h2 class="green">You've signed up</h2>
+
 <section class="mailing-reg-main">
-    <h1 class="strapline">You've signed up</h1>
     <p>You’re ready to receive email updates to help you get into teaching.</p>
 
-    <h2>What happens next?</h2>
+    <h3>What happens next?</h2>
 
     <p>
       You’ll receive an email to the address you gave us when you signed up.
@@ -12,7 +13,7 @@
       handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
     </p>
 
-    <h2>Want to speak to us?</h2>
+    <h3>Want to speak to us?</h2>
 
     <p>
       If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm.
@@ -20,8 +21,6 @@
     <p>
       You can also use this number to update or amend any of your details.
     </p>
-
-    <h2>Explore Get Into Teaching</h2>
 
     <span data-controller="pinterest"
         data-pinterest-action="track"

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,44 +1,36 @@
 <section id="talk-to-us" class="talk-to-us">
-    <section class="container">
-        <div class="talk-to-us__inner">
-
-            <h2 class="strapline">Talk to us</h2>
-            <p class="talk-to-us__inner__label">
-                How can we help you take your next step towards teacher training?
+   <section class="container">
+      <div class="talk-to-us__inner">
+         <h2 class="strapline">Talk to us</h2>
+         <p class="talk-to-us__inner__label">
+            How can we help you take your next step towards teacher training?
+         </p>
+         <div class="talk-to-us__inner__table">
+            <div class="talk-to-us__inner__table__column" data-controller="talk-to-us">
+               <p>
+                  <b>Chat online</b> <br/>
+                  If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
+                  Monday-Friday between 8.30am and 5pm.
+               </p>
+               <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
+               Chat <span>online</span>
+               </a>
+            </div>
+            <div class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
+               <p>
+                  <b>Sign up to get a teacher training adviser</b> <br/>
+                  If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
+               </p>
+               <a href="/tta-service" class="call-to-action-button">
+               Get an <span>adviser</span>
+               </a>
+            </div>
+         </div>
+         <div class="talk-to-us__inner__freephone">
+            <p>
+               If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm. You can also use this number to update or amend any of your details.
             </p>
-
-            <div class="talk-to-us__inner__table">
-
-                <div class="talk-to-us__inner__table__column" data-controller="talk-to-us">
-                    <p>
-                        <b>Chat online</b> <br/>
-                        If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
-                        Monday-Friday between 8.30am and 5pm.
-                    </p>
-
-                    <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
-                        Chat <span>online</span>
-                    </a>
-                </div>
-
-                <div class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
-                    <p>
-                        <b>Sign up to get a teacher training adviser</b> <br/>
-                        If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
-                    </p>
-                    <a href="/tta-service" class="call-to-action-button">
-                        Get an <span>adviser</span>
-                    </a>
-                </div>
-
-            </div>
-
-            <div class="talk-to-us__inner__freephone">
-                <p>
-                    If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm. You can also use this number to update or amend any of your details.
-                </p>
-            </div>
-
-        </div>
-    </div>
+         </div>
+      </div>
+   </section>
 </section>

--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -17,14 +17,14 @@
             .step-header__text {
                 text-align: left;
                 margin: 0;
-                font-size: $fs-26;
+                font-size: $fs-24;
                 flex-grow: 2;
                 white-space: initial;
                 padding: 0 2em 0 0;
                 background: transparent;
 
-                @include mq($until: tablet) {
-                    font-size: $fs-19;
+                @include mq($from: tablet) {
+                  font-size: $fs-32;
                 }
             }
 
@@ -41,9 +41,13 @@
             }
         }
 
+        .call-to-action {
+          margin: 0 1.5rem;
+        }
+
         .step-content__description {
             margin: 0;
-            padding: .8em;
+            padding: 1.5rem;
 
             blockquote {
               background: $grey;

--- a/app/webpacker/styles/breakpoints.scss
+++ b/app/webpacker/styles/breakpoints.scss
@@ -1,7 +1,7 @@
 $mq-responsive: true;
 $mq-breakpoints: (
   mobile: 500px,
-  tablet: 800px,
+  tablet: 768px,
   desktop: 1200px,
   wide: 1500px,
 );

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -96,7 +96,7 @@
 .cards-with-headers {
 
   h2 {
-    padding: 0 20px 20px ;
+    padding: 0 1.5rem 1.5rem;
     font-size: $fs-32;
   }
 

--- a/app/webpacker/styles/components/content-alert.scss
+++ b/app/webpacker/styles/components/content-alert.scss
@@ -6,7 +6,7 @@
   display: flex;
   width: 78%;
   box-sizing: border-box;
-  margin-bottom: 20px;
+  margin-bottom: 50px;
 
   @include mq($until: tablet) {
     width: inherit;

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -1,7 +1,7 @@
 @mixin content-cta {
   background: $grey;
   text-align: left;
-  padding: 20px;
+  padding: 1.5rem;
   margin: 0 -20px 30px;
   box-sizing: border-box;
   width: auto;

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -1,6 +1,6 @@
 .event-box {
     box-sizing: border-box;
-    padding: 20px;
+    padding: 1.5rem;
     display: inline-block;
     overflow: hidden;
     text-align: left;

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -13,7 +13,7 @@
     font-size: $fs-19;
     background-color: $grey;
     width: 100%;
-    padding: 20px;
+    padding: 1.5rem;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;

--- a/app/webpacker/styles/components/link-block.scss
+++ b/app/webpacker/styles/components/link-block.scss
@@ -8,7 +8,7 @@
         color: #FFFFFF;
         font-weight: bold;
         font-size: $fs-19;
-        padding: 20px 20px 20px 50px;
+        padding: 1.5rem 1.5rem 1.5rem 50px;
         margin: 0;
         position: relative;
         &:before {

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -1,7 +1,7 @@
 .event-info {
 
     h1 {
-        font-size: 42px;
+        font-size: $fs-42;
         line-height: 1.25;
         margin: 1em 0 5px 0
     }

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -8,7 +8,7 @@
 
   .event-type-descriptions__content {
     @include cards-grid;
-    padding: 20px 20px 0 20px;
+    padding: 1.5rem 1.5rem 0 1.5rem;
     margin-bottom: 0;
   }
 }
@@ -79,7 +79,7 @@
 .events-featured {
     background: #F0F0F0;
     position: relative;
-    padding: 20px;
+    padding: 1.5rem;
     width: 100%;
     margin-top: 30px;
     box-sizing: border-box;
@@ -126,6 +126,7 @@
 
     .call-to-action-button {
       margin-top: 1.5em;
+      white-space: normal;
     }
 
     &__logo {
@@ -201,8 +202,6 @@
     }
 
     .types-of-event {
-        padding-top: 20px;
-
         &__left {
 
             padding-left: 0px;
@@ -265,6 +264,10 @@
 
         &--with-logo {
           margin-top: 60px;
+
+          @include mq($until: tablet) {
+            margin-top: 30px;
+          }
         }
 
         &__heading {

--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -1,5 +1,5 @@
 .featured-content {
-    
+
     &__items {
         margin-top: 30px;
         display: flex;
@@ -81,7 +81,7 @@
             position: relative;
         }
         &__content {
-            padding: 0 20px;
+            padding: 0 1.5rem;
             p {
                 margin-top: 0;
             }
@@ -159,7 +159,7 @@
     }
     &__header {
         margin: -20px auto -20px;
-        padding: 0 20px;
+        padding: 0 1.5rem;
         &.content {
             margin-bottom: -20px;
         }

--- a/app/webpacker/styles/feedback-bar.scss
+++ b/app/webpacker/styles/feedback-bar.scss
@@ -13,7 +13,7 @@
     &__inner {
       box-sizing: border-box;
         background-color: white;
-        padding: 20px;
+        padding: 1.5rem;
         border: 1px solid $grey;
         border-width: 1px 1px 0 1px;
         width: 100%;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -5,10 +5,11 @@
         box-sizing: border-box;
     }
     .container {
-        margin: 1em auto 0;
+        margin-top: 0;
+        margin-bottom: 0;
     }
     &__inner {
-        padding: 20px 20px;
+        padding: 1.5rem;
         display: flex;
         align-items: center;
         justify-content: space-between;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -5,7 +5,7 @@
 
 .cta-link {
     width: 50%;
-    padding: 0 20px;
+    padding: 0 1.5rem;
     height: 290px;
     display: block;
     margin-bottom: 30px;
@@ -24,7 +24,7 @@
 
         background: $green-dark-90;
         display: inline-block;
-        padding: 20px 20px 20px 23px;
+        padding: 1.5rem;
         line-height: 1.2;
         font-weight: bold;
         color: white;
@@ -157,14 +157,15 @@
   max-width: 720px;
   background-position: 50% 15%;
 
+  @include mq($from: wide) {
+    left: auto;
+    right: 0;
+  }
+
   @include mq($until: tablet) {
     position: static;
     width: 100%;
     height: 300px;
-  }
-
-  @include mq($from: $max-content-width) {
-    left: img-left($max-content-width);
   }
 }
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -54,13 +54,13 @@ section.container {
   flex-wrap: wrap;
   flex-direction: column;
 
-  max-width: $content-max-width;
-  margin: 1em .8em 0;
+  margin: 1em 0;
 
   @include mq($from: tablet) {
     flex-direction: row-reverse;
     justify-content: flex-end;
-    margin: 1em auto 0;
+    margin: 1.5em auto 0;
+    max-width: $content-max-width;
   }
 
   > article {

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -4,11 +4,9 @@
   &.overhang {
     $indent-amount: 1.5rem;
 
-    @include mq($until: tablet) {
-      > *:not(table) {
-        margin-left: $indent-amount;
-        margin-right: $indent-amount;
-      }
+    > *:not(table) {
+      margin-left: $indent-amount;
+      margin-right: $indent-amount;
     }
 
     @mixin overhang { margin-left: auto; margin-right: auto; }
@@ -21,7 +19,7 @@
       margin-bottom: .2rem;
       padding: .4rem $indent-amount;
       background: $blue;
-      font-size: $fs-32;
+      font-size: $fs-24;
       font-weight: 700;
       color: $white;
       &:after {
@@ -31,17 +29,35 @@
       &.purple {
         background-color: $purple;
       }
+
+      &.green {
+        background-color: $green;
+      }
+
+      &.small {
+        font-size: $fs-19;
+      }
+
+      @include mq($from: tablet) {
+        font-size: $fs-32;
+      }
     }
 
-    .call-to-action,
+    .accordions,
+    .stories-feature,
     .feature-table,
     .secondary-button,
+    .content-alert,
+    .event-type-descriptions,
     .types-of-event,
     .content-cta,
     .featured-content,
-    .event-pagination,
     .page-helpful {
       @include overhang;
+    }
+
+    .content-alert--left {
+      margin-left: 0;
     }
   }
 

--- a/app/webpacker/styles/page-helpful.scss
+++ b/app/webpacker/styles/page-helpful.scss
@@ -1,5 +1,5 @@
 .page-helpful {
-    padding: 20px;
+    padding: 1.5rem;
     margin: 2em 0 0 0;
     background: $grey;
     display: none;
@@ -20,7 +20,7 @@
         &:last-child {
             margin-left: 20px;
         }
-        
+
         &:hover {
             text-decoration: none;
         }

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -15,11 +15,6 @@
       font-size: $fs-42;
       margin: 0;
       line-height: 1.25;
-
-      &.strapline {
-        margin-bottom: 30px;
-        margin-left: -20px;
-      }
   }
 
   h2 {
@@ -53,12 +48,6 @@
 @include mq($until: tablet) {
   .event-reg-main,
   .mailing-reg-main {
-      h1 {
-        &.strapline {
-          margin-left: 0;
-        }
-    }
-
     &__content {
 
         display: block;

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -5,7 +5,7 @@
 
     &__inner {
         position: relative;
-        top: -65px;
+        top: -55px;
         margin-bottom: -45px;
 
         &__label {
@@ -58,13 +58,14 @@
 
 @include mq($until: tablet) {
     .talk-to-us {
-        &__inner {
-            padding: 0 20px;
-            top: -45px;
+        .strapline {
+          margin-left: -1.5rem;
+          margin-right: -1.5rem;
+        }
 
-            .strapline {
-                font-size: $fs-24;
-            }
+        &__inner {
+            top: -40px;
+            padding: 0 1.5rem;
 
             &__label {
                 margin: 0;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -1,10 +1,10 @@
 .story-landing {
-    header {
-        padding: 0 20px;
+    &__header {
         width: 66.6%;
+        margin-top: 1.5rem;
 
         @include mq($until: tablet) {
-          width: 100%;
+          width: auto;
           padding: 0;
         }
 
@@ -17,26 +17,21 @@
         }
     }
 
-    .feature > section {
-        margin-bottom: 3em;
+    &__footer {
+        width: 66.6%;
 
-        > footer {
-            padding: 20px;
-            width: 66.6%;
+        @include mq($until: tablet) {
+          width: 100%;
+          margin: 0;
+          padding: 0;
+        }
 
-            @include mq($until: tablet) {
-              width: 100%;
-              margin: 0;
-              padding: 0;
-            }
-
-            a {
-                @include button;
-                @include chevron;
-                display: inline-block;
-                margin: 1em 0 0 0;
-                white-space: initial;
-            }
+        a {
+            @include button;
+            @include chevron;
+            display: inline-block;
+            margin: 1em 0 0 0;
+            white-space: initial;
         }
     }
 }
@@ -45,8 +40,6 @@
 
     display: table;
     width: 100%;
-    max-width: 1250px;
-    margin: 2em auto 2em;
 
     @include mq($from: tablet) {
       border-bottom: 2em solid $purple;
@@ -115,7 +108,7 @@
             h2 {
                 font-size: $fs-32;
                 border-bottom: none;
-                padding: 0 20px;
+                padding: 0 1.5rem;
                 margin: 0;
                 color: $black;
                 background: transparent;
@@ -183,10 +176,13 @@
 
 .stories {
   grid-gap: 1em;
-  padding: 0 20px;
 
   @include mq($until: tablet) {
     padding: 0;
+  }
+
+  &--with-padding {
+    padding: 0 1.5rem;
   }
 
   .card {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -7,7 +7,7 @@ $git-font-family: Sans-serif;
 
 h1 {
     @include font;
-    font-size: $fs-28;
+    font-size: $fs-32;
 }
 
 h2 {
@@ -50,10 +50,10 @@ a {
     @include font;
     color: $white;
     font-weight: bold;
-    font-size: $fs-32;
+    font-size: $fs-24;
     background-color: $purple;
     display: inline-block;
-    padding: 10px 20px;
+    padding: 0.4rem 1.5rem;
     &:after {
         content: ".";
     }
@@ -67,12 +67,20 @@ a {
       background-color: $blue;
     }
 
+    &--green {
+      background-color: $green;
+    }
+
     &--small {
-      font-size: $fs-16;
+      font-size: $fs-19;
 
       &:after {
         content: "";
       }
+    }
+
+    @include mq($from: tablet) {
+      font-size: $fs-32;
     }
 }
 
@@ -107,12 +115,4 @@ a {
 
 .telephone-number:hover {
     text-decoration: none;
-}
-
-@include mq($until: tablet) {
-    .strapline {
-        font-size: $fs-24;
-        padding-top: 10px;
-        padding-bottom: 10px;
-    }
 }

--- a/app/webpacker/styles/video.scss
+++ b/app/webpacker/styles/video.scss
@@ -26,7 +26,7 @@
     z-index: 1000;
     justify-content: center;
     align-items: center;
-    
+
     &__background {
         opacity: 0.4;
         background-color: $black;
@@ -86,16 +86,16 @@
         }
 
     }
-    
+
 }
 
-@include mq($until: tablet) {    
+@include mq($until: tablet) {
     .video-overlay {
-    
+
         &__video-container {
-        
+
             &__dismiss {
-                
+
                 width: 44px;
                 height: 44px;
 

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -43,6 +43,11 @@ describe Stories::StoryComponent, type: "component" do
     page
   end
 
+  describe "layout elements" do
+    it { is_expected.to have_css(".container .markdown.overhang.no-hero") }
+    it { is_expected.to have_css(".container .feature") }
+  end
+
   describe "metadata content" do
     specify "renders a story" do
       is_expected.to have_css("article.story")


### PR DESCRIPTION
### Trello card

[Trello-752](https://trello.com/c/UsPSp1jk/752-fix-page-indentation-between-800px-and-1000px)

### Context

There are inconsistencies in spacing and how the web pages behave responsively. This PR aims to tweak a bunch of the margins, layout spacings and responsive behaviours of the pages. It also includes various other minor fixes that Ben highlighted when we did a run through (strapline/h2 sizes, colours, etc). 

### Changes proposed in this pull request

- Fix responsive margins on various pages

Updates various pages to tweak how the 1.5rem margin is applied to the content at different viewport sizes. Includes a few other random fixes that Ben pointed out. Drops the mobile breakpoint to 768px.

### Guidance to review

This touches most areas so a decent run through in desktop/mobile is needed for reviewing (I've done this but worth someone else doing so as well).

There are a couple less than ideal bits of CSS in here to get around some obscurities, but it should get the website matching the design more consistently and we can refactor these later. The `1.5rem` margin value could also be extracted into a variable going forward (and a wider search of 20px padding/margin values to replace is probably needed).