### PR TITLE
Add citeable quote variation and make CSS generic

### DIFF
--- a/app/components/cards/chat_online_component.html.erb
+++ b/app/components/cards/chat_online_component.html.erb
@@ -3,7 +3,7 @@
     <%= truncated_header %>
   </header>
 
-  <a href="/helping-you-become-a-teacher" data-controller="talk-to-us" data-action="talk-to-us#startChat" class="card__thumb">
+  <a href="#" data-controller="talk-to-us" data-action="talk-to-us#startChat" class="card__thumb">
     <%= thumbnail_image_tag %>
   </a>
 
@@ -16,7 +16,7 @@
       <%= link_text %> <%= helpers.fas_icon("chevron-right") %>
     </a>
 
-    <a href="/helping-you-become-a-teacher" class="git-link no-js-fallback">
+    <a href="#" class="git-link no-js-fallback">
       Chat to us <%= helpers.fas_icon("chevron-right") %>
     </a>
   </footer>

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -4,6 +4,7 @@
 @import './components/mixins/cards-grid';
 @import './components/mixins/headings';
 
+@import 'icons';
 @import 'breakpoints';
 @import 'font-sizes';
 @import 'utility';
@@ -11,10 +12,10 @@
 @import 'layout';
 @import 'links-and-buttons';
 @import 'markdown';
+@import 'markdown-figures-and-quotes';
 @import 'feature';
 @import 'featured';
 @import 'forms';
-@import 'icons';
 @import 'video';
 @import 'header';
 @import 'footer';

--- a/app/webpacker/styles/markdown-figures-and-quotes.scss
+++ b/app/webpacker/styles/markdown-figures-and-quotes.scss
@@ -1,0 +1,76 @@
+.markdown {
+  @mixin quote-icon($quote-size) {
+    @include icon;
+    background-image: url('../images/white-quote.svg');
+    width: $quote-size;
+    height: $quote-size;
+    fill: $white;
+    content: "";
+  }
+
+  @mixin quote {
+    background-color: $yellow;
+    float: left;
+    max-width: 340px;
+    position: relative;
+  }
+
+  @mixin fancy-quotes {
+    $quote-size: 17px;
+
+    padding: 15px 44px;
+    font-weight: bold;
+
+    &:before {
+      @include quote-icon($quote-size);
+      position: absolute;
+      left: size("small");
+    }
+
+    &:after {
+      @include quote-icon($quote-size);
+      position: inline;
+      transform: rotate(180deg);
+      margin-left: 7px;
+    }
+  }
+
+  > blockquote {
+    @include quote;
+    margin: 0 25px 0 0;
+
+    p {
+      @include fancy-quotes;
+    }
+
+    @include mq($until: mobile) {
+      display: block;
+      width: 100%;
+      min-width: 100%;
+      float: none;
+      margin: 2em 0;
+    }
+  }
+
+  figure {
+    background-color: $yellow;
+    @include quote;
+
+    &.right {
+      float: right;
+    }
+
+    blockquote {
+      p {
+        @include fancy-quotes;
+        @include reset;
+      }
+    }
+
+    figcaption {
+      margin: 1em 2em 1em 3em;
+      text-align: right;
+      font-size: smaller;
+    }
+  }
+}

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -111,51 +111,6 @@
     font-weight: bold;
   }
 
-  blockquote {
-    margin: 0 25px 0 0;
-    background-color: $yellow;
-    float: left;
-    max-width: 340px;
-    position: relative;
-
-    $quote-size: 17px;
-
-    p {
-      padding: 15px 44px;
-      font-weight: bold;
-
-      @mixin quote-icon {
-        @include icon;
-        background-image: url('../images/white-quote.svg');
-        width: $quote-size;
-        height: $quote-size;
-        fill: $white;
-        content: "";
-      }
-
-      &:before {
-        @include quote-icon;
-        position: absolute;
-        left: size("small");
-      }
-
-      &:after {
-        @include quote-icon;
-        position: inline;
-        transform: rotate(180deg);
-        margin-left: 7px;
-      }
-    }
-
-    @include mq($until: mobile) {
-      display: block;
-      width: 100%;
-      min-width: 100%;
-      float: none;
-      margin: 2em 0;
-    }
-  }
-
   &__video {
     margin-bottom: 1.5em;
     width: 100%;


### PR DESCRIPTION
This change improves the way we display regular markdown blockquotes
(`>`) and also adds support for proper cited ones (`figure >
blockquote,figcaption`).

Additionally, for the latter variety, there's a 'right' class that makes
them float right instead of the default left.

![Screenshot from 2021-02-12 11-26-14](https://user-images.githubusercontent.com/128088/107764302-e2228f80-6d27-11eb-935b-bb8c4d622b81.png)


