### PR TITLE
Tweaks to search icon sizing

### DIFF
--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -77,6 +77,8 @@
     }
 
     &__search {
+      margin-left: 10px;
+
       img {
         display: block;
         width: 50px;
@@ -103,7 +105,9 @@
         display: inline-block;
 
         img {
-          width: 36px;
+          vertical-align: middle;
+          width: 28px;
+          margin-left: 0.2em ;
         }
       }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/1VGYGEd3

### Context

Minor tweaks to improve the visual appearance of the search icon in the navbar on both desktop and mobile

### Changes proposed in this pull request

Desktop:
* Added margin between menu items and search icon - this avoids the highlighted
  menu item crashing into the search icon

Mobile:
* Reduced the size of the search icon - this looks too large relative to the
  hamburger icon, particularly for the close search icon in the JS version
* Vertically centred the search icons, this avoids them getting additional
  whitespace shown below the icons for unknown reasons.
