### PR TITLE
Add content blocks to the mailing list final page

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -78,8 +78,8 @@
 
     <%= render Content::GenericBlockComponent.new(
       title: "Speak to teachers",
-      icon_image: "icon-school-black.svg",
-      icon_alt: "mortarboard icon",
+      icon_image: "icon-git-black.svg",
+      icon_alt: "site icon logo checkmark",
       classes: "blocks__directory"
     ) do %>
       <p class="block__text">

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -77,13 +77,13 @@
     <% end %>
 
     <%= render Content::GenericBlockComponent.new(
-      title: "Learn more in person",
+      title: "Speak to teachers",
       icon_image: "icon-school-black.svg",
       icon_alt: "mortarboard icon",
       classes: "blocks__directory"
     ) do %>
       <p class="block__text">
-        Attend an event and speak to real teachers or get your
+        Attend an event and speak to current teachers or get your
         questions answered by our expert advisers. You can
         also find out what it's like to train and be in the
         classroom.

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -43,3 +43,53 @@
 
   <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
 </section>
+
+<section class="supplementary">
+
+
+<%= content_for(:feature) do %>
+  <div class="blocks">
+    <%= render Content::GenericBlockComponent.new(
+      title: "Life as a teacher",
+      icon_image: "icon-school-black.svg",
+      icon_alt: "mortarboard icon",
+      classes: "blocks__directory"
+    ) do %>
+      <ul>
+        <li><a href="/my-story-into-teaching">Read teachers' stories</a></li>
+        <li><a href="https://schoolexperience.education.gov.uk/">Experience a real school</a></li>
+        <li><a href="/salaries-and-benefits">Teachers' salaries</a></li>
+      </ul>
+    <% end %>
+
+    <%= render Content::GenericBlockComponent.new(
+      title: "Your next steps",
+      icon_image: "icon-doc-black.svg",
+      icon_alt: "icon containing learning materials",
+      classes: "blocks__directory"
+    ) do %>
+      <ul>
+        <li><a href="/steps-to-become-a-teacher">How to become a teacher</a></li>
+        <li><a href="/ways-to-train">Explore ways to train</a></li>
+        <li><a href="/funding-your-training">Find your funding options</a></li>
+        <li><a href="/returning-to-teaching">Returning to teaching</a></li>
+      </ul>
+    <% end %>
+
+    <%= render Content::GenericBlockComponent.new(
+      title: "Learn more in person",
+      icon_image: "icon-school-black.svg",
+      icon_alt: "mortarboard icon",
+      classes: "blocks__directory"
+    ) do %>
+      <p class="block__text">
+        Attend an event and speak to real teachers or get your
+        questions answered by our expert advisers. You can
+        also find out what it's like to train and be in the
+        classroom.
+      </p>
+
+      <%= link_to "Find an event", events_path, class: "button button--white button--unpadded" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -72,7 +72,6 @@
         <li><a href="/steps-to-become-a-teacher">How to become a teacher</a></li>
         <li><a href="/ways-to-train">Explore ways to train</a></li>
         <li><a href="/funding-your-training">Find your funding options</a></li>
-        <li><a href="/returning-to-teaching">Returning to teaching</a></li>
       </ul>
     <% end %>
 

--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -65,6 +65,10 @@ $space-between-sections: 3.7em;
         }
       }
     }
+
+    p {
+      font-size: size('xsmall');
+    }
   }
 
   &__icon {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -45,6 +45,10 @@ a {
     @include button($bg: $white, $fg: $black);
     @include chevron($color: $black);
   }
+
+  &--unpadded {
+    padding: 0;
+  }
 }
 
 .call-to-action-icon-button {


### PR DESCRIPTION
### Trello card

https://trello.com/c/r88Wbdey/1314-re-add-cta-style-content-to-the-mailing-list-completion-page

### Context and changes

The three cards that were on this page were removed some time ago as the content was also removed from the homepage. This change adds some new content here that should hopefully signpost users onto the next step in their journey.

![Screenshot from 2021-02-22 14-23-26](https://user-images.githubusercontent.com/128088/108721271-b8cce500-7519-11eb-8540-54989a9b50c5.png)

