### PR TITLE
Improve responsiveness of story cards

### DIFF
--- a/app/webpacker/styles/breakpoints.scss
+++ b/app/webpacker/styles/breakpoints.scss
@@ -2,7 +2,7 @@ $mq-responsive: true;
 $mq-breakpoints: (
   mobile: 500px,
   tablet: 768px,
-  desktop: 1200px,
+  desktop: 1000px,
   wide: 1500px,
 );
 $mq-static-breakpoint: desktop;

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -176,9 +176,14 @@
 
 .stories {
   grid-gap: 1em;
+  @include cards-grid(1, 2.5em);
 
-  @include mq($until: tablet) {
-    padding: 0;
+  @include mq($from: mobile, $until: desktop) {
+    @include cards-grid(2, 2.5em);
+  }
+
+  @include mq($from: desktop) {
+    @include cards-grid(3, 2.5em);
   }
 
   &--with-padding {
@@ -192,12 +197,6 @@
     background-color: $grey;
     align-items: center;
 
-    @include mq($until: tablet) {
-      flex-wrap: nowrap;
-      flex-direction: column;
-      align-content: flex-start;
-    }
-
     .card__thumb {
       flex: 0 1 45%;
 
@@ -206,26 +205,10 @@
         object-fit: contain;
         height: auto;
       }
-
-      @include mq($until: tablet) {
-        flex: 1 0 auto;
-        justify-items: center;
-        text-align: center;
-
-        > img {
-          object-fit: cover;
-          max-height: 15em;
-        }
-      }
     }
 
     .card__snippet {
       flex: 0 0 50%;
-
-      @include mq($until: tablet) {
-        flex: 1 0 auto;
-        padding: 1em;
-      }
 
       padding: 0;
       margin: 0;
@@ -234,12 +217,6 @@
         padding: 0 .6em;
         margin: 0;
         font-size: $fs-16;
-
-        @include mq($until: tablet) {
-          margin-top: .5em;
-          padding: 0 .5em;
-          font-size: initial;
-        }
       }
     }
 
@@ -247,18 +224,12 @@
       padding: .6em 1em;
       flex: 1 0 80%;
       margin-left: 1em;
-
-      @include mq($until: tablet) {
-        margin: 0;
-        flex: 1 1 0;
-      }
     }
   }
 }
 
 @include mq($until: tablet) {
     .stories {
-
         &__thumbs {
             flex-wrap: wrap;
             margin-bottom: 20px;


### PR DESCRIPTION
### Trello card

[Trello-782](https://trello.com/c/wjZhTHZU/782-story-card-on-mobile-view-doesnt-match-designs)

### Context

The story cards don't currently match the designs when in a mobile viewport. We should also make better use of space on the in-between mobile and desktop breakpoints where we could fit 2 columns of cards.

### Changes proposed in this pull request

- Change desktop breakpoint to 1000px

This matches the content width of 1000px, otherwise the content was changing from the breakpoint 200px before the content actually started getting squashed.

- Improve responsiveness of story cards

Update the cards to match the designs (keep the same layout on mobile/desktop). 

We were going from 3 columns to 1 which, with the updated design, left a lot of space around the text on the cards. This updates to add a two column layout between mobile and desktop that makes better use of the space.

### Guidance to review

| Mobile      | Tablet | Desktop |
| ----------- | ----------- |----------|
| <img width="490" alt="Screenshot 2021-01-28 at 11 29 14" src="https://user-images.githubusercontent.com/29867726/106132675-23c60e80-615c-11eb-915e-de080ba2c43d.png"> | <img width="782" alt="Screenshot 2021-01-28 at 11 29 07" src="https://user-images.githubusercontent.com/29867726/106132692-2aed1c80-615c-11eb-8e39-0432866d4643.png">       |<img width="1126" alt="Screenshot 2021-01-28 at 11 29 01" src="https://user-images.githubusercontent.com/29867726/106132805-5243e980-615c-11eb-8b83-c629886cf147.png"> |




