### PR TITLE
Add CTA injector to markdown handler

### DIFF
--- a/app/components/calls_to_action/renderer_component.rb
+++ b/app/components/calls_to_action/renderer_component.rb
@@ -34,8 +34,6 @@ module CallsToAction
     #
     # cta: my_call_to_action
     def basic_call_to_action_component
-      return if @params.blank?
-
       CALLS_TO_ACTION.fetch(@params).new
     rescue KeyError
       fail(ArgumentError, "call to action not registered: #{@params}")
@@ -49,8 +47,6 @@ module CallsToAction
     #     colour: purple
     #     size: massive
     def advanced_call_to_action_component
-      return if @params.blank?
-
       CALLS_TO_ACTION
         .fetch(@params.fetch("name"))
         .new(**@params.fetch("arguments").symbolize_keys)

--- a/app/components/calls_to_action/renderer_component.rb
+++ b/app/components/calls_to_action/renderer_component.rb
@@ -1,0 +1,61 @@
+module CallsToAction
+  class RendererComponent < ViewComponent::Base
+    CALLS_TO_ACTION = {
+      "simple" => CallsToAction::SimpleComponent,
+      "chat_online" => CallsToAction::ChatOnlineComponent,
+      "story" => CallsToAction::StoryComponent,
+      "next_steps" => CallsToAction::NextStepsComponent,
+      "multiple_buttons" => CallsToAction::MultipleButtonsComponent,
+    }.freeze
+
+    def initialize(params)
+      @params = params
+    end
+
+    def render?
+      @params.present?
+    end
+
+    def call
+      render(build)
+    end
+
+  private
+
+    def build
+      if @params.is_a?(Hash)
+        advanced_call_to_action_component
+      else
+        basic_call_to_action_component
+      end
+    end
+
+    # when the CTA is some static HTML and invoked by name with no args
+    #
+    # cta: my_call_to_action
+    def basic_call_to_action_component
+      return if @params.blank?
+
+      CALLS_TO_ACTION.fetch(@params).new
+    rescue KeyError
+      fail(ArgumentError, "call to action not registered: #{@params}")
+    end
+
+    # when the CTA is configurable and is defined in the following format:
+    #
+    # cta:
+    #   name: my_call_to_action
+    #   arguments:
+    #     colour: purple
+    #     size: massive
+    def advanced_call_to_action_component
+      return if @params.blank?
+
+      CALLS_TO_ACTION
+        .fetch(@params.fetch("name"))
+        .new(**@params.fetch("arguments").symbolize_keys)
+    rescue KeyError
+      fail(ArgumentError, "call to action not properly configured: #{@params}")
+    end
+  end
+end

--- a/app/components/content/accordion_component.rb
+++ b/app/components/content/accordion_component.rb
@@ -32,54 +32,6 @@ module Content
 
     class ComposableSlot < ViewComponent::Slot
       attr_reader :call_to_action
-
-      # Calls to action (poppers) are 'registered' here and can
-      # be specified via FrontMatter
-      CALLS_TO_ACTION = {
-        "simple" => CallsToAction::SimpleComponent,
-        "chat_online" => CallsToAction::ChatOnlineComponent,
-        "story" => CallsToAction::StoryComponent,
-        "next_steps" => CallsToAction::NextStepsComponent,
-        "multiple_buttons" => CallsToAction::MultipleButtonsComponent,
-      }.freeze
-
-      def build(call_to_action)
-        @call_to_action = if call_to_action.is_a?(Hash)
-                            advanced_call_to_action_component(call_to_action)
-                          else
-                            basic_call_to_action_component(call_to_action)
-                          end
-      end
-
-    private
-
-      # when the CTA is some static HTML and invoked by name with no args
-      #
-      # cta: my_call_to_action
-      def basic_call_to_action_component(call_to_action)
-        return if call_to_action.blank?
-
-        CALLS_TO_ACTION.fetch(call_to_action).new
-      rescue KeyError
-        fail(ArgumentError, "call to action not registered: #{call_to_action}")
-      end
-
-      # when the CTA is configurable and is defined in the following format:
-      #
-      # cta:
-      #   name: my_call_to_action
-      #   arguments:
-      #     colour: purple
-      #     size: massive
-      def advanced_call_to_action_component(call_to_action)
-        return if call_to_action.blank?
-
-        CALLS_TO_ACTION
-          .fetch(call_to_action.fetch("name"))
-          .new(**call_to_action.fetch("arguments").symbolize_keys)
-      rescue KeyError
-        fail(ArgumentError, "call to action properly configured: #{call_to_action}")
-      end
     end
 
     class Step < ComposableSlot
