### PR TITLE
Remove references to Akzidenz, AkzidenzGroteskBQ

### DIFF
--- a/app/webpacker/images/steps-graphic-mob.svg
+++ b/app/webpacker/images/steps-graphic-mob.svg
@@ -3,27 +3,27 @@
     <path id="Path_1614" data-name="Path 1614" d="M-282.99,11558.619c8.948,79.262,87.188,61.18,142.62,41.137,120.8-40.068,139.391,11.941,121.427,84.267,1.54,1,3.17,2.024,4.859,3.04-51.172,103.15-84.12,111.881-177.328,48.037s-120.323,80.086-52.589,115.676,183.227-34.26,246-23.229" transform="translate(328 -10477)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
     <g id="Group_1385" data-name="Group 1385" transform="translate(-107.905 282)">
       <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
     </g>
     <g id="Group_1387" data-name="Group 1387" transform="translate(-224.905 403)">
       <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
     </g>
     <g id="Group_1388" data-name="Group 1388" transform="translate(-579.905 451)">
       <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
     </g>
     <g id="Group_1389" data-name="Group 1389" transform="translate(-819.904 572)">
       <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
     </g>
     <g id="Group_1390" data-name="Group 1390" transform="translate(-580.561 548)">
       <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
+      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
     </g>
     <g id="Group_1386" data-name="Group 1386" transform="translate(-157.561 321)">
       <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
     </g>
   </g>
 </svg>

--- a/app/webpacker/images/steps-graphic.svg
+++ b/app/webpacker/images/steps-graphic.svg
@@ -3,27 +3,27 @@
     <path id="Path_1614" data-name="Path 1614" d="M-282.547,11569.416c73.975,18.928,36.042-157.584,43.609-151.932,130.453-106.531,36.416,110.557,144.938,95.666,77.391,9.563-6.852-143.824,87-87.41s-49.412,142.451,54.563,170.207,67.609-66.766,49.773-121.946-3.109-119.876,59.664-108.845" transform="translate(935 -10495)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
     <g id="Group_1385" data-name="Group 1385" transform="translate(490.095 276)">
       <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
     </g>
     <g id="Group_1386" data-name="Group 1386" transform="translate(359.439 124)">
       <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
     </g>
     <g id="Group_1387" data-name="Group 1387" transform="translate(304.095 217)">
       <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
     </g>
     <g id="Group_1388" data-name="Group 1388" transform="translate(199.095 125)">
       <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
     </g>
     <g id="Group_1389" data-name="Group 1389" transform="translate(77.096 300)">
       <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
     </g>
     <g id="Group_1390" data-name="Group 1390" transform="translate(177.439 69)">
       <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
+      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

The missing font renders in sans serif on Mac, serif on Linux and who-knows-what on Windows; maybe cursive or fantasy! 🧙

This change forces it to sans serif, so it'll be the usual Arial/Helvetica/Roboto.

| Before | After |
| ------ | ------ | 
| ![Screenshot from 2021-02-15 11-28-13](https://user-images.githubusercontent.com/128088/107940963-ef868680-6f80-11eb-9869-5252c57b6866.png) | ![Screenshot from 2021-02-15 11-28-22](https://user-images.githubusercontent.com/128088/107940991-f3b2a400-6f80-11eb-8fe3-22421c9068ed.png) |