### PR TITLE
Homepage refresh

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -4,5 +4,6 @@ module.exports = {
     'max-nesting-depth': null,
     'selector-no-qualifying-type': [true, { ignore: ['class'] }],
     'selector-max-id': 1,
+    'declaration-block-single-line-max-declarations': 1,
   },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -5,5 +5,6 @@ module.exports = {
     'selector-no-qualifying-type': [true, { ignore: ['class'] }],
     'selector-max-id': 1,
     'declaration-block-single-line-max-declarations': 1,
+    'declaration-no-important': false,
   },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -5,6 +5,5 @@ module.exports = {
     'selector-no-qualifying-type': [true, { ignore: ['class'] }],
     'selector-max-id': 1,
     'declaration-block-single-line-max-declarations': 1,
-    'declaration-no-important': false,
   },
 };

--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
+  <div class="call-to-action__content">
+    <%= tag.div(icon, class: "call-to-action__icon__container") %>
+
+    <%= tag.span(title, class: "call-to-action__heading") %>
+
+    <div class="call-to-action__action">
+      <%= link %>
+    </div>
+  </div>
+  <%= image %>
+<% end %>

--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,12 +1,8 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
-  <div class="call-to-action__content">
     <%= tag.div(icon, class: "call-to-action__icon__container") %>
-
     <%= tag.span(title, class: "call-to-action__heading") %>
-
     <div class="call-to-action__action">
       <%= link %>
     </div>
-  </div>
-  <%= image %>
+    <%= image %>
 <% end %>

--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -1,0 +1,28 @@
+module CallsToAction
+  class HomepageComponent < ViewComponent::Base
+    attr_accessor :icon, :image, :title, :link
+
+    def initialize(icon:, title: nil, link_text:, link_target:, image:)
+      @title = title
+      @link  = link_to(tag.span(link_text), link_target)
+      @icon  = icon_element(icon)
+      @image = image_element(image)
+    end
+
+  private
+
+    def image_element(image)
+      tag.div(style: %[background-image: url('#{image}')], class: "call-to-action__image")
+    end
+
+    def icon_element(icon)
+      img = image_pack_tag("media/images/#{icon}.svg",
+                           width: 50,
+                           height: 50,
+                           alt: "#{icon} icon",
+                           class: "call-to-action__icon")
+
+      tag.div(img, class: "call-to-action__icon__box")
+    end
+  end
+end

--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -5,7 +5,11 @@
   </div>
   <% if show_subtitle? %>
     <div class="hero__subtitle">
-      <%= tag.div(subtitle) %>
+      <%= tag.div(subtitle, class: "hero__subtitle__text") %>
+
+      <% if show_subtitle_button? %>
+        <%= link_to(tag.span(@subtitle_button), @subtitle_link, class: "hero__subtitle__button") %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -15,18 +15,3 @@
     </div>
   <% end %>
 <% end %>
-
-<% if show_mailing_list %>
-  <section class="container">
-    <div class="hero__mailing-strip">
-        <div class="hero__mailing-strip__text">
-            <p>Get personalised information and updates about getting into teaching.</p>
-        </div>
-        <div class="hero__mailing-strip__cta">
-          <%= link_to(mailing_list_steps_path, class: "hero__mailing-strip__cta__button") do %>
-            <span>Sign up here <span class="visually-hidden">to receive information via email</span></span>
-          <% end %>
-        </div>
-    </div>
-  </section>
-<% end %>

--- a/app/components/sections/hero_component.rb
+++ b/app/components/sections/hero_component.rb
@@ -4,12 +4,11 @@ module Sections
 
     def initialize(front_matter)
       front_matter.with_indifferent_access.tap do |fm|
-        @title             = fm["title"]
-        @subtitle          = fm["subtitle"]
-        @subtitle_link     = fm["subtitle_link"]
-        @image             = fm["image"]
-        @mobile_image      = fm["mobileimage"]
-        @show_mailing_list = fm["mailinglist"]
+        @title         = fm["title"]
+        @subtitle      = fm["subtitle"]
+        @subtitle_link = fm["subtitle_link"]
+        @image         = fm["image"]
+        @mobile_image  = fm["mobileimage"]
       end
     end
 

--- a/app/components/sections/hero_component.rb
+++ b/app/components/sections/hero_component.rb
@@ -1,14 +1,15 @@
 module Sections
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :image, :mobile_image, :show_mailing_list
+    attr_accessor :title, :subtitle, :image, :mobile_image, :show_mailing_list
 
     def initialize(front_matter)
       front_matter.with_indifferent_access.tap do |fm|
-        @title         = fm["title"]
-        @subtitle      = fm["subtitle"]
-        @subtitle_link = fm["subtitle_link"]
-        @image         = fm["image"]
-        @mobile_image  = fm["mobileimage"]
+        @title           = fm["title"]
+        @subtitle        = fm["subtitle"]
+        @subtitle_link   = fm["subtitle_link"]
+        @subtitle_button = fm["subtitle_button"]
+        @image           = fm["image"]
+        @mobile_image    = fm["mobileimage"]
       end
     end
 
@@ -27,16 +28,12 @@ module Sections
       image_tag(image_path, class: "hero__img", srcset: image_sizes.join(", "), alt: "Student in a classroom")
     end
 
-    def subtitle
-      if @subtitle_link.present?
-        link_to(@subtitle, @subtitle_link)
-      else
-        @subtitle
-      end
-    end
-
     def show_subtitle?
       @subtitle.present?
+    end
+
+    def show_subtitle_button?
+      [@subtitle_link, @subtitle_button].all?(&:present?)
     end
 
   private

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -12,13 +12,7 @@
 
     <%= render Sections::HeroComponent.new(@front_matter) %>
 
-    <main class="semantic" role="main" id="main-content">
-      <section class="container">
-        <article class="markdown fullwidth">
-          <%= yield %>
-        </article>
-      </section>
-
+    <main class="semantic home" role="main" id="main-content">
       <% @front_matter["content"]&.each do |partial| %>
         <%= render(partial) %>
       <% end %>

