### PR TITLE
Auto chevroning

### DIFF
--- a/app/components/calls_to_action/chat_online_component.html.erb
+++ b/app/components/calls_to_action/chat_online_component.html.erb
@@ -9,8 +9,8 @@
     </p>
 
     <div class="call-to-action__action">
-      <button data-action="click->talk-to-us#startChat">
-        <%= tag.span(button_text) %>
+      <button data-action="click->talk-to-us#startChat" class="button">
+        <%= button_text %>
       </button>
     </div>
   </div>

--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -4,7 +4,7 @@ module CallsToAction
 
     def initialize(icon:, title: nil, link_text:, link_target:, image:)
       @title = title
-      @link  = link_to(tag.span(link_text), link_target)
+      @link  = link_to(link_text, link_target, class: "button")
       @icon  = icon_element(icon)
       @image = image_element(image)
     end

--- a/app/components/calls_to_action/multiple_buttons_component.rb
+++ b/app/components/calls_to_action/multiple_buttons_component.rb
@@ -5,7 +5,7 @@ module CallsToAction
     def initialize(icon:, title:, links:)
       @icon  = icon_element(icon)
       @title = title
-      @links = links.map { |text, href| link_to(tag.span(text), href) }
+      @links = links.map { |text, href| link_to(text, href) }
     end
 
   private

--- a/app/components/calls_to_action/next_steps_component.html.erb
+++ b/app/components/calls_to_action/next_steps_component.html.erb
@@ -9,8 +9,8 @@
         Our teacher training advisers can help you select a provider, prepare for interviews and complete your application successfully.
       </p>
 
-      <%= link_to("/tta-service", class: "call-to-action__button") do %>
-        <span>Sign up for a Teacher Training Adviser</span>
+      <%= link_to("/tta-service", class: "button") do %>
+        Sign up for a Teacher Training Adviser
       <% end %>
     </div>
   </div>

--- a/app/components/calls_to_action/simple_component.rb
+++ b/app/components/calls_to_action/simple_component.rb
@@ -6,7 +6,7 @@ module CallsToAction
       @icon  = icon_element(icon)
       @title = title
       @text  = text
-      @link  = link_to(tag.span(link_text), link_target)
+      @link  = link_to(link_text, link_target, class: "button")
 
       @hide_on_mobile  = hide_on_mobile
       @hide_on_tablet  = hide_on_tablet

--- a/app/components/calls_to_action/story_component.html.erb
+++ b/app/components/calls_to_action/story_component.html.erb
@@ -8,7 +8,7 @@
     <%= tag.p(text, class: "call-to-action__contents__story") %>
 
     <div class="call-to-action__action">
-      <%= link_to(tag.span("Read #{name}'s story"), link) %>
+      <%= link_to("Read #{name}'s story", link) %>
     </div>
   </div>
 <% end %>

--- a/app/components/events/type_description_component.html.erb
+++ b/app/components/events/type_description_component.html.erb
@@ -2,5 +2,5 @@
   <%= event_type_icon %>
   <h5><%= type_name_plural %></h5>
   <p><%= description %></p>
-  <a href="<%= read_more_href %>" class="type-description__link">Read <span>more</span></a>
+  <a href="<%= read_more_href %>" class="type-description__link">Read more</a>
 </div>

--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -8,7 +8,7 @@
       <%= tag.div(subtitle, class: "hero__subtitle__text") %>
 
       <% if show_subtitle_button? %>
-        <%= link_to(tag.span(@subtitle_button), @subtitle_link, class: "hero__subtitle__button") %>
+        <%= link_to(@subtitle_button, @subtitle_link, class: "hero__subtitle__button button") %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -26,8 +26,8 @@
     <% show_see_all_events ||= false %>
 
     <% if show_see_all_events %>
-      <%= link_to(event_category_path(plural_category_name.parameterize), class: "call-to-action-button") do %>
-        Explore <span><%= plural_category_name %></span>
+      <%= link_to(event_category_path(plural_category_name.parameterize), class: "call-to-action-button button") do %>
+        Explore <%= plural_category_name %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,8 +17,8 @@
 
   <p>
     <% if can_sign_up_online?(@event) %>
