### PR TITLE
Create some visual separation between table head and body

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -66,13 +66,19 @@
   }
 
   table {
-    border-spacing: 0 .5em;
+    $table-spacing: .5em;
+    border-spacing: 0 $table-spacing;
     margin: 1em $indent-amount 2em;
     width: 90%;
     border-color: $grey;
 
-    thead > tr > th {
-      text-align: left;
+    thead > tr {
+      > th {
+        text-align: left;
+        padding-bottom: $table-spacing;
+        margin-bottom: $table-spacing;
+        border-bottom: 1px solid $grey-light;
+      }
     }
 
     tbody {
@@ -101,7 +107,7 @@
         }
 
         td {
-          border-top: 1px solid $grey;
+          border-bottom: 1px solid $grey;
           padding: .5em;
 
           // used to display cookie names


### PR DESCRIPTION
Currently there's not much 'separation' in terms of style between bold text in the table and the headings, only a small difference in font size. Adding a line gives clear visual separation between the two.

| Page | Before | After |
|-----|------|------|
| Funding your training | ![Screenshot from 2021-02-04 12-37-36](https://user-images.githubusercontent.com/128088/106893659-c85cc900-66e5-11eb-8f2f-eb9ed4245507.png) | ![Screenshot from 2021-02-04 12-36-53](https://user-images.githubusercontent.com/128088/106893676-cc88e680-66e5-11eb-80ed-090d539a7348.png) |
| Cookies | ![Screenshot from 2021-02-04 12-36-32](https://user-images.githubusercontent.com/128088/106893757-e7f3f180-66e5-11eb-8343-0686fbef1268.png) | ![Screenshot from 2021-02-04 12-36-12](https://user-images.githubusercontent.com/128088/106893708-d7437b80-66e5-11eb-946e-72a66ddf13f4.png) | 

