### PR TITLE
Paginate event search results per category

### DIFF
--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -6,7 +6,6 @@ class EventCategoriesController < ApplicationController
 
   breadcrumb "events.search", :events_path
 
-  EVENTS_PER_PAGE = 9
   MAXIMUM_EVENTS_IN_CATEGORY = 1_000
 
   def show
@@ -46,8 +45,7 @@ private
     @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: period))
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
     group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
-    events_of_type = group_presenter.sorted_events_of_type(@type.id)
-    @events = paginate(events_of_type)
+    @events = group_presenter.paginated_events_of_type(@type.id, params[:page]) || []
   end
 
   def load_type
@@ -61,15 +59,6 @@ private
   def set_form_action
     @form_action = URI.parse(request.path)
     @form_action.fragment = "searchforevents"
-  end
-
-  def paginate(events)
-    return [] if events.blank?
-
-    Kaminari
-      .paginate_array(events, total_count: events&.size)
-      .page(params[:page])
-      .per(EVENTS_PER_PAGE)
   end
 
   def has_archive?(type)

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -1,5 +1,7 @@
 module Events
   class GroupPresenter
+    EVENTS_PER_TYPE = 9
+
     def initialize(events_by_type, display_empty_types = false, ascending = true)
       @display_empty_types = display_empty_types
       @events_by_type = events_by_type
@@ -11,12 +13,37 @@ module Events
         end
     end
 
+    def paginated_events_by_type(pages, per_page = EVENTS_PER_TYPE)
+      sorted_events_by_type.map do |type_id, events|
+        paginated_events = Kaminari
+          .paginate_array(events, total_count: events.count)
+          .page(pages[page_param_name(type_id)])
+          .per(per_page)
+
+        [type_id, paginated_events]
+      end
+    end
+
     def sorted_events_by_type
       populate_events_by_type.sort_by { |k, _| event_type_ids.index(k) }
     end
 
     def sorted_events_of_type(type_id)
-      sorted_events_by_type.first { |v| v.first == type_id }&.last
+      sorted_events_by_type.find { |v| v.first == type_id }&.last
+    end
+
+    def paginated_events_of_type(type_id, page, per_page = EVENTS_PER_TYPE)
+      pages_by_type = { page_param_name(type_id) => page }
+      paginated_events_by_type(pages_by_type, per_page).first { |v| v.first == type_id }&.last
+    end
+
+    def page_param_names
+      event_type_ids.index_with { |type_id| page_param_name(type_id) }
+    end
+
+    def page_param_name(type_id)
+      category_name = GetIntoTeachingApiClient::Constants::EVENT_TYPES.key(type_id)
+      "#{category_name.parameterize(separator: '_')}_page"
     end
 
   private

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -23,6 +23,12 @@
       <% end %>
     <% end %>
 
+    <% if page_param_name.present? %>
+      <div class="event-pagination">
+        <%= paginate events, param_name: page_param_name %>
+      </div>
+    <% end %>
+
     <% show_see_all_events ||= false %>
 
     <% if show_see_all_events %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -36,12 +36,17 @@
   </div>
 <% end %>
 
-<% if @events_by_type.any? %>
+<% unless @no_results %>
   <% unless @performed_search %>
   <h2>Discover events</h2>
   <% end %>
-  <% @group_presenter.sorted_events_by_type.each do |type_id, events| %>
-    <%= render partial: "event_group", locals: { type_id: type_id, events: events, show_see_all_events: true } %>
+  <% @events_by_type.each do |type_id, events| %>
+    <%= render "event_group",
+      type_id: type_id,
+      events: events,
+      page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
+      show_see_all_events: true
+    %>
   <% end %>
 <% else %>
   <%= render(Events::NoResultsComponent.new) do %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, data: { action: "click->scroll#preserve" } %>
 </span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,5 +8,5 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, data: { action: "click->scroll#preserve" } } %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, data: { action: "click->scroll#preserve" } %>
 </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
     <div id="skiplink-container">
       <div>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
     <div id="skiplink-container">
       <div>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -2,7 +2,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
     <div id="skiplink-container">
       <div>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -1,5 +1,12 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
