### PR TITLE
Allow mailing list sign up if already signed up for TTA

### DIFF
--- a/app/models/mailing_list/steps/already_subscribed.rb
+++ b/app/models/mailing_list/steps/already_subscribed.rb
@@ -2,7 +2,7 @@ module MailingList
   module Steps
     class AlreadySubscribed < ::Wizard::Step
       def skipped?
-        !subscribed_to_mailing_list? && !subscribed_to_teacher_training_adviser?
+        !subscribed_to_mailing_list?
       end
 
       def can_proceed?
@@ -11,10 +11,6 @@ module MailingList
 
       def subscribed_to_mailing_list?
         @store["already_subscribed_to_mailing_list"]
-      end
-
-      def subscribed_to_teacher_training_adviser?
-        @store["already_subscribed_to_teacher_training_adviser"]
       end
     end
   end

--- a/app/views/mailing_list/steps/_already_subscribed.html.erb
+++ b/app/views/mailing_list/steps/_already_subscribed.html.erb
@@ -1,13 +1,5 @@
-<% if f.object.subscribed_to_teacher_training_adviser? %>
-<h1>You have already signed up to an adviser</h1>
-
-<p>The email address <%= mailing_list_session["email"] %> has already signed up to get an adviser.</p>
-<p>Our email updates are intended for users who have not yet signed up for our Get an adviser service.</p>
-<p>The level of support you receive from an adviser will be more in-depth and personal to you than the information we provide in our emails.</p>
-<% else %>
 <h1>You’ve already signed up</h1>
 
 <p>
 The email address <%= mailing_list_session["email"] %> has already signed up to receive emails.
 </p>
-<% end %>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -255,8 +255,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in "Enter the verification code sent to test@user.com", with: "123456"
     click_on "Next Step"
 
-    expect(page).to have_text "You have already signed up to an adviser"
-    expect(page).not_to have_button("Next Step")
+    expect(page).to have_text "What stage are you at with your degree?"
   end
 
   scenario "Full journey as an existing candidate using a magic link" do

--- a/spec/models/mailing_list/steps/already_subscribed_spec.rb
+++ b/spec/models/mailing_list/steps/already_subscribed_spec.rb
@@ -15,21 +15,18 @@ describe MailingList::Steps::AlreadySubscribed do
       expect(subject).to be_skipped
     end
 
-    it "returns true if already_subscribed_to_teacher_training_adviser is false/nil/undefined" do
+    it "returns true if already_subscribed_to_teacher_training_adviser is false/true/nil/undefined" do
       expect(subject).to be_skipped
       wizardstore["already_subscribed_to_teacher_training_adviser"] = nil
       expect(subject).to be_skipped
       wizardstore["already_subscribed_to_teacher_training_adviser"] = false
       expect(subject).to be_skipped
+      wizardstore["already_subscribed_to_teacher_training_adviser"] = true
+      expect(subject).to be_skipped
     end
 
     it "returns false if already_subscribed_to_mailing_list is true" do
       wizardstore["already_subscribed_to_mailing_list"] = true
-      expect(subject).not_to be_skipped
-    end
-
-    it "returns false if already_subscribed_to_teacher_training_adviser is true" do
-      wizardstore["already_subscribed_to_teacher_training_adviser"] = true
       expect(subject).not_to be_skipped
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-1327](https://trello.com/c/2hX9pdEz/1327-spike-consider-unblocking-mailing-list-for-ppl-who-have-signed-up-for-an-adviser)

### Context

Previously we blocked someone signing up for the mailing list if they had already signed up for a TTA (as having a TTA meant they were further along in their journey/the mailing list wouldn't provide value).

As it turn s out, candidates (especially students), engage with an EEA in years 1 and 2. EEAs want to push them to the mailing list so they are kept engaged, so we need to unblock that journey.

### Changes proposed in this pull request

- Allow mailing list sign up if already sigend up for TTA

### Guidance to review

