### PR TITLE
Move form status styles back inside form rule

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: 'stylelint-config-gds/scss',
   rules: {
     'max-nesting-depth': null,
-    'selector-no-qualifying-type': [true, { ignore: ['class'] }],
+    'selector-no-qualifying-type': [true, { ignore: ['class', 'attribute'] }],
     'selector-max-id': 1,
     'declaration-block-single-line-max-declarations': 1,
   },

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -27,7 +27,7 @@
 </p>
 
 <div id="cookie-preferences-form-container">
-  <form id="cookie-preferences-from" novalidate data-controller="cookie-preferences">
+  <form id="cookie-preferences-form" novalidate data-controller="cookie-preferences">
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset"
         aria-describedby="cookies-non-functional-hint"

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -38,6 +38,18 @@ form {
     }
   }
 
+  &[data-cookie-preferences-save-state="saving"] {
+    .fa-sync.fa-spin {
+      display: inline-block;
+    }
+  }
+
+  &[data-cookie-preferences-save-state="saved"] {
+    .save-with-confirmation__message {
+      display: inline-block;
+    }
+  }
+
   .save-with-confirmation {
     button {
       margin-right: 1em;
@@ -50,18 +62,6 @@ form {
       color: $green;
       display: none;
     }
-  }
-}
-
-#cookie-preferences-form[data-cookie-preferences-save-state="saving"] {
-  .fa-sync.fa-spin {
-    display: inline-block;
-  }
-}
-
-#cookie-preferences-form[data-cookie-preferences-save-state="saved"] {
-  .save-with-confirmation__message {
-    display: inline-block;
   }
 }
 

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -53,13 +53,13 @@ form {
   }
 }
 
-#cookie-preferences-from[data-cookie-preferences-save-state="saving"] {
+#cookie-preferences-form[data-cookie-preferences-save-state="saving"] {
   .fa-sync.fa-spin {
     display: inline-block;
   }
 }
 
-#cookie-preferences-from[data-cookie-preferences-save-state="saved"] {
+#cookie-preferences-form[data-cookie-preferences-save-state="saved"] {
   .save-with-confirmation__message {
     display: inline-block;
   }


### PR DESCRIPTION
The prefix ampersands for the styles at target the form's status data attributes were lost during the linting process (a7e7b01) and have been re-added. As they're flagged by the linter a new config option on the 'selector-no-qualifying-type' rule has been added to make it ignore attributes.

Also fix a typo where the form had the id `cookie-preferences-from`.