### PR TITLE
Remove partial that no longer exists

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -43,9 +43,3 @@
 
   <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
 </section>
-
-<% content_for(:feature) do %>
-  <div class="explore">
-    <%= render "content/home/featured_content" %>
-  </div>
-<% end %>


### PR DESCRIPTION
This was causing the final step of the mailling list to break. ~~Will raise a Trello ticket to re-add something in its place on the completion page~~ [Also see this trello ticket that adds the content back in a less brittle fashion](https://trello.com/c/r88Wbdey/1314-re-add-cta-style-content-to-the-mailing-list-completion-page).

