### PR TITLE
Some minor styling improvements

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -8,7 +8,7 @@
   }
 
   // allow level two headings (blue boxes) and CTAs to 'overhang' on the left
-  > h2 {
+  h2 {
     @include overhang;
     @include content-heading;
   }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -16,6 +16,11 @@
   &__header {
     h2 {
       font-size: size("large");
+      background-color: inherit;
+      color: $black;
+      padding: .2em 0;
+
+      &:after { content: unset; }
     }
   }
 

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -101,3 +101,7 @@ $chevron-direction-map: (
     @content;
   }
 }
+
+.clearfix {
+  clear: both;
+}


### PR DESCRIPTION
Minor tweaks to apply the blue heading style anywhere in a `.markdown` element and to add a `.clearfix` class so content can be forced to sit beneath floating quotes.
