### PR TITLE
Remove featured story from landing template

### DIFF
--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -8,20 +8,6 @@
 
       <main class="story-landing" role="main" id="main-content">
         <section class="container">
-          <% if @front_matter.key?("featured_story") %>
-            <section class="stories-feature">
-              <div class="stories-feature__image" style="background-image:url('<%= @front_matter.dig("featured_story", "image") %>')"></div>
-              <div class="stories-feature__content">
-                <%= tag.h2(@front_matter.dig("featured_story", "heading")) %>
-                <%= tag.span(@front_matter.dig("featured_story", "subheading"), class: "stories-feature__subheading") %>
-                <%= tag.p(@front_matter.dig("featured_story", "text")) %>
-                <%= link_to(@front_matter.dig("featured_story", "link"), class: "git-link") do %>
-                  Read <%= @front_matter.dig("featured_story", "name") %>’s story <%= fas_icon("chevron-right") %>
-                <% end %>
-              </div>
-            </section>
-          <% end %>
-
           <% if @front_matter.key?("featured_page") %>
             <section class="stories-feature">
               <div class="stories-feature__image" style="background-image:url('<%= @front_matter.dig("featured_page", "image") %>')"></div>

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -44,10 +44,9 @@ describe "rendering pages with a custom layout" do
     it { expect(response).to have_http_status(200) }
     it { is_expected.to include("Landing Page Test") }
 
-    it { is_expected.to include("Featured story") }
     it { is_expected.to include("A heading") }
     it { is_expected.to include("A subheading") }
-    it { is_expected.to include("Longer featured story text") }
+    it { is_expected.to include("Longer featured page text") }
 
     it { is_expected.to include("A Section") }
     it { is_expected.to include("Longer section text") }

--- a/spec/support/views/content/stories/landing-page.md
+++ b/spec/support/views/content/stories/landing-page.md
@@ -3,13 +3,14 @@
   title: "Landing Page Test"
   hide_page_helpful_question: true
   fullwidth: true
-  featured_story:
+  featured_page:
     image: /a/story/image.jpg
-    name: Featured story
     heading: A heading
     subheading: A subheading
-    text: Longer featured story text
-    link: /a/story/link
+    text: Longer featured page text
+    link: 
+      text: a story link
+      path: /a/story/link
   sections:
     A Section:
       link: /a/section/link


### PR DESCRIPTION
### Trello card

[Trello-1344](https://trello.com/c/p27qwi1o/1344-development-add-day-in-the-life-of-a-teacher-into-stories-and-make-better-use-of-the-large-purple-banner-in-stories)

### Context

The featured story on the stories landing template has been swapped out to a featured page (day in the life of a teacher).

We now show a featured page here, so the featured story can be removed.

### Changes proposed in this pull request

- Remove featured story from landing template

### Guidance to review

