### PR TITLE
Position h1 across both cols on pages without hero

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -14,6 +14,12 @@
 
     <main class="semantic" role="main" id="main-content">
       <section class="container">
+        <% if !@front_matter["image"] %>
+          <header>
+            <%= tag.h1(@front_matter["title"]) %>
+          </header>
+        <% end %>
+
         <% if @front_matter["fullwidth"].blank? %>
         <aside>
           <% if @front_matter["jump_links"].present? %>
@@ -45,9 +51,6 @@
         <% end %>
 
         <article class="markdown <%= "fullwidth" if @front_matter["fullwidth"] %> ">
-          <% if !@front_matter["image"] %>
-            <%= tag.h1(@front_matter["title"]) %>
-          <% end %>
 
           <% if @front_matter["alert"].present? %>
             <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -61,6 +61,21 @@ section.container {
     max-width: $content-max-width;
   }
 
+  // most pages won't have a h1 here but on those where
+  // we forego the hero we want it to span both the article
+  // and the aside.
+  header {
+    flex: 0 0 100%;
+    max-width: $content-max-width;
+
+    h1 {
+      @include indent-left-and-right;
+
+      font-size: size(xxlarge);
+      margin-bottom: .5rem;
+    }
+  }
+
   > article {
     flex: 0 1 65%;
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -72,7 +72,7 @@ section.container {
       @include indent-left-and-right;
 
       font-size: size(xxlarge);
-      margin-bottom: .5rem;
+      margin-bottom: 3rem;
     }
   }
 

--- a/app/webpacker/styles/margins.scss
+++ b/app/webpacker/styles/margins.scss
@@ -1,1 +1,6 @@
 $indent-amount: 1.5rem;
+
+@mixin indent-left-and-right {
+  margin-left: $indent-amount;
+  margin-right: $indent-amount;
+}

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -3,8 +3,11 @@
   @mixin overhang { margin-left: auto; margin-right: auto; }
 
   > * {
-    margin-left: $indent-amount;
-    margin-right: $indent-amount;
+    @include indent-left-and-right;
+  }
+
+  h1 {
+    font-size: size('xxlarge');
   }
 
   // allow level two headings (blue boxes) and CTAs to 'overhang' on the left


### PR DESCRIPTION
Some pages, those that are heavy on guidance, may not need a hero image. The hero can be too far from the text and it looks like the article has no heading.

This change helps address it by making h1's on pages without a hero bigger and makes them span both the article and the aside.

![Screenshot from 2021-02-17 15-38-10](https://user-images.githubusercontent.com/128088/108227781-28b42780-7136-11eb-8993-e6aaa888799b.png)


