### PR TITLE
Only apply link/button chevron styles after spans

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -33,7 +33,7 @@ $chevron-direction-map: (
 
   $degrees: map-get($chevron-direction-map, $direction);
 
-  > * {
+  > span {
     word-break: break-word;
 
     // after governs whether the chevron is placed after (on the right) or


### PR DESCRIPTION
### Trello card

https://trello.com/c/pg5IYeu2/1393-fix-a-bug-where-multiple-chevrons-are-added-to-a-button

### Context and changes

The code that adds the abbreviation elements adds them inside links too, which we probably don't want, but that'll be addressed separately. This just ensures that chevrons are _only_ added after `<span>` elements that appear inside links with the `.button` class to stop this from happening:

![Screenshot from 2021-03-08 12-07-58](https://user-images.githubusercontent.com/128088/110329329-57763d00-8014-11eb-902d-a3c96f0f5f11.png)


