### PR TITLE
Convert front matter hash keys to strings in specs

### DIFF
--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 describe CardComponent, type: "component" do
   let(:base) do
     {
-      snippet: "Lorem ipsum ....",
-      link: "/another/page",
-      link_text: "Link to another page",
-      image: "/images/card_thumb.jpg",
-      image_description: "A thorough description of the image",
-    }.with_indifferent_access
+      "snippet" => "Lorem ipsum ....",
+      "link" => "/another/page",
+      "link_text" => "Link to another page",
+      "image" => "/images/card_thumb.jpg",
+      "image_description" => "A thorough description of the image",
+    }
   end
 
   let(:card) { base }
@@ -23,21 +23,21 @@ describe CardComponent, type: "component" do
   end
 
   specify "includes a link wrapping the story image" do
-    is_expected.to have_link(href: card[:link]) do |anchor|
-      expect(anchor).to have_css(%(img[src='#{card[:image]}']))
+    is_expected.to have_link(href: card["link"]) do |anchor|
+      expect(anchor).to have_css(%(img[src="#{card['image']}"]))
     end
   end
 
   specify "sets the image's alt text" do
-    is_expected.to have_css(%(img[alt='#{card[:image_description]}']))
+    is_expected.to have_css(%(img[alt="#{card['image_description']}"]))
   end
 
   specify "includes the snippet" do
-    is_expected.to have_content(card[:snippet])
+    is_expected.to have_content(card["snippet"])
   end
 
   specify "includes the linktext in the link" do
-    is_expected.to have_link(card[:link_text], href: card[:link], class: "git-link")
+    is_expected.to have_link(card["link_text"], href: card["link"], class: "git-link")
   end
 
   specify "no play icon is visible" do
@@ -53,7 +53,7 @@ describe CardComponent, type: "component" do
   end
 
   context "with border removed" do
-    let(:card) { base.merge(border: false) }
+    let(:card) { base.merge("border" => false) }
 
     specify "border is removed" do
       is_expected.to have_css(".card.card--no-border")
@@ -61,7 +61,7 @@ describe CardComponent, type: "component" do
   end
 
   context "with header set" do
-    let(:card) { base.merge(header: "Further info") }
+    let(:card) { base.merge("header" => "Further info") }
 
     specify "header is shown" do
       is_expected.to have_css(".card header", text: "Further info")
@@ -69,7 +69,7 @@ describe CardComponent, type: "component" do
 
     context "with long header" do
       let(:header) { "long " * 50 }
-      let(:card) { base.merge header: header }
+      let(:card) { base.merge("header" => header) }
       let(:truncated) { header.truncate(described_class::MAX_HEADER_LENGTH) }
 
       it "will be truncated" do
@@ -80,7 +80,7 @@ describe CardComponent, type: "component" do
 
   context "with title set" do
     let(:title) { "a title" }
-    let(:card) { base.merge title: title }
+    let(:card) { base.merge("title" => title) }
 
     specify "title is shown" do
       is_expected.to have_css(".card > h3", text: "a title")
@@ -89,11 +89,11 @@ describe CardComponent, type: "component" do
 
   context "with video story" do
     let(:video) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
-    let(:card) { base.merge(video: video).with_indifferent_access }
+    let(:card) { base.merge("video" => video) }
 
     specify "the image links to the video instead of the card" do
-      is_expected.to have_link(href: card[:video]) do |anchor|
-        expect(anchor).to have_css(%(img[src='#{card[:image]}']))
+      is_expected.to have_link(href: card["video"]) do |anchor|
+        expect(anchor).to have_css(%(img[src="#{card['image']}"]))
       end
     end
 
@@ -107,15 +107,15 @@ describe CardComponent, type: "component" do
   end
 
   context "with mistyped link_text key" do
-    let(:card) { base.except(:link_text).merge(linktext: "shortened linktext") }
+    let(:card) { base.except("link_text").merge("linktext" => "shortened linktext") }
 
     specify "still includes the link text" do
