### PR TITLE
Add intro/context to a mailing list sign up via magic link

### DIFF
--- a/app/models/mailing_list/steps/degree_status.rb
+++ b/app/models/mailing_list/steps/degree_status.rb
@@ -7,6 +7,8 @@ module MailingList
                 presence: true,
                 inclusion: { in: :degree_status_option_ids }
 
+      delegate :magic_link_token_used?, to: :@wizard
+
       def degree_status_options
         @degree_status_options ||= query_degree_status
       end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -4,6 +4,11 @@ module Wizard
   class AccessTokenNotSupportedError < RuntimeError; end
 
   class Base
+    module Auth
+      ACCESS_TOKEN = 0
+      MAGIC_LINK_TOKEN = 1
+    end
+
     MATCHBACK_ATTRS = %i[candidate_id qualification_id].freeze
 
     class_attribute :steps
@@ -90,6 +95,14 @@ module Wizard
       steps[(key_index(key) + 1)..].to_a.map(&:key)
     end
 
+    def magic_link_token_used?
+      @store["auth_method"] == Auth::MAGIC_LINK_TOKEN
+    end
+
+    def access_token_used?
+      @store["auth_method"] == Auth::ACCESS_TOKEN
+    end
+
     def earlier_keys(key = current_key)
       index = key_index(key)
       return [] unless index.positive?
@@ -106,12 +119,12 @@ module Wizard
 
     def process_magic_link_token(token)
       response = exchange_magic_link_token(token)
-      prepopulate_store(response)
+      prepopulate_store(response, Auth::MAGIC_LINK_TOKEN)
     end
 
     def process_access_token(token, request)
       response = exchange_access_token(token, request)
-      prepopulate_store(response)
+      prepopulate_store(response, Auth::ACCESS_TOKEN)
     end
 
   protected
@@ -126,9 +139,10 @@ module Wizard
 
   private
 
-    def prepopulate_store(response)
+    def prepopulate_store(response, auth_method)
       hash = response.to_hash.transform_keys { |k| k.to_s.underscore }
       @store.persist_crm(hash)
+      @store["auth_method"] = auth_method
     end
 
     def all_steps

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -19,16 +19,6 @@ module Wizard
         @store["authenticate"] != true
       end
 
-      def save
-        @store["authenticated"] = false
-
-        if valid?
-          @store["authenticated"] = true
-        end
-
-        super
-      end
-
       def export
         {}
       end
@@ -42,7 +32,7 @@ module Wizard
     private
 
       def perform_api_check?
-        timed_one_time_password_valid? && !@store["authenticated"]
+        timed_one_time_password_valid? && !@wizard.access_token_used?
       end
 
       def timed_one_time_password_valid?
@@ -54,8 +44,10 @@ module Wizard
 
       def timed_one_time_password_is_correct
         request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(candidate_identity_data)
-        @wizard.process_access_token(timed_one_time_password, request) if timed_one_time_password_changed?
-        clear_attribute_changes(%i[timed_one_time_password])
+        if timed_one_time_password_changed?
+          clear_attribute_changes(%i[timed_one_time_password])
+          @wizard.process_access_token(timed_one_time_password, request)
+        end
       rescue GetIntoTeachingApiClient::ApiError
         errors.add(:timed_one_time_password, :wrong_code)
       end

--- a/app/views/mailing_list/steps/_degree_status.html.erb
+++ b/app/views/mailing_list/steps/_degree_status.html.erb
@@ -1,3 +1,12 @@
+<% if f.object.magic_link_token_used? %>
+<div class="content-alert content-alert--fullwidth">
+    <div>
+      <p>Tell us more about you so that you only get emails relevant to your circumstances.</p>
+    </div>
+  </div>
+</div>
+<% end %>
+
 <h1>Do you have a degree?</h1>
 
 <p>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next Step"
 
+    expect(page).to_not have_text "Tell us more about you so that you only get emails relevant to your circumstances."
+
     expect(page).to have_text "What stage are you at with your degree?"
     choose "I am a first year student"
     click_on "Next Step"
