### PR TITLE
Replace 1.5rem/20px margins/padding with $indent-amount

### DIFF
--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -42,12 +42,12 @@
         }
 
         .call-to-action {
-          margin: 0 1.5rem;
+          margin: 0 $indent-amount;
         }
 
         .step-content__description {
             margin: 0;
-            padding: 1.5rem;
+            padding: $indent-amount;
 
             blockquote {
               background: $grey;

--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -56,7 +56,7 @@
           display: block;
           background: $blue-dark-90;
           color: white;
-          padding: 10px 20px;
+          padding: 10px $indent-amount;
           font-weight: bold;
           max-width: calc(100% - 80px);
           backdrop-filter: blur(4px);
@@ -96,7 +96,7 @@
 .cards-with-headers {
 
   h2 {
-    padding: 0 1.5rem 1.5rem;
+    padding: 0 $indent-amount $indent-amount;
     font-size: $fs-32;
   }
 

--- a/app/webpacker/styles/components/content-alert.scss
+++ b/app/webpacker/styles/components/content-alert.scss
@@ -6,7 +6,7 @@
   display: flex;
   width: 78%;
   box-sizing: border-box;
-  margin-bottom: 50px;
+  margin-bottom: $indent-amount;
 
   @include mq($until: tablet) {
     width: inherit;

--- a/app/webpacker/styles/components/content-alert.scss
+++ b/app/webpacker/styles/components/content-alert.scss
@@ -34,7 +34,7 @@
     min-width: 62px;
     max-width: 62px;
     height: 62px;
-    margin-right: 20px
+    margin-right: $indent-amount
   }
 
   img {

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -1,7 +1,7 @@
 @mixin content-cta {
   background: $grey;
   text-align: left;
-  padding: 1.5rem;
+  padding: $indent-amount;
   margin: 0 -20px 30px;
   box-sizing: border-box;
   width: auto;

--- a/app/webpacker/styles/components/event-box.scss
+++ b/app/webpacker/styles/components/event-box.scss
@@ -1,6 +1,6 @@
 .event-box {
     box-sizing: border-box;
-    padding: 1.5rem;
+    padding: $indent-amount;
     display: inline-block;
     overflow: hidden;
     text-align: left;

--- a/app/webpacker/styles/components/feature-table.scss
+++ b/app/webpacker/styles/components/feature-table.scss
@@ -3,7 +3,7 @@
     font-size: $fs-19;
     background-color: $grey;
     width: 100%;
-    padding: 1.5rem;
+    padding: $indent-amount;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;

--- a/app/webpacker/styles/components/link-block.scss
+++ b/app/webpacker/styles/components/link-block.scss
@@ -8,7 +8,7 @@
         color: #FFFFFF;
         font-weight: bold;
         font-size: $fs-19;
-        padding: 1.5rem 1.5rem 1.5rem 50px;
+        padding: $indent-amount $indent-amount $indent-amount 50px;
         margin: 0;
         position: relative;
         &:before {
@@ -48,7 +48,7 @@
             line-height: 1.25;
             text-decoration: none;
             margin-bottom: 10px;
-            padding: 5px 20px 5px 50px;
+            padding: 5px $indent-amount 5px 50px;
             &:hover {
                 text-decoration: underline;
             }

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -113,7 +113,7 @@
     .map-marker__title {
       @include govuk-font($size: 19, $line-height: 1.5, $weight: bold);
       @include govuk-responsive-margin(2, "bottom");
-      padding-right: 20px;
+      padding-right: $indent-amount;
     }
 
     .map-marker__body {
@@ -127,7 +127,7 @@
 
   .govuk-heading-s {
     @include govuk-responsive-margin(2, "bottom");
-    padding-right: 20px;
+    padding-right: $indent-amount;
   }
 
   .govuk-body,

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -8,14 +8,14 @@
   z-index: 1000;
   justify-content: center;
   align-items: center;
-  
+
   &__background {
       opacity: 0.4;
       background-color: $black;
       width: 100%;
       min-height: 100vh;
       box-sizing: border-box;
-      padding: 20px;
+      padding: $indent-amount;
       position: absolute;
       top: 0;
       left: 0;
@@ -28,7 +28,7 @@
       padding: 40px;
       box-sizing: border-box;
       position: relative;
-      margin: 20px;
+      margin: $indent-amount;
       overflow: hidden;
 
       .logo__image {
@@ -36,7 +36,7 @@
           top: 0px;
           left: -45px;
           width: 240px;
-          margin-bottom: 20px;
+          margin-bottom: $indent-amount;
 
           a {
               margin-left: 8px;
@@ -85,8 +85,8 @@
           display: inline-block;
           cursor: pointer;
           font-weight: bold;
-          margin-top: 20px;
-          padding: 0 20px;
+          margin-top: $indent-amount;
+          padding: 0 $indent-amount;
       }
   }
 }
@@ -94,7 +94,7 @@
 @include mq($until: tablet) {
   .dialog {
       &__content {
-          padding: 20px;
+          padding: $indent-amount;
           max-height: calc(100vh - 40px);
           overflow: auto;
           &__header {
@@ -102,18 +102,18 @@
           }
           .logo__image {
               width: 220px;
-              margin-left: 20px;
+              margin-left: $indent-amount;
               div {
                   margin-left: 39px;
                   margin-top: -3px;
-                  
+
               }
           }
 
           h2 {
               display: block;
               float: none;
-              margin-top: 20px;
+              margin-top: $indent-amount;
               margin-bottom: -20px;
               font-size: $fs-24;
           }

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -19,7 +19,7 @@
         float:left;
         text-align: left;
         width: calc(100% - 360px);
-        padding-top: 20px;
+        padding-top: $indent-amount;
 
         h1 {
             margin: 0;

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -8,7 +8,7 @@
 
   .event-type-descriptions__content {
     @include cards-grid;
-    padding: 1.5rem 1.5rem 0 1.5rem;
+    padding: $indent-amount $indent-amount 0 $indent-amount;
     margin-bottom: 0;
   }
 }
@@ -79,7 +79,7 @@
 .events-featured {
     background: #F0F0F0;
     position: relative;
-    padding: 1.5rem;
+    padding: $indent-amount;
     width: 100%;
     margin-top: 30px;
     box-sizing: border-box;
@@ -102,7 +102,7 @@
     &__heading {
       > h3 {
         font-size: $fs-28;
-        margin: 0 0 20px 0;
+        margin: 0 0 $indent-amount 0;
         line-height: 1.25;
       }
     }

--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -9,7 +9,7 @@
         width: 33.333%;
         margin-bottom: 30px;
         text-align: left;
-        padding: 0px 20px;
+        padding: 0px $indent-amount;
         position: relative;
     }
 
@@ -81,7 +81,7 @@
             position: relative;
         }
         &__content {
-            padding: 0 1.5rem;
+            padding: 0 $indent-amount;
             p {
                 margin-top: 0;
             }
@@ -119,7 +119,7 @@
 
         &__item {
             width: 100%;
-            padding: 0px 20px;
+            padding: 0px $indent-amount;
             margin-bottom: 50px;
         }
 
@@ -128,7 +128,7 @@
             position: relative;
             &__image {
                 width: 100%;
-                margin-bottom: 20px;
+                margin-bottom: $indent-amount;
             }
 
             &__right {
@@ -153,7 +153,7 @@
     }
     &__header {
         margin: -20px auto -20px;
-        padding: 0 1.5rem;
+        padding: 0 $indent-amount;
         &.content {
             margin-bottom: -20px;
         }
@@ -161,7 +161,7 @@
     h2 {
         margin: 0;
         @include mq($until: tablet) {
-            margin-bottom: 20px;
+            margin-bottom: $indent-amount;
         }
     }
 }

--- a/app/webpacker/styles/feedback-bar.scss
+++ b/app/webpacker/styles/feedback-bar.scss
@@ -13,7 +13,7 @@
     &__inner {
       box-sizing: border-box;
         background-color: white;
-        padding: 1.5rem;
+        padding: $indent-amount;
         border: 1px solid $grey;
         border-width: 1px 1px 0 1px;
         width: 100%;
@@ -23,7 +23,7 @@
     &__left {
         display: flex;
         align-items: flex-start;
-        padding-right: 20px;
+        padding-right: $indent-amount;
         line-height: 1.2;
     }
 
@@ -35,8 +35,8 @@
         color: white;
         font-weight: bold;
         display: inline-block;
-        padding: 8px 20px;
-        margin-right: 20px;
+        padding: 8px $indent-amount;
+        margin-right: $indent-amount;
     }
     a {
         color: $blue-dark;

--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -3,10 +3,10 @@ html {
 }
 
 /*
- * Numbers refer to pixel size when the base font 
+ * Numbers refer to pixel size when the base font
  * size of the broswer is 16px (most broswers)
  */
- 
+
 $fs-15: 0.93rem;
 $fs-16: 1rem;
 $fs-19: 1.1875rem;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -9,7 +9,7 @@
         margin-bottom: 0;
     }
     &__inner {
-        padding: 1.5rem;
+        padding: $indent-amount;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -21,10 +21,10 @@
     }
 
     &__text {
-        padding-right: 20px;
+        padding-right: $indent-amount;
         font-weight: bold;
         @include mq($until: tablet) {
-            margin-bottom: 20px;
+            margin-bottom: $indent-amount;
         }
     }
 }
@@ -56,7 +56,7 @@ footer.site-footer {
             &__link {
                 color: white;
                 display: block;
-                margin-right: 20px;
+                margin-right: $indent-amount;
                 .icon {
                     font-size: $fs-32;
                 }
@@ -195,9 +195,9 @@ footer.site-footer {
     footer.site-footer {
 
         .site-footer-top {
-            padding-left: 20px;
-            padding-right: 20px;
-            padding-top: 20px;
+            padding-left: $indent-amount;
+            padding-right: $indent-amount;
+            padding-top: $indent-amount;
             flex-direction: column-reverse;
             align-items: flex-start;
 
@@ -235,8 +235,8 @@ footer.site-footer {
         .site-footer-bottom {
             display: block;
             height: 360px;
-            padding-left: 20px;
-            padding-right: 20px;
+            padding-left: $indent-amount;
+            padding-right: $indent-amount;
             padding-top: 0;
 
             &__logo-container {

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -1,8 +1,8 @@
 
 select, input {
     font-size: $fs-19;
-    margin-left: 20px;
-    margin-right: 20px;
+    margin-left: $indent-amount;
+    margin-right: $indent-amount;
     border: 2px solid $black;
     background-color: $white;
     height: 42px;

--- a/app/webpacker/styles/govuk-reset.scss
+++ b/app/webpacker/styles/govuk-reset.scss
@@ -2,7 +2,7 @@
  * As well as our own stylesheet, we also import the GOV.UK design system styles.
  *
  * There are a number of generic selectors used in our stylesheets (anchor
- * tags, lists, etc) that end up adding attributes to some of the GOV.UK styles. 
+ * tags, lists, etc) that end up adding attributes to some of the GOV.UK styles.
  * We need to undo these style changes when they occur, which is what this set of
  * styles is for.
  */
@@ -17,5 +17,5 @@
 }
 
 h2.govuk-error-summary__title {
-  margin-bottom: 20px;
+  margin-bottom: $indent-amount;
 }

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -13,23 +13,23 @@
         max-width: 630px;
         float:right;
         margin-top:20px;
-        margin-right: 20px;
-    
+        margin-right: $indent-amount;
+
         div {
             width: 100%;
             height: 30px;
         }
-        
-        ul {    
+
+        ul {
             list-style-type: none;
             margin: 0;
             padding: 0;
         }
-    
+
         li {
             float: right;
         }
-    
+
         li a {
             @include font;
             font-size: $fs-16;
@@ -55,14 +55,14 @@
         max-width: calc(100% - 350px);
         float:right;
         margin-top: 0px;
-        margin-right: 20px;
-    
+        margin-right: $indent-amount;
+
         div {
             width: 100%;
             height: 30px;
         }
-        
-        ul {    
+
+        ul {
             list-style-type: none;
             margin: 0;
             padding: 0;
@@ -70,7 +70,7 @@
             flex-wrap: wrap;
             justify-content: flex-end;
         }
-    
+
         li {
             float: right;
             padding: 8px 16px;
@@ -98,22 +98,22 @@
 
         $border-width: 2.5px;
         $padding-space: 2.5px;
-      
+
         %hover-shared {
           padding-bottom: 2.5px;
           margin-bottom: -$border-width - $padding-space;
         }
-      
+
         a:hover:not(:focus):not(.active) {
           @extend %hover-shared;
           border-bottom: solid $border-width $black;
         }
-      
+
         .active a:hover:not(:focus) {
           @extend %hover-shared;
           border-bottom: solid $border-width $white;
         }
-      
+
         .active {
           background-color: $blue-dark;
           color: $white;
@@ -124,9 +124,9 @@
     }
 
     &__mobile {
-        
+
         display:none;
-    
+
         a {
             text-decoration: none;
         }
@@ -139,7 +139,7 @@
             float: right;
             color: $black;
             margin-top: 33px;
-            margin-right: 20px;
+            margin-right: $indent-amount;
         }
 
         .icon-close {
@@ -165,7 +165,7 @@
             padding: 1px;
             background-color: $grey;
             width: 100%;
-        
+
             text-align: right;
             font-weight: bold;
             a {
@@ -203,7 +203,7 @@
 
         &__container {
             margin-right : 10px;
-            margin-top :47px; 
+            margin-top :47px;
         }
     }
 
@@ -241,7 +241,7 @@
         left:-10px;
         z-index: 1000;
 
-    
+
         img {
             transform: rotate(3deg);
             margin-left: 40px;
@@ -259,8 +259,8 @@
     line-height: 1.25;
     background-color: $black;
     color: $white;
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding-top: $indent-amount;
+    padding-bottom: $indent-amount;
     padding-left: 35px;
     padding-right: 35px;
     p {
@@ -310,14 +310,14 @@
             top: 4px;
 
             img {
-                margin-top: 20px;
+                margin-top: $indent-amount;
                 margin-left: 24px;
                 width: 142px;
                 height: 48px;
             }
         }
     }
-    
+
     .navbar {
 
         position: relative;
@@ -331,7 +331,7 @@
         display: block;
         width: 100%;
     }
-    
+
 }
 
 .skiplink {
@@ -378,7 +378,7 @@
     .logo {
         top: 18px;
     }
-}    
+}
 
 
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -5,7 +5,7 @@
 
 .cta-link {
     width: 50%;
-    padding: 0 1.5rem;
+    padding: 0 $indent-amount;
     height: 290px;
     display: block;
     margin-bottom: 30px;
@@ -24,7 +24,7 @@
 
         background: $green-dark-90;
         display: inline-block;
-        padding: 1.5rem;
+        padding: $indent-amount;
         line-height: 1.2;
         font-weight: bold;
         color: white;
@@ -174,7 +174,7 @@
 }
 
 .home-inset-content {
-    margin: 0 20px;
+    margin: 0 $indent-amount;
 }
 .home-quote {
     &__text {
@@ -185,7 +185,7 @@
     }
 
     &__quote {
-        margin: 0 0 20px;
+        margin: 0 0 $indent-amount;
         font-weight: bold;
         font-size: $fs-28;
         line-height: 1.25;
@@ -247,8 +247,8 @@
     .steps {
         .git-link {
             padding-left: 40px;
-            padding-right: 20px;
-            margin-top: 20px;
+            padding-right: $indent-amount;
+            margin-top: $indent-amount;
         }
 
         &__table {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -4,7 +4,7 @@
     background-color: $bg;
     text-decoration: none;
     color: $fg;
-    padding: 14px 20px;
+    padding: 14px $indent-amount;
     font-size: $fs-19;
     white-space: nowrap;
     border: none;

--- a/app/webpacker/styles/page-helpful.scss
+++ b/app/webpacker/styles/page-helpful.scss
@@ -1,5 +1,5 @@
 .page-helpful {
-    padding: 1.5rem;
+    padding: $indent-amount;
     margin: 2em 0 0 0;
     background: $grey;
     display: none;
@@ -18,7 +18,7 @@
         display: inline-block;
 
         &:last-child {
-            margin-left: 20px;
+            margin-left: $indent-amount;
         }
 
         &:hover {

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -29,7 +29,7 @@
     font-size: $fs-28;
     margin: 0;
     padding: 0;
-    margin-top: 20px;
+    margin-top: $indent-amount;
     margin-bottom: 10px;
   }
 
@@ -40,7 +40,7 @@
   }
 
   button.call-to-action-button {
-    margin-top: 20px;
+    margin-top: $indent-amount;
   }
 
 }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -211,12 +211,16 @@ $mobile-cutoff: 800px;
     padding-right: 150px;
 
     @include mq($until: tablet) {
-      padding-right: 20px;
+      padding-right: $indent-amount;
     }
   }
 
   &__cta {
-    margin: 0.4em 1em 20px;
+    margin: $indent-amount 1em;
+
+    @include mq($until: tablet) {
+      margin-top: 0;
+    }
 
     &__button {
       @include button($bg: $white, $fg: $black);

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -12,8 +12,8 @@
         }
 
         &__label {
-            margin-left: 20px;
-            margin-top: 20px;
+            margin-left: $indent-amount;
+            margin-top: $indent-amount;
         }
 
         &__table {
@@ -22,14 +22,14 @@
             &__column {
                 display: inline-block;
                 box-sizing: border-box;
-                padding-left: 20px;
-                padding-right: 20px;
+                padding-left: $indent-amount;
+                padding-right: $indent-amount;
                 flex: 1;
                 min-width: 245px;
                 vertical-align: top;
 
                 h2 {
-                    margin-top: 20px;
+                    margin-top: $indent-amount;
                     margin-bottom: 40px;
                 }
 
@@ -57,7 +57,7 @@
         }
 
         &__freephone {
-            padding-left: 20px;
+            padding-left: $indent-amount;
             padding-top: 10px;
             padding-right: 10px;
         }
@@ -68,10 +68,10 @@
     .talk-to-us {
         &__inner {
             top: -20px;
-            padding: 0 1.5rem;
+            padding: 0 $indent-amount;
 
             &__label {
-                margin: 1.5rem 0;
+                margin: $indent-amount 0;
             }
 
             &__table {

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -1,7 +1,7 @@
 .story-landing {
     &__header {
         width: 66.6%;
-        margin-top: 1.5rem;
+        margin-top: $indent-amount;
 
         @include mq($until: tablet) {
           width: auto;
@@ -59,7 +59,7 @@
         box-sizing: border-box;
         padding-left: 40px;
         padding-right: 40px;
-        padding-top: 20px;
+        padding-top: $indent-amount;
         padding-bottom: 40px;
         color: $white;
 
@@ -108,7 +108,7 @@
             h2 {
                 font-size: $fs-32;
                 border-bottom: none;
-                padding: 0 1.5rem;
+                padding: 0 $indent-amount;
                 margin: 0;
                 color: $black;
                 background: transparent;
@@ -187,7 +187,7 @@
   }
 
   &--with-padding {
-    padding: 0 1.5rem;
+    padding: 0 $indent-amount;
   }
 
   .card {
@@ -232,7 +232,7 @@
     .stories {
         &__thumbs {
             flex-wrap: wrap;
-            margin-bottom: 20px;
+            margin-bottom: $indent-amount;
             margin-right: 0;
             padding: 0;
             &__thumb {

--- a/app/webpacker/styles/video.scss
+++ b/app/webpacker/styles/video.scss
@@ -33,7 +33,7 @@
         width: 100%;
         min-height: 100vh;
         box-sizing: border-box;
-        padding: 20px;
+        padding: $indent-amount;
         position: absolute;
     }
 
@@ -41,7 +41,7 @@
         width: 100%;
         max-width: tablet;
         background-color: $white;
-        padding: 20px;
+        padding: $indent-amount;
         box-sizing: border-box;
         position: relative;
         margin: 40px;
@@ -106,7 +106,7 @@
 @include mq($until: mobile) {
     .video-overlay__video-container {
         padding: 10px;
-        margin: 20px;
+        margin: $indent-amount;
     }
 
     .video-overlay__video-container__dismiss {


### PR DESCRIPTION
- Replace 1.5rem margins/padding with $indent-amount

The `h2` have their own top margin now that the `.strapline` class was removed
in an earlier PR. We no longer need such a large bottom margin.
We have a standard `$indent-amount` already defined as 1.5rem, so it makes sense to reuse this where possible in case we want to tweak it in the future.

Also replaces 20px margin/padding values with `$indent-amount` as there is only 4px difference and it makes things align more nicely across the board.

- Tweak content-alert bottom margin

The `h2` have their own top margin now that the `.strapline` class was removed in an earlier PR. We no longer need such a large bottom margin.