-      is_expected.to have_link("shortened linktext", href: card[:link], class: "git-link")
+      is_expected.to have_link("shortened linktext", href: card["link"], class: "git-link")
     end
   end
 
   context "when no image_description is provided" do
-    let(:card) { base.merge(image_description: nil).with_indifferent_access }
+    let(:card) { base.merge("image_description" => nil) }
 
     it "has no image description attribute" do
       expect(subject.find("img")["alt"]).to be_nil

--- a/spec/components/cards/find_events_component_spec.rb
+++ b/spec/components/cards/find_events_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Cards::FindEventsComponent, type: :component do
   let(:page_data) { Pages::Data.new }
   let(:url_helpers) { Rails.application.routes.url_helpers }
   let(:event) { build(:event_api, name: "Test event") }
-  let(:card) { {}.with_indifferent_access }
+  let(:card) { {} }
   let(:instance) { described_class.new card: card, page_data: page_data }
 
   it { is_expected.to have_css ".card" }

--- a/spec/components/cards/latest_event_component_spec.rb
+++ b/spec/components/cards/latest_event_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
   let(:url_helpers) { Rails.application.routes.url_helpers }
   let(:event) { build(:event_api, name: "Test event") }
   let(:instance) { described_class.new card: card, page_data: page_data }
-  let(:card) { { category: "train to teach event" }.with_indifferent_access }
+  let(:card) { { "category" => "train to teach event" } }
   let(:find_events_header) { Cards::FindEventsComponent::HEADER }
 
   context "with category" do
@@ -43,7 +43,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
   context "with unknown category" do
     include_context "stub types api"
 
-    let(:card) { { category: "unknown" }.with_indifferent_access }
+    let(:card) { { "category" => "unknown" } }
 
     before { expect(Raven).to receive(:capture_exception).and_call_original }
 

--- a/spec/components/cards/renderer_component_spec.rb
+++ b/spec/components/cards/renderer_component_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe Cards::RendererComponent, type: :component do
 
     let :card do
       {
-        name: "Edna Krabappel",
-        snippet: "Your education is important. Roman numerals, et cetera",
-        link: "/stories/edna-k",
-        image: "/images/edna-k.jpg",
-      }.with_indifferent_access
+        "name" => "Edna Krabappel",
+        "snippet" => "Your education is important. Roman numerals, et cetera",
+        "link" => "/stories/edna-k",
+        "image" => "/images/edna-k.jpg",
+      }
     end
 
     before do
       allow(Pages::Frontmatter).to \
-        receive(:find).with(card[:link]).and_return edna
+        receive(:find).with(card["link"]).and_return edna
     end
 
     it { is_expected.to have_css ".card" }
@@ -38,7 +38,7 @@ RSpec.describe Cards::RendererComponent, type: :component do
   end
 
   context "with card type specified" do
-    let(:card) { { category: "Train to Teach event", card_type: "latest_event" }.with_indifferent_access }
+    let(:card) { { "category" => "Train to Teach event", "card_type" => "latest_event" } }
     let(:event) { build(:event_api, name: "Test event") }
     let(:page_data) { double Pages::Data, latest_event_for_category: event }
 
@@ -50,13 +50,13 @@ RSpec.describe Cards::RendererComponent, type: :component do
   end
 
   context "with unknown card type specified" do
-    let(:card) { { card_type: "random" }.with_indifferent_access }
+    let(:card) { { "card_type" => "random" } }
 
     it { expect { subject }.to raise_exception described_class::InvalidComponent }
   end
 
   context "with excluded type specified" do
-    let(:card) { { card_type: "renderer" }.with_indifferent_access }
+    let(:card) { { "card_type" => "renderer" } }
 
     it { expect { subject }.to raise_exception described_class::InvalidComponent }
   end

