### PR TITLE
Hide pre-filled optional fields and steps

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -32,12 +32,17 @@ private
   end
 
   def wizard_store
-    Wizard::Store.new session_store
+    ::Wizard::Store.new app_store, crm_store
   end
 
-  def session_store
+  def app_store
     session[:events] ||= {}
     session[:events][params[:event_id]] ||= {}
+  end
+
+  def crm_store
+    session[:events_crm] ||= {}
+    session[:events_crm][params[:event_id]] ||= {}
   end
 
   def load_event

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -14,11 +14,15 @@ module MailingList
     helper_method :step_path
 
     def wizard_store
-      ::Wizard::Store.new session_store
+      ::Wizard::Store.new app_store, crm_store
     end
 
-    def session_store
+    def app_store
       session[:mailinglist] ||= {}
+    end
+
+    def crm_store
+      session[:mailinglist_crm] ||= {}
     end
 
     def set_step_page_title

--- a/app/models/events/steps/contact_details.rb
+++ b/app/models/events/steps/contact_details.rb
@@ -7,6 +7,10 @@ module Events
       before_validation if: :telephone do
         self.telephone = telephone.to_s.strip.presence
       end
+
+      def optional?
+        true
+      end
     end
   end
 end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -20,7 +20,13 @@ module Events
       end
 
       def hide_postcode_field?
-        @store.crm(:address_postcode).present?
+        postcode_in_crm.present?
+      end
+
+      def export
+        super.tap do |hash|
+          hash["address_postcode"] = postcode_in_crm if hide_postcode_field?
+        end
       end
 
       def degree_status_options
@@ -50,6 +56,12 @@ module Events
 
       def teaching_subject_option_ids
         teaching_subject_options.map(&:id)
+      end
+
+    private
+
+      def postcode_in_crm
+        @store.crm(:address_postcode)
       end
     end
   end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -19,6 +19,10 @@ module Events
         !@store["subscribe_to_mailing_list"]
       end
 
+      def hide_postcode_field?
+        @store.crm(:address_postcode).present?
+      end
+
       def degree_status_options
         @degree_status_options ||=
           GetIntoTeachingApiClient::PickListItemsApi.new.get_qualification_degree_status

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -7,6 +7,10 @@ module MailingList
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
+
+      def optional?
+        true
+      end
     end
   end
 end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -52,13 +52,13 @@ module Wizard
 
     def previous_key(key = current_key)
       earlier_keys(key).reverse.find do |k|
-        find(k).show?
+        !find(k).skipped?
       end
     end
 
     def next_key(key = current_key)
       later_keys(key).find do |k|
-        find(k).show?
+        !find(k).skipped?
       end
     end
 
@@ -136,7 +136,7 @@ module Wizard
     end
 
     def active_steps
-      all_steps.select(&:show?)
+      all_steps.reject(&:skipped?)
     end
   end
 end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -52,13 +52,13 @@ module Wizard
 
     def previous_key(key = current_key)
       earlier_keys(key).reverse.find do |k|
-        !find(k).skipped?
+        find(k).show?
       end
     end
 
     def next_key(key = current_key)
       later_keys(key).find do |k|
-        !find(k).skipped?
+        find(k).show?
       end
     end
 
@@ -136,7 +136,7 @@ module Wizard
     end
 
     def active_steps
-      all_steps.reject(&:skipped?)
+      all_steps.select(&:show?)
     end
   end
 end

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -128,7 +128,7 @@ module Wizard
 
     def prepopulate_store(response)
       hash = response.to_hash.transform_keys { |k| k.to_s.underscore }
-      @store.persist(hash)
+      @store.persist_crm(hash)
     end
 
     def all_steps

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -36,11 +36,24 @@ module Wizard
       true
     end
 
-    def persisted?
-      !id.nil?
+    def show?
+      !skipped? && !hidden?
     end
 
+    # Step not shown and data not exported if skipped
     def skipped?
+      false
+    end
+
+    # Step not shown, but data still exported if hidden
+    def hidden?
+      return false unless optional?
+
+      @store.fetch(attribute_names, source: :crm).values.all?(&:present?)
+    end
+
+    # Step will be hidden if all attributes are pre-filled from CRM
+    def optional?
       false
     end
 

--- a/app/models/wizard/step.rb
+++ b/app/models/wizard/step.rb
@@ -36,23 +36,16 @@ module Wizard
       true
     end
 
