### PR TITLE
Change `full_width` to `fullwidth`

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,7 +1,7 @@
 module ContentHelper
   def article_classes(front_matter)
     ["markdown", front_matter["article_classes"]].flatten.compact.tap do |classes|
-      classes << "fullwidth" if front_matter["full_width"]
+      classes << "fullwidth" if front_matter["fullwidth"]
     end
   end
 end

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -12,8 +12,8 @@ describe ContentHelper, type: :helper do
       end
     end
 
-    context "when full_width is true" do
-      let(:front_matter) { { "full_width" => true } }
+    context "when fullwidth is true" do
+      let(:front_matter) { { "fullwidth" => true } }
 
       it %(returns an array containing "markdown" and "fullwidth") do
         expect(subject).to match_array(%w[markdown fullwidth])


### PR DESCRIPTION
We're no longer using `full_width` anywhere and this inconsistency was causing a couple of pages to be narrower than they should be.
