### PR TITLE
Log address postcodes

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,7 +2,6 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[
-  address_postcode
   email
   first_name
   last_name


### PR DESCRIPTION
We are seeing an issue where a postcode passes the Ruby validation but fails the API validation. This shouldn't happen as both use the same regex. Logging out the postcode will give us an example we can use to diagnose what's going on the next time this happens.

This shouldn't constitute personally identifiable information:

> The guidance is that Postcode will only count as PII if combined with other information which is ‘in the possession of, or is likely to come into the possession of, the data controller’ to identify a living individual.
