### PR TITLE
Accessibility fixes

### DIFF
--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -2,9 +2,7 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-    <h4 class="call-to-action__heading">
-      Chat to us
-    </h4>
+    <%= tag.span("Chat to us", class: "call-to-action__heading") %>
 
     <p class="call-to-action__text">
       If you're unsure whether your qualifications are equivalent, you can chat to us.

--- a/app/components/calls_to_action/multiple_buttons_component.html.erb
+++ b/app/components/calls_to_action/multiple_buttons_component.html.erb
@@ -2,9 +2,7 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-    <h4 class="call-to-action__heading">
-      <%= title %>
-    </h4>
+    <%= tag.span(title, class: "call-to-action__heading") %>
 
     <div class="call-to-action__button-row">
       <% links.each do |link| %>

--- a/app/components/calls_to_action/narrow_component.html.erb
+++ b/app/components/calls_to_action/narrow_component.html.erb
@@ -2,9 +2,7 @@
   <header>
     <%= icon %>
     <% if title.present? %>
-      <h4 class="call-to-action__heading">
-        <%= title %>
-      </h4>
+      <%= tag.span(title, class: "call-to-action__heading") %>
     <% end %>
   </header>
 

--- a/app/components/calls_to_action/next_steps_component.html.erb
+++ b/app/components/calls_to_action/next_steps_component.html.erb
@@ -2,9 +2,7 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-    <h4 class="call-to-action__heading">
-      Get support from an adviser
-    </h4>
+    <%= tag.span("Get support from an adviser", class: "call-to-action__heading") %>
 
     <div class="call-to-action__action">
       <p class="call-to-action__text">

--- a/app/components/calls_to_action/simple_component.html.erb
+++ b/app/components/calls_to_action/simple_component.html.erb
@@ -2,11 +2,8 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-
     <% if title.present? %>
-      <h4 class="call-to-action__heading">
-        <%= title %>
-      </h4>
+      <%= tag.span(title, class: "call-to-action__heading") %>
     <% end %>
 
     <% if text.present? %>

--- a/app/components/calls_to_action/story_component.html.erb
+++ b/app/components/calls_to_action/story_component.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="call-to-action__content">
-    <%= tag.h3(heading, class: "call-to-action__contents__heading") %>
+    <%= tag.span(heading, class: "call-to-action__contents__heading") %>
     <%= tag.p(text, class: "call-to-action__contents__story") %>
 
     <div class="call-to-action__action">

--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -23,7 +23,7 @@
         </div>
         <div data-navigation-target="links" id="navbar-mobile-links" class="navbar__mobile__links">
             <ul>
-                <li><a href="/">Home</a></li>
+                <li><%= link_to("Home", root_path) %></li>
                 <% resources.each do |resource| %>
                     <li><%= link_to resource[:front_matter][:title], resource[:path] %></li>
                 <% end %>

--- a/app/components/navbar/navbar_component.html.erb
+++ b/app/components/navbar/navbar_component.html.erb
@@ -23,11 +23,11 @@
         </div>
         <div data-navigation-target="links" id="navbar-mobile-links" class="navbar__mobile__links">
             <ul>
-                <li><%= link_to("Home", root_path) %></li>
+                <%= nav_link("Home", '/') %>
                 <% resources.each do |resource| %>
-                    <li><%= link_to resource[:front_matter][:title], resource[:path] %></li>
+                    <%= nav_link resource[:front_matter][:title], resource[:path] %>
                 <% end %>
-                <li><%= link_to "Find an event near you", events_path %></li>
+                <%= nav_link "Find an event near you", events_path %>
             </ul>
         </div>
     </div>

--- a/app/components/navbar/navbar_component.rb
+++ b/app/components/navbar/navbar_component.rb
@@ -10,7 +10,7 @@ module Navbar
       class_name = "active" if first_uri_segment_matches_link?(link_path)
 
       content_tag(:li, class: class_name) do
-        link_to link_text, link_path
+        link_to_unless_current link_text, link_path
       end
     end
 

--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -15,7 +15,6 @@ module StoriesHelper
       width: 560,
       height: 315,
       src: url,
-      frameborder: 0,
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
       allowfullscreen: true,
       class: "story__video",

--- a/app/views/components/_videoplayer.html.erb
+++ b/app/views/components/_videoplayer.html.erb
@@ -4,6 +4,7 @@
     <div class='video-overlay__video-container'>
         <div class="video-overlay__video-container__wrapper">
             <iframe data-video-target="iframe"
+                title="Get into Teaching Video Player"
                 width="800"
                 height="450"
                 src=""

