### PR TITLE
Make the right column (aside) content sticky

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -100,6 +100,11 @@ section.container {
     @include mq($from: tablet) {
       flex: 0 0 calc(30% - 1em);
       margin-left: 1em;
+
+      > * {
+        position: sticky;
+        top: 1em;
+      }
     }
   }
 


### PR DESCRIPTION
This is more of an experiment than anything else. It makes the content, usually jump links or a CTA, follow the user as they scroll down the page. We can amend this to _only_ make it work for jump links if the CTA is unwanted.

It's only enabled on desktop and should work in all non-IE browsers, they'll have to scroll up to the top as they currently do.


https://user-images.githubusercontent.com/128088/109325964-7889a180-784e-11eb-9e41-62e5987c3f5c.mp4

(As a bonus, turn audio on for the video).