-    def show?
-      !skipped? && !hidden?
+    def persisted?
+      !id.nil?
     end
 
-    # Step not shown and data not exported if skipped
     def skipped?
-      false
-    end
-
-    # Step not shown, but data still exported if hidden
-    def hidden?
       return false unless optional?
 
       @store.fetch(attribute_names, source: :crm).values.all?(&:present?)
     end
 
-    # Step will be hidden if all attributes are pre-filled from CRM
     def optional?
       false
     end
@@ -62,12 +55,15 @@ module Wizard
     end
 
     def export
-      return {} if skipped?
-
-      Hash[attributes.keys.zip([])].merge attributes_from_store
+      attributes = skipped? ? attributes_from_crm : attributes_from_store
+      Hash[attributes.keys.zip([])].merge attributes
     end
 
   private
+
+    def attributes_from_crm
+      @store.fetch attributes.keys, source: :crm
+    end
 
     def attributes_from_store
       @store.fetch attributes.keys

--- a/app/models/wizard/steps/authenticate.rb
+++ b/app/models/wizard/steps/authenticate.rb
@@ -34,7 +34,7 @@ module Wizard
       end
 
       def candidate_identity_data
-        @store.fetch(IDENTITY_ATTRS).transform_keys do |k|
+        @store.fetch(IDENTITY_ATTRS).compact.transform_keys do |k|
           k.camelize(:lower).to_sym
         end
       end

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -1,36 +1,63 @@
 module Wizard
   class Store
-    attr_reader :data
-    delegate :keys, :to_h, :to_hash, to: :data
+    class InvalidBackingStore < RuntimeError; end
 
-    def initialize(data)
-      raise InvalidBackingStore unless data.respond_to?(:[]=)
+    delegate :keys, :to_h, :to_hash, to: :combined_data
 
-      @data = data
+    def initialize(app_data, crm_data)
+      stores = [app_data, crm_data]
+      raise InvalidBackingStore unless stores.all? { |s| s.respond_to?(:[]=) }
+
+      @app_data = app_data
+      @crm_data = crm_data
     end
 
     def [](key)
-      data[key.to_s]
+      combined_data[key.to_s]
     end
 
     def []=(key, value)
-      data[key.to_s] = value
+      @app_data[key.to_s] = value
     end
 
-    def fetch(*keys)
-      data.slice(*Array.wrap(keys).flatten.map(&:to_s)).stringify_keys
+    def crm(key)
+      @crm_data[key.to_s]
+    end
+
+    def fetch(*keys, source: :both)
+      array_of_keys = Array.wrap(keys).flatten.map(&:to_s)
+      Hash[array_of_keys.zip].merge(store(source).slice(*array_of_keys))
     end
 
     def persist(attributes)
-      data.merge! attributes.stringify_keys
+      @app_data.merge!(attributes.stringify_keys)
+
+      true
+    end
+
+    def persist_crm(attributes)
+      @crm_data.merge!(attributes.stringify_keys)
 
       true
     end
 
     def purge!
-      data.clear
+      @app_data.clear
+      @crm_data.clear
     end
 
-    class InvalidBackingStore < RuntimeError; end
+  private
+
+    def store(source)
+      case source
+      when :crm then @crm_data
+      when :app then @app_data
+      else combined_data
+      end
+    end
+
+    def combined_data
+      @crm_data.merge(@app_data)
+    end
   end
 end

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -10,7 +10,7 @@
       :value,
       options: { prompt: true } %>
 
-<%= f.govuk_text_field :address_postcode %>
+<%= f.govuk_text_field :address_postcode unless f.object.hide_postcode_field? %>
 
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
     f.object.teaching_subject_options,

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -109,9 +109,6 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in "Enter the verification code sent to test@user.com", with: "123456"
     click_on "Next Step"
 
-    expect(page).to have_field("Phone number (optional)", with: response.telephone)
-    click_on "Next Step"
-
     expect(page).to have_text "Are you over 16 and do you agree"
     expect(page).to have_text "Would you like to receive email updates"
     click_on "Complete sign up"
@@ -128,6 +125,7 @@ RSpec.feature "Event wizard", type: :feature do
     end
     click_on "Complete sign up"
 
+    expect(page).to_not have_text("What is your postcode? (optional)")
     fill_in_personalised_updates
     click_on "Complete sign up"
 
