### PR TITLE
Skip pre-filled optional steps and hide pre-filled optional fields

### DIFF
--- a/app/models/events/steps/contact_details.rb
+++ b/app/models/events/steps/contact_details.rb
@@ -7,6 +7,10 @@ module Events
       before_validation if: :telephone do
         self.telephone = telephone.to_s.strip.presence
       end
+
+      def optional?
+        true
+      end
     end
   end
 end

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -7,6 +7,10 @@ module MailingList
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
+
+      def optional?
+        true
+      end
     end
   end
 end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -5,6 +5,7 @@ module Wizard
 
   class Base
     MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
+    ATTRIBUTE_IN_CRM_SUFFIX = "_in_crm".freeze
 
     class_attribute :steps
 
@@ -128,7 +129,14 @@ module Wizard
 
     def prepopulate_store(response)
       hash = response.to_hash.transform_keys { |k| k.to_s.underscore }
+      retain_values_in_crm(hash)
       @store.persist(hash)
+    end
+
+    def retain_values_in_crm(hash)
+      hash.dup.each do |key, value|
+        hash["#{key}#{ATTRIBUTE_IN_CRM_SUFFIX}"] = value
+      end
     end
 
     def all_steps

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -40,8 +40,14 @@ module Wizard
       !id.nil?
     end
 
-    def skipped?
+    def optional?
       false
+    end
+
+    def skipped?
+      return false unless optional?
+
+      attributes_in_crm.values.all?(&:present?)
     end
 
     def flash_error(message)
@@ -54,7 +60,28 @@ module Wizard
       Hash[attributes.keys.zip([])].merge attributes_from_store
     end
 
+    def method_missing(method_name, *arguments, &block)
+      return @store[method_name] if respond_to_missing?(method_name)
+
+      super
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      if method_name.to_s =~ /(.*)#{Base::ATTRIBUTE_IN_CRM_SUFFIX}/
+        respond_to?(Regexp.last_match(1), include_private)
+      else
+        super
+      end
+    end
+
   private
+
+    def attributes_in_crm
+      attributes.each_with_object({}) do |(k), hash|
+        in_crm_key = "#{k}#{Base::ATTRIBUTE_IN_CRM_SUFFIX}"
+        hash[in_crm_key] = @store[in_crm_key]
+      end
+    end
 
     def attributes_from_store
       @store.fetch attributes.keys

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -10,7 +10,7 @@
       :value,
       options: { prompt: true } %>
 
-<%= f.govuk_text_field :address_postcode %>
+<%= f.govuk_text_field :address_postcode unless f.object.address_postcode_in_crm.present? %>
 
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
     f.object.teaching_subject_options,

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -109,9 +109,6 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in "Enter the verification code sent to test@user.com", with: "123456"
     click_on "Next Step"
 
-    expect(page).to have_field("Phone number (optional)", with: response.telephone)
-    click_on "Next Step"
-
     expect(page).to have_text "Are you over 16 and do you agree"
     expect(page).to have_text "Would you like to receive email updates"
     click_on "Complete sign up"
@@ -128,6 +125,7 @@ RSpec.feature "Event wizard", type: :feature do
     end
     click_on "Complete sign up"
 
+    expect(page).to_not have_text("What is your postcode? (optional)")
     fill_in_personalised_updates
     click_on "Complete sign up"
 
@@ -269,7 +267,9 @@ RSpec.feature "Event wizard", type: :feature do
   )
     select_value_or_default "What stage are you at with your degree?", degree_status
     select_value_or_default "How close are you to applying for teacher training?", consideration_journey_stage
-    fill_in "What is your postcode? (optional)", with: postcode
+    if page.has_text?("What is your postcode? (optional)")
+      fill_in "What is your postcode? (optional)", with: postcode
+    end
     select_value_or_default "What subject do you want to teach?", preferred_teaching_subject
   end
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -168,10 +168,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
     )
     click_on "Next Step"
 
