### PR TITLE
Re-instate button class

### DIFF
--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -12,7 +12,7 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <%= f.button class: "call-to-action-button" do %>
+      <%= f.button class: "call-to-action-button button" do %>
         <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
         <span></span>
       <% end %>


### PR DESCRIPTION
This was lost in a previous commit, causing the styling to disappear.

<img width="297" alt="Screenshot 2021-02-16 at 09 16 04" src="https://user-images.githubusercontent.com/29867726/108042358-9a597c00-7037-11eb-94c4-b2560757e06b.png">
<img width="285" alt="Screenshot 2021-02-16 at 09 16 50" src="https://user-images.githubusercontent.com/29867726/108042461-b65d1d80-7037-11eb-86cd-37f4825c4612.png">