@@ -269,7 +267,9 @@ RSpec.feature "Event wizard", type: :feature do
   )
     select_value_or_default "What stage are you at with your degree?", degree_status
     select_value_or_default "How close are you to applying for teacher training?", consideration_journey_stage
-    fill_in "What is your postcode? (optional)", with: postcode
+    if page.has_text?("What is your postcode? (optional)")
+      fill_in "What is your postcode? (optional)", with: postcode
+    end
     select_value_or_default "What subject do you want to teach?", preferred_teaching_subject
   end
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -168,10 +168,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
     )
     click_on "Next Step"
 
-    expect(page).to have_text "Events in your area"
-    expect(page).to have_field("What's your postcode?", with: response.address_postcode)
-    click_on "Next Step"
-
     expect(page).to have_text "Accept privacy policy"
     click_on "Complete sign up"
 

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -6,6 +6,7 @@ describe Events::Steps::ContactDetails do
   it_behaves_like "a wizard step"
 
   it { is_expected.to respond_to :telephone }
+  it { expect(subject).to be_optional }
 
   describe "validations" do
     it { is_expected.to allow_value("").for :telephone }

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -49,6 +49,20 @@ describe Events::Steps::PersonalisedUpdates do
     end
   end
 
+  describe "#hide_postcode_field?" do
+    context "when the postcode is present in the crm store" do
+      let(:crm_backingstore) { { "address_postcode" => "TE5 1NG" } }
+
+      it { is_expected.to be_hide_postcode_field }
+    end
+
+    context "when the postcode is not present in the crm store" do
+      let(:crm_backingstore) { { "address_postcode" => nil } }
+
+      it { is_expected.not_to be_hide_postcode_field }
+    end
+  end
+
   describe "#skipped?" do
     let(:mailing_list) { nil }
     let(:backingstore) { { "subscribe_to_mailing_list" => mailing_list } }

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -82,6 +82,21 @@ describe Events::Steps::PersonalisedUpdates do
     end
   end
 
+  describe "#export" do
+    let(:backingstore) { { "subscribe_to_mailing_list" => true, "address_postcode" => "app-postcode" } }
+    let(:crm_backingstore) { {} }
+
+    subject { instance.export["address_postcode"] }
+
+    it { is_expected.to eq("app-postcode") }
+
+    context "when the postcode exists in the CRM" do
+      let(:crm_backingstore) { { "address_postcode" => "crm-postcode" } }
+
+      it { is_expected.to eq("crm-postcode") }
+    end
+  end
+
   describe "#teaching_subject_options" do
     let(:teaching_subject_types) do
       subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -10,7 +10,7 @@ describe Events::Wizard do
       "last_name" => "Joseph",
     } }
   end
-  let(:wizardstore) { Wizard::Store.new store[uuid] }
+  let(:wizardstore) { Wizard::Store.new store[uuid], {} }
   subject { described_class.new wizardstore, "personalised_updates" }
 
   describe ".steps" do

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -7,6 +7,7 @@ describe MailingList::Steps::Postcode do
   let(:msg) { "Enter a valid postcode" }
 
   it { is_expected.to respond_to :address_postcode }
+  it { expect(subject).to be_optional }
 
   describe "validations for address_postcode" do
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -9,7 +9,7 @@ describe MailingList::Wizard do
       "last_name" => "Joseph",
     } }
   end
-  let(:wizardstore) { Wizard::Store.new store[uuid] }
+  let(:wizardstore) { Wizard::Store.new store[uuid], {} }
   subject { described_class.new wizardstore, "privacy_policy" }
 
   describe ".steps" do

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -79,7 +79,7 @@ describe Wizard::Base do
 
     subject do
       wizard.process_magic_link_token(token)
-      wizardstore.fetch(%w[candidate_id first_name last_name email])
+      wizardstore.fetch(%w[candidate_id first_name last_name email], source: :crm)
     end
 
     it { is_expected.to eq response_hash }
@@ -115,7 +115,7 @@ describe Wizard::Base do
 
     subject do
       wizard.process_access_token(token, request)
-      wizardstore.fetch(%w[candidate_id first_name last_name email])
+      wizardstore.fetch(%w[candidate_id first_name last_name email], source: :crm)
     end
 
     it { is_expected.to eq response_hash }

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -295,7 +295,7 @@ describe Wizard::Base do
       end
 
       it { is_expected.to include "name" => "Joe" }