+  <% content_for(:head) do %>
+    <!--
+    Turbolinks preview cache occasionally causes the page to jump
+    back to the top after we restore the scroll position on pagination.
+    -->
+    <meta name="turbolinks-cache-control" content="no-cache">
+  <% end %>
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <%= render Navigation::BreadcrumbComponent.new %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <%= render Sections::HeroComponent.new(@front_matter) %>
       <%= render Navigation::BreadcrumbComponent.new %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
       <%= render "sections/header" %>
       <main role="main" id="main-content">
         <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>

--- a/app/webpacker/controllers/scroll_controller.js
+++ b/app/webpacker/controllers/scroll_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static previousTopKey = 'scroll-previousTop';
+
+  connect() {
+    this.restore();
+  }
+
+  restore() {
+    if (this.previousTop) {
+      window.scrollTo(0, this.previousTop);
+      this.clearPreviousTop();
+    }
+  }
+
+  preserve() {
+    this.previousTop = document.documentElement.scrollTop;
+  }
+
+  clearPreviousTop() {
+    window.localStorage.removeItem(this.constructor.previousTopKey);
+  }
+
+  set previousTop(value) {
+    window.localStorage.setItem(this.constructor.previousTopKey, value);
+  }
+
+  get previousTop() {
+    return window.localStorage.getItem(this.constructor.previousTopKey);
+  }
+}

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "Finding an event", type: :feature do
     end
   end
   let(:events_by_type) { group_events_by_type(events) }
-  let(:event) { events.last }
+  let(:event) { events.first }
+  let(:event_category_slug) { "train-to-teach-events" }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -25,7 +26,7 @@ RSpec.feature "Finding an event", type: :feature do
     expect(page).to have_text "Search for events"
     expect(page).to have_css "h3", text: "Train to Teach events"
 
-    click_on(event.name)
+    first(:link, event.name).click
 
     expect(page).to have_css "h1", text: event.name
     click_on "Sign up for this event", match: :first
@@ -47,7 +48,22 @@ RSpec.feature "Finding an event", type: :feature do
     click_on "Sign up for this event", match: :first
   end
 
-  let(:event_category_slug) { "train-to-teach-events" }
+  scenario "Paging through search results" do
+    visit events_path
+
+    expect(page).to have_text "Search for events"
+    expect(page).to_not have_css ".pagination"
+
+    click_on "Update results"
+
+    expect(page).to have_css ".pagination"
+
+    # there are 11 events and 9 per page
+    expect(page).to have_css(".event-box", count: 9)
+    click_on("2")
+    expect(page).to have_css(".event-box", count: 2)
+  end
+
   scenario "Navigating events by page" do
     visit event_category_path(event_category_slug)
 

--- a/spec/javascript/controllers/mailing-list_controller_spec.js
+++ b/spec/javascript/controllers/mailing-list_controller_spec.js
@@ -1,19 +1,6 @@
 import { Application } from 'stimulus';
 import MailingListController from 'mailing-list_controller.js';
