### PR TITLE
Improve margin behaviour

### DIFF
--- a/app/components/stories/story_component.html.erb
+++ b/app/components/stories/story_component.html.erb
@@ -1,32 +1,30 @@
 
 <section class="container">
-  <article class="markdown overhang no-hero">
-    <article class="story markdown">
-      <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
+  <article class="story markdown no-hero">
+    <%= helpers.back_link(backlink, text: tag.span(backlink_text)) %>
 
-      <%= tag.h1(title) %>
+    <%= tag.h1(title) %>
 
-      <header class="story__header">
-        <% if image.present? %>
-          <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
-        <% end %>
-        <div class="story__header__label">
-          <%= helpers.story_heading(teacher, position) %>
-        </div>
-      </header>
-
-      <% if show_video? %>
-        <%= helpers.youtube(video) %>
+    <header class="story__header">
+      <% if image.present? %>
+        <%= image_tag(image, width: 200, height: 200, alt: helpers.story_image_alt(teacher), class: "story__header__thumb") %>
       <% end %>
+      <div class="story__header__label">
+        <%= helpers.story_heading(teacher, position) %>
+      </div>
+    </header>
 
-      <%= content %>
+    <% if show_video? %>
+      <%= helpers.youtube(video) %>
+    <% end %>
 
-      <% if show_more_information? %>
-        <%= link_to(more_information_link, class: "git-link") do %>
-          <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
-        <% end %>
+    <%= content %>
+
+    <% if show_more_information? %>
+      <%= link_to(more_information_link, class: "git-link") do %>
+        <%= more_information_text %> <%= helpers.fas_icon "chevron-right" %>
       <% end %>
-    </article>
+    <% end %>
   </article>
   <section class="feature">
     <% if show_more_stories? %>

--- a/app/views/layouts/accordion.html.erb
+++ b/app/views/layouts/accordion.html.erb
@@ -16,7 +16,7 @@
               <%= render partial: "layouts/shared/narrow_call_to_action" %>
             </aside>
 
-            <article class="markdown overhang">
+            <article class="markdown">
               <% if @front_matter["alert"].present? %>
                 <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
               <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
         <% unless @fullwidth %>
           <aside></aside>
         <% end %>
-        <article class="markdown overhang<%= " fullwidth" if @fullwidth %><%= " no-hero" if @skip_hero %>">
+        <article class="markdown <%= " fullwidth" if @fullwidth %><%= " no-hero" if @skip_hero %>">
           <%= yield %>
         </article>
         <section class="feature">

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -44,7 +44,7 @@
         </aside>
         <% end %>
 
-        <article class="markdown overhang <%= "fullwidth" if @front_matter["fullwidth"] %> ">
+        <article class="markdown <%= "fullwidth" if @front_matter["fullwidth"] %> ">
           <% if !@front_matter["image"] %>
             <%= tag.h1(@front_matter["title"]) %>
           <% end %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -14,7 +14,7 @@
 
     <main class="semantic" role="main" id="main-content">
       <section class="container">
-        <article class="markdown overhang<%= " fullwidth" if @before_search_fullwidth %> ">
+        <article class="markdown<%= " fullwidth" if @before_search_fullwidth %> ">
           <%= yield :before_search %>
         </article>
       </section>
@@ -22,7 +22,7 @@
         <%= render @search_component %>
       </div>
       <section class="container">
-        <article class="markdown overhang fullwidth">
+        <article class="markdown fullwidth">
           <%= yield %>
         </article>
       </section>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -14,7 +14,7 @@
 
     <main class="semantic" role="main" id="main-content">
       <section class="container">
-        <article class="markdown overhang fullwidth">
+        <article class="markdown fullwidth">
           <%= yield %>
         </article>
       </section>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -7,26 +7,25 @@
 
       <main class="semantic story-landing" role="main" id="main-content">
         <section class="container">
-          <article class="markdown fullwidth no-hero">
-            <div class="stories-feature">
-              <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
-              <div class="stories-feature__content">
-                <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
-                <%= tag.h3(@front_matter.dig("featured_story", "subheading")) %>
-                <%= tag.p(@front_matter.dig("featured_story", "text")) %>
-                <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
-                  Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
-                <% end %>
-              </div>
+          <section class="stories-feature">
+            <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
+            <div class="stories-feature__content">
+              <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
+              <%= tag.span(@front_matter.dig("featured_story", "subheading"), class: "stories-feature__subheading") %>
+              <%= tag.p(@front_matter.dig("featured_story", "text")) %>
+              <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
+                Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
+            <% end %>
             </div>
