### PR TITLE
Add 3 purple box CTAs to event completion pages

### DIFF
--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -66,7 +66,7 @@
     classes: "blocks__directory"
   ) do %>
     <p class="block__text">
-      If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
+      If you're ready to get into teaching, you can get free, one-to-one, support from a dedicated, experienced teaching professional to guide you through the process. 
     </p>
 
     <%= link_to "Get an adviser", "/tta-service", class: "button button--white button--unpadded" %>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -31,3 +31,44 @@
         data-pinterest-action="track"
         data-pinterest-event="Event_Registrations"></span>
 </section>
+
+<div class="blocks">
+  <%= render Content::GenericBlockComponent.new(
+    title: "Life as a teacher",
+    icon_image: "icon-school-black.svg",
+    icon_alt: "mortarboard icon",
+    classes: "blocks__directory"
+  ) do %>
+    <ul>
+      <li><a href="/my-story-into-teaching">Read teachers' stories</a></li>
+      <li><a href="https://schoolexperience.education.gov.uk/">Experience a real school</a></li>
+      <li><a href="/salaries-and-benefits">Teachers' salaries</a></li>
+    </ul>
+  <% end %>
+
+  <%= render Content::GenericBlockComponent.new(
+    title: "Your next steps",
+    icon_image: "icon-doc-black.svg",
+    icon_alt: "icon containing learning materials",
+    classes: "blocks__directory"
+  ) do %>
+    <ul>
+      <li><a href="/steps-to-become-a-teacher">How to become a teacher</a></li>
+      <li><a href="/ways-to-train">Explore ways to train</a></li>
+      <li><a href="/funding-your-training">Find your funding options</a></li>
+    </ul>
+  <% end %>
+
+  <%= render Content::GenericBlockComponent.new(
+    title: "Sign up to get a Teacher Training Adviser",
+    icon_image: "icon-git-black.svg",
+    icon_alt: "site icon logo checkmark",
+    classes: "blocks__directory"
+  ) do %>
+    <p class="block__text">
+      If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
+    </p>
+
+    <%= link_to "Get an adviser", "/tta-service", class: "button button--white button--unpadded" %>
+  <% end %>
+</div>


### PR DESCRIPTION
### Trello card

[Trello-1345](https://trello.com/c/gvReABsd/1345-dev-add-next-steps-boxes-to-the-2-event-completion-pages-one-for-ml-and-one-without-the-ml)

### Context

We want to show 3 purple CTAs on the event sign up completion page (regardless of if they sign up and opt-in to the mailing list or not).

We already do this on the mailing list completion page.

### Changes proposed in this pull request

- Add 3 purple box CTAs to event completion pages

### Guidance to review

<img width="1401" alt="Screenshot 2021-02-26 at 14 23 05" src="https://user-images.githubusercontent.com/29867726/109311802-25a7ee00-783e-11eb-8169-9b0778e4cd79.png">
