### PR TITLE
Add some left/right margin around blocks on mob

### DIFF
--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -39,6 +39,10 @@ $space-between-sections: 3.7em;
     border: 3px solid $purple;
     padding: 1em;
 
+    @include mq($until: tablet) {
+      margin: 0 $indent-amount;
+    }
+
     h3 {
       font-size: size('small');
       margin: .2em auto .1em;


### PR DESCRIPTION
Minor fix to the CSS, adds a little left/right margin on mobile:

![Screenshot from 2021-02-19 14-50-01](https://user-images.githubusercontent.com/128088/108519664-c4be6a00-72c1-11eb-9382-ebe37219c0c7.png)