-      it { is_expected.not_to include "age" }
+      it { is_expected.to include "age" => nil }
       it { is_expected.to include "postcode" => nil }
     end
 

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -27,14 +27,68 @@ describe Wizard::Step do
     it { is_expected.to be_instance_of FirstStep }
     it { is_expected.to have_attributes key: "first_step" }
     it { is_expected.to have_attributes id: "first_step" }
-    it { is_expected.to have_attributes persisted?: true }
     it { is_expected.to have_attributes name: "Joe" }
     it { is_expected.to have_attributes age: 20 }
     it { is_expected.to have_attributes skipped?: false }
+    it { is_expected.to have_attributes optional?: false }
+    it { is_expected.to have_attributes can_proceed?: true }
   end
 
-  describe "#can_proceed" do
-    it { expect(subject).to be_can_proceed }
+  describe "#show?" do
+    it "returns true if not hidden or skipped" do
+      allow(subject).to receive(:hidden?) { false }
+      allow(subject).to receive(:skipped?) { false }
+      expect(subject).to be_show
+    end
+
+    it "returns false if hidden but not skipped" do
+      allow(subject).to receive(:hidden?) { true }
+      allow(subject).to receive(:skipped?) { false }
+      expect(subject).not_to be_show
+    end
+
+    it "returns false if skipped but not hidden" do
+      allow(subject).to receive(:hidden?) { false }
+      allow(subject).to receive(:skipped?) { true }
+      expect(subject).not_to be_show
+    end
+  end
+
+  describe "#hidden?" do
+    context "when optional" do
+      before { expect(subject).to receive(:optional?) { true } }
+
+      context "when values for all attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = 18
+        end
+
+        it { is_expected.to be_hidden }
+      end
+
+      context "when values for some attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = nil
+        end
+
+        it { is_expected.not_to be_hidden }
+      end
+    end
+
+    context "when not optional" do
+      before { expect(subject).to receive(:optional?) { false } }
+
+      context "when values for all attributes are present in the CRM" do
+        before do
+          crm_backingstore["name"] = "John"
+          crm_backingstore["age"] = 18
+        end
+
+        it { is_expected.to_not be_hidden }
+      end
+    end
   end
 
   describe "#flash_error" do

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -27,6 +27,7 @@ describe Wizard::Step do
     it { is_expected.to be_instance_of FirstStep }
     it { is_expected.to have_attributes key: "first_step" }
     it { is_expected.to have_attributes id: "first_step" }
+    it { is_expected.to have_attributes persisted?: true }
     it { is_expected.to have_attributes name: "Joe" }
     it { is_expected.to have_attributes age: 20 }
     it { is_expected.to have_attributes skipped?: false }
@@ -34,27 +35,7 @@ describe Wizard::Step do
     it { is_expected.to have_attributes can_proceed?: true }
   end
 
-  describe "#show?" do
-    it "returns true if not hidden or skipped" do
-      allow(subject).to receive(:hidden?) { false }
-      allow(subject).to receive(:skipped?) { false }
-      expect(subject).to be_show
-    end
-
-    it "returns false if hidden but not skipped" do
-      allow(subject).to receive(:hidden?) { true }
-      allow(subject).to receive(:skipped?) { false }
-      expect(subject).not_to be_show
-    end
-
-    it "returns false if skipped but not hidden" do
-      allow(subject).to receive(:hidden?) { false }
-      allow(subject).to receive(:skipped?) { true }
-      expect(subject).not_to be_show
-    end
-  end
-
-  describe "#hidden?" do
+  describe "#skipped?" do
     context "when optional" do
       before { expect(subject).to receive(:optional?) { true } }
 
@@ -64,7 +45,7 @@ describe Wizard::Step do
           crm_backingstore["age"] = 18
         end
 
-        it { is_expected.to be_hidden }
+        it { is_expected.to be_skipped }
       end
 
       context "when values for some attributes are present in the CRM" do
@@ -73,7 +54,7 @@ describe Wizard::Step do
           crm_backingstore["age"] = nil
         end
 
-        it { is_expected.not_to be_hidden }
+        it { is_expected.not_to be_skipped }
       end
     end
 
@@ -86,7 +67,7 @@ describe Wizard::Step do
           crm_backingstore["age"] = 18
         end
 
-        it { is_expected.to_not be_hidden }
+        it { is_expected.to_not be_skipped }
       end
     end
   end
@@ -123,5 +104,14 @@ describe Wizard::Step do
     subject { instance.export }
     it { is_expected.to include "name" => "Joe" }
     it { is_expected.to include "age" => nil } # should only export persisted data
