### PR TITLE
Log full API request response models

### DIFF
--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -1,3 +1,5 @@
+require "attribute_filter"
+
 module Events
   class Wizard < ::Wizard::Base
     include ::Wizard::ApiClientSupport
@@ -22,8 +24,7 @@ module Events
     def exchange_access_token(timed_one_time_password, request)
       @api ||= GetIntoTeachingApiClient::TeachingEventsApi.new
       response = @api.exchange_access_token_for_teaching_event_add_attendee(timed_one_time_password, request)
-      # TEMP: debugging invalid postcode issue
-      Rails.logger.info("Events::Wizard#exchange_access_token with postcode: #{response.address_postcode}")
+      Rails.logger.info("Events::Wizard#exchange_access_token: #{AttributeFilter.filtered_json(response)}")
       response
     end
 
@@ -32,8 +33,7 @@ module Events
     def add_attendee_to_event
       request = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::TeachingEventsApi.new
-      # TEMP: debugging invalid postcode issue
-      Rails.logger.info("Events::Wizard#add_attendee_to_event with postcode: #{request.address_postcode}")
+      Rails.logger.info("Events::Wizard#add_attendee_to_event: #{AttributeFilter.filtered_json(request)}")
       api.add_teaching_event_attendee(request)
     end
   end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -1,3 +1,5 @@
+require "attribute_filter"
+
 module MailingList
   class Wizard < ::Wizard::Base
     include ::Wizard::ApiClientSupport
@@ -25,8 +27,7 @@ module MailingList
     def exchange_access_token(timed_one_time_password, request)
       @api ||= GetIntoTeachingApiClient::MailingListApi.new
       response = @api.exchange_access_token_for_mailing_list_add_member(timed_one_time_password, request)
-      # TEMP: debugging invalid postcode issue
-      Rails.logger.info("MailingList::Wizard#exchange_access_token with postcode: #{response.address_postcode}")
+      Rails.logger.info("MailingList::Wizard#exchange_access_token: #{AttributeFilter.filtered_json(response)}")
       response
     end
 
@@ -34,7 +35,9 @@ module MailingList
 
     def exchange_magic_link_token(token)
       api = GetIntoTeachingApiClient::MailingListApi.new
-      api.exchange_magic_link_token_for_mailing_list_add_member(token)
+      response = api.exchange_magic_link_token_for_mailing_list_add_member(token)
+      Rails.logger.info("MailingList::Wizard#exchange_magic_link_token: #{AttributeFilter.filtered_json(response)}")
+      response
     end
 
   private
@@ -42,8 +45,7 @@ module MailingList
     def add_member_to_mailing_list
       request = GetIntoTeachingApiClient::MailingListAddMember.new(export_camelized_hash)
       api = GetIntoTeachingApiClient::MailingListApi.new
-      # TEMP: debugging invalid postcode issue
-      Rails.logger.info("MailingList::Wizard#add_mailing_list_member with postcode: #{request.address_postcode}")
+      Rails.logger.info("MailingList::Wizard#add_mailing_list_member: #{AttributeFilter.filtered_json(request)}")
       api.add_mailing_list_member(request)
     end
   end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -8,4 +8,7 @@ Rails.application.config.filter_parameters += %i[
   password
   telephone
   timed_one_time_password
+  firstName
+  lastName
+  timedOneTimePassword
 ]

--- a/lib/attribute_filter.rb
+++ b/lib/attribute_filter.rb
@@ -1,0 +1,7 @@
+module AttributeFilter
+  def self.filtered_json(obj)
+    filters = Rails.application.config.filter_parameters
+    param_filter = ActiveSupport::ParameterFilter.new(filters)
+    param_filter.filter(obj.to_hash).to_json
+  end
+end

--- a/spec/lib/attribute_filter_spec.rb
+++ b/spec/lib/attribute_filter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require "attribute_filter"
+
+describe AttributeFilter, type: :helper do
+  describe ".filtered_json" do
+    let(:model) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", telephone: "1234567") }
+    let(:expected_json) { { "candidateId" => "123", "telephone" => "[FILTERED]" }.to_json }
+
+    subject { described_class.filtered_json(input) }
+
+    context "with an object" do
+      let(:input) { model }
+
+      it { is_expected.to eq(expected_json) }
+    end
+
+    context "with a hash" do
+      let(:input) { model.to_hash }
+
+      it { is_expected.to eq(expected_json) }
+    end
+  end
+end

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -48,13 +48,19 @@ describe MailingList::StepsController do
       end
 
       before do
-        expect_any_instance_of(MailingList::Wizard).to \
-          receive(:exchange_magic_link_token).with(token) { stub_response }
+        expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+          receive(:exchange_magic_link_token_for_mailing_list_add_member).with(token) { stub_response }
+        allow(Rails.logger).to receive(:info)
         get step_path
         follow_redirect!
       end
 
       it { is_expected.to redirect_to(mailing_list_step_path(:degree_status)) }
+
+      it "logs the response model (filtering sensitive attributes)" do
+        filtered_json = { "candidateId" => "abc123", "email" => "[FILTERED]", "firstName" => "[FILTERED]", "lastName" => "[FILTERED]" }.to_json
+        expect(Rails.logger).to have_received(:info).with("MailingList::Wizard#exchange_magic_link_token: #{filtered_json}")
+      end
     end
 
     context "when the token is not valid" do


### PR DESCRIPTION
- Filter additional parameters

When we start logging the API client request/response models they will contain camel case versions of attributes we should filter (firstName, lastName and timedOneTimePassword).

As we are going to use the global `filter_parameters` to sanitize before logging, this commit updates the list to include the camel case versions.

- Add AttribtueFilter to sanitize logging objects/hashes

Rails takes care of filtering out sensitive attribute values from the request parameters, however it does not apply the filters to our direct logging.

Adds a helper that will enable us to filter parameters in an object/hash before logging it out.

- Update logging to include full request/response models

We were logging the postcode in an attempt to diagnose a 400 error we receive from the API on some requests. It turns out the postcodes themselves are valid, so it may be other attributes contributing to the failure.

Log out the entire request/response, with sensitive data filtered.
