### PR TITLE
Add a max-height to the hero when in desktop mode

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -5,6 +5,10 @@ $mobile-cutoff: 800px;
 
 // fallback styles (IE)
 .hero {
+  @include mq($from: tablet) {
+    max-height: 30em;
+  }
+
   &__title {
     display: block;
     max-width: 90%;


### PR DESCRIPTION
One of our images (on /my-story-into-teaching/career-changers) is much taller than the others and it pushes the content *way down*. This caps it at 30em, really we should standardise the dimensions of our hero photos.

| Before | After |
| ------ | ------- |
| ![Screenshot from 2021-02-12 12-05-26](https://user-images.githubusercontent.com/128088/107765945-9b826480-6d2a-11eb-99cd-f8ebc1bd0c05.png) | ![Screenshot from 2021-02-12 12-05-55](https://user-images.githubusercontent.com/128088/107766005-b523ac00-6d2a-11eb-887e-74816decba80.png) |

