### PR TITLE
Remove the semantic scaffolding class

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%= yield :hero %>
     <%= render Navigation::BreadcrumbComponent.new %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="container">
         <% unless @fullwidth %>
           <aside></aside>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     <% end %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="container">
         <article class="markdown hero-nav">
           <%= yield %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -13,7 +13,7 @@
     <%= render Sections::HeroComponent.new(@front_matter) %>
     <%= render Navigation::BreadcrumbComponent.new %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="container">
         <% if !@front_matter["image"] %>
           <header>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -14,7 +14,7 @@
     <%= render Sections::HeroComponent.new(@front_matter) %>
     <%= render Navigation::BreadcrumbComponent.new %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="container">
         <article class="markdown disclaimer fullwidth">
           <% if !@front_matter["image"] %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -13,7 +13,7 @@
     <%= yield :hero %>
     <%= render Navigation::BreadcrumbComponent.new %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="container">
         <article class="markdown<%= " fullwidth" if @before_search_fullwidth %> ">
           <%= yield :before_search %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -12,7 +12,7 @@
 
     <%= render Sections::HeroComponent.new(@front_matter) %>
 
-    <main class="semantic home" role="main" id="main-content">
+    <main class="home" role="main" id="main-content">
       <% @front_matter["content"]&.each do |partial| %>
         <%= render(partial) %>
       <% end %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -10,7 +10,7 @@
 
     <%= render "sections/header" %>
 
-    <main class="semantic" role="main" id="main-content">
+    <main role="main" id="main-content">
       <section class="feature registration container">
         <%= yield %>
         <%= render "sections/page_helpful" unless @hide_page_helpful_question %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -6,7 +6,7 @@
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <%= render Navigation::BreadcrumbComponent.new %>
 
-      <main class="semantic story-landing" role="main" id="main-content">
+      <main class="story-landing" role="main" id="main-content">
         <section class="container">
           <section class="stories-feature">
             <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -5,7 +5,7 @@
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <%= render Navigation::BreadcrumbComponent.new %>
-      <main role="main" class="semantic" id="main-content">
+      <main role="main" id="main-content">
         <section class="container">
           <article class="markdown fullwidth">
             <%= yield %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
-      <main class="semantic" role="main" id="main-content">
+      <main role="main" id="main-content">
         <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
           <%= render Navigation::BreadcrumbComponent.new %>
           <%= yield %>

--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -11,8 +11,11 @@ $space-between-sections: 3.7em;
   // This is a fix to make IE display the content
   // centrally.
   margin: $space-between-sections auto 0;
-  @supports (display: grid) {
-    margin: $space-between-sections $px-either-side-of-content 0;
+
+  &.homepage-feature {
+    @supports (display: grid) {
+      margin: $space-between-sections $px-either-side-of-content 0;
+    }
   }
 
   > * {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -39,7 +39,7 @@ main,
 
 $content-max-width: 1000px;
 
-main.semantic {
+main {
   margin-bottom: 3em;
 
   @include mq($from: tablet) {


### PR DESCRIPTION
Now the non-semantic main styles are gone we don't need to refer to the semantic ones by name any more.

I've checked this quite thoroughly and everything looks identical. We now only have `main` CSS rules in `layout.scss` and `home.scss` and the only class on any of the `main` elements in the app is `home` on the homepage layout.