### PR TITLE
Add article_classes helper method

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,0 +1,7 @@
+module ContentHelper
+  def article_classes(front_matter)
+    ["markdown", front_matter["article_classes"]].flatten.compact.tap do |classes|
+      classes << "fullwidth" if front_matter["full_width"]
+    end
+  end
+end

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -51,7 +51,7 @@
         </aside>
         <% end %>
 
-        <article class="markdown <%= "fullwidth" if @front_matter["fullwidth"] %> ">
+        <%= tag.article(class: article_classes(@front_matter)) do %>
 
           <% if @front_matter["alert"].present? %>
             <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>
@@ -86,7 +86,7 @@
           <% end %>
 
           <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
-        </article>
+        <% end %>
       </section>
     </main>
 

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe ContentHelper, type: :helper do
+  describe "#article_classes" do
+    subject { article_classes(front_matter) }
+
+    context "with no arguments" do
+      let(:front_matter) { {} }
+
+      it %(returns an array containing only "markdown") do
+        expect(subject).to match_array(%w[markdown])
+      end
+    end
+
+    context "when full_width is true" do
+      let(:front_matter) { { "full_width" => true } }
+
+      it %(returns an array containing "markdown" and "fullwidth") do
+        expect(subject).to match_array(%w[markdown fullwidth])
+      end
+    end
+
+    context "when article_classes are provided" do
+      let(:custom_classes) { %w[super-important big-headings] }
+      let(:front_matter) { { "article_classes" => custom_classes } }
+
+      it %(returns an array containing "markdown" and the extra custom classes) do
+        expect(subject).to match_array(%w[markdown].concat(custom_classes))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The article_classes method returns the classes that will be set on the article element which surrounds most content on the site. By default it'll just return `markdown`, but can append `fullwidth` when the `full_width` key is set in the frontmatter.

Additionally, it can add arbitrary classes set via `article_classes`. The intended use is to allow special classes to be used in certain unusual situations, like on guidance pages or disclaimers.

