### PR TITLE
Support accordions in the content layout

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -62,6 +62,28 @@
             <%= render(partial) %>
           <% end %>
 
+          <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
+            <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered"), active_step: accordion_fm.dig("active_step")) do |accordion| %>
+              <%= accordion.slot(
+                :content_before_accordion,
+                partial: accordion_fm.dig("content_before_accordion", "partial"),
+                call_to_action: accordion_fm.dig("content_before_accordion", "cta")
+              ) %>
+
+              <% accordion_fm["steps"]&.each do |title, contents| %>
+                <%= accordion.slot(:step, title: title, call_to_action: contents["cta"]) do %>
+                  <%= render(partial: contents["partial"]) %>
+                <% end %>
+              <% end %>
+
+              <%= accordion.slot(
+                :content_after_accordion,
+                partial: accordion_fm.dig("content_after_accordion", "partial"),
+                call_to_action: accordion_fm.dig("content_after_accordion", "cta")
+              ) %>
+            <% end %>
+          <% end %>
+
           <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
         </article>
       </section>


### PR DESCRIPTION
The accordion and content pages are so similar that it doesn't really make sense to have two layouts, this change allows us to render accordions beneath content on content pages.

The next steps will be to:

1. remove the accordion layout directives in the steps frontmatter
2. delete the accordion layout.
