### PR TITLE
Fixed card images showing as too wide on mobile

### DIFF
--- a/app/webpacker/styles/components/cards.scss
+++ b/app/webpacker/styles/components/cards.scss
@@ -9,6 +9,7 @@
         flex-direction: column;
         text-decoration: none;
         position: relative;
+        box-sizing: border-box;
 
         &__thumb {
             width: 100%;
@@ -94,7 +95,6 @@
 }
 
 .cards-with-headers {
-
   h2 {
     padding: 0 $indent-amount $indent-amount;
     font-size: $fs-32;
@@ -103,6 +103,18 @@
   .card {
     margin-left: 1em;
     overflow: initial;
+  }
+
+  @include mq($until: tablet) {
+    .card {
+      margin-left: 0;
+      padding-left: 1em;
+      padding-right: 1em;
+
+      &__header {
+        left: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/isashLvM

### Context

Cards with headers are showing images too wide on mobile

### Changes proposed in this pull request

1. Tweaked CSS so solve cards being too wide when on mobile

### Guidance to review

1. Is the change of box sizing on `.card` likely to cause an issue elsewhere.

`content-box` seems to be being used by default - most layout frameworks seem to have concluded `border-box` leads to better behaviour because 100% actually is 100% unlike with `content-box`

**Before:**

![Screenshot from 2021-02-01 14-28-56](https://user-images.githubusercontent.com/10818/106472554-b1766680-649a-11eb-86a2-d63dee145f10.png)

**After**

![Screenshot from 2021-02-01 14-28-20](https://user-images.githubusercontent.com/10818/106472576-b804de00-649a-11eb-9e74-fe0c0a93b467.png)


