### PR TITLE
Stop accordion headings from reaching large size

### DIFF
--- a/app/webpacker/styles/accordion.scss
+++ b/app/webpacker/styles/accordion.scss
@@ -23,10 +23,6 @@
         white-space: initial;
         padding: 0 2em 0 0;
         background: transparent;
-
-        @include mq($from: tablet) {
-          font-size: size("large");
-        }
       }
 
       .step-header__chevron {


### PR DESCRIPTION
When they're large they're the size as the blue headings and it overpowers the page:

| Before | After |
| ------ | ------ |
| ![Screenshot from 2021-02-18 12-52-08](https://user-images.githubusercontent.com/128088/108359689-37f3ad80-71e8-11eb-9ce2-1590d2ee9ec8.png) | ![Screenshot from 2021-02-18 12-52-23](https://user-images.githubusercontent.com/128088/108359697-3aee9e00-71e8-11eb-9ea7-3c60b0ee3c32.png) |


