### PR TITLE
Add instructions for providers to update a teaching event

### DIFF
--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -38,13 +38,13 @@
 <% end %>
 
 <% if @show_archive_link %>
-  <div class="event-content-cta content-cta">
-    <h2><%= past_category_name(@type.id) %></h2>
+  <section class="content-cta">
+    <h3><%= past_category_name(@type.id) %></h3>
     <p>
       You can see <%= past_category_name(@type.id).downcase %>, including
       all questions and answers,
       <%= link_to "on this page",
                   archive_event_category_path(pluralised_category_name(@type.id).parameterize) %>
     </p>
-  </div>
+  </section>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -49,17 +49,15 @@
   <% end %>
 <% end %>
 
-<section class="event-content-cta">
-  <div class="content-cta">
-    <h2>Do you have a teaching event?</h2>
-    <p>
-      If you'd like to advertise your teaching event in this listing, <a href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
-        title="Submit your event details on GOV.UK"
-        target="_blank"
-        rel="noopener norefferer">
-      please fill in our online form</a>.
-    </p>
-  </div>
+<section class="content-cta">
+  <h3>Do you have a teaching event?</h3>
+  <p>
+    If you'd like to advertise your teaching event in this listing, <a href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
+      title="Submit your event details on GOV.UK"
+      target="_blank"
+      rel="noopener norefferer">
+    please fill in our online form</a>.
+  </p>
 </section>
 
 <span data-controller="lid" data-lid-action="track" data-lid-event="Events"></span>

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -2,16 +2,18 @@
   background: $grey;
   text-align: left;
   padding: $indent-amount;
-  margin: 0 -20px 30px;
   box-sizing: border-box;
   width: auto;
 
-  h2 {
-    margin-bottom: 5px;
-    margin-top: 0;
+  h3 {
+    margin: 0 0 0.5em 0;
     font-size: size("medium");
     background: transparent;
     color: $black;
+  }
+
+  p:first-child {
+    margin-top: 0;
   }
 
   p:last-child {
@@ -22,7 +24,7 @@
 .content-cta {
   @include content-cta;
   width: 65%;
-  margin: 0 auto;
+  margin: 3em auto 0;
 
   @include mq($until: tablet) {
     width: auto;

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -13,10 +13,6 @@
   }
 }
 
-.event-content-cta {
-  margin: 70px 0 50px;
-}
-
 .search-for-events-results {
   display: flex;
   flex-wrap: wrap;

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Finding an event", type: :feature do
     uri = URI.parse(page.current_url)
     expect(uri.fragment).to eq("searchforevents")
 
-    within(:css, ".event-content-cta") do
+    within(:css, ".content-cta") do
       click_on "on this page"
     end
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -4,7 +4,7 @@ describe "Find an event near you" do
   include_context "stub types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }
-
+  let(:category_headings_regex) { /<h3>([Train|Online|School].*)<\/h3>/ }
   let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
     5.times.collect do |index|
@@ -76,7 +76,7 @@ describe "Find an event near you" do
       end
 
       it "presents the types in the correct order" do
-        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        headings = response.body.scan(category_headings_regex).flatten
         expected_headings = [
           "Train to Teach events",
           "Online Q&amp;As",
@@ -100,7 +100,7 @@ describe "Find an event near you" do
     before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
     it "displays only the category filtered to" do
-      headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+      headings = response.body.scan(category_headings_regex).flatten
       expected_headings = ["Train to Teach events"]
 
       expect(headings).to eq(expected_headings)
@@ -119,7 +119,7 @@ describe "Find an event near you" do
       end
 
       it "does not display any categories" do
-        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        headings = response.body.scan(category_headings_regex).flatten
         expect(headings).to be_empty
       end
     end
@@ -146,7 +146,7 @@ describe "Find an event near you" do
     end
 
     it "categorises the results" do
-      headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+      headings = response.body.scan(category_headings_regex).flatten
       expected_headings = [
         "Train to Teach events",
       ]
@@ -168,7 +168,7 @@ describe "Find an event near you" do
       let(:events) { [build(:event_api, type_id: type_id)] }
 
       it "displays the no results message per category" do
-        headings = response.body.scan(/<h3>(.*)<\/h3>/).flatten
+        headings = response.body.scan(category_headings_regex).flatten
         no_results_messages = response.body.scan(no_events_regex).flatten
         expect(headings.count).to eq(Events::Search.available_event_types.count)
         expect(headings.count - 1).to eq(no_results_messages.count)


### PR DESCRIPTION
- Clean up CTA component

Minor clean up of the `content-cta` component. Fixes alignment issue and full stop being appended.

<img width="1038" alt="Screenshot 2021-03-02 at 13 21 50" src="https://user-images.githubusercontent.com/29867726/109654592-42a03200-7b5a-11eb-8af3-013d311b661f.png">
