### PR TITLE
Correct destination of jump link

### DIFF
--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,7 +1,7 @@
-<section id="talk-to-us" class="talk-to-us">
+<section class="talk-to-us">
    <section class="container">
       <div class="talk-to-us__inner">
-         <h2 class="purple">Talk to us</h2>
+         <h2 class="purple" id="talk-to-us">Talk to us</h2>
          <p class="talk-to-us__inner__label">
             How can we help you take your next step towards teacher training?
          </p>


### PR DESCRIPTION
### Trello card
https://trello.com/c/rOCr6IsT

### Context
When the user clicks a same page link `talk to us`, they are navigated to the talk to us section instead of the header. This results in in the header appearing cut off.

### Changes proposed in this pull request
- Correct destination of same page link to "talk to us"

### Guidance to review