@@ -87,7 +39,7 @@ module Content
 
       def initialize(title:, call_to_action: nil)
         @title = title
-        @call_to_action = build(call_to_action)
+        @call_to_action = CallsToAction::RendererComponent.new(call_to_action)
       end
     end
 
@@ -95,7 +47,7 @@ module Content
       attr_accessor :partial
 
       def initialize(call_to_action: nil, partial: nil)
-        @call_to_action = build(call_to_action)
+        @call_to_action = CallsToAction::RendererComponent.new(call_to_action)
         @partial = partial
       end
     end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -55,13 +55,15 @@ module TemplateHandlers
       add_acronyms autolink_html render_markdown
     end
 
+    # rubocop:disable Style/PerlBackrefs
     def markdown
-      parsed.content.tap do |body|
-        body.scan(/(\$[A-z0-9-]+\$)/).flatten.each do |placeholder|
-          body.gsub!(placeholder, call_to_action)
-        end
-      end
+      # use $1 rather than a block argument here because gsub assigns the
+      # entire placeholder to the arg (including dollar symbols) but we only
+      # want what's inside the capture group
+
+      parsed.content.gsub(/\$([A-z0-9-]+)\$/) { call_to_action($1) }
     end
+    # rubocop:enable Style/PerlBackrefs
 
     def call_to_action(placeholder)
       ApplicationController.render(CallsToAction::RendererComponent.new(front_matter.dig("calls_to_action", placeholder)))

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -63,8 +63,8 @@ module TemplateHandlers
       end
     end
 
-    def call_to_action
-      ApplicationController.render(CallsToAction::ChatOnlineComponent.new)
+    def call_to_action(placeholder)
+      ApplicationController.render(CallsToAction::RendererComponent.new(front_matter.dig("calls_to_action", placeholder)))
     end
 
     def front_matter

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -56,7 +56,15 @@ module TemplateHandlers
     end
 
     def markdown
-      parsed.content
+      parsed.content.tap do |body|
+        body.scan(/(\$[A-z0-9-]+\$)/).flatten.each do |placeholder|
+          body.gsub!(placeholder, call_to_action)
+        end
+      end
+    end
+
+    def call_to_action
+      ApplicationController.render(CallsToAction::ChatOnlineComponent.new)
     end
 
     def front_matter

--- a/spec/components/calls_to_action/renderer_component_spec.rb
+++ b/spec/components/calls_to_action/renderer_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CallsToAction::RendererComponent, type: :component do
+  {
+    "simple component" => {
+      "name" => "simple",
+      "arguments" => {
+        "title" => "simple component",
+        "link_target" => "#simple-component",
+        "link_text" => "simple component link",
+        "icon" => "icon-person",
+      },
+    },
+    "chat online component" => "chat_online",
+    "next steps component" => "next_steps",
+    "story component" => {
+      "name" => "story",
+      "arguments" => {
+        "name" => "story component",
+        "link" => "/story/component",
+        "text" => "this is a story component",
+        "heading" => "story component heading",
+        "image" => "chat-online-card.jpg",
+      },
+    },
+  }.each do |name, meta|
+    describe "rendering a #{name}" do
+      let(:component) { described_class.new(meta) }
+      before { render_inline(component) }
+
+      specify "renders the #{name} component correctly" do
+        expect(page).to have_css(".call-to-action")
+      end
+    end
+  end
+end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -193,6 +193,7 @@ describe TemplateHandlers::Markdown, type: :view do
               "icon" => "icon-arrow",
             },
           },
