### PR TITLE
Create a blocks component for homepage and mailinglist content

### DIFF
--- a/app/components/content/generic_block_component.html.erb
+++ b/app/components/content/generic_block_component.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div(class: classes) do %>
+  <%= icon %>
+  <%= tag.h3(title) %>
+  <%= content %>
+<% end %>

--- a/app/components/content/generic_block_component.rb
+++ b/app/components/content/generic_block_component.rb
@@ -1,0 +1,18 @@
+module Content
+  class GenericBlockComponent < ViewComponent::Base
+    attr_reader :title, :classes
+
+    def initialize(title:, icon_image:, icon_alt:, classes: [])
+      @title      = title
+      @icon_image = icon_image
+      @icon_alt   = icon_alt
+      @classes    = classes
+    end
+
+    def icon
+      tag.div(class: "blocks__icon") do
+        image_pack_tag(@icon_image, alt: @icon_alt)
+      end
+    end
+  end
+end

--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -1,0 +1,70 @@
+$px-either-side-of-content: 15px;
+$space-between-sections: 3.7em;
+
+// blocks is a utility class that allows a several
+// items of block content on a page; on desktop they'll
+// be in a row and on mobile in a column
+.blocks {
+  display: flex;
+  gap: 1em;
+
+  // This is a fix to make IE display the content
+  // centrally.
+  margin: $space-between-sections auto 0;
+  @supports (display: grid) {
+    margin: $space-between-sections $px-either-side-of-content 0;
+  }
+
+  > * {
+    flex: 1 0;
+
+    // this can be deleted once gap is supported by
+    // Safari, it's currently only in the TP (tech preview)
+    // build https://caniuse.com/?search=gap
+    @include safari-only {
+      margin: .3em;
+    }
+
+    @include ie-only {
+      margin: .3em;
+    }
+  }
+
+  @include mq($until: tablet) {
+    flex-direction: column;
+    margin: 1em;
+  }
+
+  &__directory {
+    border: 3px solid $purple;
+    padding: 1em;
+
+    h3 {
+      font-size: size('small');
+      margin: .2em auto .1em;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+
+      li > a {
+        font-size: size('xsmall');
+        color: $black;
+        line-height: 1.8em;
+        text-underline-offset: .2em;
+
+        &:hover {
+          color: $purple;
+          text-decoration: underline;
+          text-decoration-thickness: .12em;
+        }
+      }
+    }
+  }
+
+  &__icon {
+    // placeholders for now
+    font-size: size('xlarge');
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -24,6 +24,7 @@
 @import 'page-helpful';
 @import 'call-to-action';
 @import 'accordion';
+@import 'blocks';
 @import 'search-page' ;
 
 @import './sections/hero';

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -1,6 +1,3 @@
-$px-either-side-of-content: 15px;
-$space-between-sections: 3.7em;
-
 main.home {
   // the homepage is a few px wider than the regular max width so we can
   // make things overhang if neccessary
@@ -25,33 +22,6 @@ main.home {
 
   &.steps-to-become-a-teacher {
     width: 100%;
-  }
-
-  &.blocks {
-    display: flex;
-    gap: 1em;
-
-    // This is a fix to make IE display the content
-    // centrally.
-    margin: $space-between-sections auto 0;
-    @supports (display: grid) {
-      margin: $space-between-sections $px-either-side-of-content 0;
-    }
-
-    > * {
-      flex: 1 0;
-
-      // this can be deleted once gap is supported by
-      // Safari, it's currently only in the TP (tech preview)
-      // build https://caniuse.com/?search=gap
-      @include safari-only {
-        margin: .3em;
-      }
-
-      @include ie-only {
-        margin: .3em;
-      }
-    }
   }
 }
 
@@ -191,45 +161,5 @@ main.home {
     }
 
     &__cta { grid-area: 4 / 1 / 5 / 2; }
-  }
-}
-
-.blocks {
-  @include mq($until: tablet) {
-    flex-direction: column;
-    margin: 1em;
-  }
-
-  &__directory {
-    border: 3px solid $purple;
-    padding: 1em;
-
-    h3 {
-      font-size: size('small');
-      margin: .2em auto .1em;
-    }
-
-    ul {
-      list-style: none;
-      padding: 0;
-
-      li > a {
-        font-size: size('xsmall');
-        color: $black;
-        line-height: 1.8em;
-        text-underline-offset: .2em;
-
-        &:hover {
-          color: $purple;
-          text-decoration: underline;
-          text-decoration-thickness: .12em;
-        }
-      }
-    }
-  }
-
-  &__icon {
-    // placeholders for now
-    font-size: size('xlarge');
   }
 }

--- a/spec/components/content/generic_block_component_spec.rb
+++ b/spec/components/content/generic_block_component_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe Content::GenericBlockComponent, type: "component" do
+  let(:title) { "Block of content" }
+  let(:content) { "Some content" }
+  let(:icon_image) { "icon-school-black.svg" }
+  let(:icon_alt) { "description of image" }
+  let(:custom_class) { "purple" }
+
+  subject! do
+    render_inline(described_class.new(title: title, icon_image: icon_image, icon_alt: icon_alt, classes: Array.wrap(custom_class))) do
+      content
+    end
+    page
+  end
+
+  it { is_expected.to have_css("div.#{custom_class}") }
+  it { is_expected.to have_css("h3", text: title) }
+  it { is_expected.to have_content(content) }
+  it { is_expected.to have_css(%(img[alt="#{icon_alt}"])) }
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/r88Wbdey/1314-re-add-cta-style-content-to-the-mailing-list-completion-page

### Context and changes

The content on the homepage with calls to action and mini 'directories' should be reusable anywhere. There's a want to add some informative blocks of content to the mailing list completion page.

This change paves the way by implementing a _very basic_ view component that lays out content with a icon, title and some arbitrary HTML:
![Screenshot from 2021-02-19 11-45-01](https://user-images.githubusercontent.com/128088/108500742-283b9e00-72a8-11eb-9d51-e6e95ba10cc5.png)

There's no visible changes yet and this work won't have any impact on the site until we start using it.