### PR TITLE
Rename online events to online Q&As

### DIFF
--- a/app/components/events/event_box_component.html.erb
+++ b/app/components/events/event_box_component.html.erb
@@ -10,7 +10,7 @@
     <%= divider %>
 
     <footer class="event-box__footer">
-      <% if type && type != GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] %>
+      <% if show_category? %>
         <div class="event-box__footer__item">
           <div class="event-box__footer__icon-wrapper">
             <%= event_type_icon %>

--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -7,6 +7,14 @@ module Events
     alias_method :virtual?, :virtual
 
     def initialize(event)
+      # An event can have three different 'states':
+      # - Offline (in person)
+      #   - is_online == false && is_virtual == false
+      # - Moved online (online, but has an associated building - aka virtual)
+      #   - is_online == true && is_virtual == true
+      # - Online (fully online with no building)
+      #   - is_online == true && is_virtual == false
+
       @event       = event
       @title       = event.name
       @type        = event.type_id
@@ -51,10 +59,18 @@ module Events
       "Online event"
     end
 
+    def show_category?
+      type && !is_online_event_category?
+    end
+
   private
 
     def event_box_footer_icon_class
       "event-box__footer__icon"
+    end
+
+    def is_online_event_category?
+      type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
     end
   end
 end

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -1,7 +1,6 @@
 class EventCategoriesController < ApplicationController
-  before_action -> { @period = :past }, only: %i[show_archive]
-  before_action -> { @period = :future }, only: %i[show]
-  before_action :load_type, :load_events, :set_form_action
+  before_action :load_type
+  before_action :set_form_action
   layout "events"
 
   breadcrumb "events.search", :events_path
@@ -11,21 +10,33 @@ class EventCategoriesController < ApplicationController
 
   def show
     @show_archive_link = has_archive?(@type)
+
+    @category_name = helpers.pluralised_category_name(@type.id)
+    @page_title = @category_name
+
+    load_events(:future)
   end
 
   def show_archive
-    raise_not_found && return unless has_archive?(@type)
+    raise_not_found unless has_archive?(@type)
 
-    category_name = t("event_types.#{@type.id}.name.plural")
-    breadcrumb category_name, event_category_path(category_name.parameterize)
+    @category_name = helpers.past_category_name(@type.id)
+    @page_title = @category_name
+
+    load_events(:past)
+
+    future_events_category_name = helpers.pluralised_category_name(@type.id)
+    breadcrumb \
+      future_events_category_name,
+      event_category_path(future_events_category_name.parameterize)
 
     render :show
   end
 
 private
 
-  def load_events
-    @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: @period))
+  def load_events(period)
+    @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: period))
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
     group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
     events_of_type = group_presenter.sorted_events_of_type(@type.id)
@@ -37,7 +48,7 @@ private
       I18n.t("event_types.#{type.id}.name.plural").parameterize == params[:id]
     end
 
-    raise_not_found && return if @type.nil?
+    raise_not_found if @type.nil?
   end
 
   def set_form_action

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -91,11 +91,8 @@ module EventsHelper
     t("event_types.#{type_id}.name.plural")
   end
 
-  def past_category_name(category_name)
-    if category_name.downcase.include? "online"
-      "Past online events"
-    else
-      "Past #{category_name}"
-    end
+  def past_category_name(type_id)
+    t "event_types.#{type_id}.name.past",
+      default: "Past " + pluralised_category_name(type_id)
   end
 end

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -1,18 +1,15 @@
-<% category_name = pluralised_category_name(@type.id) %>
-<% category_name = past_category_name(category_name) if @period == :past %>
 <% @search_component = Events::SearchComponent.new(
         @event_search,
         @form_action.to_s,
         include_type: false,
-        heading: "Search for #{category_name}",
+        heading: "Search for #{@category_name}",
         allow_blank_month: true,
       )
 %>
