### PR TITLE
Clean up SearchComponent HTML/CSS

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -2,49 +2,43 @@
   <section class="container">
     <article class="markdown overhang fullwidth">
       <h2 id="searchforevents" class="colored-stripe__title purple"><%= heading %></h2>
-      <div class="colored-stripe__content search-for-events">
-        <div class="search-for-events__content">
+      <div class="colored-stripe__content">
+        <div class="search">
           <%= form_for search, method: :get, url: path do |f| %>
-            <div class="search-for-events__content__inputs"
-                  data-controller="conditional-field"
-                  data-conditional-field-mode="hide"
-                  data-conditional-field-expected="">
-
+            <div class="search__controls" data-controller="conditional-field" data-conditional-field-mode="hide" data-conditional-field-expected="">
               <% if include_type %>
                 <%= tag.div(class: input_field_classes(:type)) do %>
-                    <%= f.label :type, "Event type", class: "search-for-events__content__input__label" %>
+                    <%= f.label :type, "Event type" %>
                     <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
                 <% end %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:distance)) do %>
-                  <%= f.label :distance, "Location", class: "search-for-events__content__input__label" %>
+                  <%= f.label :distance, "Location" %>
                   <%= f.select :distance, search.class.available_distances, {},
                         data: { action: "conditional-field#toggle", "conditional-field-target": "source" } %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:postcode), data: { "conditional-field-target": "showhide" }) do %>
-                <%= f.label :postcode, "Postcode", class: "search-for-events__content__input__label" %>
+                <%= f.label :postcode, "Postcode" %>
                 <%= f.text_field :postcode %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:month)) do %>
-                  <%= f.label :month, "Month", class: "search-for-events__content__input__label" %>
+                  <%= f.label :month, "Month" %>
                   <%= f.select :month, search.available_months, **month_args %>
               <% end %>
             </div>
 
             <% if error_messages.any? %>
-              <div class="search-for-events__content__errors">
+              <div class="search__errors">
                 <% error_messages.each do |error_message| %>
                   <%= tag.div(error_message) %>
                 <% end %>
               </div>
             <% end %>
 
-            <div class="search-for-events__content__update">
-              <button class="request-button">Update results <%= helpers.fas_icon "sync" %></button>
-            </div>
+            <button class="request-button">Update results <%= helpers.fas_icon "sync" %></button>
           <% end %>
         </div>
       </div>

--- a/app/components/events/search_component.rb
+++ b/app/components/events/search_component.rb
@@ -13,11 +13,7 @@ module Events
     end
 
     def input_field_classes(field)
-      error_class = "search-for-events__content__error"
-
-      %w[search-for-events__content__input].tap do |classes|
-        classes << error_class if search.errors[field].any?
-      end
+      return "search__field--error" if search.errors[field].any?
     end
 
     def month_args

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -19,3 +19,4 @@ $white-90: rgba($white, .9);
 $yellow: #FBBA20;
 $yellow-dark: #F9B400;
 $yellow-dark-90: rgba($yellow-dark, .9);
+$red: #d4351c;

--- a/app/webpacker/styles/components/search.scss
+++ b/app/webpacker/styles/components/search.scss
@@ -1,0 +1,30 @@
+.search {
+  select, input {
+    margin-left: 0;
+    margin-right: 0;
+    box-sizing: border-box;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 5px;
+  }
+
+  &__field--error {
+    input, select {
+      border-color: $red;
+    }
+  }
+
+  &__controls {
+    @include cards-grid(4);
+
+    margin: $indent-amount 0;
+  }
+
+  &__errors {
+    color: $red;
+    font-weight: bold;
+    margin-bottom: $indent-amount;
+  }
+}

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -17,47 +17,6 @@
   margin: 70px 0 50px 0;
 }
 
-.search-for-events-heading {
-  background-color: $purple;
-}
-
-.search-for-events {
-    text-align: left;
-
-    &__content {
-        padding-top: 2em;
-        font-size: $fs-19;
-
-        &__inputs {
-            display: flex;
-            flex-wrap: wrap;
-            margin: 0 -10px;
-        }
-
-        &__input {
-            margin-bottom: 30px;
-            display: block;
-            width: 25%;
-            padding: 0 10px;
-            box-sizing: border-box;
-            &--hidden {
-                display: none;
-            }
-        }
-    }
-
-    label {
-        display: block;
-        margin-bottom: 5px;
-    }
-
-    input, select {
-        margin: 0;
-        width: 100%;
-        box-sizing: border-box;
-    }
-}
-
 .search-for-events-results {
     display: flex;
     flex-wrap: wrap;
@@ -216,36 +175,6 @@
             padding: 0;
             display: block;
             width: 100%;
-        }
-    }
-
-    .search-for-events {
-        margin-top: 55px;
-        margin-bottom: 30px;
-        &__header {
-            top: -45px
-        }
-        &__content {
-            &__input {
-                width: 100%;
-                display: block;
-
-                &__label {
-                    display: block;
-                }
-
-                &__select {
-                    display: block;
-
-                    select {
-                        margin-top: 10px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        width: 100%;
-                    }
-                }
-
-            }
         }
     }
 

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -47,27 +47,6 @@ form {
   }
 }
 
-.search-for-events__content__errors {
-    color: #d4351c;
-    margin: -13px 0 25px;
-    font-weight: bold;
-
-  div {
-    margin: 0.2em 0 ;
-  }
-}
-
-.search-for-events__content__error {
-  input {
-    border-color: #d4351c;
-  }
-}
-
-form div.hidden {
-  display: none;
-}
-
-
 form {
   .save-with-confirmation {
     button {

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -34,6 +34,7 @@
 @import './components/content-alert';
 @import './components/feature-table';
 @import './components/link-block';
+@import './components/search';
 @import './components/colored-stripe';
 @import './components/type-description';
 @import './components/events/no-results';


### PR DESCRIPTION
### Trello card

[Trello-758](https://trello.com/c/rG3bNDXw/758-clean-up-the-searchcomponent-css-html)

### Context

The `SearchComponent` CSS and HTML is getting a bit busy and the CSS is also spread across multiple files. We want to consolidate the CSS, extracting it into its own component SASS file and simplify the HTML where possible.

### Changes proposed in this pull request

- Simplify the `SearchComponent` HTML/CSS

### Guidance to review

Visually it should be identical (aside from standardising some of the margins).

| Desktop      | Mobile | Errors |
| ----------- | ----------- | ----- |
| <img width="1173" alt="Screenshot 2021-01-28 at 15 41 56" src="https://user-images.githubusercontent.com/29867726/106161845-5b927d80-617f-11eb-8fe7-53d0cd0bfabd.png">      | <img width="518" alt="Screenshot 2021-01-28 at 15 42 07" src="https://user-images.githubusercontent.com/29867726/106161868-6220f500-617f-11eb-9637-bf70a75b2182.png">       | <img width="974" alt="Screenshot 2021-01-28 at 15 42 22" src="https://user-images.githubusercontent.com/29867726/106161899-6b11c680-617f-11eb-9c60-041356f40fd4.png"> |