### PR TITLE
New ML title copy

### DIFF
--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -20,7 +20,7 @@
   <section class="container">
     <div class="hero__mailing-strip">
         <div class="hero__mailing-strip__text">
-            <p>Get personalised information and advice about getting into teaching.</p>
+            <p>Get personalised information and updates about getting into teaching.</p>
         </div>
         <div class="hero__mailing-strip__cta">
           <%= link_to(mailing_list_steps_path, class: "hero__mailing-strip__cta__button") do %>

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -22,7 +22,7 @@ module MailingList
     end
 
     def set_step_page_title
-      @page_title = "Get personalised information and advice about getting into teaching"
+      @page_title = "Get personalised information and updates about getting into teaching"
       unless @current_step.nil?
         @page_title += ", #{@current_step.title.downcase} step"
       end

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -1,4 +1,4 @@
-<h1>Get personalised information and advice about getting into teaching</h1>
+<h1>Get personalised information and updates about getting into teaching</h1>
 
 <p>
   We know you’ll only want to receive updates that help you 

--- a/app/views/sections/_footer-signup.html.erb
+++ b/app/views/sections/_footer-signup.html.erb
@@ -1,7 +1,7 @@
 <section id="footer-signup" class="footer-signup">
     <section class="container">
         <div class="footer-signup__inner">
-            <span class="footer-signup__text">Get personalised information and advice about getting into teaching</span>
+            <span class="footer-signup__text">Get personalised information and updates about getting into teaching</span>
             <%= link_to(mailing_list_steps_path, class: "call-to-action-button call-to-action-button--white") do %>
                 <span>Sign up here <span class="visually-hidden">to receive information via email</span></span>
             <% end %>

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -81,7 +81,7 @@ describe Sections::HeroComponent, type: "component" do
         end
 
         specify "the mailing list strip contains text and a button" do
-          expect(page).to have_css(".hero__mailing-strip__text", text: /Get personalised information and advice about getting into teaching/)
+          expect(page).to have_css(".hero__mailing-strip__text", text: /Get personalised information and updates about getting into teaching/)
           expect(page).to have_css(".hero__mailing-strip__cta > a.hero__mailing-strip__cta__button", text: /Sign up here/)
         end
       end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -50,9 +50,9 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_title("Get into teaching: Get personalised information and advice about getting into teaching, name step")
+    expect(page).to have_title("Get into teaching: Get personalised information and updates about getting into teaching, name step")
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -93,7 +93,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     channel_id = channels.first.id
     visit mailing_list_steps_path({ id: :name, channel: channel_id })
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -141,7 +141,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -197,7 +197,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -228,7 +228,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -252,7 +252,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -276,7 +276,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step
     click_on "Next Step"
 
@@ -293,7 +293,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
-    expect(page).to have_text "Get personalised information and advice about getting into teaching"
+    expect(page).to have_text "Get personalised information and updates about getting into teaching"
     fill_in_name_step(email: "test2@user.com")
     click_on "Next Step"
 


### PR DESCRIPTION
Based on feedback that users were confusing the copy with the Adviser service, updating to reflect 'updates and information' instead of 'advice'.

### Trello card

### Context

### Changes proposed in this pull request

### Guidance to review

