### PR TITLE
Consolidate main page header CSS

### DIFF
--- a/app/components/content/feature_table_component.html.erb
+++ b/app/components/content/feature_table_component.html.erb
@@ -1,7 +1,8 @@
+<% if title? %>
+  <h2 class="always-indent"><%= title %></h2>
+<% end %>
+
 <div class="<%= wrapper_class %>">
-  <% if title? %>
-    <h2 class="strapline strapline--blue"><%= title %></h2>
-  <% end %>
   <dl>
     <% data.map do |key, value| %>
       <dt><%= key %></dt>

--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -30,10 +30,12 @@
   </article>
   <section class="feature">
     <% if show_more_stories? %>
-      <h2 class="strapline">More stories</h2>
-      <div class="cards stories stories--with-padding">
-        <%= render Cards::RendererComponent.with_collection(more_stories) %>
-      </div>
+      <h2 class="purple">More stories</h2>
+      <p>
+        <div class="cards stories stories--with-padding">
+          <%= render Cards::RendererComponent.with_collection(more_stories) %>
+        </div>
+      </p>
     <% end %>
 
     <% if show_explore? %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,8 +14,8 @@
 <% @before_search_fullwidth = true %>
 
 <% content_for :before_search do %>
+<h2>Types of events</h2>
 <section class="event-type-descriptions">
-  <h2 class="strapline strapline--blue">Types of events</h2>
   <section class="event-type-descriptions__content">
     <% GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.each do |type_id| %>
       <%= render Events::TypeDescriptionComponent.new(type_id) %>
@@ -23,7 +23,6 @@
   </section>
 </section>
 <% end %>
-
 
 <% unless @performed_search %>
   <div class="content-alert content-alert--left">
@@ -39,7 +38,7 @@
 
 <% if @events_by_type.any? %>
   <% unless @performed_search %>
-  <h2 class="strapline strapline--blue">Discover events</h2>
+  <h2>Discover events</h2>
   <% end %>
   <% @group_presenter.sorted_events_by_type.each do |type_id, events| %>
     <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,7 +1,7 @@
 <section id="talk-to-us" class="talk-to-us">
    <section class="container">
       <div class="talk-to-us__inner">
