### PR TITLE
Fix the event start times to 07:30

### DIFF
--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     sequence(:summary) { |i| "Become a Teacher #{i} event summary" }
     message { "An important message" }
     video_url { "https://video.com" }
-    sequence(:start_at) { |i| i.weeks.from_now }
+    sequence(:start_at) { |i| i.weeks.from_now.change(hour: 7, minute: 30) }
     end_at { start_at + 2.hours }
     is_online { false }
     is_virtual { false }


### PR DESCRIPTION
We hit a problem in CI where when the event spans two days it's rendered as with both full days instead of a the first day and a range, e.g.,

22 April 2021 23:17 to 23 April 2021 01:17

instead of:

22 April 2021 23:17 - 01:17

Instead of generating the start date based on the current time,
overwrite it with 7:30 in the morning to prevent this problem from
happening.