+          "small-warning" => "chat_online",
         },
       }
     end
@@ -206,6 +207,10 @@ describe TemplateHandlers::Markdown, type: :view do
         $big-warning$
 
         Donec in leo enim. Mauris aliquet nulla dolor
+
+        $small-warning$
+
+        $one-that-does-not-exist$
       MARKDOWN
     end
 
@@ -219,7 +224,11 @@ describe TemplateHandlers::Markdown, type: :view do
     end
 
     specify "should render the component" do
-      expect(rendered).to have_css(".call-to-action")
+      expect(rendered).to have_css(".call-to-action", count: front_matter_with_calls_to_action["calls_to_action"].size)
+    end
+
+    specify "unregistered calls to action should be omitted" do
+      expect(rendered).not_to have_content(/one-that-does-not-exist/)
     end
   end
 end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -178,4 +178,41 @@ describe TemplateHandlers::Markdown, type: :view do
 
     it { is_expected.to have_css "abbr[title=\"Pay as you earn\"]", text: "PAYE" }
   end
+
+  describe "injecting rich content" do
+    let(:original_front_matter) do
+      {
+        "title": "Page with rich content (calls to action)",
+        "calls_to_action" => {
+          "big-warning" => {
+            name: "simple",
+            title: "be careful",
+            link_text: "something is about to happen",
+            link_target: "#",
+          },
+        },
+      }
+    end
+
+    let :markdown do
+      <<~MARKDOWN
+        # Some page
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing
+
+        $big-warning$
+
+        Donec in leo enim. Mauris aliquet nulla dolor
+      MARKDOWN
+    end
+
+    before do
+      stub_template "page_with_rich_content.md" => markdown
+      render template: "page_with_rich_content.md"
+    end
+
+    specify "should render the component" do
+      expect(rendered).to have_css(".call-to-action")
+    end
+  end
 end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -180,15 +180,18 @@ describe TemplateHandlers::Markdown, type: :view do
   end
 
   describe "injecting rich content" do
-    let(:original_front_matter) do
+    let(:front_matter_with_calls_to_action) do
       {
         "title": "Page with rich content (calls to action)",
         "calls_to_action" => {
           "big-warning" => {
-            name: "simple",
-            title: "be careful",
-            link_text: "something is about to happen",
-            link_target: "#",
+            "name" => "simple",
+            "arguments" => {
+              "title" => "be careful",
+              "link_text" => "something is about to happen",
+              "link_target" => "#",
+              "icon" => "icon-arrow",
+            },
           },
         },
       }
@@ -204,6 +207,10 @@ describe TemplateHandlers::Markdown, type: :view do
 
         Donec in leo enim. Mauris aliquet nulla dolor
       MARKDOWN
+    end
+
+    before do
+      allow(described_class).to receive(:global_front_matter).and_return(front_matter_with_calls_to_action)
     end
 
     before do


### PR DESCRIPTION
Currently we're breaking large documents up into little chunks so we can place _rich content_, aka calls to action, buttons and other bits of HTML amongst them.

This makes working with documents tricky as it's difficult to see them all at once, we end up flitting between several files.

This approach make the following improvement:

* CTA's can be _registered_ on a page by adding a `calls_to_action`
  section to the front matter
* the `calls_to_action` section will be a list of keys of arbitrary
  names where the value is the arguments required to generate the CTA
* the arbitrary names will need to be matched by placeholders in the
  document in order for the CTA to be injected in the right place
* placeholders will take the form: `$get-an-adviser$`
