### PR TITLE
Remove nowrap from button mixin

### DIFF
--- a/app/views/sections/_footer-signup.html.erb
+++ b/app/views/sections/_footer-signup.html.erb
@@ -2,7 +2,7 @@
     <section class="container">
         <div class="footer-signup__inner">
             <span class="footer-signup__text">Get personalised information and updates about getting into teaching</span>
-            <%= link_to(mailing_list_steps_path, class: "call-to-action-button button button--white") do %>
+            <%= link_to(mailing_list_steps_path, class: "call-to-action-button button--white button--nowrap") do %>
                 Sign up here
             <% end %>
             <span class="visually-hidden">to receive information via email</span>

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -6,7 +6,6 @@
   color: $fg;
   padding: 14px $indent-amount;
   font-size: size("small");
-  white-space: nowrap;
   border: none;
 
   &:hover {
@@ -44,6 +43,10 @@ a {
   &--white {
     @include button($bg: $white, $fg: $black);
     @include chevron($color: $black);
+  }
+
+  &--nowrap {
+    white-space: nowrap;
   }
 
   &--unpadded {


### PR DESCRIPTION
### Trello card
N/A

### Context
Long buttons were not wrapping on mobile.

### Changes proposed in this pull request
- Remove nowrap from button mixin
- Add class for when nowrap is needed