### PR TITLE
Try downgrading webmock to make content specs pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ end
 group :test do
   gem "shoulda-matchers"
   gem "webdrivers", "~> 4.5"
-  gem "webmock"
+  gem "webmock", "~> 3.11.2"
 end
 
 group :rolling, :preprod, :userresearch, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webmock (3.12.0)
+    webmock (3.11.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -400,7 +400,7 @@ DEPENDENCIES
   view_component
   web-console (>= 3.3.0)
   webdrivers (~> 4.5)
-  webmock
+  webmock (~> 3.11.2)
   webpacker
 
 RUBY VERSION


### PR DESCRIPTION
We've seen some failures on the content repo content page specs and webmock looks like the only recently-updated related gem, so this is just testing the theory that it's affected the test suite in some way.

Reverting #943 