-         <h2 class="strapline">Talk to us</h2>
+         <h2 class="purple">Talk to us</h2>
          <p class="talk-to-us__inner__label">
             How can we help you take your next step towards teacher training?
          </p>

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -1,14 +1,4 @@
 .feature-table {
-  margin: 30px 0;
-
-  .strapline {
-    margin: 0 4em 0 0;
-
-    &:after {
-      content: '';
-    }
-  }
-
   dl {
     font-size: $fs-19;
     background-color: $grey;
@@ -44,10 +34,6 @@
   }
 
   @include mq($until: tablet) {
-    .strapline {
-      margin-right: 1.2em;
-    }
-
     dl {
       dt, dd {
         flex-basis: 100%;

--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -1,9 +1,34 @@
 @mixin content-heading {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: .2rem;
+  padding: .4rem $indent-amount;
+  background: $blue;
+  font-size: $fs-24;
+  font-weight: 700;
+  margin-right: 8rem;
+  color: $white;
+  &:after {
+    content: ".";
+  }
+
+  &.purple {
+    background-color: $purple;
+  }
+
+  &.green {
+    background-color: $green;
+  }
+
+  &.small {
+    font-size: $fs-19;
+  }
+
+  @include mq($from: tablet) {
     font-size: $fs-32;
-    font-weight: bold;
-    color: $white;
-    background-color: $blue;
-    margin: 0 -20px 20px -20px;
-    padding: 10px 20px;
-    display: inline-block;
+
+    &:not(.always-indent) {
+      margin-right: 0;
+    }
+  }
 }

--- a/app/webpacker/styles/feature.scss
+++ b/app/webpacker/styles/feature.scss
@@ -1,0 +1,5 @@
+.feature {
+  > h2 {
+    @include content-heading;
+  }
+}

--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -126,12 +126,6 @@
         &__item-wide {
             display: block;
             position: relative;
-            .strapline {
-                position: absolute;
-                top: -45px;
-                left: 0;
-                padding-left: 20px;
-            }
             &__image {
                 width: 100%;
                 margin-bottom: 20px;

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -1,11 +1,17 @@
-@import 'breakpoints';
 @import 'colours';
+@import 'margins';
+
+@import './components/mixins/cards-grid';
+@import './components/mixins/headings';
+
+@import 'breakpoints';
 @import 'font-sizes';
 @import 'utility';
 @import 'text';
 @import 'layout';
 @import 'links-and-buttons';
 @import 'markdown';
+@import 'feature';
 @import 'featured';
 @import 'forms';
 @import 'icons';
@@ -22,8 +28,6 @@
 @import './sections/hero/content';
 @import './sections/talk-to-us';
 
-@import './components/mixins/cards-grid';
-@import './components/mixins/headings';
 @import './components/cards.scss';
 @import './components/event-box';
 @import './components/content-cta';

--- a/app/webpacker/styles/margins.scss
+++ b/app/webpacker/styles/margins.scss
@@ -1,0 +1,1 @@
+$indent-amount: 1.5rem;

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -2,8 +2,6 @@
 
   // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
   &.overhang {
-    $indent-amount: 1.5rem;
-
     > *:not(table) {
       margin-left: $indent-amount;
       margin-right: $indent-amount;
@@ -13,34 +11,7 @@
 
     > h2 {
       @include overhang;
-
-      display: inline-block;
-      margin-top: 0;
-      margin-bottom: .2rem;
-      padding: .4rem $indent-amount;
-      background: $blue;
-      font-size: $fs-24;
-      font-weight: 700;
-      color: $white;
-      &:after {
-        content: ".";
-      }
-
-      &.purple {
-        background-color: $purple;
-      }
-
-      &.green {
-        background-color: $green;
-      }
-
-      &.small {
-        font-size: $fs-19;
-      }
-
-      @include mq($from: tablet) {
-        font-size: $fs-32;
-      }
+      @include content-heading;
     }
 
     .accordions,
@@ -61,7 +32,7 @@
     }
   }
 
-  h2:not(:first-of-type) {
+  h2:not(:first-child) {
     margin-top: 1em;
   }
 

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -5,8 +5,11 @@
 
     &__inner {
         position: relative;
-        top: -55px;
-        margin-bottom: -45px;
+        top: -27px;
+
+        h2 {
+          @include content-heading;
+        }
 
         &__label {
             margin-left: 20px;
@@ -58,17 +61,12 @@
 
 @include mq($until: tablet) {
     .talk-to-us {
-        .strapline {
-          margin-left: -1.5rem;
-          margin-right: -1.5rem;
-        }
-
         &__inner {
-            top: -40px;
+            top: -20px;
             padding: 0 1.5rem;
 
             &__label {
-                margin: 0;
+                margin: 1.5rem 0;
             }
 
             &__table {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -46,44 +46,6 @@ a {
     }
 }
 
-.strapline {
-    @include font;
-    color: $white;
-    font-weight: bold;
-    font-size: $fs-24;
-    background-color: $purple;
-    display: inline-block;
-    padding: 0.4rem 1.5rem;
-    &:after {
-        content: ".";
-    }
-    &--overlap {
-        background-color: $blue-dark-90;
-        padding: 10px 20px 10px 40px;
-        margin: 20px -20px;
-    }
-
-    &--blue {
-      background-color: $blue;
-    }
-
-    &--green {
-      background-color: $green;
-    }
-
-    &--small {
-      font-size: $fs-19;
-
-      &:after {
-        content: "";
-      }
-    }
-
-    @include mq($from: tablet) {
-      font-size: $fs-32;
-    }
-}
-
 .git-link {
     @include font;
     font-weight: bold;

--- a/spec/support/views/content/home/_test_content.erb
+++ b/spec/support/views/content/home/_test_content.erb
@@ -1,6 +1,6 @@
 <div class="steps-home">
     <section class="container">
-        <div class="strapline strapline--blue">Steps</div>
+        <h2>Steps</h2>
 
         <div class="home-inset-content">
           <h1>Discover the steps to become a teacher.</h1>


### PR DESCRIPTION
### Trello card

[Trello-784](https://trello.com/c/YDFJTUGD/784-kill-off-all-the-strapline-classes-in-favour-of-the-markdown-h2-styling)

### Context

We currently have two ways of styling h2 headings; by `.markdown > h2` and a `.strapline` class (legacy and for places where a wrapping div prevents the `.markdown > h2` selector applying).

This commit removes all uses of the `.strapline` class by bubbling the `h2` up a level where possible so that the `.markdown > h2` selector applies.

There are a couple of use cases outside the `.markdown` class, such as `.feature` and `footer`. To cover these the heading CSS has been abstracted into a mixin and mixed in to the particular classes.

Also adds a global right-margin on the headings when in mobile, as per the design (apart from on the feature tables where the right margin should always be present).

### Changes proposed in this pull request

- Remove strapline class

### Guidance to review

I think this could be taken further in terms of formalising the different non-markdown content throughout the site, but this should be a step in the right direction.