-      <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
-          Sign up for this <span>event</span>
+      <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button button" do %>
+          Sign up for this event
       <% end %>
     <% end %>
   </p>
@@ -69,8 +69,8 @@
         Please note: to access this event you will require a laptop/desktop pc and be using chrome as your browser.
       </p>
       <p>
-        <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button" do %>
-            Sign up for this <span>event</span>
+        <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button button" do %>
+            Sign up for this event
         <% end %>
       </p>
     <% elsif is_event_type?(@event, "School or University event") %>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -7,7 +7,7 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <%= f.button class: "call-to-action-button" do %>
+      <%= f.button class: "call-to-action-button button" do %>
         <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
         <span></span>
       <% end %>

--- a/app/views/sections/_footer-signup.html.erb
+++ b/app/views/sections/_footer-signup.html.erb
@@ -2,9 +2,10 @@
     <section class="container">
         <div class="footer-signup__inner">
             <span class="footer-signup__text">Get personalised information and updates about getting into teaching</span>
-            <%= link_to(mailing_list_steps_path, class: "call-to-action-button call-to-action-button--white") do %>
-                <span>Sign up here <span class="visually-hidden">to receive information via email</span></span>
+            <%= link_to(mailing_list_steps_path, class: "call-to-action-button button button--white") do %>
+                Sign up here
             <% end %>
+            <span class="visually-hidden">to receive information via email</span>
         </div>
     </section>
-</section> 
+</section>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -12,8 +12,8 @@
                   If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
                   Monday-Friday between 8.30am and 5pm.
                </p>
-               <a href="#" class="call-to-action-button" data-action="click->talk-to-us#startChat">
-               Chat <span>online</span>
+               <a href="#" class="button" data-action="click->talk-to-us#startChat">
+                 Chat online
                </a>
 
             </section>
@@ -22,11 +22,11 @@
                <p>
                   If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
                </p>
-               <a href="/tta-service" class="call-to-action-button">
-               Get an <span>adviser</span>
+               <a href="/tta-service" class="button">
+                 Get an adviser
                </a>
             </section>
-            
+
          </div>
                <div class="talk-to-us__inner__freephone">
                   <h3 class="talk-to-us__inner__table__column__heading">Call us</h3>

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -56,7 +56,6 @@ export default class extends Controller {
 
     return words
       .map((word, i) => {
-        console.debug(word, i);
         return i === wordCount ? `<span>${word}</span>` : word;
       })
       .join(' ');

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
   connect() {
     this.preventTurboLinksOnJumpLinks();
     this.openExternalContentLinksInNewWindow();
+    this.prepareChevronOnButtonLinks();
   }
 
   preventTurboLinksOnJumpLinks() {
@@ -34,5 +35,30 @@ export default class extends Controller {
         l.appendChild(linkOpensInNewWindow);
       }
     });
+  }
+
+  prepareChevronOnButtonLinks() {
+    const links = this.contentTarget.querySelectorAll(
+      '.button,.type-description__link'
+    );
+
+    [...links]
+      .filter((link) => link.querySelector('span') === null) // don't touch buttons that already include a span
+      .forEach((link) => {
+        link.innerHTML = this.wrapFinalWordInSpan(
+          link.textContent.trim().split(' ')
+        );
+      });
+  }
+
+  wrapFinalWordInSpan(words) {
+    const wordCount = words.length - 1;
+
+    return words
+      .map((word, i) => {
+        console.debug(word, i);
+        return i === wordCount ? `<span>${word}</span>` : word;
+      })
+      .join(' ');
   }
 }

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -52,12 +52,6 @@ export default class extends Controller {
   }
 
   wrapFinalWordInSpan(words) {
-    const wordCount = words.length - 1;
-
-    return words
-      .map((word, i) => {
-        return i === wordCount ? `<span>${word}</span>` : word;
-      })
-      .join(' ');
+    return words.concat(`<span>${words.pop()}</span>`).join(' ');
   }
 }

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -37,6 +37,10 @@ a {
   @include chevron;
   display: inline-block;
 
+  span {
+    white-space: nowrap;
+  }
+
   &--white {
     @include button($bg: $white, $fg: $black);
     @include chevron($color: $black);

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -32,7 +32,7 @@ a {
   }
 }
 
-.call-to-action-button {
+.button {
   @include button;
   @include chevron;
   display: inline-block;

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -88,4 +88,54 @@ describe('LinkController', () => {
       });
     });
   });
