### PR TITLE
Black site footer background to match rest of footer when wide

### DIFF
--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -34,10 +34,7 @@
 
 footer.site-footer {
   clear: both; // IE-specific fix to make sure footer stays below main content
-
-  .site-footer__wrapper {
-    background-color: $black;
-  }
+  background-color: $black;
 
   .site-footer-top {
     width: 100%;


### PR DESCRIPTION
### Trello card
N/A

### Context
See pics. Black footer background doesn't match rest of footer past 2000px

### Changes proposed in this pull request
- Move background colour to footer vs width limited wrapper

### Guidance to review
![image](https://user-images.githubusercontent.com/47089130/109799500-08936680-7c14-11eb-8b6f-0e8772b15326.png)
![image](https://user-images.githubusercontent.com/47089130/109799578-177a1900-7c14-11eb-8e19-7fd8850b951e.png)

