### PR TITLE
Add support for title captions

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -17,6 +17,10 @@
       <section class="container">
         <% if !@front_matter["image"] %>
           <header>
+            <% if @front_matter["title_caption"].present? %>
+              <%= tag.span(@front_matter["title_caption"], class: "caption") %>
+            <% end %>
+
             <%= tag.h1(@front_matter["title"]) %>
           </header>
         <% end %>

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -7,6 +7,7 @@ $green-dark: #009157;
 $green-dark-90: rgba($green-dark, .9);
 $grey: #f0f0f0;
 $grey-light: #cccccc;
+$grey-dark: #656565;
 $grey-mid: #b7b9bb;
 $pink: #db5e9e;
 $pink-dark: #d34491;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -74,12 +74,22 @@ section.container {
   header {
     flex: 0 0 100%;
     max-width: $content-max-width;
+    @include indent-left-and-right;
 
     h1 {
-      @include indent-left-and-right;
 
       font-size: size(xxlarge);
       margin-bottom: 3rem;
+    }
+
+    span.caption {
+      font-size: size(medium);
+      margin-top: 3em;
+      color: $grey-dark;
+    }
+
+    span.caption + h1 {
+      margin-top: 0;
     }
   }
 


### PR DESCRIPTION
Captions are a [GOV.UK Design System pattern](https://design-system.service.gov.uk/styles/typography/#headings-with-captions
) and they're useful for adding a bit more context to headings without them getting too long.

This one will only be included when there's a `title_caption` in the front matter and the CSS will place it just above the title while maintaining the margin above.

The intended use case here is for the new international applicants page: https://github.com/DFE-Digital/get-into-teaching-content/pull/329#issuecomment-788815986

![Screenshot from 2021-03-02 12-47-49](https://user-images.githubusercontent.com/128088/109650722-880e3080-7b55-11eb-9d07-ae45cb386bb3.png)