--- a/spec/components/cards/story_component_spec.rb
+++ b/spec/components/cards/story_component_spec.rb
@@ -10,11 +10,11 @@ describe Cards::StoryComponent, type: "component" do
 
   let :base do
     {
-      name: "Edna Krabappel",
-      snippet: "Your education is important. Roman numerals, et cetera",
-      link: "/stories/edna-k",
-      image: "/images/edna-k.jpg",
-    }.with_indifferent_access
+      "name" => "Edna Krabappel",
+      "snippet" => "Your education is important. Roman numerals, et cetera",
+      "link" => "/stories/edna-k",
+      "image" => "/images/edna-k.jpg",
+    }
   end
 
   let(:story) { base }
@@ -29,14 +29,14 @@ describe Cards::StoryComponent, type: "component" do
   it { is_expected.to have_css ".card.card--no-border" }
   it { is_expected.not_to have_css ".card header" }
   it { is_expected.to have_css "img[src=\"#{story['image']}\"]" }
-  it { is_expected.to have_content story[:snippet] }
+  it { is_expected.to have_content story["snippet"] }
 
   specify "includes the name in a link" do
-    is_expected.to have_link(%(Read #{story[:name]}'s story), href: story[:link], class: "git-link")
+    is_expected.to have_link(%(Read #{story['name']}'s story), href: story["link"], class: "git-link")
   end
 
   context "with supplied header" do
-    let(:story) { base.merge header: "Edna's story" }
+    let(:story) { base.merge "header" => "Edna's story" }
 
     it { is_expected.to have_css ".card header" }
   end
@@ -47,7 +47,7 @@ describe Cards::StoryComponent, type: "component" do
 
     before do
       allow(Pages::Frontmatter).to \
-        receive(:find).with(story[:link]).and_return edna
+        receive(:find).with(story["link"]).and_return edna
     end
 
     it do

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -10,7 +10,7 @@ describe Content::AccordionComponent, type: "component" do
         "Step one" => "some content",
         "Step two" => "some other content",
         "Step three" => "even more content",
-      }.with_indifferent_access
+      }
     end
 
     subject! do

--- a/spec/components/grouped_cards/card_component_spec.rb
+++ b/spec/components/grouped_cards/card_component_spec.rb
@@ -6,11 +6,11 @@ describe GroupedCards::CardComponent, type: "component" do
   let(:instance) { described_class.new organisation }
   let(:organisation) do
     {
-      header: "First organisation",
-      name: "Joe Bloggs",
-      telephone: "01234 567890 (ext 123)",
-      email: "joe.bloggs@first.org",
-    }.with_indifferent_access
+      "header" => "First organisation",
+      "name" => "Joe Bloggs",
+      "telephone" => "01234 567890 (ext 123)",
+      "email" => "joe.bloggs@first.org",
+    }
   end
 
   it { is_expected.to have_css "h4", text: "First organisation" }
@@ -23,11 +23,11 @@ describe GroupedCards::CardComponent, type: "component" do
   context "with link" do
     let(:organisation) do
       {
-        header: "First organisation",
-        link: "https://education.gov.uk",
-        name: "Joe Bloggs",
-        email: "joe.bloggs@first.org",
-      }.with_indifferent_access
+        "header" => "First organisation",
+        "link" => "https://education.gov.uk",
+        "name" => "Joe Bloggs",
+        "email" => "joe.bloggs@first.org",
+      }
     end
 
     it { is_expected.to have_link href: "https://education.gov.uk" }

