### PR TITLE
Add temp logging to diagnose postcode validation error

### DIFF
--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -21,7 +21,10 @@ module Events
 
     def exchange_access_token(timed_one_time_password, request)
       @api ||= GetIntoTeachingApiClient::TeachingEventsApi.new
-      @api.exchange_access_token_for_teaching_event_add_attendee(timed_one_time_password, request)
+      response = @api.exchange_access_token_for_teaching_event_add_attendee(timed_one_time_password, request)
+      # TEMP: debugging invalid postcode issue
+      Rails.logger.info("Events::Wizard#exchange_access_token with postcode: #{response.address_postcode}")
+      response
     end
 
   private
@@ -29,6 +32,8 @@ module Events
     def add_attendee_to_event
       request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::TeachingEventsApi.new
+      # TEMP: debugging invalid postcode issue
+      Rails.logger.info("Events::Wizard#add_attendee_to_event with postcode: #{request.address_postcode}")
       api.add_teaching_event_attendee(request)
     end
   end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -24,7 +24,10 @@ module MailingList
 
     def exchange_access_token(timed_one_time_password, request)
       @api ||= GetIntoTeachingApiClient::MailingListApi.new
-      @api.exchange_access_token_for_mailing_list_add_member(timed_one_time_password, request)
+      response = @api.exchange_access_token_for_mailing_list_add_member(timed_one_time_password, request)
+      # TEMP: debugging invalid postcode issue
+      Rails.logger.info("MailingList::Wizard#exchange_access_token with postcode: #{response.address_postcode}")
+      response
     end
 
   protected
@@ -39,6 +42,8 @@ module MailingList
     def add_member_to_mailing_list
       request = GetIntoTeachingApiClient::MailingListAddMember.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::MailingListApi.new
+      # TEMP: debugging invalid postcode issue
+      Rails.logger.info("MailingList::Wizard#add_mailing_list_member with postcode: #{request.address_postcode}")
       api.add_mailing_list_member(request)
     end
   end


### PR DESCRIPTION
We are seeing an error where an invalid postcode is being submitted as part of a mailing list or teaching event sign up. I suspect this is an invalid postcode against a candidate already in the CRM, which is then pre-filling the store in the app and being submitted _back_ to the API on completion (which picks it up as a validation error).

Add temp logging to see if this is in fact the case. If it is, I can sanitise the postcodes sent back as match-back data from the API (I would have logged this out in the API but doing it in the Rails app is far easier! ☹️)