### PR TITLE
Fix save cookies preferences animation

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -26,7 +26,7 @@
   for us to use.
 </p>
 
-<div id="cookie-preferences-form">
+<div id="cookie-preferences-form-container">
   <form id="cookie-preferences-from" novalidate data-controller="cookie-preferences">
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset"

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -42,6 +42,8 @@ form {
     button {
       margin-right: 1em;
       margin-bottom: 1em;
+      @include button;
+      display: inline-block;
     }
 
     span {

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -49,17 +49,17 @@ form {
       display: none;
     }
   }
+}
 
-  [data-cookie-preferences-save-state="saving"] {
-    .fa-sync.fa-spin {
-      display: inline-block;
-    }
+#cookie-preferences-from[data-cookie-preferences-save-state="saving"] {
+  .fa-sync.fa-spin {
+    display: inline-block;
   }
+}
 
-  [data-cookie-preferences-save-state="saved"] {
-    .save-with-confirmation__message {
-      display: inline-block;
-    }
+#cookie-preferences-from[data-cookie-preferences-save-state="saved"] {
+  .save-with-confirmation__message {
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
The animation was broken because the CSS selectors were looking _inside_ the form rather than at the form itself.