-<% @page_title = category_name %>
 
 <% content_for :hero do %>
   <%= render Sections::HeroComponent.new(
-      title: category_name,
+      title: @category_name,
       image: "media/images/events-hero-dt.jpg")
   %>
 <% end %>
@@ -35,15 +32,19 @@
 </div>
 <% else %>
   <%= render(Events::NoResultsComponent.new) do %>
-    Sorry your search has not found any events, try a different location or month. <%= link_to("Search for another event type", events_path) %></a>.
+    Sorry your search has not found any events, try a different location or month.
+    <%= link_to("Search for another event type", events_path) %>.
   <% end %>
 <% end %>
 
 <% if @show_archive_link %>
   <div class="event-content-cta content-cta">
-    <h2> <%= past_category_name(category_name) %> </h2>
+    <h2><%= past_category_name(@type.id) %></h2>
     <p>
-      You can see <%= past_category_name(category_name).downcase %>, including all questions and answers, <%= link_to("on this page", archive_event_category_path(pluralised_category_name(@type.id).parameterize)) %>
+      You can see <%= past_category_name(@type.id).downcase %>, including
+      all questions and answers,
+      <%= link_to "on this page",
+                  archive_event_category_path(pluralised_category_name(@type.id).parameterize) %>
     </p>
   </div>
 <% end %>

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -85,6 +85,13 @@
   height: 32px;
 }
 