-    expect(page).to have_text "Events in your area"
-    expect(page).to have_field("What's your postcode?", with: response.address_postcode)
-    click_on "Next Step"
-
     expect(page).to have_text "Accept privacy policy"
     click_on "Complete sign up"
 

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -6,6 +6,7 @@ describe Events::Steps::ContactDetails do
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }
+  it { expect(subject).to be_optional }
 
   describe "validations" do
     it { is_expected.to allow_value("").for :telephone }

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -7,6 +7,7 @@ describe MailingList::Steps::Postcode do
   let(:msg) { "Enter a valid postcode" }
 
   it { is_expected.to respond_to :address_postcode }
+  it { expect(subject).to be_optional }
 
   describe "validations for address_postcode" do
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -71,6 +71,7 @@ describe Wizard::Base do
       )
     end
     let(:response_hash) { stub_response.to_hash.transform_keys { |k| k.to_s.underscore } }
+    let(:keys) { response_hash.keys }
 
     before do
       allow_any_instance_of(TestWizard).to \
@@ -79,10 +80,11 @@ describe Wizard::Base do
 
     subject do
       wizard.process_magic_link_token(token)
-      wizardstore.fetch(%w[candidate_id first_name last_name email])
+      wizardstore
     end
 
-    it { is_expected.to eq response_hash }
+    it { expect(subject.fetch(keys)).to eq response_hash }
+    it { expect(subject.fetch(keys.map { |k| "#{k}_in_crm" }).values).to match_array response_hash.values }
 
     context "when the wizard does not implement exchange_magic_link_token" do
       before do
@@ -107,6 +109,7 @@ describe Wizard::Base do
       )
     end
     let(:response_hash) { stub_response.to_hash.transform_keys { |k| k.to_s.underscore } }
+    let(:keys) { response_hash.keys }
 
     before do
       allow_any_instance_of(TestWizard).to \
@@ -115,10 +118,11 @@ describe Wizard::Base do
 
     subject do
       wizard.process_access_token(token, request)
-      wizardstore.fetch(%w[candidate_id first_name last_name email])
+      wizardstore
     end
 
-    it { is_expected.to eq response_hash }
+    it { expect(subject.fetch(keys)).to eq response_hash }
+    it { expect(subject.fetch(keys.map { |k| "#{k}_in_crm" }).values).to match_array response_hash.values }
 
     context "when the wizard does not implement exchange_magic_link_token" do
       before do


### PR DESCRIPTION
### Trello card

[Trello-771](https://trello.com/c/tHRHvxLk/771-if-a-matched-back-candidate-pre-fills-an-optional-field-then-clears-it-during-sign-up-we-wont-clear-it-in-the-crm)

### Context

If a candidate is matched back to an existing contact in the CRM we pre-fill the form fields where possible.

Currently, if the user lands on an optional step that is pre-filled with a value and they then clear the value the change won't be reflected in the CRM, as the API only supports sending non-nil values to the CRM.

To make the user-experience consistent with the data that ends up in the CRM for now we are going to skip optional steps that get pre-filled (and hide optional fields on required steps).

A more robust solution (which is also a lot more work) would be to update the API to support PATCH requests so that partial updates containing `nil` values could be performed. The difficulty with this is that the `swagger-codegen` doesn't look like it will generate a client that supports it, but I'm going to investigate it further.

### Changes proposed in this pull request

- Support skipping optional steps that get pre-filled
- Skip optional steps/fields that are pre-filled

### Guidance to review

I couldn't think of a better naming convention than `<attribute>_in_crm` to store/determine if the candidate already has a field value set in the CRM. I figured it followed the `ActiveModel::Dirty` convention of `<attribute>_in_database`, so you can do, for example:

```
contact_step.telephone
contact_step.telephone_in_crm
```

I'm not sure a step should know about the CRM though... does this feel too convoluted? The way the logic is split between the `Wizard::Step` and `Wizard::Base` classes doesn't feel quite right, but I can't put my finger on a better approach yet. Open to suggestions...

I also thought about inferring the `optional?` state of a step from the validations applied, but it got pretty complicated to do this dynamically so I opted to hardcode it.