### PR TITLE
Give precedence to shown steps during export

### DIFF
--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -99,8 +99,10 @@ module Wizard
 
     def export_data
       matchback_data = @store.fetch(MATCHBACK_ATTRS)
-      step_data = all_steps.map(&:export).reduce({}, :merge)
-
+      # Ensure skipped step data is overwritten by shown step data.
+      # Important as two steps can write to the same attribute.
+      skipped_steps_first = all_steps.partition(&:skipped?).flatten
+      step_data = skipped_steps_first.map(&:export).reduce({}, :merge)
       step_data.merge!(matchback_data)
     end
 

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -87,6 +87,12 @@ class TestWizard < Wizard::Base
     validates :name, presence: true
   end
 
+  # To simulate two steps writing to the same attribute.
+  class OtherAge < Wizard::Step
+    attribute :age, :integer
+    validates :age, presence: false
+  end
+
   class Age < Wizard::Step
     attribute :age, :integer
     validates :age, presence: true
@@ -97,5 +103,5 @@ class TestWizard < Wizard::Base
     validates :postcode, presence: true
   end
 
-  self.steps = [Name, Age, Postcode].freeze
+  self.steps = [Name, OtherAge, Age, Postcode].freeze
 end


### PR DESCRIPTION
It is possible to have steps that write to the same attribute (though we only have this in the TTA currently). With the way we currently export the later of the steps value is used (regardless of if its skipped or not). This can lead to incorrect data being exported; instead, we need to prioritise the shown steps so that they overwrite data exported from skipped steps.