--- a/app/webpacker/images/icon-doc-black.svg
+++ b/app/webpacker/images/icon-doc-black.svg
@@ -1,0 +1,7 @@
+<svg id="icon.application" xmlns="http://www.w3.org/2000/svg" width="41.451" height="36.279" viewBox="0 0 41.451 36.279">
+  <path id="Path_1322" data-name="Path 1322" d="M521.613,608.034h13.4v3.8h-17.1V587.659h3.691v-2.766h-6.457V614.6h22.628v-6.569h6.459v-29.71H521.613Zm2.766-26.944h17.1v24.176h-17.1Z" transform="translate(-515.154 -578.324)" fill="#0b0c0c"/>
+  <rect id="Rectangle_886" data-name="Rectangle 886" width="10.679" height="2.766" transform="translate(12.447 7.301)" fill="#0b0c0c"/>
+  <rect id="Rectangle_887" data-name="Rectangle 887" width="10.679" height="2.766" transform="translate(12.447 13.194)" fill="#0b0c0c"/>
+  <rect id="Rectangle_888" data-name="Rectangle 888" width="10.679" height="2.766" transform="translate(12.447 19.086)" fill="#0b0c0c"/>
+  <path id="Path_1323" data-name="Path 1323" d="M624.349,586.722l-4.327,9.025v22.086h8.654V595.747Zm-1.559,24.254v-14.6l1.559-3.253,1.559,3.253v14.6Z" transform="translate(-587.225 -584.095)" fill="#0b0c0c"/>
+</svg>

--- a/app/webpacker/images/icon-git-black.svg
+++ b/app/webpacker/images/icon-git-black.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="33.879" height="33.653" viewBox="0 0 33.879 33.653">
+  <g id="icon.GiT" transform="translate(0)">
+    <path id="Path_1025" data-name="Path 1025" d="M119.635,33.653h33.878V0H119.635Zm3.582-30.095h26.714V30.094H123.219V3.558Z" transform="translate(-119.635)" fill="#0b0c0c" fill-rule="evenodd"/>
+    <path id="Path_1027" data-name="Path 1027" d="M140.7,9.248,129.4,20.157l-3.781-3.65L123.1,18.94l6.3,6.083,13.815-13.342Z" transform="translate(-116.752 0.215)" fill="#0b0c0c" fill-rule="evenodd"/>
+  </g>
+</svg>

--- a/app/webpacker/images/icon-school-black.svg
+++ b/app/webpacker/images/icon-school-black.svg
@@ -1,0 +1,5 @@
+<svg id="icon.school-uni" xmlns="http://www.w3.org/2000/svg" width="41.828" height="28.196" viewBox="0 0 41.828 28.196">
+  <g id="Group_805" data-name="Group 805" transform="translate(0 0)">
+    <path id="Path_1309" data-name="Path 1309" d="M744.732,408.543l-20.914-10.55L702.9,408.543l3.174,1.681v13.538l2.8,1.494V411.718l1.867.934v7.1l13.071,6.442,13.071-6.442v-7.1Zm-36.226,0,15.312-7.469,15.312,7.469-15.312,7.843Zm15.312,14.565-10.27-5.228v-3.735l10.27,5.135,10.27-5.135v3.735Z" transform="translate(-702.904 -397.993)" fill="#0b0c0c"/>
+  </g>
+</svg>

