### PR TITLE
Improve table formatting and allow custom chat text

### DIFF
--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -2,17 +2,15 @@
   <%= icon %>
 
   <div class="call-to-action__content">
-    <%= tag.span("Chat to us", class: "call-to-action__heading") %>
+    <%= tag.span(title, class: "call-to-action__heading") %>
 
     <p class="call-to-action__text">
-      If you're unsure whether your qualifications are equivalent, you can chat to us.
+      <%= text %>
     </p>
 
     <div class="call-to-action__action">
       <button data-action="click->talk-to-us#startChat">
-        <span>
-          Chat online
-        </span>
+        <%= tag.span(button_text) %>
       </button>
     </div>
   </div>

--- a/app/components/calls_to_action/chat_online_component.rb
+++ b/app/components/calls_to_action/chat_online_component.rb
@@ -1,11 +1,33 @@
 module CallsToAction
   class ChatOnlineComponent < ViewComponent::Base
+    attr_accessor :title, :text, :button_text
+
+    def initialize(title: default_title, text: default_text, button_text: default_button_text)
+      @title       = title
+      @text        = text
+      @button_text = button_text
+    end
+
     def icon
       image_pack_tag("media/images/icon-question.svg",
                      width: 50,
                      height: 50,
                      alt: "Chat with a adviser online",
                      class: "call-to-action__icon")
+    end
+
+  private
+
+    def default_title
+      "Chat to us"
+    end
+
+    def default_text
+      "If you're unsure whether your qualifications are equivalent, you can chat to us."
+    end
+
+    def default_button_text
+      "Chat online"
     end
   end
 end

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,12 +1,12 @@
 .markdown {
   @mixin overhang { margin-left: auto; margin-right: auto; }
 
-  // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
-  > *:not(table) {
+  > * {
     margin-left: $indent-amount;
     margin-right: $indent-amount;
   }
 
+  // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
   > h2 {
     @include overhang;
     @include content-heading;
@@ -61,6 +61,21 @@
     // this is added by Kramdown when using the ToC (table of contents) plugin
     #markdown-toc {
       margin-bottom: 3em;
+    }
+  }
+
+  table {
+    border-spacing: 0 .5em;
+    margin: 1em $indent-amount 2em;
+    width: 90%;
+    border-color: $grey;
+
+    thead > tr > th {
+      text-align: left;
+    }
+
+    tbody {
+      font-size: $fs-16;
     }
   }
 }

--- a/spec/components/calls_to_action/chat_online_component_spec.rb
+++ b/spec/components/calls_to_action/chat_online_component_spec.rb
@@ -22,4 +22,31 @@ RSpec.describe CallsToAction::ChatOnlineComponent, type: :component do
       text: "Chat online",
     )
   end
+
+  context "when a custom title is passed in" do
+    let(:title_text) { "Converse" }
+    let(:component) { described_class.new(title: title_text) }
+
+    specify "some useful text is included" do
+      expect(page).to have_css(".call-to-action .call-to-action__heading", text: title_text)
+    end
+  end
+
+  context "when custom text is passed in" do
+    let(:content) { "Some helpful text should go here" }
+    let(:component) { described_class.new(text: content) }
+
+    specify "some useful text is included" do
+      expect(page).to have_css(".call-to-action .call-to-action__text", text: content)
+    end
+  end
+
+  context "when custom button text is passed in" do
+    let(:button_text) { "Gossip instantly" }
+    let(:component) { described_class.new(button_text: button_text) }
+
+    specify "some useful text is included" do
+      expect(page).to have_css(".call-to-action .call-to-action__action", text: button_text)
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

N/A, related to @MylesJarvis's PR here https://github.com/DFE-Digital/get-into-teaching-content/pull/301

### Context and changes

Improve the look of Markdown tables and allow the chat component to have its title, text and button text configured.

![Screenshot from 2021-02-02 11-30-00](https://user-images.githubusercontent.com/128088/106604386-7a19bf80-6557-11eb-8182-85b452471342.png)


https://user-images.githubusercontent.com/128088/106604404-8140cd80-6557-11eb-9fdd-852db6f5d490.mp4





