### PR TITLE
Fix incorrect heading indentation

### DIFF
--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -4,7 +4,7 @@
   </p>
 
   <h1>Sign up for this event:</h1>
-  <h2><%= event.name %></h2>
+  <h2 id="event-reg-main-title"><%= event.name %></h2>
 
   <%= govuk_form_for current_step, url: step_path do |f| %>
     <%= f.govuk_error_summary %>

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -43,6 +43,10 @@
     margin-top: $indent-amount;
   }
 
+  #event-reg-main-title{
+    padding: 0;
+    margin: 25px 0;
+  }
 }
 
 @include mq($until: tablet) {


### PR DESCRIPTION
### Trello card
https://trello.com/c/Csz3XTbz

### Context
- Heading indentation and padding are not correct in event sign up. 

### Changes proposed in this pull request
- Fix event sign up heading indentaion/padding

### Guidance to review
![image](https://user-images.githubusercontent.com/47089130/106617772-d33d1f80-6566-11eb-84bf-caed7a89b7ff.png)