@@ -273,6 +275,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
       receive(:exchange_magic_link_token_for_mailing_list_add_member).with(token) { response }
 
     visit mailing_list_steps_path(magic_link_token: token)
+
+    expect(page).to have_text "Tell us more about you so that you only get emails relevant to your circumstances."
 
     expect(page).to have_text "What stage are you at with your degree?"
     expect(find("[name=\"mailing_list_steps_degree_status[degree_status_id]\"][checked]").value).to eq(

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -30,4 +30,14 @@ describe MailingList::Steps::DegreeStatus do
     it { is_expected.not_to allow_value("").for :degree_status_id }
     it { is_expected.not_to allow_value(12_345).for :degree_status_id }
   end
+
+  describe "#wizard_magic_link_token_used?" do
+    it { is_expected.not_to be_magic_link_token_used }
+
+    context "when magic link token was used" do
+      before { wizardstore["auth_method"] = Wizard::Base::Auth::MAGIC_LINK_TOKEN }
+
+      it { is_expected.to be_magic_link_token_used }
+    end
+  end
 end

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -6,6 +6,28 @@ describe Wizard::Base do
   let(:wizardclass) { TestWizard }
   let(:wizard) { wizardclass.new wizardstore, "age" }
 
+  describe "#access_token_used?" do
+    subject { wizard }
+
+    it { is_expected.not_to be_access_token_used }
+
+    context "when auth method is set" do
+      before { wizardstore["auth_method"] = described_class::Auth::ACCESS_TOKEN }
+      it { is_expected.to be_access_token_used }
+    end
+  end
+
+  describe "#magic_link_token_used?" do
+    subject { wizard }
+
+    it { is_expected.not_to be_magic_link_token_used }
+
+    context "when auth method is set" do
+      before { wizardstore["auth_method"] = described_class::Auth::MAGIC_LINK_TOKEN }
+      it { is_expected.to be_magic_link_token_used }
+    end
+  end
+
   describe ".indexed_steps" do
     subject { wizardclass.indexed_steps }
 
@@ -77,12 +99,13 @@ describe Wizard::Base do
         receive(:exchange_magic_link_token).with(token) { stub_response }
     end
 
-    subject do
+    subject! do
       wizard.process_magic_link_token(token)
       wizardstore.fetch(%w[candidate_id first_name last_name email], source: :crm)
     end
 
     it { is_expected.to eq response_hash }
+    it { expect(wizard).to be_magic_link_token_used }
 
     context "when the wizard does not implement exchange_magic_link_token" do
       before do
@@ -113,12 +136,13 @@ describe Wizard::Base do
         receive(:exchange_access_token).with(token, request) { stub_response }
     end
 
-    subject do
+    subject! do
       wizard.process_access_token(token, request)
       wizardstore.fetch(%w[candidate_id first_name last_name email], source: :crm)
     end
 
     it { is_expected.to eq response_hash }
+    it { expect(wizard).to be_access_token_used }
 
     context "when the wizard does not implement exchange_magic_link_token" do
       before do


### PR DESCRIPTION
### Trello card

[Trello-776](https://trello.com/c/HILK0xws/776-mailing-list-sign-up-process-for-crm-data-migration)

### Context

When a user signs up to the mailing list via a magic link we take them straight to the degree status question with no context/intro to the sign up process. We want to add some information so its clear why they are signing up.

### Changes proposed in this pull request

- Add intro to mailing list sign up via magic link
- Simplify Authenticate step with access_token_used? helper

The `Wizard::Base` now contains a method to determine if/what kind of authentication method has been used.

Instead of manually tracking this information in the `Authenticate` step we can remove the logic and call out to the wizard.

Ensure `timed_one_time_password` dirty tracking is cleared on `ApiError` so that if a user enters a bad code we only try and validate it with the API once (unless they change the code and try again).

### Guidance to review

<img width="856" alt="Screenshot 2021-02-16 at 15 39 57" src="https://user-images.githubusercontent.com/29867726/108085451-410c3f80-706d-11eb-8f7f-67745823af2f.png">
