### PR TITLE
Add a little more space above h2s and CTAs

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -32,8 +32,9 @@
     }
   }
 
-  h2:not(:first-child) {
-    margin-top: 1em;
+  h2:not(:first-child),
+  .call-to-action {
+    margin-top: 1.5em;
   }
 
   a {


### PR DESCRIPTION
This gives them a little more breathing space and creates separation between the element and the content above.

| Before | After |
| ------- | ------ |
|![Screenshot from 2021-02-01 12-18-11](https://user-images.githubusercontent.com/128088/106457969-a6fea180-6487-11eb-990f-d21a447d499b.png) | ![Screenshot from 2021-02-01 12-17-42](https://user-images.githubusercontent.com/128088/106457983-aa922880-6487-11eb-952d-cee42c03a100.png)|
