### PR TITLE
Make layout header rule only apply to main title

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -71,7 +71,7 @@ section.container {
   // most pages won't have a h1 here but on those where
   // we forego the hero we want it to span both the article
   // and the aside.
-  header {
+  > header {
     flex: 0 0 100%;
     max-width: $content-max-width;
     @include indent-left-and-right;


### PR DESCRIPTION
The selector was making the header apply to _all_ header elements in the  page and not just the intended one (i.e. the one that contains the main page title on non-hero pages).
