### PR TITLE
Change event_categories routes to event-categories

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,15 +41,17 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :event_categories, only: %i[show] do
+  resources :event_categories, only: %i[show], path: "event-categories" do
     member do
       get "archive", to: "event_categories#show_archive"
     end
   end
   # The event category pages used to exist here - once we're sure no traffic is
   # coming to these paths we can safely remove these redirects.
-  get "events/category/:id/", to: redirect("/event_categories/%{id}/")
-  get "events/category/:id/archive", to: redirect("/event_categories/%{id}/archive")
+  get "events/category/:id/", to: redirect("/event-categories/%{id}")
+  get "events/category/:id/archive", to: redirect("/event-categories/%{id}/archive")
+  get "event_categories/:id", to: redirect("/event-categories/%{id}")
+  get "event_categories/:id/archive", to: redirect("/event-categories/%{id}/archive")
 
   namespace :mailing_list, path: "/mailinglist" do
     resources :steps,

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -22,6 +22,6 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has a read more link" do
-    expect(page).to have_link("Read more", href: "/event_categories/online-events", class: "type-description__link")
+    expect(page).to have_link("Read more", href: "/event-categories/online-events", class: "type-description__link")
   end
 end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -179,4 +179,22 @@ describe EventsController do
       it { is_expected.to have_http_status :not_found }
     end
   end
+
+  describe "redirects" do
+    {
+      "/events/category/some-event-category" => "/event-categories/some-event-category",
+      "/event_categories/some-event-category" => "/event-categories/some-event-category",
+
+      "/events/category/some-event-category/archive" => "/event-categories/some-event-category/archive",
+      "/event_categories/some-event-category/archive" => "/event-categories/some-event-category/archive",
+    }.each do |from, to|
+      describe from do
+        subject { get(from) }
+
+        specify "redirects to #{to}" do
+          expect(subject).to redirect_to(to)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a cosmetic change to make event routes look a bit nicer.

Now, instead of `"/event_categories/some-event-category` the route will be `/event-categories/some-event-category`

The specs are requests specs rather than routing specs because routing specs haven't supported redirects for quite some time (link to 10 year old RSpec issue in commit message).
