### PR TITLE
Support magic links for mailing list sign up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 6c2969f0685d49b02527d2d499431498938c3a08
+  revision: b560e0d2b37a55b765256e76f7ba329b037bcff8
   specs:
-    get_into_teaching_api_client (1.1.10)
+    get_into_teaching_api_client (1.1.11)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.14)
+    get_into_teaching_api_client_faraday (0.1.15)
       activesupport
       faraday
       faraday-encoding

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -66,7 +66,8 @@ private
     magic_link_token_error = params[:magic_link_token_error]
     return if magic_link_token_error.blank?
 
-    message = t("activemodel.errors.magic_link_token.#{magic_link_token_error.underscore}")
+    key = "activemodel.errors.magic_link_token"
+    message = t("#{key}.#{magic_link_token_error.underscore}", default: t("#{key}.invalid"))
     @current_step.flash_error(message)
   end
 

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -22,6 +22,13 @@ module MailingList
       end
     end
 
+  protected
+
+    def exchange_magic_link_token(token)
+      api = GetIntoTeachingApiClient::MailingListApi.new
+      api.exchange_magic_link_token_for_mailing_list_add_member(token)
+    end
+
   private
 
     def add_member_to_mailing_list

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -3,6 +3,8 @@ module Wizard
   class MagicLinkTokenNotSupportedError < RuntimeError; end
 
   class Base
+    MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
+
     class_attribute :steps
 
     class << self
@@ -95,7 +97,10 @@ module Wizard
     end
 
     def export_data
-      all_steps.map(&:export).reduce({}, :merge)
+      matchback_data = @store.fetch(MATCHBACK_ATTRS)
+      step_data = all_steps.map(&:export).reduce({}, :merge)
+
+      step_data.merge!(matchback_data)
     end
 
     def process_magic_link_token(token)

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -1,5 +1,6 @@
 module Wizard
   class UnknownStep < RuntimeError; end
+  class MagicLinkTokenNotSupportedError < RuntimeError; end
 
   class Base
     class_attribute :steps
@@ -97,7 +98,23 @@ module Wizard
       all_steps.map(&:export).reduce({}, :merge)
     end
 
+    def process_magic_link_token(token)
+      response = exchange_magic_link_token(token)
+      prepopulate_store(response)
+    end
+
+  protected
+
+    def exchange_magic_link_token(_token)
+      raise(MagicLinkTokenNotSupportedError)
+    end
+
   private
+
+    def prepopulate_store(response)
+      hash = response.to_hash.transform_keys { |k| k.to_s.underscore }
+      @store.persist(hash)
+    end
 
     def all_steps
       step_keys.map(&method(:find))

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -44,6 +44,10 @@ module Wizard
       false
     end
 
+    def flash_error(message)
+      errors.add(:base, message)
+    end
+
     def export
       return {} if skipped?
 

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -2,7 +2,6 @@ module Wizard
   module Steps
     class Authenticate < ::Wizard::Step
       IDENTITY_ATTRS = %i[email first_name last_name date_of_birth].freeze
-      MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
 
       attribute :timed_one_time_password
 
@@ -30,9 +29,7 @@ module Wizard
       end
 
       def export
-        return {} if skipped?
-
-        @store.fetch(MATCHBACK_ATTRS)
+        {}
       end
 
       def timed_one_time_password=(value)

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -15,7 +15,7 @@ module Wizard
       end
 
       def skipped?
-        @store["authenticate"] == false
+        @store["authenticate"] != true
       end
 
       def save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,11 @@ en:
         Find out what they have to offer and help make your decision on where to apply.
   activemodel:
     errors:
+      magic_link_token:
+        invalid: "We could not find this link. Enter the details below to help us verify you."
+        expired: "This link has expired. Enter the details below to help us verify you."
+        already_exchanged: "This link has been used already. Enter the details below to help us verify you."
+
       models:
         wizard/steps/authenticate:
           attributes:

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -315,6 +315,9 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path(magic_link_token_error: GetIntoTeachingApiClient::ExchangeStatus::ALREADY_EXCHANGED)
     expect(page).to have_text "This link has been used already"
+
+    visit mailing_list_steps_path(magic_link_token_error: "UnknownError")
+    expect(page).to have_text "We could not find this link"
   end
 
   scenario "Start as an existing candidate then switch to new candidate" do

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -264,6 +264,59 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).not_to have_button("Next Step")
   end
 
