### PR TITLE
Re-add chevron to "sign up here"

### DIFF
--- a/app/views/sections/_footer-signup.html.erb
+++ b/app/views/sections/_footer-signup.html.erb
@@ -2,7 +2,7 @@
     <section class="container">
         <div class="footer-signup__inner">
             <span class="footer-signup__text">Get personalised information and updates about getting into teaching</span>
-            <%= link_to(mailing_list_steps_path, class: "call-to-action-button button--white button--nowrap") do %>
+            <%= link_to(mailing_list_steps_path, class: "call-to-action-button button button--white button--nowrap") do %>
                 Sign up here
             <% end %>
             <span class="visually-hidden">to receive information via email</span>


### PR DESCRIPTION
### Trello card
N/A

### Context
Removed `button` class in previous [PR](https://github.com/DFE-Digital/get-into-teaching-app/pull/956) thinking that it didn't do anything.

### Changes proposed in this pull request
Add button class to display chevron