### PR TITLE
Circuit breaker redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-debug.log*
 app/views/content
 /config/credentials/*.key
 /coverage
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,17 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: b560e0d2b37a55b765256e76f7ba329b037bcff8
+  revision: 73e455e0f3fd17a2308c6fb0a2dde5f5985ee812
   specs:
-    get_into_teaching_api_client (1.1.11)
+    get_into_teaching_api_client (1.1.12)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.15)
+    get_into_teaching_api_client_faraday (0.1.17)
       activesupport
       faraday
       faraday-encoding
       faraday-http-cache
       faraday_middleware
+      faraday_middleware-circuit_breaker
       get_into_teaching_api_client
 
 GIT
@@ -128,6 +129,9 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
+    faraday_middleware-circuit_breaker (0.4.1)
+      faraday (>= 0.9, < 2.0)
+      stoplight (~> 2.1)
     ffi (1.14.2)
     foreman (0.87.2)
     globalid (0.4.2)
@@ -314,6 +318,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stoplight (2.2.1)
     thor (1.1.0)
     thread_safe (0.3.6)
     typhoeus (1.4.0)

--- a/app/components/service_unavailable_component.html.erb
+++ b/app/components/service_unavailable_component.html.erb
@@ -1,0 +1,3 @@
+<h1>Sorry, the <%= @service_type %> service is currently unavailable</h1>
+<p>To sign up whilst this service is unavailable, you can call us on
+  <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a></p>

--- a/app/components/service_unavailable_component.rb
+++ b/app/components/service_unavailable_component.rb
@@ -1,0 +1,5 @@
+class ServiceUnavailableComponent < ViewComponent::Base
+  def initialize(service_type:)
+    @service_type = service_type
+  end
+end

--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -1,5 +1,4 @@
 module CircuitBreaker
-  class CircuitBrokenError < RuntimeError; end
   class NotAvailablePathMissingError < RuntimeError; end
 
   extend ActiveSupport::Concern

--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -1,0 +1,20 @@
+module CircuitBreaker
+  class CircuitBrokenError < RuntimeError; end
+  class NotAvailablePathMissingError < RuntimeError; end
+
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from GetIntoTeachingApiClient::CircuitBrokenError, with: :redirect_to_not_available
+  end
+
+protected
+
+  def redirect_to_not_available
+    redirect_to(not_available_path)
+  end
+
+  def not_available_path
+    raise NotAvailablePathMissingError
+  end
+end

--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -14,6 +14,6 @@ protected
   end
 
   def not_available_path
-    raise NotAvailablePathMissingError
+    raise NotAvailablePathMissingError, "#not_available_path hasn't been overridden"
   end
 end

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -1,4 +1,5 @@
 class EventCategoriesController < ApplicationController
+  include CircuitBreaker
   before_action :load_type
   before_action :set_form_action
   layout "events"
@@ -31,6 +32,12 @@ class EventCategoriesController < ApplicationController
       event_category_path(future_events_category_name.parameterize)
 
     render :show
+  end
+
+protected
+
+  def not_available_path
+    events_not_available_path
   end
 
 private

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -1,4 +1,6 @@
 class EventStepsController < ApplicationController
+  include CircuitBreaker
+
   before_action :load_event
 
   include WizardSteps
@@ -9,6 +11,12 @@ class EventStepsController < ApplicationController
   before_action :set_completed_page_title, only: [:completed]
 
   layout "registration"
+
+protected
+
+  def not_available_path
+    events_not_available_path
+  end
 
 private
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,6 @@
 class EventsController < ApplicationController
   include CircuitBreaker
 
-  rescue_from CircuitBreaker::CircuitBrokenError, with: :redirect_to_not_available
   before_action :load_event_search, only: %i[search index]
   before_action :search_events, only: %i[search]
   before_action :load_upcoming_events, only: %i[index]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,7 @@
 class EventsController < ApplicationController
+  include CircuitBreaker
+
+  rescue_from CircuitBreaker::CircuitBrokenError, with: :redirect_to_not_available
   before_action :load_event_search, only: %i[search index]
   before_action :search_events, only: %i[search]
   before_action :load_upcoming_events, only: %i[index]
@@ -23,6 +26,16 @@ class EventsController < ApplicationController
     breadcrumb "events.search", :events_path
     category_name = t("event_types.#{@event.type_id}.name.plural")
     breadcrumb category_name, event_category_path(category_name.parameterize)
+  end
+
+  def not_available
+    render "not_available"
+  end
+
+protected
+
+  def not_available_path
+    events_not_available_path
   end
 
 private

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -1,5 +1,7 @@
 module MailingList
   class StepsController < ApplicationController
+    include CircuitBreaker
+
     include WizardSteps
     self.wizard_class = MailingList::Wizard
 
@@ -7,6 +9,16 @@ module MailingList
     before_action :set_completed_page_title, only: [:completed]
 
     layout "registration"
+
+    def not_available
+      render "not_available"
+    end
+
+  protected
+
+    def not_available_path
+      mailinglist_not_available_path
+    end
 
   private
 

--- a/app/views/events/not_available.html.erb
+++ b/app/views/events/not_available.html.erb
@@ -1,5 +1,1 @@
-<% @fullwidth = @skip_hero = @hide_page_helpful_question = true %>
-<% @page_title = "Sorry, the events service is currently unavailable" %>
-<h1><%= @page_title %></h1>
-<p>To sign up whilst this service is unavailable, you can call us on
-  <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a></p>
+<%= render ServiceUnavailableComponent.new(service_type: "events") %>

--- a/app/views/events/not_available.html.erb
+++ b/app/views/events/not_available.html.erb
@@ -1,0 +1,5 @@
+<% @fullwidth = @skip_hero = @hide_page_helpful_question = true %>
+<% @page_title = "Sorry, the events service is currently unavailable" %>
+<h1><%= @page_title %></h1>
+<p>To sign up whilst this service is unavailable, you can call us on
+  <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a></p>

--- a/app/views/mailing_list/steps/not_available.html.erb
+++ b/app/views/mailing_list/steps/not_available.html.erb
@@ -1,5 +1,1 @@
-<% @fullwidth = @skip_hero = @hide_page_helpful_question = true %>
-<% @page_title = "Sorry, the events service is currently unavailable" %>
-<h1><%= @page_title %></h1>
-<p>To sign up whilst this service is unavailable, you can call us on
-  <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a></p>
+<%= render ServiceUnavailableComponent.new(service_type: "sign up for updates") %>

--- a/app/views/mailing_list/steps/not_available.html.erb
+++ b/app/views/mailing_list/steps/not_available.html.erb
@@ -1,0 +1,5 @@
+<% @fullwidth = @skip_hero = @hide_page_helpful_question = true %>
+<% @page_title = "Sorry, the events service is currently unavailable" %>
+<h1><%= @page_title %></h1>
+<p>To sign up whilst this service is unavailable, you can call us on
+  <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,7 @@ Rails.application.configure do
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
+    config.circuit_breaker = :circuit_breaker_config
   else
     config.action_controller.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,6 @@ Rails.application.configure do
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
-    config.circuit_breaker = :circuit_breaker_config
   else
     config.action_controller.perform_caching = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root to: "pages#show", page: "home"
 
+  get "/events/not-available", to: "events#not_available"
+  get "/mailinglist/not-available", to: "mailing_list/steps#not_available"
+
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all

--- a/spec/components/service_unavailable_component_spec.rb
+++ b/spec/components/service_unavailable_component_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe ServiceUnavailableComponent, type: :component do
+  let(:title) { "test" }
+
+  it "render the correct heading" do
+    render_inline(described_class.new(service_type: title))
+    expect(page).to have_text("Sorry, the #{title} service is currently unavailable")
+  end
+end

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "Circuit breaker" do
+  let(:error) { GetIntoTeachingApiClient::CircuitBrokenError }
+
+  before do
+    api_constants = GetIntoTeachingApiClient.constants.select { |klass| klass.to_s.end_with?("Api") }
+    apis_to_mock = api_constants.map { |const| GetIntoTeachingApiClient.const_get(const) }
+    apis_to_mock.each do |api|
+      api.instance_methods(false).each do |method|
+        allow_any_instance_of(api).to receive(method).and_raise(error)
+      end
+    end
+  end
+
+  context "when the API returns a CircuitBrokenError" do
+    it "the EventsController redirects to an error page" do
+      get event_path("event-id")
+      expect(response).to redirect_to(events_not_available_path)
+    end
+
+    it "the EventCategoriesController redirects to an error page" do
+      get event_category_path("category-id")
+      expect(response).to redirect_to(events_not_available_path)
+    end
+
+    it "the EventStepsController redirects to an error page" do
+      get event_step_path("event-id", "privacy_policy")
+      expect(response).to redirect_to(events_not_available_path)
+    end
+
+    it "the MailingList::StepsController redirects to an error page" do
+      get mailing_list_step_path("privacy_policy")
+      expect(response).to redirect_to(mailinglist_not_available_path)
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/e9vBMLJE

### Context
When repeated API failures occur, circuit breaker middleware in the Ruby client will raise a `GetIntoTeachingApiClient::CircuitBrokenError`. This is an attempt to reduce the impact of any future service failures.

### Changes proposed in this pull request
- Redirect to service unavailable pages when there is a `GetIntoTeachingApiClient::CircuitBrokenError`

### Guidance to review
This PR is paired with https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/37