--- a/app/views/components/_videoplayer.html.erb
+++ b/app/views/components/_videoplayer.html.erb
@@ -8,7 +8,6 @@
                 height="450"
                 src=""
                 alt="Watch a video for more information about becoming a teacher"
-                frameborder="0"
                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                 allowfullscreen
                 playsinline="false">

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<section class="mailing-reg-main" role="main" id="main-content">
+<section class="mailing-reg-main">
   <p>
     <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
   </p>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -26,7 +26,7 @@
         </a>
       </div>
       <div class="site-footer-top__links-container">
-        <%= link_to("Home", page_path(page: :home)) %>
+        <%= link_to("Home", root_path) %>
         <% navigation_resources.each do |resource| %>
           <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
         <% end %>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -6,25 +6,25 @@
             How can we help you take your next step towards teacher training?
          </p>
          <div class="talk-to-us__inner__table">
-            <div class="talk-to-us__inner__table__column" data-controller="talk-to-us">
+            <section class="talk-to-us__inner__table__column" data-controller="talk-to-us">
+               <h3 class="talk-to-us__inner__table__column__heading">Chat online</h3>
                <p>
-                  <b>Chat online</b> <br/>
                   If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
                   Monday-Friday between 8.30am and 5pm.
                </p>
                <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
                Chat <span>online</span>
                </a>
-            </div>
-            <div class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
+            </section>
+            <section class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
+               <h3 class="talk-to-us__inner__table__column__heading">Sign up to get a teacher training adviser</h3>
                <p>
-                  <b>Sign up to get a teacher training adviser</b> <br/>
                   If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
                </p>
                <a href="/tta-service" class="call-to-action-button">
                Get an <span>adviser</span>
                </a>
-            </div>
+            </section>
          </div>
          <div class="talk-to-us__inner__freephone">
             <p>

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -38,6 +38,7 @@
 
   .call-to-action__heading {
     font-size: $fs-26;
+    font-weight: bold;
     margin-bottom: 1em;
   }
 

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -166,6 +166,8 @@
             background-color: $grey;
             width: 100%;
         
+            text-align: right;
+            font-weight: bold;
             a {
                 display: block;
                 text-align: center;
@@ -174,7 +176,6 @@
                 font-weight: bold;
                 letter-spacing: 0px;
                 color: #1D1D1B;
-                margin-right: 40px;
                 padding-right: 0px;
             }
 
@@ -183,7 +184,19 @@
             }
 
             ul {
+                margin-right: 40px;
                 list-style-type:none;
+
+                li {
+                  margin: .2em;
+                }
+
+                li.active {
+                  background-color: $blue;
+                  color: $white;
+                  display: inline-block;
+                  padding: .2em .3em;
+                }
             }
 
         }

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -75,8 +75,14 @@
             float: right;
             padding: 8px 16px;
         }
