### PR TITLE
Standardise the way nav lists are built

### DIFF
--- a/app/components/navigation/navbar_component.html.erb
+++ b/app/components/navigation/navbar_component.html.erb
@@ -42,11 +42,11 @@
             </div>
             <div data-navigation-target="links" id="navbar-mobile-links" class="navbar__mobile__links">
                 <ul>
-                    <li><a href="/">Home</a></li>
-                    <% resources.each do |resource| %>
-                        <li><%= link_to resource[:front_matter][:title], resource[:path] %></li>
-                    <% end %>
-                    <li><%= link_to "Find an event near you", events_path %></li>
+                  <%= nav_link("Home", '/') %>
+                  <% resources.each do |resource| %>
+                    <%= nav_link(resource[:front_matter][:title], resource[:path]) %>
+                  <% end %>
+                  <%= nav_link("Find an event near you", events_path) %>
                 </ul>
             </div>
         </div>

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -64,35 +64,33 @@ RSpec.feature "content pages check", type: :feature, content: true do
     end
   end
 
-  PageLister.content_urls.first.tap do |first_url|
-    describe "navbar" do
-      subject { page }
+  describe "navbar" do
+    subject { page }
 
-      before { visit first_url }
+    before { visit "/" }
 
-      let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
+    let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
 
-      scenario "navigable pages appear in desktop navbar" do
-        navigation_pages.each do |url, frontmatter|
-          page.within "nav .navbar__desktop" do
-            is_expected.to have_link frontmatter[:title], href: url
-          end
+    scenario "navigable pages appear in desktop navbar" do
+      navigation_pages.each do |url, frontmatter|
+        page.within "nav .navbar__desktop" do
+          is_expected.to have_link frontmatter[:title], href: url
         end
       end
+    end
 
-      scenario "navigable pages appear in mobile navbar" do
-        navigation_pages.each do |url, frontmatter|
-          page.within "nav .navbar__mobile" do
-            is_expected.to have_link frontmatter[:title], href: url
-          end
+    scenario "navigable pages appear in mobile navbar" do
+      navigation_pages.each do |url, frontmatter|
+        page.within "nav .navbar__mobile" do
+          is_expected.to have_link frontmatter[:title], href: url
         end
       end
+    end
 
-      scenario "mobile nav matches desktop nav" do
-        document.css("nav .navbar__desktop a").each do |desktop_link|
-          page.within "nav .navbar__mobile" do
-            is_expected.to have_link desktop_link.text, href: desktop_link["href"]
-          end
+    scenario "mobile nav matches desktop nav" do
+      document.css("nav .navbar__desktop a").each do |desktop_link|
+        page.within "nav .navbar__mobile" do
+          is_expected.to have_link desktop_link.text, href: desktop_link["href"]
         end
       end
     end


### PR DESCRIPTION
Previously there was an inconsistency between the way the desktop and mobile lists were built, the desktop variant used the `#nav_link helper` and the mobile one didn't.

Also, instead of visiting one of the dynamically-added nav pages to conduct the tests, visit the home page instead. This will ensure none of the linked pages fall foul of `#link_to_unless_current`, which is used by the `#nav_link` helper.

