### PR TITLE
Standardise registration styling

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -8,6 +8,8 @@ class EventStepsController < ApplicationController
   before_action :set_step_page_title, only: [:show]
   before_action :set_completed_page_title, only: [:completed]
 
+  layout "events/registration"
+
 private
 
   def redirect_closed_events

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -1,4 +1,4 @@
-<section class="event-reg-main">
+<section class="registration__event">
   <p>
     <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
   </p>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -1,35 +1,33 @@
 <% @skip_hero = @hide_page_helpful_question = true %>
 
-<h2 class="green">Sign up complete</h2>
-
-<section class="event-reg-main" role="main" id="main-content">
+<section class="text-content">
+  <h2 class="green">Sign up complete</h2>
   <h3>You are signed up for the following event:</h3>
 
   <b><%= @event.name %></b>
   <p><%= format_event_date @event, stacked: false %></p>
 
   <%- if params[:subscribed].to_s == "1" -%>
-  <h3>You've also signed up for email updates</h3>
-  <p>
-      You're ready to receive email updates to help you get
-      into teaching.
-  </p>
+    <h3>You've also signed up for email updates</h3>
+
+    <p>You're ready to receive email updates to help you get into teaching.</p>
   <%- end -%>
 
   <h3>What happens next?</h3>
   <p>
-      You will receive a confirmation email with details of the event. If there is an issue with the event we will contact you via phone.
+    You will receive a confirmation email with details of the event. If there
+    is an issue with the event we will contact you via phone.
   </p>
 
   <span data-controller="pinterest"
-      data-pinterest-action="track"
-      data-pinterest-event="custom"></span>
+        data-pinterest-action="track"
+        data-pinterest-event="custom"></span>
 
   <span data-controller="snapchat"
-      data-pinterest-action="track"
-      data-pinterest-event="INVITE"></span>
+        data-pinterest-action="track"
+        data-pinterest-event="INVITE"></span>
 
   <span data-controller="facebook"
-      data-pinterest-action="track"
-      data-pinterest-event="Event_Registrations"></span>
+        data-pinterest-action="track"
+        data-pinterest-event="Event_Registrations"></span>
 </section>

--- a/app/views/layouts/events/registration.html.erb
+++ b/app/views/layouts/events/registration.html.erb
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+  <%= render "sections/head" %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <div id="skiplink-container">
+      <div>
+        <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
+    </div>
+
+    <%= render "sections/header" %>
+
+    <main class="semantic" role="main" id="main-content">
+      <section class="feature registration container">
+        <%= yield %>
+        <%= render "sections/page_helpful" unless @hide_page_helpful_question %>
+      </section>
+    </main>
+
+    <%= render "sections/footer" %>
+    <%= render "sections/cookie-acceptance" %>
+    <%= render "sections/feedback-bar" %>
+    <%= render "components/videoplayer" %>
+  <% end %>
+</html>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<section class="mailing-reg-main">
+<section class="registration__mailing-list">
   <p>
     <%= back_link step_path(wizard.previous_key) if wizard.previous_key %>
   </p>
@@ -14,4 +14,3 @@
     <% end %>
   <% end %>
 </section>
-

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,48 +1,51 @@
 <% @skip_hero = @hide_page_helpful_question = true %>
 
-<h2 class="green">You've signed up</h2>
+<section class="text-content">
+  <h2 class="green">You've signed up</h2>
 
-<section class="mailing-reg-main">
-    <p>You’re ready to receive email updates to help you get into teaching.</p>
+  <p>You’re ready to receive email updates to help you get into teaching.</p>
 
-    <h3>What happens next?</h2>
+  <h3>What happens next?</h3>
 
-    <p>
-      You’ll receive an email to the address you gave us when you signed up.
-      You can unsubscribe if you change your mind. To find out how we
-      handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
-    </p>
+  <p>
+    You’ll receive an email to the address you gave us when you signed up.
+    You can unsubscribe if you change your mind. To find out how we
+    handle your personal data, you can read our <%= link_to("privacy policy", privacy_policy_path) %>.
+  </p>
 
-    <h3>Want to speak to us?</h2>
+  <h3>Want to speak to us?</h3>
 