+.icon-online-q-a {
+  @include icon;
+  background-image: url("../images/icon-online-blue.svg");
+  width: 34px;
+  height: 34px;
+}
+
 .icon-quote {
   @include icon;
   background-image: url("../images/white-quote.svg");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,9 +71,9 @@ en:
         will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
     222750008:
       name:
-        singular: "Online event"
-        plural: "Online events"
-        past: "Past online events"
+        singular: "Online Q&A"
+        plural: "Online Q&As"
+        past: "Past online Q&As"
       description: |-
         In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
         Get fast answers to your questions so you can take the next step to becoming a teacher.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       name:
         singular: "Online event"
         plural: "Online events"
+        past: "Past online events"
       description: |-
         In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
         Get fast answers to your questions so you can take the next step to becoming a teacher.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # Needs to have higher priority to redirect the category
+  get "event-categories/online-events", to: redirect("/event-categories/online-q-as")
+  get "event-categories/online-events/archive", to: redirect("/event-categories/online-q-as/archive")
+
   resources :event_categories, only: %i[show], path: "event-categories" do
     member do
       get "archive", to: "event_categories#show_archive"

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -89,7 +89,7 @@ describe Events::EventBoxComponent, type: "component" do
     end
 
     specify %(the box should have the right type of divider) do
-      expect(page).to have_css(%(.event-box__divider.event-box__divider--online-event))
+      expect(page).to have_css(%(.event-box__divider.event-box__divider--online-q-a))
     end
   end
 

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -10,11 +10,11 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has an event type icon" do
-    expect(page).to have_css("div.icon-online-event")
+    expect(page).to have_css("div.icon-online-q-a")
   end
 
   it "has a heading" do
-    expect(page).to have_css("h5", text: "Online events")
+    expect(page).to have_css("h5", text: "Online Q&As")
   end
 
   it "has a description" do
@@ -22,6 +22,6 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has a read more link" do
-    expect(page).to have_link("Read more", href: "/event-categories/online-events", class: "type-description__link")
+    expect(page).to have_link("Read more", href: "/event-categories/online-q-as", class: "type-description__link")
   end
 end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -65,9 +65,9 @@ RSpec.feature "Finding an event", type: :feature do
   end
 
   scenario "Searching events within a category" do
-    visit event_category_path("online-events")
+    visit event_category_path("online-q-as")
 
-    expect(page).to have_text "Search for Online events"
+    expect(page).to have_text "Search for Online Q&As"
 
     click_on "Update results"
 
@@ -78,6 +78,6 @@ RSpec.feature "Finding an event", type: :feature do
       click_on "on this page"
     end
 
-    expect(page).to have_text "Search for Past online events"
+    expect(page).to have_text "Search for Past online Q&As"
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -185,11 +185,11 @@ describe EventsHelper, type: "helper" do
 
   describe "#past_category_name" do
     it "returns 'Past online events' if the category name contains 'online'" do
-      expect(past_category_name("Online events")).to eql("Past online events")
+      expect(past_category_name(222_750_008)).to eql("Past online events")
     end
 
     it "returns the category name with 'Past' prepended if the category name does not contain 'online'" do
-      expect(past_category_name("Train to Teach events")).to eql("Past Train to Teach events")
+      expect(past_category_name(222_750_001)).to eql("Past Train to Teach events")
     end
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -120,7 +120,7 @@ describe EventsHelper, type: "helper" do
     it "returns blue for non-train to teach events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
       expect(event_type_color(type_id)).to eq("blue")
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University Events"]
+      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University event"]
       expect(event_type_color(type_id)).to eq("blue")
     end
   end
@@ -174,7 +174,7 @@ describe EventsHelper, type: "helper" do
   describe "#pluralised_category_name" do
     {
       222_750_001 => "Train to Teach events",
-      222_750_008 => "Online events",
+      222_750_008 => "Online Q&As",
       222_750_009 => "School and University events",
     }.each do |type_id, name|
       specify "#{type_id} => #{name}" do
@@ -184,8 +184,8 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#past_category_name" do
-    it "returns 'Past online events' if the category name contains 'online'" do
-      expect(past_category_name(222_750_008)).to eql("Past online events")
+    it "returns 'Past online Q&As' if the category name contains 'online'" do
+      expect(past_category_name(222_750_008)).to eql("Past online Q&As")
     end
 
     it "returns the category name with 'Past' prepended if the category name does not contain 'online'" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -70,6 +70,22 @@ describe "View events by category" do
     end
   end
 
+  context "when viewing old online-events url" do
+    subject { response }
+
+    context "when current events" do
+      before { get event_category_path "online-events" }
+
+      it { is_expected.to redirect_to event_category_path "online-q-as" }
+    end
+
+    context "when archive events" do
+      before { get archive_event_category_path "online-events" }
+
+      it { is_expected.to redirect_to archive_event_category_path "online-q-as" }
+    end
+  end
+
   context "when viewing the schools and university events category" do
     let(:start_after) { DateTime.now.utc.beginning_of_day }
     let(:start_before) { start_after.advance(months: 5).end_of_month }

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -19,7 +19,7 @@ describe "View events by category" do
   end
 
   context "when viewing a category archive" do
-    let(:category) { "online-events" }
+    let(:category) { "online-q-as" }
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
@@ -29,7 +29,7 @@ describe "View events by category" do
     subject { response }
 
     it { is_expected.to have_http_status :success }
-    it { expect(response.body).to include "Past online events" }
+    it { expect(response.body).to include "Past online Q&amp;As" }
 
     it "displays all events in the category, ordered by date descending" do
       expect(response.body.scan(/Event \d/)).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -79,7 +79,7 @@ describe "Find an event near you" do
         headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
         expected_headings = [
           "Train to Teach events",
-          "Online events",
+          "Online Q&amp;As",
           "School and University events",
         ]
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/qFdcdHa2

### Context

We are now calling online events, online Q&As

### Changes proposed in this pull request

1. Some refactoring - moving variable names and simplifying tests
2. Changed the category name
3. Redirect the old category name

### Review notes

There's a few different refactors in here - they are each split out as their own commit so I can submit them as separate PRs if thats easier?

The `EventBoxComponent` spec changes do drop 3 tests. When I expanded it out I found 1 test checking for an empty string, 1 test running, but the expectation inside it not running because of the conditional, and 2 tests both check for the presence of the 'Online event' text - instead I've change that to be a check that theres only 1 footer item for online events