+  scenario "Full journey as an existing candidate using a magic link" do
+    token = "magic-link-token"
+    response = GetIntoTeachingApiClient::MailingListAddMember.new(
+      firstName: "Test",
+      lastName: "User",
+      email: "test@user.com",
+      considerationJourneyStageId: GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES["I’m very sure and think I’ll apply"],
+      degreeStatusId: GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["Final year"],
+    )
+    allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+      receive(:exchange_magic_link_token_for_mailing_list_add_member).with(token) { response }
+
+    visit mailing_list_steps_path(magic_link_token: token)
+
+    expect(page).to have_text "What stage are you at with your degree?"
+    expect(find("[name=\"mailing_list_steps_degree_status[degree_status_id]\"][checked]").value).to eq(
+      response.degree_status_id.to_s,
+    )
+    click_on "Next Step"
+
+    expect(page).to have_text "How close are you to applying"
+    expect(find("[name=\"mailing_list_steps_teacher_training[consideration_journey_stage_id]\"][checked]").value).to eq(
+      response.consideration_journey_stage_id.to_s,
+    )
+    click_on "Next Step"
+
+    expect(page).to have_text "Which subject do you want to teach"
+    select "Maths"
+    click_on "Next Step"
+
+    expect(page).to have_text "Events in your area"
+    fill_in "What's your postcode", with: "TE57 1NG"
+    click_on "Next Step"
+
+    expect(page).to have_text "Accept privacy policy"
+    check "Yes"
+    click_on "Complete sign up"
+
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text "What happens next"
+  end
+
+  scenario "Invalid magic link tokens" do
+    visit mailing_list_steps_path(magic_link_token_error: GetIntoTeachingApiClient::ExchangeStatus::INVALID)
+    expect(page).to have_text "We could not find this link"
+
+    visit mailing_list_steps_path(magic_link_token_error: GetIntoTeachingApiClient::ExchangeStatus::EXPIRED)
+    expect(page).to have_text "This link has expired"
+
+    visit mailing_list_steps_path(magic_link_token_error: GetIntoTeachingApiClient::ExchangeStatus::ALREADY_EXCHANGED)
+    expect(page).to have_text "This link has been used already"
+  end
+
   scenario "Start as an existing candidate then switch to new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token)

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -262,5 +262,15 @@ describe Wizard::Base do
       it { is_expected.not_to include "age" }
       it { is_expected.to include "postcode" => nil }
     end
+
+    context "when the store was populated with matchback data" do
+      before do
+        wizardstore["candidate_id"] = "abc-123"
+        wizardstore["qualification_id"] = "def-456"
+      end
+
+      it { is_expected.to include "candidate_id" => "abc-123" }
+      it { is_expected.to include "qualification_id" => "def-456" }
+    end
   end
 end

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -37,6 +37,12 @@ describe Wizard::Step do
     it { expect(subject).to be_can_proceed }
   end
 
+  describe "#flash_error" do
+    before { subject.flash_error("error message") }
+
+    it { expect(subject.errors[:base]).to include("error message") }
+  end
+
   describe "#save" do
     let(:backingstore) { {} }
 

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -23,8 +23,10 @@ describe Wizard::Steps::Authenticate do
   end
 
   describe "#skipped?" do
-    it "returns true if authenticate is false" do
+    it "returns true if authenticate is false or nil" do
       wizardstore["authenticate"] = false
+      expect(subject).to be_skipped
+      wizardstore["authenticate"] = nil
       expect(subject).to be_skipped
     end
 
@@ -36,6 +38,7 @@ describe Wizard::Steps::Authenticate do
 
   describe "#export" do
     it "returns a hash containing the matchback fields" do
+      allow_any_instance_of(described_class).to receive(:skipped?) { false }
       wizardstore["candidate_id"] = "abc-123"
       wizardstore["qualification_id"] = "def-456"
       subject.timed_one_time_password = "123456"

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -37,21 +37,10 @@ describe Wizard::Steps::Authenticate do
   end
 
   describe "#export" do
-    it "returns a hash containing the matchback fields" do
+    it "returns an empty hash" do
       allow_any_instance_of(described_class).to receive(:skipped?) { false }
-      wizardstore["candidate_id"] = "abc-123"
-      wizardstore["qualification_id"] = "def-456"
       subject.timed_one_time_password = "123456"
-      expect(subject.export).to eq({
-        "candidate_id" => "abc-123",
-        "qualification_id" => "def-456",
-      })
-    end
-
-    it "does not include matchback fields in export if skipped" do
-      wizardstore["candidate_id"] = "abc-123"
-      allow_any_instance_of(described_class).to receive(:skipped?) { true }
-      expect(subject.export.values).to all(be_nil)
+      expect(subject.export).to be_empty
     end
   end
 


### PR DESCRIPTION
[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

This PR deals with the app changes required to migrate existing candidates onto the new privacy policy via a mailing list sign up:

- [x] Update the GiT app to handle mailing list sign up via magic links
- [x] Handle scenario where a user clicks on an expired magic link

---

- Update API client to include magic link methods

- Support magic link tokens on mailing list sign up

A magic link token can be supplied to the mailing list sign up in the form of a query string parameter:

```
GET mailinglist/signup?magic_link_token=<token>
```

The app then calls out to the API to exchange the token for a pre-filled mailing list sign up object.

If this is successful, then the candidate skips to the step _after_ `Authenticate`, with their information pre-filled.

If the token is not valid we redirect to the first step of the mailing list sign up form and display an error to the user, ecouraging them to proceed through the form using the current matchback/verification token mechanism.

- Always export matchback attributes

Previously the `Authenticate` step was responsible for exporting the matchback attributes. This made sense as that step was pre-populating the store with them, however going forward the magic link token mechanism will also be doing this and the logic is shifting to the `Wizard` class, so it makes sense to tack them on to the export there instead.

---
This PR will be followed up by another that consolidates the existing `access_token` logic into the `Wizard` (abstracting it from the `Authenticate` step and making the two mechanisms more consistent).
