### PR TITLE
Support featured page in stories landing template

### DIFF
--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -8,17 +8,34 @@
 
       <main class="story-landing" role="main" id="main-content">
         <section class="container">
-          <section class="stories-feature">
-            <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.jpg')"></div>
-            <div class="stories-feature__content">
-              <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
-              <%= tag.span(@front_matter.dig("featured_story", "subheading"), class: "stories-feature__subheading") %>
-              <%= tag.p(@front_matter.dig("featured_story", "text")) %>
-              <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
-                Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
-            <% end %>
-            </div>
-          </section>
+          <% if @front_matter.key?("featured_story") %>
+            <section class="stories-feature">
+              <div class="stories-feature__image" style="background-image:url('<%= @front_matter.dig("featured_story", "image") %>')"></div>
+              <div class="stories-feature__content">
+                <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
+                <%= tag.span(@front_matter.dig("featured_story", "subheading"), class: "stories-feature__subheading") %>
+                <%= tag.p(@front_matter.dig("featured_story", "text")) %>
+                <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
+                  Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
+                <% end %>
+              </div>
+            </section>
+          <% end %>
+
+          <% if @front_matter.key?("featured_page") %>
+            <section class="stories-feature">
+              <div class="stories-feature__image" style="background-image:url('<%= @front_matter.dig("featured_page", "image") %>')"></div>
+              <div class="stories-feature__content">
+                <%= tag.h2(@front_matter.dig("featured_page", "heading")) %>
+                <%= tag.span(@front_matter.dig("featured_page", "subheading"), class: "stories-feature__subheading") %>
+                <%= tag.p(@front_matter.dig("featured_page", "text")) %>
+                <%= link_to(@front_matter.dig("featured_page", "link", "path"), class: "git-link") do %>
+                  <%= @front_matter.dig("featured_page", "link", "text") %> <%= fas_icon("chevron-right") %>
+                <% end %>
+              </div>
+            </section>
+          <% end %>
+
           <article class="markdown fullwidth">
             <% @front_matter["sections"]&.each do |name, section| %>
               <% if section["stories"].present? %>

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -46,6 +46,11 @@
     background-size: cover;
     flex: 1 0 40%;
     min-height: 15em;
+    background-position: 0 -1.5em;
+
+    @include mq($from: tablet) {
+      background-position: 0 0;
+    }
   }
 
   &__content {


### PR DESCRIPTION
### Trello card

[Trello-1344](https://trello.com/c/p27qwi1o/1344-development-add-day-in-the-life-of-a-teacher-into-stories-and-make-better-use-of-the-large-purple-banner-in-stories)

### Context

We are swapping out the featured story to be a featured page, initially pointing to the day in the life of a teacher content.

This will support both sets of frontmatter and, once the content has been updated, the featured story support can be removed. The background position of the image is tweaked on mobile to better centre on the teacher's face; this is applied to both images (current story image and the new day in the life of image) -- it looks fine on both and will only change the existing image for a few minutes anyway until the new content goes out.

### Changes proposed in this pull request

- Support featured page in stories landing template

### Guidance to review

Content changes to follow: https://github.com/DFE-Digital/get-into-teaching-content/pull/337

|  Desktop | Mobile |
|---|---|
| ![Screenshot 2021-03-08 at 09 23 11](https://user-images.githubusercontent.com/29867726/110301395-f0df2800-7fef-11eb-9a07-a7cbd064ba39.png) | <img width="496" alt="Screenshot 2021-03-08 at 09 23 52" src="https://user-images.githubusercontent.com/29867726/110301453-02283480-7ff0-11eb-8e35-622139e174df.png"> | 