--- a/spec/components/grouped_cards/listing_component_spec.rb
+++ b/spec/components/grouped_cards/listing_component_spec.rb
@@ -6,17 +6,17 @@ describe GroupedCards::ListingComponent, type: "component" do
   let(:instance) { described_class.new data }
   let(:organisation) do
     {
-      header: "First organisation",
-      name: "Joe Bloggs",
-      telephone: "01234567890",
-      email: "joe.bloggs@first.org",
-    }.with_indifferent_access
+      "header" => "First organisation",
+      "name" => "Joe Bloggs",
+      "telephone" => "01234567890",
+      "email" => "joe.bloggs@first.org",
+    }
   end
   let :data do
     {
       "Region 1" => [organisation, organisation],
       "Region 2" => [organisation],
-    }.with_indifferent_access
+    }
   end
 
   it { is_expected.to have_css "ul", count: 1 }

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -3,14 +3,14 @@ require "rails_helper"
 describe Sections::HeroComponent, type: "component" do
   let(:front_matter) do
     {
-      title: "Teaching, it's pretty awesome",
-      fullwidth: true,
-      hide_page_helpful_question: true,
-      subtitle: "Teach all the subjects!",
-      subtitle_link: "/signup",
-      subtitle_button: "Find out more",
-      image: "media/images/hero-home-dt.jpg",
-    }.with_indifferent_access
+      "title" => "Teaching, it's pretty awesome",
+      "fullwidth" => true,
+      "hide_page_helpful_question" => true,
+      "subtitle" => "Teach all the subjects!",
+      "subtitle_link" => "/signup",
+      "subtitle_button" => "Find out more",
+      "image" => "media/images/hero-home-dt.jpg",
+    }
   end
   let(:component) { described_class.new(front_matter) }
   subject! { render_inline(component) }
@@ -18,21 +18,21 @@ describe Sections::HeroComponent, type: "component" do
   describe "rendering a hero section" do
     describe "title and subtitle" do
       specify "renders the title" do
-        expect(page).to have_css(".hero__title > h1", text: front_matter[:title])
+        expect(page).to have_css(".hero__title > h1", text: front_matter["title"])
       end
 
       specify "renders the subtitle" do
-        expect(page).to have_css(".hero__subtitle > .hero__subtitle__text", text: front_matter[:subtitle])
+        expect(page).to have_css(".hero__subtitle > .hero__subtitle__text", text: front_matter["subtitle"])
       end
 
       context "when a subtitle link exists" do
         let(:front_matter) do
           {
-            title: "Teaching, it's pretty awesome",
-            subtitle: "Teach all the subjects!",
-            subtitle_button: "Click here to find out",
-            subtitle_link: "https://foo.com",
-            image: "media/images/hero-home-dt.jpg",
+            "title" => "Teaching, it's pretty awesome",
+            "subtitle" => "Teach all the subjects!",
+            "subtitle_button" => "Click here to find out",
+            "subtitle_link" => "https://foo.com",
+            "image" => "media/images/hero-home-dt.jpg",
           }
         end
 
@@ -40,7 +40,7 @@ describe Sections::HeroComponent, type: "component" do
 
         specify "renders the subtitle button" do
           expect(page).to have_css(".hero__subtitle") do |div|
-            expect(div).to have_link(front_matter[:subtitle_button], href: front_matter[:subtitle_link])
+            expect(div).to have_link(front_matter["subtitle_button"], href: front_matter["subtitle_link"])
           end
         end
       end
@@ -48,7 +48,7 @@ describe Sections::HeroComponent, type: "component" do
 
     describe "images" do
       context "when no image is present" do
-        let(:component) { described_class.new(front_matter.merge(image: nil)) }
+        let(:component) { described_class.new(front_matter.merge("image" => nil)) }
 
         specify "nothing is rendered" do
           expect(rendered_component).to be_empty

--- a/spec/components/stories/card_component_spec.rb
+++ b/spec/components/stories/card_component_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe Stories::CardComponent, type: "component" do
   let(:story) do
     {
-      name: "Edna Krabappel",
-      snippet: "Your education is important. Roman numerals, et cetera",
-      link: "/stories/edna-k",
-      image: "/images/edna-k.jpg",
-    }.with_indifferent_access
+      "name" => "Edna Krabappel",
+      "snippet" => "Your education is important. Roman numerals, et cetera",
+      "link" => "/stories/edna-k",
+      "image" => "/images/edna-k.jpg",
+    }
   end
 
   subject do