-
-class FakeLocalStorage {
-  constructor(store = {}) {
-    this.store = store;
-  }
-
-  getItem(key) {
-    return this.store[key];
-  }
-
-  setItem(key, value) {
-    return (this.store[key] = value);
-  }
-}
+import StubLocalStorage from '../stubs/local_storage';
 
 describe('MailingListController', () => {
   beforeEach(() => {
@@ -79,7 +66,7 @@ describe('MailingListController', () => {
   describe('when the user has visited 3 or more pages', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'localStorage', {
-        value: new FakeLocalStorage(),
+        value: new StubLocalStorage(),
       });
       window.localStorage.setItem('mailingListPageCount', '5');
 
@@ -96,7 +83,7 @@ describe('MailingListController', () => {
   describe('viewing a page increments the counter', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'localStorage', {
-        value: new FakeLocalStorage(),
+        value: new StubLocalStorage(),
       });
       window.localStorage.setItem('mailingListPageCount', '2');
 
@@ -114,7 +101,7 @@ describe('MailingListController', () => {
   describe('dismissing the mailing list box', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'localStorage', {
-        value: new FakeLocalStorage({ mailingListPageCount: '2' }),
+        value: new StubLocalStorage({ mailingListPageCount: '2' }),
       });
 
       const application = Application.start();
@@ -133,7 +120,7 @@ describe('MailingListController', () => {
   describe("once dismissed the mailing list bar shouldn't be shown", () => {
     beforeEach(() => {
       Object.defineProperty(window, 'localStorage', {
-        value: new FakeLocalStorage({
+        value: new StubLocalStorage({
           mailingListDismissed: 'true',
           mailingListPageCount: '8',
         }),

--- a/spec/javascript/controllers/scroll_controller_spec.js
+++ b/spec/javascript/controllers/scroll_controller_spec.js
@@ -1,0 +1,42 @@
+import { Application } from 'stimulus';
+import ScrollController from 'scroll_controller';
+
+describe('ScrollController', () => {
+  var application;
+
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="controller" data-controller="scroll" style="height: 10000px;">
+        <div style="height: 5000px;"></div>
+        <a id="link" href="/path" data-action="click->scroll#preserve">Link</a>
+      </div>`;
+
+    application = Application.start();
+  });
+
+  describe('arriving on a page after preserving the scroll position', () => {
+    it('restores the scroll position', () => {
+      window.localStorage.setItem(ScrollController.previousTopKey, '7000');
+      window.scrollTo = jest.fn();
+
+      application.register('scroll', ScrollController);
+
+      expect(window.scrollTo).toHaveBeenCalledWith(0, '7000');
+      expect(window.localStorage.getItem(ScrollController.previousTopKey)).toBeNull();
+    });
+  });
+
+  describe('clicking on an element that preserves the scroll position', () => {
+    it('records the scroll position', () => {
+      application.register('scroll', ScrollController);
+
+      // The browser will set this on click, but Jest doesn't
+      // so we need to set it manually.
+      document.documentElement.scrollTop = '5000';
+
+      const link = document.getElementById('link');
+      link.click();
+
+      expect(window.localStorage.getItem(ScrollController.previousTopKey)).toEqual('5000');
+    });
+  });
+});

--- a/spec/javascript/stubs/local_storage.js
+++ b/spec/javascript/stubs/local_storage.js
@@ -1,0 +1,13 @@
+export default class StubLocalStorage {
+  constructor(store = {}) {
+    this.store = store;
+  }
+
+  getItem(key) {
+    return this.store[key];
+  }
+
+  setItem(key, value) {
+    return (this.store[key] = value);
+  }
+}

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Events::GroupPresenter do
-  let(:train_to_teach_events) { build_list(:event_api, 3, :train_to_teach_event) }
-  let(:online_events) { build_list(:event_api, 3, :online_event) }
-  let(:school_and_university_events) { build_list(:event_api, 3, :school_or_university_event) }
+  let(:train_to_teach_events) { build_list(:event_api, 5, :train_to_teach_event) }
+  let(:online_events) { build_list(:event_api, 2, :online_event) }
+  let(:school_and_university_events) { build_list(:event_api, 15, :school_or_university_event) }
   let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
   let(:events_by_type) { group_events_by_type(all_events) }
   let(:display_empty_types) { false }
@@ -66,8 +66,60 @@ describe Events::GroupPresenter do
     end
   end
 
+  describe "#paginated_events_by_type" do
+    it "paginates the events sorted by type" do
+      pages_by_type = {
+        "train_to_teach_event_page" => nil,
+        "online_event_page" => 1,
+        "school_or_university_event_page" => 2,
+      }
+      paginated_events_by_type = subject.paginated_events_by_type(pages_by_type, 3)
+
+      expect(paginated_events_by_type).to eq([
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events[0...3]],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"], online_events[0...2]],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events[3...6]],
+      ])
+    end
+
+    it "defaults to 9 events per page" do
+      pages_by_type = GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.product([nil]).to_h
+      paginated_events_by_type = subject.paginated_events_by_type(pages_by_type)
+
+      expect(paginated_events_by_type).to include(
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events[0...9]],
+      )
+    end
+  end
+
+  describe "#paginated_events_of_type" do
+    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:page) { 2 }
+    let(:per_page) { 2 }
+
+    it "returns paginated events of the given type" do
+      expect(subject.paginated_events_of_type(type, page, per_page)).to eq(train_to_teach_events[2...4])
+    end
+  end
+
+  describe "#page_param_names" do
+    it "returns a hash of page param names" do
+      expect(subject.page_param_names).to eq({
+        222_750_001 => "train_to_teach_event_page",
+        222_750_008 => "online_event_page",
+        222_750_009 => "school_or_university_event_page",
+      })
+    end
+  end
+
+  describe "#page_param_name" do
+    it { expect(subject.page_param_name(222_750_001)).to eq("train_to_teach_event_page") }
+    it { expect(subject.page_param_name(222_750_008)).to eq("online_event_page") }
+    it { expect(subject.page_param_name(222_750_009)).to eq("school_or_university_event_page") }
+  end
+
   describe "#sorted_events_of_type" do
-    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach Event"] }
+    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
 
     it "returns the events of the given type" do
       expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events)

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -117,7 +117,7 @@ describe "View events by category" do
   describe "pagination" do
     before { get(path) }
 
-    let(:events_per_page) { EventCategoriesController::EVENTS_PER_PAGE }
+    let(:events_per_page) { Events::GroupPresenter::EVENTS_PER_TYPE }
     let(:parsed_response) { Nokogiri.parse(response.body) }
 
     context "when there are more than one page's worth of events" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -24,7 +24,7 @@ describe EventsController do
   end
 
   describe "#search" do
-    let(:results_per_type) { Events::Search::RESULTS_PER_TYPE }
+    let(:results_per_type) { EventsController::MAXIMUM_EVENTS_PER_CATEGORY }
     let(:events) { [build(:event_api, name: "First"), build(:event_api, name: "Second")] }
     let(:events_by_type) { group_events_by_type(events) }
     let(:search_key) { Events::Search.model_name.param_key }


### PR DESCRIPTION
### Trello card

[Trello-1389](https://trello.com/c/SHyE7HUc/1389-paginate-event-search-results)

### Context

When a user searches for events in a given month we currently only show 9 per category. Whilst this can show the majority of some event types there are often more School and University events, resulting in the user only seeing events for the next few days (even though they have the whole month selected).

It's not clear that there are more events matching their search parameters - they would need to click on `Explore School and University Events` and then re-filter by their month to see them, which is a lot to expect users to work out.

Instead, we want to add a pagination control per category so that users can quickly cycle through to future events matching their search terms. We want the user's position on the page to remain static so they don't have to keep scrolling back down to the category they are paginating through, which would be jarring.

### Changes proposed in this pull request

- Add ScrollController to preserve position on page change

We want to be able to preserve the scroll position when selecting pagination pages (so the transition is not jarring to the user).

```
1. Add `ScrollController` to preserve/restore scroll position.
2. Add controller to all layouts.
3. Update pagination partials to preserve scroll position.
```

- Extract localStorage stub into module

We will need to re-use this for the `ScrollController` specs potentially, so making it reusable.

- Update GroupPresenter to handle pagination

We want to be able to paginate the events sorted by type if they are part of search results (as opposed to the upcoming events).

Add `paginated_events_by_type` method that paginates each set of events according to the arguments (`pages_by_type` contains the active page for each type and `per_page` is how many events per page we want to display).

Add `paginated_events_of_type` convenience method so that we can update `EventCategoriesController` to use the presenter for pagination as well.

- Display search results paginated

When we land on the search page we want to continue to show the next 3 events per category. When we search for events we want to show 9 per category and offer the user a page control to navigate to more events matching their search criteria.

- Use GroupPresenter pagination methods

We now paginate in the `GroupPresenter` for the main event search results; this updates EventCategoriesController to use the presenter methods.

### Guidance to review

I think the event controllers are probably a bit busier than they need to be; I may follow this up with another PR to try and DRY them up.

https://user-images.githubusercontent.com/29867726/110491459-359aba00-80e9-11eb-9409-64fed937f003.mov