--- a/app/webpacker/images/steps-graphic-mob.svg
+++ b/app/webpacker/images/steps-graphic-mob.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="330.689" height="338.344" viewBox="0 0 330.689 338.344">
+  <g id="Group_1442" data-name="Group 1442" transform="translate(-21.655 -1058.001)">
+    <path id="Path_1614" data-name="Path 1614" d="M-282.99,11558.619c8.948,79.262,87.188,61.18,142.62,41.137,120.8-40.068,139.391,11.941,121.427,84.267,1.54,1,3.17,2.024,4.859,3.04-51.172,103.15-84.12,111.881-177.328,48.037s-120.323,80.086-52.589,115.676,183.227-34.26,246-23.229" transform="translate(328 -10477)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
+    <g id="Group_1385" data-name="Group 1385" transform="translate(-107.905 282)">
+      <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+    </g>
+    <g id="Group_1387" data-name="Group 1387" transform="translate(-224.905 403)">
+      <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+    </g>
+    <g id="Group_1388" data-name="Group 1388" transform="translate(-579.905 451)">
+      <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+    </g>
+    <g id="Group_1389" data-name="Group 1389" transform="translate(-819.904 572)">
+      <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
+    </g>
+    <g id="Group_1390" data-name="Group 1390" transform="translate(-580.561 548)">
+      <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
+    </g>
+    <g id="Group_1386" data-name="Group 1386" transform="translate(-157.561 321)">
+      <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/images/steps-graphic.svg
+++ b/app/webpacker/images/steps-graphic.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="490.689" height="279.344" viewBox="0 0 490.689 279.344">
+  <g id="Group_1441" data-name="Group 1441" transform="translate(-619.656 -845.001)">
+    <path id="Path_1614" data-name="Path 1614" d="M-282.547,11569.416c73.975,18.928,36.042-157.584,43.609-151.932,130.453-106.531,36.416,110.557,144.938,95.666,77.391,9.563-6.852-143.824,87-87.41s-49.412,142.451,54.563,170.207,67.609-66.766,49.773-121.946-3.109-119.876,59.664-108.845" transform="translate(935 -10495)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
+    <g id="Group_1385" data-name="Group 1385" transform="translate(490.095 276)">
+      <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+    </g>
+    <g id="Group_1386" data-name="Group 1386" transform="translate(359.439 124)">
+      <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+    </g>
+    <g id="Group_1387" data-name="Group 1387" transform="translate(304.095 217)">
+      <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+    </g>
+    <g id="Group_1388" data-name="Group 1388" transform="translate(199.095 125)">
+      <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+    </g>
+    <g id="Group_1389" data-name="Group 1389" transform="translate(77.096 300)">
+      <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
+    </g>
+    <g id="Group_1390" data-name="Group 1390" transform="translate(177.439 69)">
+      <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
+      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -183,7 +183,7 @@
 
       .call-to-action__heading {
         grid-area: 2 / 1 / 3 / 3;
-        margin: 1em auto .5em;
+        margin: 1em auto .5em 0;
       }
 
       .call-to-action__action {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -106,70 +106,95 @@
   }
 
   &--homepage {
-    display: flex;
-    flex-direction: row;
+    display: grid;
     margin-bottom: 0;
+    gap: .2em;
 
-    .call-to-action {
+    grid-template-rows: 1em 1fr 2fr .8fr 1em;
+    grid-template-columns: 1.2fr .8fr;
+    overflow: hidden;
+
+    .call-to-action__icon__container {
       @include reset;
 
-      // the icon__container is the container used
-      // by flex to position the div
-      &__icon__container {
-        transform: rotate(-3deg);
-      }
+      grid-area: 1 / 1 / 3 / 2;
+      transform: rotate(-3deg);
 
       // the box exists so we can rotate the icon's background
       // and the icon itself separately in opposite directions
-      &__icon__box {
+      .call-to-action__icon__box {
         margin: 1em auto auto -.2em;
         padding-left: .2em;
         background-color: $yellow;
         display: inline-block;
       }
 
-      &__icon {
+      .call-to-action__icon {
         background: transparent;
         transform: rotate(3deg);
       }
+    }
 
-      &__heading {
+    .call-to-action__heading {
+      @include reset;
+      align-self: center;
+      padding: 0 1em;
+      font-size: size(medium);
+      text-decoration: underline;
+      text-underline-offset: .2em;
+      line-height: 1.3em;
+      text-decoration-thickness: .12em;
+
+      grid-area: 3 / 1 / 4 / 2;
+    }
+
+    .call-to-action__action {
+      @include reset;
+      grid-area: 4 / 1 / 6 / 2;
+
+      a {
+        margin: .3em 1.5em;
         display: inline-block;
-        padding: .5em;
-        margin: .2em 0;
-
-        font-size: size(medium);
-        text-decoration: underline;
-        text-underline-offset: .2em;
-        line-height: 1.3em;
-        text-decoration-thickness: .12em;
+        font-size: size("small");
       }
+    }
 
-      &__content {
-        @include reset;
+    .call-to-action__image {
+      @include reset;
+      grid-area: 2 / 2 / 5 / 3;
+      background-position: center;
+      background-size: cover;
+    }
 
-        flex: 1 0 50%;
-        overflow: hidden;
-      }
+    @include mq($until: tablet) {
+      grid-template-rows: 12em 1fr auto;
+      grid-template-columns: .8fr 1.2fr;
 
-      &__image {
-        flex: 1 0 50%;
+      .call-to-action__icon__container {
+        grid-area: 1 / 1 / 2 / 2;
         align-self: center;
-        overflow: hidden;
-        object-fit: cover;
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: cover;
-        width: 80%;
-        height: 90%;
-        @include mq($until: tablet) {
-          display: none;
+
+        img {
+          padding: 1.2em;
+          height: 3em;
+          width: 3em;
         }
       }
 
-      &__action {
-        margin: .2em .5em 1em;
+      .call-to-action__heading {
+        grid-area: 2 / 1 / 3 / 3;
+        margin: 1em auto .5em;
       }
+
+      .call-to-action__action {
+        grid-area: 3 / 1 / 4 / 3;
+
+        a {
+          margin: 1em 1.5em;
+        }
+      }
+
+      .call-to-action__image { grid-area: 1 / 2 / 2 / 3; }
     }
   }
 }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -104,4 +104,72 @@
       }
     }
   }
+
+  &--homepage {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 0;
+
+    .call-to-action {
+      @include reset;
+
+      // the icon__container is the container used
+      // by flex to position the div
+      &__icon__container {
+        transform: rotate(-3deg);
+      }
+
+      // the box exists so we can rotate the icon's background
+      // and the icon itself separately in opposite directions
+      &__icon__box {
+        margin: 1em auto auto -.2em;
+        padding-left: .2em;
+        background-color: $yellow;
+        display: inline-block;
+      }
+
+      &__icon {
+        background: transparent;
+        transform: rotate(3deg);
+      }
+
+      &__heading {
+        display: inline-block;
+        padding: .5em;
+        margin: .2em 0;
+
+        font-size: size(medium);
+        text-decoration: underline;
+        text-underline-offset: .2em;
+        line-height: 1.3em;
+        text-decoration-thickness: .09em;
+      }
+
+      &__content {
+        @include reset;
+
+        flex: 1 0 50%;
+        overflow: hidden;
+      }
+
+      &__image {
+        flex: 1 0 50%;
+        align-self: center;
+        overflow: hidden;
+        object-fit: cover;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: cover;
+        width: 80%;
+        height: 90%;
+        @include mq($until: tablet) {
+          display: none;
+        }
+      }
+
+      &__action {
+        margin: .2em .5em 1em;
+      }
+    }
+  }
 }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -142,7 +142,7 @@
         text-decoration: underline;
         text-underline-offset: .2em;
         line-height: 1.3em;
-        text-decoration-thickness: .09em;
+        text-decoration-thickness: .12em;
       }
 
       &__content {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -110,7 +110,7 @@
     margin-bottom: 0;
     gap: .2em;
 
-    grid-template-rows: 1em 1fr 2fr .8fr 1em;
+    grid-template-rows: 1em 1fr 2fr 1fr 1em;
     grid-template-columns: 1.2fr .8fr;
     overflow: hidden;
 
@@ -151,6 +151,7 @@
     .call-to-action__action {
       @include reset;
       grid-area: 4 / 1 / 6 / 2;
+      margin-bottom: .5em;
 
       a {
         margin: .3em 1.5em;
@@ -184,13 +185,14 @@
       .call-to-action__heading {
         grid-area: 2 / 1 / 3 / 3;
         margin: 1em auto .5em 0;
+        font-size: size('small');
       }
 
       .call-to-action__action {
         grid-area: 3 / 1 / 4 / 3;
 
         a {
-          margin: 1em 1.5em;
+          margin: 1em;
         }
       }
 

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -1,6 +1,6 @@
 .navbar {
   min-height: 112px;
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  @mixin ie-only {
     // IE hack - IE can't vertically align flexbox items without a fixed height
     height: 112px;
   }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -34,6 +34,13 @@ main.home {
 
     > * {
       flex: 1 0;
+
+      // this can be deleted once gap is supported by
+      // Safari, it's currently only in the TP (tech preview)
+      // build https://caniuse.com/?search=gap
+      @include safari-only {
+        margin: .3em;
+      }
     }
   }
 }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -201,7 +201,7 @@ main.home {
   }
 
   &__directory {
-    border: 2px solid $purple;
+    border: 3px solid $purple;
     padding: 1em;
 
     h3 {

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -29,8 +29,14 @@ main.home {
 
   &.blocks {
     display: flex;
-    margin: 1em $px-either-side-of-content;
     gap: 1em;
+
+    // This is a fix to make IE display the content
+    // centrally.
+    margin: 1em auto;
+    @supports (display: grid) {
+      margin: 1em $px-either-side-of-content;
+    }
 
     > * {
       flex: 1 0;
@@ -39,6 +45,10 @@ main.home {
       // Safari, it's currently only in the TP (tech preview)
       // build https://caniuse.com/?search=gap
       @include safari-only {
+        margin: .3em;
+      }
+
+      @include ie-only {
         margin: .3em;
       }
     }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -29,6 +29,8 @@ main.home {
 
   &.blocks {
     display: flex;
+    width: auto;
+    margin: 1em $px-either-side-of-content;
     gap: 1em;
 
     > * {
@@ -151,7 +153,7 @@ main.home {
 
   @include mq($until: mobile) {
     grid-template-columns: auto;
-    grid-template-rows: $px-above-content repeat(5, 1fr);
+    grid-template-rows: $px-above-content repeat(4, 1fr);
 
     &__purple-box { grid-area: 2 / 1 / 6 / 2; }
     &__heading { grid-area: 3 / 1 / 4 / 2; }
@@ -164,5 +166,40 @@ main.home {
       background-size: contain;
       background-position: center;
     }
+  }
+}
+
+.blocks {
+  @include mq($until: tablet) {
+    flex-direction: column;
+    margin: 1em;
+  }
+
+  width: auto;
+
+  &__directory {
+    border: 2px solid $purple;
+    padding: 1em;
+
+    h3 {
+      font-size: size('small');
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+
+      li > a {
+        font-size: size('xsmall');
+        color: $black;
+        line-height: 1.8em;
+        text-underline-offset: .2em;
+      }
+    }
+  }
+
+  &__icon {
+    // placeholders for now
+    font-size: size('xlarge');
   }
 }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -1,4 +1,5 @@
 $px-either-side-of-content: 15px;
+$space-between-sections: 3.7em;
 
 main.home {
   // the homepage is a few px wider than the regular max width so we can
@@ -8,7 +9,7 @@ main.home {
   max-width: $homepage-max-width;
 
   section {
-    margin-top: 2em;
+    margin-top: $space-between-sections;
     max-width: $homepage-max-width;
   }
 
@@ -32,9 +33,9 @@ main.home {
 
     // This is a fix to make IE display the content
     // centrally.
-    margin: 1em auto;
+    margin: $space-between-sections auto 0;
     @supports (display: grid) {
-      margin: 1em $px-either-side-of-content;
+      margin: $space-between-sections $px-either-side-of-content 0;
     }
 
     > * {

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -73,7 +73,7 @@ main.home {
 
     padding: .4em .4em .4em 1.4em;
     margin: 1em 0 0 -.4em;
-    line-height: 2em;
+    line-height: 1.25em;
     max-width: 80%;
   }
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -114,7 +114,7 @@ main.home {
   //    mobile:   5    × 1
   @supports (display: grid) {
     display: grid;
-    grid-template-columns: $px-either-side-of-content repeat(4, 1fr) $px-either-side-of-content;
+    grid-template-columns: $px-either-side-of-content repeat(2, 1.2fr) repeat(2, .8fr) $px-either-side-of-content;
     grid-template-rows: repeat(3, minmax(min-content, max-content));
 
     padding: inherit;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -1,278 +1,60 @@
-.cta-links {
-  display: flex;
-  margin-bottom: 30px;
+main.home {
+  // the homepage is 100px wider than the regular
+  // max width so we can make things overhang if
+  // neccessary
+  $homepage-max-width: $content-max-width + 100px;
+  outline: 1px solid $red;
+
+  max-width: $homepage-max-width;
+  outline: 1px dashed $blue;
+
+  section {
+    margin-top: 0;
+    width: $content-max-width;
+  }
+
+  section + section {
+    margin-top: 2em;
+  }
+
+  .homepage-feature {
+    &.steps-to-become-a-teacher {
+      width: 100%;
+    }
+  }
 }
 
-.cta-link {
-  width: 50%;
-  padding: 0 $indent-amount;
-  height: 290px;
-  display: block;
-  margin-bottom: 30px;
+.homepage-feature {
+  outline: 1px dashed pink;
+  margin: 0 auto;
 
-  &__img {
+  &.steps-to-become-a-teacher {
     width: 100%;
-    height: 100%;
-    background-size: cover;
-    background-position: 50%;
-    position: relative;
-    overflow: hidden;
-  }
+    display: grid;
 
-  &__label {
-    @include rotated-block;
-    @include chevron;
+    grid-template-columns: 50px auto 50px;
 
-    background: $green-dark-90;
-    display: inline-block;
-    padding: $indent-amount;
-    line-height: 1.2;
-    font-weight: bold;
-    color: $white;
-    position: absolute;
-    bottom: 30px;
-    left: -3px;
-    text-align: left;
-    max-width: 75%;
-  }
+    .purple-box {
+      background-color: $purple;
+      grid-area: 1 / 2 / 2 / 3;
 
-  &:hover {
-    .cta-link__label {
-      background: $green;
+      h2 {
+        display: inline-block;
+        color: black;
+        background-color: white;
+        padding: .4em;
+      }
     }
   }
 
-  &:focus {
-    background-color: transparent;
-    box-shadow: none;
-
-    .cta-link__label {
-      outline: 3px solid transparent;
-      color: $black;
-      background-color: $yellow;
-      box-shadow: 0 -2px $yellow, 0 4px $black;
-      text-decoration: none;
-    }
-  }
-}
-
-.steps {
-  &__wrapper {
+  &__content {
     display: flex;
 
-    @include mq($until: tablet) {
-      flex-direction: column;
+    * {
+      flex: 1;
+      border: 1px dashed fuchsia;
+      padding: 1em;
+      margin: .5em;
     }
-
-    // This is a bit of a hack to target IE, which has a horrendous bug
-    // that prevents it from wrapping text inside hyperlinks. So we
-    // needn't wrap, always display the steps in a column format on IE */
-    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-      flex-direction: column;
-
-      > * {
-        padding: .5em 0;
-      }
-    }
-  }
-
-  &__step {
-    display: flex;
-    align-items: center;
-    min-width: 20%;
-
-    @include mq($until: tablet) {
-      flex-direction: row;
-      justify-content: flex-start;
-      margin: .5em 0;
-      align-items: center;
-    }
-
-    @include mq($from: tablet, $until: desktop) {
-      flex-direction: column;
-      align-items: baseline;
-    }
-
-    @include mq($from: desktop) {
-      align-items: baseline;
-      padding-right: .5em;
-
-      .steps__link {
-        padding-top: 0;
-      }
-    }
-  }
-
-  &__link {
-    @include chevron($color: $black);
-
-    color: $black;
-    font-weight: bold;
-    word-break: break-all;
-    text-decoration: none;
-    font-size: size("xsmall");
-    padding: .5em;
-
-    &:hover {
-      color: $black;
-      text-decoration: underline;
-    }
-
-    @include mq($until: tablet) {
-      margin-left: .5em;
-      font-size: inherit;
-    }
-  }
-
-  &__number {
-    @include rotated-block;
-
-    span {
-      display: inline-block;
-      box-sizing: border-box;
-      background-color: $pink;
-      color: $white;
-      font-weight: bold;
-      text-align: center;
-      line-height: 40px;
-      width: 40px;
-      height: 40px;
-    }
-  }
-}
-
-.featured-content {
-  margin-top: 45px;
-}
-
-@function img-left($view-width) {
-  @return calc( ((1000px / 3) * 2) + ((#{$view-width} - 934px) / 2));
-}
-
-.home-quote-img,
-.home-find-event-img {
-  position: absolute;
-  top: 0;
-  height: 100%;
-  background-size: cover;
-  // Width calculated to be a third of the content column plus half of the viewport
-  left: img-left(100vw);
-  width: calc((1000px / 3) + ((100vw - 1066px) / 2));
-  max-width: 720px;
-  background-position: 50% 15%;
-
-  @include mq($from: wide) {
-    left: auto;
-    right: 0;
-  }
-
-  @include mq($until: tablet) {
-    position: static;
-    width: 100%;
-    height: 300px;
-  }
-}
-
-.home-find-event-img {
-  background-image: url('../images/home-events.jpg');
-}
-
-.home-inset-content {
-  margin: 0 $indent-amount;
-}
-
-.home-quote {
-  &__text {
-    width: 60%;
-    margin-left: 50px;
-    text-align: left;
-    position: relative;
-  }
-
-  &__quote {
-    margin: 0 0 $indent-amount;
-    font-weight: bold;
-    font-size: size("medium");
-    line-height: 1.25;
-    display: block;
-
-    &:before {
-      position: absolute;
-      top: 4px;
-      left: -30px;
-      width: 22px;
-      height: 21px;
-      background-image: url('../images/white-quote.svg');
-      content: "";
-      display: block;
-    }
-
-    &:after {
-      display: inline-block;
-      position: relative;
-      transform: rotate(-180deg);
-      width: 22px;
-      height: 21px;
-      background-image: url('../images/white-quote.svg');
-      content: "";
-      margin-left: 8px;
-    }
-  }
-
-  &__citation {
-    font-weight: bold;
-  }
-}
-
-@include mq($until: tablet) {
-  .steps {
-    &__table {
-      margin-top: 0;
-      margin-bottom: 0;
-
-      &__row {
-        &__cell {
-          padding-left: 20px;
-        }
-      }
-    }
-
-    &__row {
-      &__cell {
-        display: block;
-        width: 100%;
-        margin-top: 10px;
-        margin-bottom: 10px;
-      }
-    }
-
-    .git-link {
-      padding-left: 40px;
-      padding-right: $indent-amount;
-      margin-top: $indent-amount;
-    }
-  }
-
-  .home-quote {
-    &__text {
-      width: calc(100% - 80px);
-      margin: 30px 30px 30px 50px;
-    }
-
-    &__quote {
-      font-size: size("small");
-    }
-  }
-}
-
-@include mq($until: tablet) {
-  .cta-links {
-    flex-direction: column;
-  }
-
-  .cta-link {
-    width: 100%;
-    padding: 0;
-    height: 290px;
   }
 }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -83,7 +83,6 @@ main.home {
   }
 
   &__cta {
-    display: inline-block;
     padding: 1.5em;
     margin: 1em 0;
 
@@ -91,6 +90,8 @@ main.home {
       @include button;
       @include chevron;
       white-space: inherit;
+
+      display: inline-block !important; // override the block set by button mixin
     }
   }
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -1,5 +1,4 @@
 $px-either-side-of-content: 15px;
-$px-above-content: 10px;
 
 main.home {
   // the homepage is a few px wider than the regular max width so we can
@@ -172,19 +171,25 @@ main.home {
 
   @include mq($until: mobile) {
     grid-template-columns: auto;
-    grid-template-rows: $px-above-content repeat(4, 1fr);
+    grid-template-rows: .5fr .5fr 2fr .5fr;
 
-    &__purple-box { grid-area: 2 / 1 / 6 / 2; }
-    &__heading { grid-area: 3 / 1 / 4 / 2; }
-    &__text { grid-area: 4 / 1 / 5 / 2; }
-    &__cta { grid-area: 5 / 1 / 6 / 2; }
+    &__purple-box { grid-area: 1 / 1 / 6 / 2; }
+
+    &__heading { grid-area: 1 / 1 / 2 / 2; }
+
+    &__text {
+      font-size: size(small);
+      grid-area: 2 / 1 / 3 / 2;
+    }
 
     &__graphic {
-      grid-area: 1 / 1 / 3 / 2;
+      grid-area: 3 / 1 / 4 / 2;
       @include background-image($image: "mobile");
       background-size: contain;
       background-position: center;
     }
+
+    &__cta { grid-area: 4 / 1 / 5 / 2; }
   }
 }
 

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -1,20 +1,16 @@
+$px-either-side-of-content: 15px;
+$px-above-content: 10px;
+
 main.home {
-  // the homepage is 100px wider than the regular
-  // max width so we can make things overhang if
-  // neccessary
-  $homepage-max-width: $content-max-width + 100px;
-  outline: 1px solid $red;
+  // the homepage is a few px wider than the regular max width so we can
+  // make things overhang if neccessary
+  $homepage-max-width: $content-max-width + (2 * $px-either-side-of-content);
 
   max-width: $homepage-max-width;
-  outline: 1px dashed $blue;
 
   section {
-    margin-top: 0;
-    width: $content-max-width;
-  }
-
-  section + section {
     margin-top: 2em;
+    width: $content-max-width;
   }
 
   .homepage-feature {
@@ -25,36 +21,148 @@ main.home {
 }
 
 .homepage-feature {
-  outline: 1px dashed pink;
   margin: 0 auto;
 
   &.steps-to-become-a-teacher {
     width: 100%;
+  }
+
+  &.blocks {
+    display: flex;
+    gap: 1em;
+
+    > * {
+      flex: 1;
+    }
+  }
+}
+
+.steps-to-become-a-teacher {
+  background: $purple;
+  color: $white;
+
+  &__purple-box {
+    display: none;
+  }
+
+  // general styles (grid fallback)
+  &__heading {
+    @include rotated-block;
+    font-size: size('medium');
+    display: inline-block;
+    color: $black;
+    background-color: $white;
+
+    padding: .4em .4em .4em 1.4em;
+    margin: 1em 0 0 -.4em;
+    line-height: 2em;
+    max-width: 80%;
+  }
+
+  &__text {
+    color: $white;
+    padding: 1em 1.5em 0;
+  }
+
+  &__cta {
+    display: inline-block;
+    padding: 1.5em;
+
+    > a {
+      @include button;
+      @include chevron;
+      white-space: inherit;
+    }
+  }
+
+  @mixin background-image($size: 85%, $align: center, $image: "desktop") {
+    $background-images: (
+      "desktop": "../images/steps-graphic.svg",
+      "mobile": "../images/steps-graphic-mob.svg"
+    );
+
+    background: $align / $size no-repeat url(#{map-get($background-images, $image)});
+  }
+
+  // grid-specifics. We're using a grid here so that we can allow part of the SVG
+  // to 'overhang' the edge. This would be possible by just nudging the SVG right
+  // using some margin-left but then we'd need to make further steps to guess
+  // when to change the layout so it's not hanging off the edge of the screen.
+  // dimensions: (rows × columns)
+  //   desktop:   4    × 6
+  //    tablet:   3    × 3
+  //    mobile:   5    × 1
+  @supports (display: grid) {
     display: grid;
+    grid-template-columns: $px-either-side-of-content repeat(4, 1fr) $px-either-side-of-content;
+    grid-template-rows: repeat(3, 1fr);
 
-    grid-template-columns: 50px auto 50px;
+    padding: inherit;
+    background-color: inherit;
 
-    .purple-box {
+    &__purple-box {
+      display: block;
       background-color: $purple;
-      grid-area: 1 / 2 / 2 / 3;
+      grid-area: 1 / 2 / 4 / 6;
+    }
 
-      h2 {
-        display: inline-block;
-        color: black;
-        background-color: white;
-        padding: .4em;
+    &__heading {
+      grid-area: 1 / 2 / 2 / 4;
+      align-self: center;
+    }
+
+    &__text { grid-area: 2 / 2 / 3 / 4; }
+
+    &__graphic {
+      grid-area: 1 / 4 / 4 / 7;
+      @include background-image($align: right, $image: "desktop");
+    }
+
+    &__cta {
+      grid-area: 3 / 2 / 3 / 4;
+      align-self: center;
+
+      padding: 0 1em;
+
+      a {
+        @include button;
+        @include chevron;
+        white-space: inherit;
       }
     }
   }
 
-  &__content {
-    display: flex;
+  @include mq($until: tablet) {
+    // stop overhanging when the screen is this narrow
+    width: 100%;
+    grid-template-columns: 60% repeat(2, 1fr);
+    grid-template-rows: repeat(3, 1fr);
 
-    * {
-      flex: 1;
-      border: 1px dashed fuchsia;
-      padding: 1em;
-      margin: .5em;
+    &__purple-box { grid-area: 1 / 1 / 4 / 4; }
+    &__heading { grid-area: 1 / 1 / 2 / 2; }
+    &__text { grid-area: 2 / 1 / 3 / 2; }
+    &__cta { grid-area: 3 / 1 / 4 / 2; }
+
+    &__graphic {
+      grid-area: 1 / 2 / 4 / 4;
+      @include background-image($image: "mobile");
+    }
+  }
+
+  @include mq($until: mobile) {
+    grid-template-columns: auto;
+    grid-template-rows: $px-above-content repeat(5, 1fr);
+
+    &__purple-box { grid-area: 2 / 1 / 6 / 2; }
+    &__heading { grid-area: 3 / 1 / 4 / 2; }
+    &__text { grid-area: 4 / 1 / 5 / 2; }
+    &__cta { grid-area: 5 / 1 / 6 / 2; }
+
+    &__graphic {
+      grid-area: 1 / 1 / 3 / 2;
+      @include background-image($image: "mobile");
+      background-size: contain;
+      background-position: center;
     }
   }
 }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -66,7 +66,7 @@ main.home {
   // general styles (grid fallback)
   &__heading {
     @include rotated-block;
-    font-size: size('medium');
+    font-size: size('large');
     display: inline-block;
     color: $black;
     background-color: $white;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -218,6 +218,12 @@ main.home {
         color: $black;
         line-height: 1.8em;
         text-underline-offset: .2em;
+
+        &:hover {
+          color: $purple;
+          text-decoration: underline;
+          text-decoration-thickness: .12em;
+        }
       }
     }
   }

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -136,6 +136,7 @@ main.home {
     &__graphic {
       grid-area: 1 / 4 / 4 / 7;
       @include background-image($align: right, $image: "desktop");
+      background-size: contain;
     }
 
     &__cta {

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -10,7 +10,7 @@ main.home {
 
   section {
     margin-top: 2em;
-    width: $content-max-width;
+    max-width: $homepage-max-width;
   }
 
   .homepage-feature {
@@ -29,12 +29,11 @@ main.home {
 
   &.blocks {
     display: flex;
-    width: auto;
     margin: 1em $px-either-side-of-content;
     gap: 1em;
 
     > * {
-      flex: 1;
+      flex: 1 0;
     }
   }
 }
@@ -69,6 +68,7 @@ main.home {
   &__cta {
     display: inline-block;
     padding: 1.5em;
+    margin: 1em 0;
 
     > a {
       @include button;
@@ -97,7 +97,7 @@ main.home {
   @supports (display: grid) {
     display: grid;
     grid-template-columns: $px-either-side-of-content repeat(4, 1fr) $px-either-side-of-content;
-    grid-template-rows: repeat(3, 1fr);
+    grid-template-rows: repeat(3, minmax(min-content, max-content));
 
     padding: inherit;
     background-color: inherit;
@@ -174,8 +174,6 @@ main.home {
     flex-direction: column;
     margin: 1em;
   }
-
-  width: auto;
 
   &__directory {
     border: 2px solid $purple;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -198,6 +198,7 @@ main.home {
 
     h3 {
       font-size: size('small');
+      margin: .2em auto .1em;
     }
 
     ul {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -3,18 +3,6 @@
 // layout, mobile-first
 $mobile-cutoff: 800px;
 
-@mixin safari-only {
-  // Hack for Safari: Safari has a different take on calculating the height
-  // of flex/grid elements that contain an image with 100% height. This selector
-  // identifies Safari so we can apply a maximim height that won't also apply
-  // to Firefox or Blink-based browsers
-  //
-  // https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-    @content;
-  }
-}
-
 // fallback styles (IE)
 .hero {
   &__title {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -51,15 +51,6 @@ $mobile-cutoff: 800px;
       margin: initial;
       width: initial;
     }
-
-    a {
-      color: $black;
-      text-decoration: none;
-
-      &:hover {
-        border-bottom: 2px solid $black;
-      }
-    }
   }
 
   &__img {
@@ -110,6 +101,13 @@ $mobile-cutoff: 800px;
 
       @include mq($from: tablet) {
         margin: 1em 2em .5em;
+      }
+
+      &__button {
+        @include button;
+        @include chevron;
+        margin-top: 1.5em;
+        display: inline-block;
       }
     }
 

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -81,6 +81,8 @@ $chevron-direction-map: (
 }
 /* stylelint-enable */
 
+// Mixins for targetting specific legacy/quirky/inferior browsers
+
 @mixin safari-only {
   // Hack for Safari: Safari has a different take on calculating the height
   // of flex/grid elements that contain an image with 100% height. This selector
@@ -89,6 +91,13 @@ $chevron-direction-map: (
   //
   // https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
   @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    @content;
+  }
+}
+
+@mixin ie-only {
+  // IE only, use sparingly, won't need to be supported for ever
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
     @content;
   }
 }

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -1,3 +1,8 @@
+@mixin reset {
+  margin: 0;
+  padding: 0;
+}
+
 // these are typically headers or section headings, often
 // placed over images or other sections
 @mixin rotated-block($degrees: -3deg, $blur: 4px) {

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -80,3 +80,15 @@ $chevron-direction-map: (
   }
 }
 /* stylelint-enable */
+
+@mixin safari-only {
+  // Hack for Safari: Safari has a different take on calculating the height
+  // of flex/grid elements that contain an image with 100% height. This selector
+  // identifies Safari so we can apply a maximim height that won't also apply
+  // to Firefox or Blink-based browsers
+  //
+  // https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    @content;
+  }
+}

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe CallsToAction::HomepageComponent, type: :component do
+  let(:icon) { "icon-question" }
+  let(:image) { "some-image.jpg" }
+  let(:title) { "Joey" }
+  let(:link_text) { "Click here" }
+  let(:link_target) { "/some-dir/some-page" }
+
+  describe "rendering the component" do
+    let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target, image: image } }
+
+    let(:component) { described_class.new(kwargs) }
+    before { render_inline(component) }
+
+    specify "renders the call to action" do
+      expect(page).to have_css(".call-to-action")
+    end
+
+    specify "the icon is present" do
+      image_element = page.find(".call-to-action__icon")
+      expect(image_element[:src]).to match(Regexp.new(icon))
+    end
+
+    specify "the title is present" do
+      expect(page).to have_css(".call-to-action__heading", text: title)
+    end
+
+    specify "the link is present" do
+      expect(page).to have_link(link_text, href: link_target)
+    end
+
+    specify "the image is present" do
+      expect(page.find(".call-to-action__image")["style"]).to eql(%(background-image: url('#{image}')))
+    end
+  end
+end

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -7,6 +7,8 @@ describe Sections::HeroComponent, type: "component" do
       fullwidth: true,
       hide_page_helpful_question: true,
       subtitle: "Teach all the subjects!",
+      subtitle_link: "/signup",
+      subtitle_button: "Find out more",
       image: "media/images/hero-home-dt.jpg",
       backlink: "/",
     }.with_indifferent_access
@@ -21,14 +23,15 @@ describe Sections::HeroComponent, type: "component" do
       end
 
       specify "renders the subtitle" do
-        expect(page).to have_css(".hero__subtitle > div", text: front_matter[:subtitle])
+        expect(page).to have_css(".hero__subtitle > .hero__subtitle__text", text: front_matter[:subtitle])
       end
 
-      context "when the subtitle is a link" do
+      context "when a subtitle link exists" do
         let(:front_matter) do
           {
             title: "Teaching, it's pretty awesome",
             subtitle: "Teach all the subjects!",
+            subtitle_button: "Click here to find out",
             subtitle_link: "https://foo.com",
             image: "media/images/hero-home-dt.jpg",
           }
@@ -36,9 +39,9 @@ describe Sections::HeroComponent, type: "component" do
 
         subject! { render_inline(component) }
 
-        specify "renders the subtitle" do
-          expect(page).to have_css(".hero__subtitle > div") do |div|
-            expect(div).to have_link(front_matter[:subtitle], href: front_matter[:subtitle_link])
+        specify "renders the subtitle button" do
+          expect(page).to have_css(".hero__subtitle") do |div|
+            expect(div).to have_link(front_matter[:subtitle_button], href: front_matter[:subtitle_link])
           end
         end
       end

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -4,7 +4,6 @@ describe Sections::HeroComponent, type: "component" do
   let(:front_matter) do
     {
       title: "Teaching, it's pretty awesome",
-      mailinglist: true,
       fullwidth: true,
       hide_page_helpful_question: true,
       subtitle: "Teach all the subjects!",
@@ -68,21 +67,6 @@ describe Sections::HeroComponent, type: "component" do
           img_tag = page.find("img.hero__img")
 
           expect(img_tag[:srcset].split(",").map { |img| img.split.last }).to match_array(%w[600w 800w])
-        end
-      end
-    end
-
-    describe "mailing list cta" do
-      context "when mailinglist: true" do
-        let(:component) { described_class.new(front_matter.merge(deepheader: true)) }
-
-        specify "renders a mailing list strip beneath the header" do
-          expect(page).to have_css(".hero__mailing-strip")
-        end
-
-        specify "the mailing list strip contains text and a button" do
-          expect(page).to have_css(".hero__mailing-strip__text", text: /Get personalised information and updates about getting into teaching/)
-          expect(page).to have_css(".hero__mailing-strip__cta > a.hero__mailing-strip__cta__button", text: /Sign up here/)
         end
       end
     end


### PR DESCRIPTION
### Trello card

https://trello.com/c/hkyt13A7/1116-pete-to-code-up-update-to-homepage-following-the-homepage-refinement-session

### Context and changes

The homepage was due a refresh and the new design is based on lots of research and user data.

![Screenshot_2021-02-09 Get into teaching Inspire the next generation(1)](https://user-images.githubusercontent.com/128088/107382261-9a152a00-6ae7-11eb-9bc9-0359322cbf12.png)



### Sections

#### Steps to become a teacher (the purple box)

~~The original design had the SVG overlapping the right of the purple box. This was implemented using a grid but dropped in favour of a simpler approach for the time being. Using grid would give the desired result at the expense of a complicated layout. The newer, simpler version is based on Flexbox and is fully responsive.~~

The 'purple box' is a large CTA that appears at the top of the homepage. In the new design it contains a header, some text, a call to action button and a SVG graphic.

The complexity in this compenent lies in the fact that it overhangs the right of the purple box; this means we need to wrap the regular container in an outer container (which includes all content *plus* the overhanging part of the SVG).

As a result of this we can't use just go down the basic route of a pair of nested flexbox elements; the requirement for part of one element to overlap another requires either grid or hacks with margins.

This approach uses grid; the overhang amount is controlled vertically and horizontally via the variables `$px-either-side-of-content` and `$px-above-content` and the remainder of the grid should automatically fit the content. `$px-either-side-of-content` is also used to constrain the other homepage content accordingly, so it lines up with the purple box.




Fallback (no grid mode 😢 )| Desktop | Tablet | Mobile | Grid |
| ------- | ------- | ------- | ------- | ------ |
|  ![Screenshot from 2021-02-08 12-44-02](https://user-images.githubusercontent.com/128088/107225097-484da080-6a10-11eb-81a5-239633c62d4a.png) | ![Screenshot from 2021-02-08 12-44-19](https://user-images.githubusercontent.com/128088/107225117-50a5db80-6a10-11eb-9a9a-cbe9b9adebe7.png) |  ![Screenshot from 2021-02-08 12-44-30](https://user-images.githubusercontent.com/128088/107225134-57cce980-6a10-11eb-9c65-489d5aa75c51.png) | ![Screenshot from 2021-02-08 12-50-28](https://user-images.githubusercontent.com/128088/107225205-6ddaaa00-6a10-11eb-84a8-66f846a0e6b6.png) | ![Screenshot from 2021-02-05 13-35-41](https://user-images.githubusercontent.com/128088/107382484-d3e63080-6ae7-11eb-95f9-acda1655575d.png) |


#### Calls to action

| Desktop | Mobile |
| ------ | ------- |
| ![Screenshot from 2021-02-09 11-54-07](https://user-images.githubusercontent.com/128088/107360230-8d83d800-6acd-11eb-9724-a62d4c869f88.png) | ![Screenshot from 2021-02-09 11-27-56](https://user-images.githubusercontent.com/128088/107360256-94aae600-6acd-11eb-83da-d91cabe15197.png) |




#### Directory

The 'directory' is an alternative set of navigation links. Unlike the primary nav it's categorised and this should make it easer for people to find the exact content they're after. Awaiting icons so there's emoji in their place for the time being 👨🏽‍🏫 

| Desktop | Mobile |
| ------- | ------ |
| ![Screenshot from 2021-02-09 11-28-16](https://user-images.githubusercontent.com/128088/107360320-a8564c80-6acd-11eb-8f1b-67b744eb7799.png) | ![Screenshot from 2021-02-09 11-28-24](https://user-images.githubusercontent.com/128088/107360329-abe9d380-6acd-11eb-966e-b4a238876017.png) |