+
+    context "when the step is skipped" do
+      let(:crm_backingstore) { { "name" => "Jimmy" } }
+
+      before { expect(instance).to receive(:skipped?) { true } }
+
+      it { is_expected.to include "name" => "Jimmy" }
+      it { is_expected.to include "age" => nil } # should only export persisted data
+    end
   end
 end

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -1,22 +1,29 @@
 require "rails_helper"
 
 describe Wizard::Store do
-  let(:backingstore) do
-    { "first_name" => "Joe", "age" => 20, "region" => "Manchester" }
-  end
-  let(:instance) { described_class.new backingstore }
+  let(:app_data) { { "first_name" => "Joe", "last_name" => nil, "age" => 20 } }
+  let(:crm_data) { { "first_name" => "James", "last_name" => "Doe", "region" => "Manchester" } }
+  let(:instance) { described_class.new app_data, crm_data }
+
   subject { instance }
 
   describe ".new" do
     context "with valid source data" do
       it { is_expected.to be_instance_of(described_class) }
-      it { is_expected.to have_attributes data: backingstore }
       it { is_expected.to respond_to :[] }
       it { is_expected.to respond_to :[]= }
     end
 
-    context "with invalid source data" do
-      subject { described_class.new nil }
+    context "with invalid app_data source" do
+      subject { described_class.new nil, crm_data }
+
+      it "should raise an InvalidBackingStore" do
+        expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
+      end
+    end
+
+    context "with invalid crm_data source" do
+      subject { described_class.new app_data, nil }
 
       it "should raise an InvalidBackingStore" do
         expect { subject }.to raise_exception(Wizard::Store::InvalidBackingStore)
@@ -25,14 +32,28 @@ describe Wizard::Store do
   end
 
   describe "#[]" do
-    context "first_name" do
+    context "when the attribute exists in app and crm data" do
       subject { instance["first_name"] }
-      it { is_expected.to eql "Joe" }
+
+      it { is_expected.to eq("Joe") }
     end
 
-    context "age" do
+    context "when the attribute is nil in the app data and not nil in the crm data" do
+      subject { instance["last_name"] }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the attribute exists in only the app data" do
       subject { instance["age"] }
-      it { is_expected.to eql 20 }
+
+      it { is_expected.to eq(20) }
+    end
+
+    context "when the attribute exists in only the crm data" do
+      subject { instance["region"] }
+
+      it { is_expected.to eq("Manchester") }
     end
   end
 
@@ -43,20 +64,63 @@ describe Wizard::Store do
     end
   end
 
+  describe "#crm" do
+    it { expect(instance.crm(:first_name)).to eq("James") }
+    it { expect(instance.crm(:age)).to be_nil }
+  end
+
   describe "#fetch" do
     context "with multiple keys" do
-      subject { instance.fetch :first_name, :region }
-      it "will return hash of requested keys" do
-        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      subject { instance.fetch :first_name, :last_name, :age, :region, source: source }
+
+      context "when source is both" do
+        let(:source) { :both }
+
+        it { is_expected.to eql({ "first_name" => "Joe", "last_name" => nil, "age" => 20, "region" => "Manchester" }) }
+      end
+
+      context "when source is app" do
+        let(:source) { :app }
+
+        it { is_expected.to eql({ "first_name" => "Joe", "last_name" => nil, "age" => 20, "region" => nil }) }
+      end
+
+      context "when source is crm" do
+        let(:source) { :crm }
+
+        it { is_expected.to eql({ "first_name" => "James", "age" => nil, "last_name" => "Doe", "region" => "Manchester" }) }
       end
     end
 
     context "with array of keys" do
-      subject { instance.fetch %w[first_name region] }
-      it "will return hash of requested keys" do
-        is_expected.to eql({ "first_name" => "Joe", "region" => "Manchester" })
+      subject { instance.fetch %w[first_name age region] }
+
+      it { is_expected.to eql({ "first_name" => "Joe", "age" => 20, "region" => "Manchester" }) }
+    end
+
+    context "when a key is not present in the store" do
+      subject { instance.fetch %w[first_name missing_key] }
+
+      it "will return it with a nil value in the hash" do
+        is_expected.to eql({ "first_name" => "Joe", "missing_key" => nil })
       end
     end
