### PR TITLE
Swap to new token exchange methods/endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 61152b6255ba9ea824d28c5db3c0dce75658dd2e
+  revision: f4d48fc3310db7e6a95df63f284a84f1375d5629
   specs:
-    get_into_teaching_api_client (1.1.9)
+    get_into_teaching_api_client (1.1.10)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.12)
+    get_into_teaching_api_client_faraday (0.1.13)
       activesupport
       faraday
       faraday-encoding
@@ -125,7 +125,7 @@ GEM
       faraday
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
-    faraday-net_http (1.0.0)
+    faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.14.2)
@@ -283,7 +283,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     secure_headers (6.3.1)
     selenium-webdriver (3.142.7)

--- a/app/models/events/steps/authenticate.rb
+++ b/app/models/events/steps/authenticate.rb
@@ -5,7 +5,7 @@ module Events
 
       def perform_existing_candidate_request(request)
         @api ||= GetIntoTeachingApiClient::TeachingEventsApi.new
-        @api.get_pre_filled_teaching_event_add_attendee(timed_one_time_password, request)
+        @api.exchange_access_token_for_teaching_event_add_attendee(timed_one_time_password, request)
       end
     end
   end

--- a/app/models/mailing_list/steps/authenticate.rb
+++ b/app/models/mailing_list/steps/authenticate.rb
@@ -5,7 +5,7 @@ module MailingList
 
       def perform_existing_candidate_request(request)
         @api ||= GetIntoTeachingApiClient::MailingListApi.new
-        @api.get_pre_filled_mailing_list_add_member(timed_one_time_password, request)
+        @api.exchange_access_token_for_mailing_list_add_member(timed_one_time_password, request)
       end
     end
   end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Event wizard", type: :feature do
       telephone: "1234567890",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
     visit event_steps_path(event_id: event_readable_id)
 
@@ -141,9 +141,9 @@ RSpec.feature "Event wizard", type: :feature do
 
     response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).with("654321", anything).and_raise(GetIntoTeachingApiClient::ApiError)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).with("654321", anything).and_raise(GetIntoTeachingApiClient::ApiError)
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
     visit event_steps_path(event_id: event_readable_id)
 
@@ -176,7 +176,7 @@ RSpec.feature "Event wizard", type: :feature do
       alreadySubscribedToMailingList: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
     visit event_steps_path(event_id: event_readable_id)
 
@@ -218,7 +218,7 @@ RSpec.feature "Event wizard", type: :feature do
       alreadySubscribedToTeacherTrainingAdviser: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).with("123456", anything).and_return(response)
 
     visit event_steps_path(event_id: event_readable_id)
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
       addressPostcode: "TE57 1NG",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything) { response }
+      receive(:exchange_access_token_for_mailing_list_add_member).with("123456", anything) { response }
 
     visit mailing_list_steps_path
 
@@ -191,9 +191,9 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     response = GetIntoTeachingApiClient::MailingListAddMember.new
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("654321", anything).and_raise(GetIntoTeachingApiClient::ApiError)
+      receive(:exchange_access_token_for_mailing_list_add_member).with("654321", anything).and_raise(GetIntoTeachingApiClient::ApiError)
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_mailing_list_add_member).with("123456", anything).and_return(response)
 
     visit mailing_list_steps_path
 
@@ -224,7 +224,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
       alreadySubscribedToMailingList: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_mailing_list_add_member).with("123456", anything).and_return(response)
 
     visit mailing_list_steps_path
 
@@ -248,7 +248,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
       alreadySubscribedToTeacherTrainingAdviser: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_mailing_list_add_member).with("123456", anything).and_return(response)
 
     visit mailing_list_steps_path
 
@@ -272,7 +272,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
       alreadySubscribedToMailingList: true,
     )
     allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).with("123456", anything).and_return(response)
+      receive(:exchange_access_token_for_mailing_list_add_member).with("123456", anything).and_return(response)
 
     visit mailing_list_steps_path
 

--- a/spec/models/events/steps/authenticate_spec.rb
+++ b/spec/models/events/steps/authenticate_spec.rb
@@ -5,10 +5,10 @@ describe Events::Steps::Authenticate do
 
   it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
 
-  it "calls get_pre_filled_teaching_event_add_attendee on valid save" do
+  it "calls exchange_access_token_for_teaching_event_add_attendee on valid save" do
     response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new
     expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_pre_filled_teaching_event_add_attendee).and_return(response)
+      receive(:exchange_access_token_for_teaching_event_add_attendee).and_return(response)
     subject.assign_attributes(attributes_for(:authenticate))
     subject.save
   end

--- a/spec/models/mailing_list/steps/authenticate_spec.rb
+++ b/spec/models/mailing_list/steps/authenticate_spec.rb
@@ -5,10 +5,10 @@ describe MailingList::Steps::Authenticate do
 
   it { is_expected.to be_kind_of(::Wizard::Steps::Authenticate) }
 
-  it "calls get_pre_filled_mailing_list_add_member on valid save" do
+  it "calls exchange_access_token_for_mailing_list_add_member on valid save" do
     response = GetIntoTeachingApiClient::MailingListAddMember.new
     expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-      receive(:get_pre_filled_mailing_list_add_member).and_return(response)
+      receive(:exchange_access_token_for_mailing_list_add_member).and_return(response)
     subject.assign_attributes(attributes_for(:authenticate))
     subject.save
   end


### PR DESCRIPTION
### Trello card

[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

### Context

The existing methods/endpoints to exchange an access token for a pre-filled mailing list/teaching event sign up model are being deprecated and removed. This commit transitions the codebase to use the new exchange_access_token
method.

### Changes proposed in this pull request

- Swap to new token exchange methods/endpoints

### Guidance to review

I've manually tested a match back for event/mailing list sign up.