-    <p>
-      If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and 5pm.
-    </p>
-    <p>
-      You can also use this number to update or amend any of your details.
-    </p>
+  <p>
+    If you’d prefer, you can call us about teaching or teacher training on
+    Freephone <a href="tel:08003892501" class="telephone-number"
+    aria-label="Telephone">0800 389 2501</a>, Monday-Friday between 8.30am and
+    5pm.
+  </p>
 
-    <span data-controller="pinterest"
+  <p>
+    You can also use this number to update or amend any of your details.
+  </p>
+
+  <span data-controller="pinterest"
         data-pinterest-action="track"
         data-pinterest-event="lead"
         data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
 
-    <span data-controller="snapchat"
+  <span data-controller="snapchat"
         data-snapchat-action="track"
         data-snapchat-event="SUBSCRIBE"></span>
 
-    <span data-controller="facebook"
+  <span data-controller="facebook"
         data-facebook-action="trackCustom"
         data-facebook-event="Newsletter_Subscribers"></span>
 
-    <span data-controller="bam" data-bam-action="track"></span>
+  <span data-controller="bam" data-bam-action="track"></span>
 
-    <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
+  <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
 </section>
 
 <% content_for(:feature) do %>
-    <div class="explore">
-        <%= render "content/home/featured_content" %>
-    </div>
+  <div class="explore">
+    <%= render "content/home/featured_content" %>
+  </div>
 <% end %>
-

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,4 +1,5 @@
-.markdown {
+.markdown,
+.text-content {
   @mixin overhang { margin-left: auto; margin-right: auto; }
 
   > * {

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -1,66 +1,14 @@
-.event-reg-main,
-.mailing-reg-main {
-  margin-bottom: 1em;
+.registration {
+  .registration__event,
+  .registration__mailing-list {
+    margin: auto $indent-amount;
 
-  .govuk-checkboxes__item,
-  .govuk-form-group {
-    margin-bottom: 10px;
-  }
+    h1 {
+      font-size: $fs-42;
+    }
 
-  .govuk-input {
-    margin-left: 0;
-  }
-
-  h1 {
-    font-size: $fs-42;
-    margin: 0;
-    line-height: 1.25;
-  }
-
-  h2 {
-    @include content-heading;
-    margin-bottom: 0;
-    font-size: $fs-28;
-    background: transparent;
-    color: $black;
-  }
-
-  h3 {
-    font-size: $fs-28;
-    margin: 0;
-    padding: 0;
-    margin-top: $indent-amount;
-    margin-bottom: 10px;
-  }
-
-  .govuk-input,
-  .govuk-select {
-    max-width: 375px;
-    margin-bottom: 15px;
-    margin-left: 0;
-  }
-
-  button.call-to-action-button {
-    margin-top: $indent-amount;
-  }
-}
-
-@include mq($until: tablet) {
-  .event-reg-main,
-  .mailing-reg-main {
-    &__content {
-
-      display: block;
-
-      &__left {
-        display: block;
-        margin-right: 40px;
-      }
-
-      &__right {
-        display: block;
-        margin-top: 40px;
-      }
+    h2 {
+      font-size: $fs-28;
     }
   }
 }


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

Some headings were incorrectly indented #847. Rather than fix them individually this PR removes all the custom CSS and restructures the page via a new `registration` layout so they inherit from the new standard `semantic` layout.

Some examples of how the pages now look:

![Screenshot from 2021-02-03 13-31-42](https://user-images.githubusercontent.com/128088/106754176-8d469100-6624-11eb-8489-3cf501474897.png)
![Screenshot from 2021-02-03 13-28-33](https://user-images.githubusercontent.com/128088/106754180-8e77be00-6624-11eb-9961-23465e28eada.png)
![Screenshot from 2021-02-03 13-27-14](https://user-images.githubusercontent.com/128088/106754183-8e77be00-6624-11eb-82dd-5769fccea1f7.png)
![Screenshot from 2021-02-03 13-26-48](https://user-images.githubusercontent.com/128088/106754185-8f105480-6624-11eb-8c0e-8842f52c3072.png)
![Screenshot from 2021-02-03 13-26-37](https://user-images.githubusercontent.com/128088/106754187-8fa8eb00-6624-11eb-93b8-ca8921b65074.png)
![Screenshot from 2021-02-03 13-26-33](https://user-images.githubusercontent.com/128088/106754188-90418180-6624-11eb-9baf-a81d77a61466.png)

Fixes #847
