### PR TITLE
Re-add the ampersands for external link selectors

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -36,7 +36,7 @@
   }
 
   a {
-    [href*="//"] {
+    &[href*="//"] {
       &:after {
         content: url('../images/icon-external.svg');
         margin-left: .2em;
@@ -51,7 +51,7 @@
   .call-to-action__action,
   .featured-content__item {
     a {
-      [href*="//"] {
+      &[href*="//"] {
         &:after {
           content: none;
           margin-left: unset;


### PR DESCRIPTION
The external link icons were lost as part of [the lint](a7e7b01409), this re-adds them. See #888 for more details.