@@ -20,17 +20,17 @@ describe Stories::CardComponent, type: "component" do
   end
 
   specify "includes a link wrapping the story image" do
-    is_expected.to have_link(href: story[:link]) do |anchor|
-      expect(anchor).to have_css(%(img[src='#{story[:image]}']))
+    is_expected.to have_link(href: story["link"]) do |anchor|
+      expect(anchor).to have_css(%(img[src="#{story['image']}"]))
     end
   end
 
   specify "includes the snippet" do
-    is_expected.to have_content(story[:snippet])
+    is_expected.to have_content(story["snippet"])
   end
 
   specify "includes the name in a link" do
-    is_expected.to have_link(%(Read #{story[:name]}'s story), href: story[:link], class: "git-link")
+    is_expected.to have_link(%(Read #{story['name']}'s story), href: story["link"], class: "git-link")
   end
 
   specify "no play icon is visible" do
@@ -39,7 +39,7 @@ describe Stories::CardComponent, type: "component" do
 
   context "with video stories" do
     let(:video) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
-    let(:video_story) { story.merge(video: video).with_indifferent_access }
+    let(:video_story) { story.merge("video" => video) }
 
     subject do
       render_inline(described_class.new(card: video_story))
@@ -47,8 +47,8 @@ describe Stories::CardComponent, type: "component" do
     end
 
     specify "the image links to the video instead of the story" do
-      is_expected.to have_link(href: video_story[:video]) do |anchor|
-        expect(anchor).to have_css(%(img[src='#{story[:image]}']))
+      is_expected.to have_link(href: video_story["video"]) do |anchor|
+        expect(anchor).to have_css(%(img[src="#{story['image']}"]))
       end
     end
 

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -3,35 +3,35 @@ require "rails_helper"
 describe Stories::StoryComponent, type: "component" do
   let(:default_front_matter) do
     {
-      title: "Swapping senior management for students",
-      image: "/assets/images/stories/stories-karen.jpg",
-      story: {
-        teacher: "Karen Roberts",
-        video: "https://www.youtube.com/embed/riY-1DUkLVk",
-        position: "languages teacher",
+      "title" => "Swapping senior management for students",
+      "image" => "/assets/images/stories/stories-karen.jpg",
+      "story" => {
+        "teacher" => "Karen Roberts",
+        "video" => "https://www.youtube.com/embed/riY-1DUkLVk",
+        "position" => "languages teacher",
       },
-      more_stories: [
+      "more_stories" => [
         {
-          name: "Zainab",
-          snippet: "School experience helped me decide to switch",
-          image: "/assets/images/stories/stories-zainab.jpg",
-          link: "/life-as-a-teacher/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch",
+          "name" => "Zainab",
+          "snippet" => "School experience helped me decide to switch",
+          "image" => "/assets/images/stories/stories-zainab.jpg",
+          "link" => "/life-as-a-teacher/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch",
         },
         {
-          name: "Katie",
-          snippet: "Returning to teach with international experience",
-          image: "/assets/images/stories/stories-katie.png",
-          link: "/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience",
+          "name" => "Katie",
+          "snippet" => "Returning to teach with international experience",
+          "image" => "/assets/images/stories/stories-katie.png",
+          "link" => "/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience",
         },
         {
-          name: "Helen",
-          snippet: "Lawyer to assistant headteacher",
-          image: "/assets/images/stories/stories-helen.jpg",
-          link: "/life-as-a-teacher/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher",
+          "name" => "Helen",
+          "snippet" => "Lawyer to assistant headteacher",
+          "image" => "/assets/images/stories/stories-helen.jpg",
+          "link" => "/life-as-a-teacher/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher",
         },
       ],
-      build_layout_from_frontmatter: true,
-    }.with_indifferent_access
+      "build_layout_from_frontmatter" => true,
+    }
   end
 
   let(:front_matter) { default_front_matter }
@@ -52,15 +52,15 @@ describe Stories::StoryComponent, type: "component" do
     end
 
     specify "the story's title forms the main heading" do
-      is_expected.to have_css("h1", text: front_matter[:title])
+      is_expected.to have_css("h1", text: front_matter["title"])
     end
 
     specify "the story's image is rendered" do
-      is_expected.to have_css(%(img[src='#{front_matter[:image]}']))
+      is_expected.to have_css(%(img[src="#{front_matter['image']}"]))
     end
 
     specify "the teacher name and position are in secondary heading" do
-      [front_matter.dig(:story, :teacher), front_matter.dig(:story, :position)].each do |part|
+      [front_matter.dig("story", "teacher"), front_matter.dig("story", "position")].each do |part|
         is_expected.to have_css("h2", text: Regexp.new(part))
       end
     end
@@ -69,7 +69,7 @@ describe Stories::StoryComponent, type: "component" do
   describe "video" do
     let(:video_url) { "https://www.youtube.com/embed/riY-1DUkLVk" }
     let(:video_story) do
-      { story: { teacher: "Karen Roberts", video: video_url, position: "languages teacher" } }
+      { story: { "teacher" => "Karen Roberts", "video" => video_url, "position" => "languages teacher" } }
     end
 
     let(:front_matter) { default_front_matter.merge(video_story) }
@@ -82,7 +82,7 @@ describe Stories::StoryComponent, type: "component" do
   describe "more information" do
     let(:text) { "Really interesting stuff" }
     let(:link) { "/really-interesting-stuff" }
-    let(:more_information) { { more_information: { link: link, text: text } } }
+    let(:more_information) { { "more_information" => { "link" => link, "text" => text } } }
     let(:front_matter) { default_front_matter.merge(more_information) }
 
     specify "the link is present in the document" do
@@ -112,12 +112,12 @@ describe Stories::StoryComponent, type: "component" do
       end
 
       specify "there should be a story card for each story" do
-        is_expected.to have_css(".cards.stories > .card", count: front_matter[:more_stories].length)
+        is_expected.to have_css(".cards.stories > .card", count: front_matter["more_stories"].length)
       end
     end
 
     context "when there are no more stories" do
-      let(:front_matter) { default_front_matter.merge(more_stories: nil) }
+      let(:front_matter) { default_front_matter.merge("more_stories" => nil) }
 
       specify "there is no more stories header" do
         is_expected.not_to have_css("h2", text: "More stories")
@@ -128,10 +128,10 @@ describe Stories::StoryComponent, type: "component" do
   describe "explore" do
     context "when there are is explore frontmatter" do
       let(:explore) do
-        default_front_matter[:more_stories].map { |s| s.merge(header: "Test") }
+        default_front_matter["more_stories"].map { |s| s.merge("header" => "Test") }
       end
 
-      let(:front_matter) { default_front_matter.merge(explore: explore) }
+      let(:front_matter) { default_front_matter.merge("explore" => explore) }
 
       specify "there is an explore header" do
         is_expected.to have_css "section.cards-with-headers h2"
@@ -155,7 +155,7 @@ describe Stories::StoryComponent, type: "component" do
 
   describe "with page_data" do
     let(:page_data) { Pages::Data.new }
-    let(:more_stories) { front_matter[:more_stories].length }
+    let(:more_stories) { front_matter["more_stories"].length }
 
     specify "renders a story" do
       is_expected.to have_css("article.story")


### PR DESCRIPTION
### Trello Card

https://trello.com/c/TUQV9Gtq/669-normalize-keys-format-for-frontmatter

### Context and changes

Parsing front matter *always* results in a hash with string keys. We're working around this in the specs by building hashes with symbol keys and then calling `#with_indifferent_access`

This obfuscates what's going on and will add confusion for future developers.

`ag with_indifferent_access spec/` should yield no results.
