### PR TITLE
Fix for nav items showing too high on wide displays with search enabled

### DIFF
--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -14,6 +14,7 @@
 
   &__desktop {
     display: flex;
+    align-items: center;
     box-sizing: border-box;
     margin-left: 280px;
     width: 100%;
@@ -76,8 +77,6 @@
     }
 
     &__search {
-      align-self: center;
-
       img {
         display: block;
         width: 50px;


### PR DESCRIPTION
### Trello card

https://trello.com/c/1VGYGEd3

### Context

Nav bar items are showing too high when highlighted on desktop when there is only a single row of nav items and fonts are rendering with a thinner font/narrower stride - ie quite a wide monitor on Chrome/IE on windows

### Changes proposed in this pull request

1. Ensure flexbox is vertically centering the nav items

### Guidance to review

View in chrome on Windows with the page hitting its max-width limits

**Before**

![Screenshot from 2021-02-09 16-40-17](https://user-images.githubusercontent.com/10818/107396818-05fe8f00-6af6-11eb-845e-bd3c895abe57.png)

**After**

![Screenshot from 2021-02-09 16-39-17](https://user-images.githubusercontent.com/10818/107396849-0e56ca00-6af6-11eb-95a4-a4764c2015a5.png)