-
+          </section>
+          <article class="markdown fullwidth no-hero">
             <% @front_matter["sections"]&.each do |name, section| %>
-              <div class="story-landing__header">
-                <%= tag.h2(name) %>
-                <%= tag.p(section["text"]) %>
-              </div>
               <% if section["stories"].present? %>
                 <div class="story-landing__stories">
+                  <div class="story-landing__header">
+                    <%= tag.h2(name) %>
+                    <%= tag.p(section["text"]) %>
+                  </div>
                   <div class="story-landing__cards cards stories">
                     <%= render Cards::RendererComponent.with_collection(section["stories"]) %>
                   </div>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -7,7 +7,7 @@
 
       <main class="semantic story-landing" role="main" id="main-content">
         <section class="container">
-          <article class="markdown overhang fullwidth no-hero">
+          <article class="markdown fullwidth no-hero">
             <div class="stories-feature">
               <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
               <div class="stories-feature__content">

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -6,7 +6,7 @@
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <main role="main" class="semantic" id="main-content">
         <section class="container">
-          <article class="markdown overhang fullwidth">
+          <article class="markdown fullwidth">
             <%= back_link "/my-story-into-teaching", text: "All stories" %>
             <%= yield %>
 

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,35 +1,32 @@
 .markdown {
+  @mixin overhang { margin-left: auto; margin-right: auto; }
 
   // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
-  &.overhang {
-    > *:not(table) {
-      margin-left: $indent-amount;
-      margin-right: $indent-amount;
-    }
+  > *:not(table) {
+    margin-left: $indent-amount;
+    margin-right: $indent-amount;
+  }
 
-    @mixin overhang { margin-left: auto; margin-right: auto; }
+  > h2 {
+    @include overhang;
+    @include content-heading;
+  }
 
-    > h2 {
-      @include overhang;
-      @include content-heading;
-    }
+  .accordions,
+  .stories-feature,
+  .feature-table,
+  .secondary-button,
+  .content-alert,
+  .event-type-descriptions,
+  .types-of-event,
+  .content-cta,
+  .featured-content,
+  .page-helpful {
+    @include overhang;
+  }
 
-    .accordions,
-    .stories-feature,
-    .feature-table,
-    .secondary-button,
-    .content-alert,
-    .event-type-descriptions,
-    .types-of-event,
-    .content-cta,
-    .featured-content,
-    .page-helpful {
-      @include overhang;
-    }
-
-    .content-alert--left {
-      margin-left: 0;
-    }
+  .content-alert--left {
+    margin-left: 0;
   }
 
   h2:not(:first-child) {

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -1,88 +1,71 @@
 .story-landing {
-    &__header {
-        width: 66.6%;
-        margin-top: $indent-amount;
+  &__footer {
+    display: inline-block;
+    margin: 1em 0;
 
-        @include mq($until: tablet) {
-          width: auto;
-          padding: 0;
-        }
+    a {
+      @include button;
+      @include chevron;
 
-        h2 {
-            @include content-heading;
-            color: $black;
-            background-color: inherit;
-            size: 110%;
-            margin-bottom: 0;
-        }
+      span {
+        white-space: normal;
+      }
     }
+  }
 
-    &__footer {
-        width: 66.6%;
-
-        @include mq($until: tablet) {
-          width: 100%;
-          margin: 0;
-          padding: 0;
-        }
-
-        a {
-            @include button;
-            @include chevron;
-            display: inline-block;
-            margin: 1em 0 0 0;
-            white-space: initial;
-        }
+  &__header {
+    h2 {
+      font-size: $fs-32;
     }
+  }
+
+  &__stories + &__stories {
+    margin-top: 2em;
+  }
 }
 
 .stories-feature {
+  background: $purple;
+  color: $white;
+  display: flex;
+  flex-direction: column;
 
-    display: table;
-    width: 100%;
+  @include mq($from: tablet) {
+    border-bottom: inherit;
+    flex-direction: row;
+    border-bottom: 2em solid $purple;
+  }
+
+  &__image {
+    background-repeat: no-repeat;
+    background-size: cover;
+    flex: 1 0 40%;
+    min-height: 15em;
+  }
+
+  &__content {
+    flex: 1 0 60%;
+    margin: auto $indent-amount;
+    padding-bottom: 2em;
+
+    a.git-link {
+      color: $white;
+    }
 
     @include mq($from: tablet) {
-      border-bottom: 2em solid $purple;
+      flex-shrink: 1;
+      padding-left: 1em;
     }
 
-    &__image {
-        display: table-cell;
-        width: 38%;
-        background-repeat: no-repeat;
-        background-size: cover;
+    h2 {
+      font-size: $fs-28;
     }
 
-    &__content {
-        display: table-cell;
-        background-color: $purple;
-        vertical-align: top;
-        box-sizing: border-box;
-        padding-left: 40px;
-        padding-right: 40px;
-        padding-top: $indent-amount;
-        padding-bottom: 40px;
-        color: $white;
-
-        h2 {
-            font-size: $fs-28;
-        }
-
-        h3 {
-            padding: 0;
-            margin: 0;
-        }
-
-        p {
-            padding-top: 0;
-            margin-top: 0;
-        }
-
-        a.git-link {
-            color: $white;
-            cursor: pointer;
-        }
-
+    .stories-feature__subheading {
+      font-size: $fs-19;
+      font-weight: bold;
     }
+  }
 }
 
 .content-wrapper {
@@ -251,22 +234,5 @@
             }
 
         }
-    }
-
-    .stories-feature {
-        display: block;
-        width: auto;
-        margin-bottom: 0px;
-
-        &__image {
-            display: block;
-            width: 100%;
-            height:400px;
-        }
-
-        &__content {
-            display: block;
-        }
-
     }
 }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -99,6 +99,11 @@
         align-items: center;
         margin-bottom: 30px;
 
+        @include mq($until: mobile) {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
         &__thumb {
             object-fit: cover;
         }
@@ -106,12 +111,17 @@
         &__label {
 
             h2 {
-                font-size: $fs-32;
+                font-size: $fs-26;
                 border-bottom: none;
                 padding: 0 $indent-amount;
                 margin: 0;
                 color: $black;
                 background: transparent;
+
+                @include mq($until: mobile) {
+                  padding: 0;
+                  margin-top: $indent-amount;
+                }
             }
         }
     }

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -44,7 +44,7 @@ describe Stories::StoryComponent, type: "component" do
   end
 
   describe "layout elements" do
-    it { is_expected.to have_css(".container .markdown.overhang.no-hero") }
+    it { is_expected.to have_css(".container .markdown.no-hero") }
     it { is_expected.to have_css(".container .feature") }
   end
 


### PR DESCRIPTION
Some pages had inconsistent margins and some had regressed to having none. This PR should bring them all in line. It also heavily refactors the stories landing page.

| Before | After |
| ------ | ------ |
| ![Screenshot from 2021-02-02 09-56-56](https://user-images.githubusercontent.com/128088/106584001-990b5800-653d-11eb-8c32-bce47beda378.png) | ![Screenshot from 2021-02-02 09-56-58](https://user-images.githubusercontent.com/128088/106584017-9e68a280-653d-11eb-89fe-8d23b638f32d.png) |
| ![Screenshot from 2021-02-02 09-57-38](https://user-images.githubusercontent.com/128088/106584062-aa546480-653d-11eb-99f0-9c779dfb2359.png) | ![Screenshot from 2021-02-02 09-57-40](https://user-images.githubusercontent.com/128088/106585151-ef2ccb00-653e-11eb-90f5-040d94330536.png) |
| ![Screenshot from 2021-02-02 09-58-07](https://user-images.githubusercontent.com/128088/106586658-a1b15d80-6540-11eb-80b3-d23bd447e425.png) | ![Screenshot from 2021-02-02 09-58-11](https://user-images.githubusercontent.com/128088/106586677-a70ea800-6540-11eb-9e11-f7029fb9277a.png) |
| ![Screenshot from 2021-02-02 09-59-38](https://user-images.githubusercontent.com/128088/106586741-b7bf1e00-6540-11eb-9597-e18a2d0535d9.png) | ![Screenshot from 2021-02-02 09-59-41](https://user-images.githubusercontent.com/128088/106586758-bc83d200-6540-11eb-9b7a-15e866e0350f.png) |
| ![Screenshot from 2021-02-02 10-00-01](https://user-images.githubusercontent.com/128088/106586803-c73e6700-6540-11eb-8d48-a2a79b0d6ae7.png) | ![Screenshot from 2021-02-02 10-00-02](https://user-images.githubusercontent.com/128088/106586823-cad1ee00-6540-11eb-8463-1e7ff1178dab.png) |