+
+  describe('wrapping the last button in a span', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="link" data-link-target="content">
+        <h2>should be affected:</h2>
+        <a id="one" href="#" class="button">The quick</a>
+        <a id="two" href="#" class="button">brown fox jumped</a>
+        <a id="three" href="#" class="type-description__link">over the lazy</a>
+        <a id="four" href="#" class="type-description__link">fox</a>
+
+        <h2>should not be affected:</h2>
+
+        <p>(doesn't match the class)</p>
+        <a id="five" href="#" class="other">The quick brown</a>
+
+        <p>(already contains a span)</p>
+        <a id="six" href="#" class="other">Jumped <span>over the lazy</span></a>
+      </div>`;
+    });
+
+    beforeEach(() => {
+      const application = Application.start();
+      application.register('link', LinkController);
+    });
+
+    describe('when loaded', () => {
+      it('wraps the last word in a span', () => {
+        const span1 = document.querySelector('a#one > span');
+        expect(span1.textContent).toEqual('quick');
+
+        const span2 = document.querySelector('a#two > span');
+        expect(span2.textContent).toEqual('jumped');
+
+        const span3 = document.querySelector('a#three > span');
+        expect(span3.textContent).toEqual('lazy');
+
+        const span4 = document.querySelector('a#four > span');
+        expect(span4.textContent).toEqual('fox');
+      });
+
+      it("doesn't affect non .button/.type-description__link links", () => {
+        const span5 = document.querySelector('a#five > span');
+        expect(span5).toBeNull();
+
+        const span6 = document.querySelector('a#six > span');
+        expect(span6.textContent).toEqual('over the lazy');
+      });
+    });
+  });
 });

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -19,7 +19,7 @@ describe EventsController do
     end
 
     specify "rendering the see all events button" do
-      expect(subject.body).to match(%r{explore <span>train to teach events</span>}i)
+      expect(subject.body).to match(%r{explore train to teach events}i)
     end
   end
 
@@ -121,7 +121,7 @@ describe EventsController do
         context "when the event can be registered for online" do
           let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id) }
 
-          it { is_expected.to match(/Sign up for this <span>event<\/span>/) }
+          it { is_expected.to match(/Sign up for this event/) }
         end
 
         context "when the event can be registered for by email" do


### PR DESCRIPTION
### Trello card

N/A (tech debt)

### Context and changes

We currently have to manually add spans around the final text in button-style links so the chevron won't wrap to the next line. This is a pain, adds noise to templates, complicates testing, is easily forgettable and generally a bit of a code smell.

This addition to the link controller automates the process by:

1. looping through the links with a `.button` class (also `.type-description__link` but I'll probably replace this later with a more-descriptive name)
2. splitting the words into an array and wrapping the final one in a `span` tag
3. recombining the text into a string and overwriting the original button text

**At the moment it'll ignore any link that already contains a `<span>`, which should make the upgrade smoother. We can probably remove that step once the `content` repo has been updates (DFE-Digital/get-into-teaching-content/pull/312).**

| Before | After |
| ------ | ------- |
| ![Screenshot from 2021-02-11 16-02-27](https://user-images.githubusercontent.com/128088/107663167-f8c2db00-6c82-11eb-8c62-4608f6807ee5.png) | ![Screenshot from 2021-02-11 16-02-52](https://user-images.githubusercontent.com/128088/107663183-fceef880-6c82-11eb-8fa4-556355f8fbf9.png) |

### Guidance to review

Concentrate on `link_controller.js`.

Is the approach sensible? If people have JavaScript disabled they'll get no chevrons. The replacement appears to work well.