-    
-        li a {
+
+        li {
+          @include font;
+          font-size: $fs-16;
+          font-weight: bold;
+          line-height: 1;
+
+          a {
             @include font;
             font-size: $fs-16;
             display: block;
@@ -87,6 +93,7 @@
             letter-spacing: 0px;
             color: #1D1D1B;
             line-height: 1;
+          }
         }
 
         $border-width: 2.5px;
@@ -109,6 +116,7 @@
       
         .active {
           background-color: $blue-dark;
+          color: $white;
           a {
             color: $white;
           }

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -33,6 +33,11 @@
                 a{
                     text-decoration: none;
                 }
+
+                &__heading {
+                    font-size: $fs-26;
+                    margin: .5em 0;
+                }
             }
 
             &__column:first-child {

--- a/spec/components/calls_to_action/multiple_buttons_component_spec.rb
+++ b/spec/components/calls_to_action/multiple_buttons_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CallsToAction::MultipleButtonsComponent, type: :component do
   end
 
   specify "the title is present" do
-    expect(page).to have_css("h4", text: title)
+    expect(page).to have_css(".call-to-action__heading", text: title)
   end
 
   specify "all the links are present" do

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
     end
 
     specify "the title is present" do
-      expect(page).to have_css("h4", text: title)
+      expect(page).to have_css(".call-to-action__heading", text: title)
     end
 
     specify "the text is present" do

--- a/spec/components/calls_to_action/story_component_spec.rb
+++ b/spec/components/calls_to_action/story_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CallsToAction::StoryComponent, type: :component do
   end
 
   specify "the heading and text are present" do
-    expect(page).to have_css("h3", text: heading)
-    expect(page).to have_css("p", text: text)
+    expect(page).to have_css(".call-to-action__contents__heading", text: heading)
+    expect(page).to have_css(".call-to-action__contents__story", text: text)
   end
 end

--- a/spec/components/navbar/navbar_component_spec.rb
+++ b/spec/components/navbar/navbar_component_spec.rb
@@ -21,7 +21,7 @@ describe Navbar::NavbarComponent, type: "component" do
 
       it "shows background colour on link that matches the current page" do
         expect(page).to have_css("li.active") do |active_li|
-          expect(active_li).to have_link("Home", href: "/")
+          expect(active_li).to have_content("Home")
         end
       end
 

--- a/spec/javascript/controllers/video_controller_spec.js
+++ b/spec/javascript/controllers/video_controller_spec.js
@@ -26,7 +26,6 @@ describe('AccordionController', () => {
                         width="800"
                         height="450"
                         src=""
-                        frameborder="0"
                         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                         allowfullscreen>
                     </iframe>


### PR DESCRIPTION
## Trello card

## Context

Some issues were highlighted by an accessibility review that was conducted using the [SiteImprove](https://siteimprove.com/) browser extension.

## Issues

### Homepage (Page 1)

#### 1- Text Alternatives: 
* [x] Image with no alt attribute

Caused by injected advertising/tracking.

![Screenshot from 2021-01-28 13-00-46](https://user-images.githubusercontent.com/128088/106142282-3561e300-6169-11eb-8170-f65ea3af7c44.png)



#### Adaptable:
* [x] Input field has no description - caused by the SnapChat injection, see below
* [x] **Bold** tag used to format text - 030a22b
* [x] HTML is used to format content - 4d56968 

#### Distinguishable:

* [x] Color contrast is insufficient

Unsure why, but SiteImprove is reporting the text as white when it's clearly black.

| SiteImprove | Contrast checking |
| -------- | --------- |
| ![Screenshot from 2021-01-28 12-23-25](https://user-images.githubusercontent.com/128088/106138189-b4541d00-6163-11eb-936c-03be5539c272.png) | ![Screenshot from 2021-01-28 12-22-27](https://user-images.githubusercontent.com/128088/106138204-b8803a80-6163-11eb-80f1-8badd46a29c7.png) |



#### Link Purpose (In Context): 

* [x] Link text used for multiple different destinations - 75974efd54a2

This was caused by the 'Home' link in the top nav bar linking to `/` and the one in the footer linking to `/home`. They've both been change to link to the `root_path`.

#### Predictable, Labels or Instructions, and Input Assistance

These issues all seem to be caused by SnapChat injecting a poorly marked-up form into our page.

* [x] Missing button in form
* [x] Input field has no description
* [x] Input field has no description
* [x] Frame is missing a title
* [x] Form is missing button

![Screenshot from 2021-01-28 12-27-19](https://user-images.githubusercontent.com/128088/106138560-32182880-6164-11eb-813b-d7964ee9a9db.png)

### Mailing list wizard first page (Page 2)

#### Adaptable:
* [x] Input field has no description - SnapChat (same as above)
* [x] Element ID is not unique - df638542d725
* [x] HTML is used to format content - 4d56968 (same as above)

#### Navigable:

* [x] Link text used for multiple different destinations - 75974efd54a2 (same as above)

#### Predictable:

* [x]  Missing button in form - SnapChat (same as above)

#### Input Assistance

* [x] Input field has no description - SnapChat (same as above)

#### Compatible

* [x] iFrame is missing a title - 9151c581ca

### Teaching as a career (Page 3)

#### Adaptable:
* [x] **Bold** tag used to format text - 030a22b (as above)
* [x] HTML is used to format content - 4d56968 

#### Distinguishable:
* [x] Color contrast is insufficient - (as above, looks like a false positive)

#### Navigable:

* [x] Link text used for multiple different destinations - 75974efd54a2 (same as above)

#### Compatible:

* [x] iFrame is missing a title - 9151c581ca

## Other changes

* [x] Update the CTA headings so they're rendered in a `span` (with bold text) instead of a `h3`/`h4`

![Screenshot from 2021-01-28 15-41-48](https://user-images.githubusercontent.com/128088/106161830-59302380-617f-11eb-9925-22004dba077b.png)

* [x] Make the mobile nav bar work like the desktop one, remove links to the current page and style the active page accordingly
![Screenshot from 2021-01-28 15-33-53](https://user-images.githubusercontent.com/128088/106161940-7533c500-617f-11eb-8e9a-e9e8cd470790.png)


