### PR TITLE
Remove hero size capping

### DIFF
--- a/app/components/sections/hero_component.html.erb
+++ b/app/components/sections/hero_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.header(class: classes) do %>
-  <%= responsive_image %>
+  <%= background_image %>
   <div class="hero__title">
     <h1><%= tag.span(title) %></h1>
   </div>

--- a/app/components/sections/hero_component.rb
+++ b/app/components/sections/hero_component.rb
@@ -1,6 +1,6 @@
 module Sections
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :subtitle, :image, :mobile_image, :show_mailing_list
+    attr_accessor :title, :subtitle, :image, :show_mailing_list
 
     def initialize(front_matter)
       front_matter.with_indifferent_access.tap do |fm|
@@ -21,11 +21,8 @@ module Sections
       image.present?
     end
 
-    def responsive_image
-      image_sizes = [%(#{image_path} 800w)]
-      image_sizes << %(#{mobile_image_path} 600w) if mobile_image.present?
-
-      image_tag(image_path, class: "hero__img", srcset: image_sizes.join(", "), alt: "Student in a classroom")
+    def background_image
+      tag.div(class: "hero__img", style: "background-image: url(#{image_path})")
     end
 
     def show_subtitle?

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -68,7 +68,7 @@ $mobile-cutoff: 800px;
 
     grid-template-columns: 3em repeat(3, 1fr);
     grid-template-rows:
-      max-content $title-overlap-img repeat(
+      8em $title-overlap-img repeat(
         2,
         minmax(1em, max-content)
       );

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -5,10 +5,6 @@ $mobile-cutoff: 800px;
 
 // fallback styles (IE)
 .hero {
-  @include mq($from: tablet) {
-    max-height: 30em;
-  }
-
   &__title {
     display: block;
     max-width: 90%;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -192,8 +192,9 @@ $mobile-cutoff: 800px;
   &__img {
     height: 100%;
     width: 100%;
-    object-fit: cover;
-    object-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
 
     @include safari-only {
       max-height: 30em;

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -58,18 +58,8 @@ describe Sections::HeroComponent, type: "component" do
 
       context "when an image is present in the front matter" do
         specify "the hero renders it" do
-          img_tag = page.find("img.hero__img")
-          img_tag[:src].match?(Regexp.new(front_matter[:image].delete_suffix(".jpg")))
-        end
-      end
-
-      describe "responsive images" do
-        let(:component) { described_class.new(front_matter.merge(mobileimage: "media/images/events-hero-mob.jpg")) }
-
-        specify "the image's srcset should contain desktop and mobile" do
-          img_tag = page.find("img.hero__img")
-
-          expect(img_tag[:srcset].split(",").map { |img| img.split.last }).to match_array(%w[600w 800w])
+          expect(page).to have_css(%(div.hero__img))
+          expect(rendered_component).to match(/images\/hero-home-dt-[0-9a-f]+\.jpg/)
         end
       end
     end


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

The hero size capping was introduced before the extra height from the button. This makes it possible for some hero content to be made to 'disappear'. The hero cap has been removed entirely and the image has been changed from an `img` tag to a background-image. This should allow us to just allow the grid to contain all the hero content and let the image resize accordingly:

This change does away with responsive images, the same image will be used throughout. We only have a few content pages with mobile images anyway, we can probably remove these.

https://user-images.githubusercontent.com/128088/108066564-68f0a880-7057-11eb-9406-214150dd95cf.mp4

### Guidance to review

Does it work ok? Are you able to make any of the hero disappear?