### PR TITLE
Make the component renderer more generic

### DIFF
--- a/app/components/content/accordion_component.rb
+++ b/app/components/content/accordion_component.rb
@@ -39,7 +39,7 @@ module Content
 
       def initialize(title:, call_to_action: nil)
         @title = title
-        @call_to_action = CallsToAction::RendererComponent.new(call_to_action)
+        @call_to_action = Content::ComponentInjector.new(call_to_action).component
       end
     end
 
@@ -47,7 +47,7 @@ module Content
       attr_accessor :partial
 
       def initialize(call_to_action: nil, partial: nil)
-        @call_to_action = CallsToAction::RendererComponent.new(call_to_action)
+        @call_to_action = Content::ComponentInjector.new(call_to_action).component
         @partial = partial
       end
     end

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -66,7 +66,11 @@ module TemplateHandlers
     # rubocop:enable Style/PerlBackrefs
 
     def call_to_action(placeholder)
-      ApplicationController.render(CallsToAction::RendererComponent.new(front_matter.dig("calls_to_action", placeholder)))
+      component = Content::ComponentInjector.new(front_matter.dig("calls_to_action", placeholder)).component
+
+      return unless component
+
+      ApplicationController.render(component)
     end
 
     def front_matter

--- a/spec/presenters/content/component_injector_spec.rb
+++ b/spec/presenters/content/component_injector_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CallsToAction::RendererComponent, type: :component do
+RSpec.describe Content::ComponentInjector, type: :component do
   {
     "simple component" => {
       "name" => "simple",
@@ -25,12 +25,21 @@ RSpec.describe CallsToAction::RendererComponent, type: :component do
     },
   }.each do |name, meta|
     describe "rendering a #{name}" do
-      let(:component) { described_class.new(meta) }
-      before { render_inline(component) }
+      subject { described_class.new(meta).component }
 
-      specify "renders the #{name} component correctly" do
-        expect(page).to have_css(".call-to-action")
+      specify "generates a view component from the arguments" do
+        is_expected.to be_a(ViewComponent::Base)
       end
+    end
+  end
+
+  context "with invalid arguments" do
+    let(:invalid_args) do
+      { "story component" => { "name" => "story", "arguments" => { "something" => "story component" } } }
+    end
+
+    specify "raises an error describing bad config of the component" do
+      expect { described_class.new(invalid_args).component }.to raise_error(ArgumentError, /call to action not properly configured/)
     end
   end
 end


### PR DESCRIPTION
Now it can render types of component other than calls to action and it can handle arrays of arguments in addition to hashes of keyword args.