+  end
+
+  describe "#persist" do
+    subject! { instance.persist({ first_name: "Jim" }) }
+
+    it { is_expected.to be_truthy }
+    it { expect(instance["first_name"]).to eq("Jim") }
+    it { expect(instance["age"]).to eq(20) }
+  end
+
+  describe "#persist_crm" do
+    subject! { instance.persist_crm({ first_name: "Jim" }) }
+
+    it { is_expected.to be_truthy }
+    it { expect(instance.crm("first_name")).to eq("Jim") }
+    it { expect(instance.crm("age")).to be_nil }
   end
 
   describe "#purge!" do

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -1,6 +1,7 @@
 shared_context "wizard store" do
   let(:backingstore) { { "name" => "Joe", "age" => 35 } }
-  let(:wizardstore) { Wizard::Store.new backingstore }
+  let(:crm_backingstore) { {} }
+  let(:wizardstore) { Wizard::Store.new backingstore, crm_backingstore }
 end
 
 shared_context "wizard step" do


### PR DESCRIPTION
### Trello card

[Trello-771](https://trello.com/c/tHRHvxLk/771-if-a-matched-back-candidate-pre-fills-an-optional-field-then-clears-it-during-sign-up-we-wont-clear-it-in-the-crm)

### Context

If a candidate is matched back to an existing contact in the CRM we pre-fill the form fields where possible.

Currently, if the user lands on an optional step that is pre-filled with a value and they then clear the value the change won't be reflected in the CRM, as the API only supports sending non-nil values to the CRM.

To make the user-experience consistent with the data that ends up in the CRM for now we are going to skip optional steps that get pre-filled (and hide optional fields on required steps).

In addition, to make it so that the API can write `nil` values to the CRM going forward the app logic has changed so that if a step is `skipped?` we will still export the CRM data for the step _back_ to the API. This means we have a complete request model that we can write back to the CRM and avoids duplicating the 'was this attribute shown/filled in by the candidate' logic in the API. This will ultimately let us write `nil` values back to the CRM.

### Changes proposed in this pull request

- Add crm data support to store

We want to hide steps that are optional and have been pre-filled with candidate information.

In order to determine if a step can be pre-filled from the CRM we need to retain the CRM values in the store so that they
can later be queried independently of the data written by the app.

The `fetch` method has also been updated to return values for all keys passed in; this makes the logic to determine if all
values are present in a store simpler (otherwise we would also have to check the `count` to ensure all values are present):

```
fetch(%[...], source: :crm).values.all(&:present?)
```

- Support hidden and optional wizard steps

Currently if a step is `skipped?` it will not show in the wizard and the data will not be exported to the CRM.

We are introducing `optional?` steps, whereby if they are pre-filled from the CRM we will not show them to the user. We
do, however, want to export the data to the CRM still (as this may make partial updates more straight forward in the future). The `skipped?` export logic has been changed in a subsequent PR to facilitate this.

- Hide pre-filled optional steps/fields from wizard

When an optional step is pre-filled from the CRM, or when an optional field within a step is pre-filled, we want to hide it from the user.

- Consolidate hidden/skipped states

Instead of having a separate `hidden?` state - which is not shown to the user but is exported - we combine it with the
`skipped?` state and change so that attributes are exported from skipped steps using the existing CRM data.

This is going to be useful because skipped step values will be `nil` for new candidates and will contain the data already in
the CRM for existing candidates. Ultimately this will make it easier to update the API to support sending `nil` values to
the CRM (it avoids having to duplicate the logic for 'was this step shown to the user' in the API).

### Guidance to review

I chose to do a couple of aspects slightly differently from the suggestions in #884:

- Have the `Wizard` persist the crm data to the store

It worked fine writing to the session instead of the store for the magic link operation as that is initiated in a controller, but the access token exchange is performed in the `Authenticate` step and coupled to the validation of the model; it would be tricky to split that out into a controller action and feed the state back to the model.

- Updated the existing store to contain the logic for the crm/combined data

I felt it was getting overly complex to do this in a subclass; you end up hijacking most of the superclass logic. In addition, the store gets coupled to the `Authenticate` step and any optional steps anyway -- I feel it would be better to combine into the existing store for now and split it out if we ever get a use case for a `Wizard` that isn't backed by the CRM.

- Explicitly set `optional?` in the step subclass

The suggestion was to have optional fields in the `Step` base class that are globally applied, but in the TTA we have a number of instances where an attribute will be optional in one journey and required in another, so doing this explicitly in the subclass feels like it will translate easier when we come to port this across.