### PR TITLE
Bugfix/button title styling cookie prefs

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -17,9 +17,7 @@
   as the pages you visit.
 </p>
 
-<h2 class="govuk-heading-m">
-  Cookie settings
-</h2>
+<h2 class="govuk-heading-m">Cookie settings</h2>
 
 <p>
   We use 3 types of cookie. You can choose which cookies you're happy

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -49,8 +49,8 @@ a {
 }
 
 .secondary-button {
-  width: 100%;
   @include button($bg: $grey-light, $fg: black);
+  display: inline-block;
 }
 
 .request-button {

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -16,7 +16,6 @@
   .accordions,
   .stories-feature,
   .feature-table,
-  .secondary-button,
   .content-alert,
   .event-type-descriptions,
   .types-of-event,


### PR DESCRIPTION
### Trello card
https://trello.com/c/Qr8UjQMn

### Context
"Back to page" button was spanning the width of the content

### Changes proposed in this pull request
- Fix space in header
- Fix button width

### Guidance to review
![image](https://user-images.githubusercontent.com/47089130/106921395-e1747280-6703-11eb-8be6-a9856dcad3e5.png)



