### PR TITLE
Tweak grid so the arrows don't overlap the image

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -121,7 +121,7 @@ $mobile-cutoff: 800px;
       }
 
       &__content {
-        grid-area: 5 / 1 / 7 / 5;
+        grid-area: 5 / 1 / 7 / 4;
       }
 
       &__img {
@@ -131,7 +131,7 @@ $mobile-cutoff: 800px;
 
     @include mq($from: wide) {
       &__content {
-        grid-area: 5 / 2 / 7 / 5;
+        grid-area: 5 / 2 / 7 / 4;
       }
     }
   }


### PR DESCRIPTION
Quick CSS tweak, at some point the image was widened but the content container wasn't made narrower.


https://user-images.githubusercontent.com/128088/108528982-e6245380-72cb-11eb-8dd0-0550b1cc2d94.mp4


