### PR TITLE
Ensure query string is maintained when redirecting

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
 
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
-    redirect_rules.each { |from, to| get from, to: redirect(to) }
+    redirect_rules.each { |from, to| get from, to: redirect(path: to) }
   end
 
   if Rails.env.rolling? || Rails.env.preprod? || Rails.env.production?

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,12 +1,33 @@
 require "rails_helper"
 
 describe "Redirects" do
+  let(:query_string) { "abc=def&ghi=jkl" }
+
   redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")
 
+  def build_url(base, query_string)
+    [base, query_string].join("?")
+  end
+
   redirects.each do |from, to|
-    specify "'#{from}' redirects to '#{to}'" do
-      expect(get(from)).to be 301
-      expect(response).to redirect_to(to)
+    describe "'#{from}' redirects to '#{to}'" do
+      context "without a query string" do
+        subject { get(from) }
+
+        specify "redirects successfully" do
+          expect(subject).to be 301
+          expect(response).to redirect_to(to)
+        end
+      end
+
+      context "with a query string" do
+        subject { get(build_url(from, query_string)) }
+
+        specify "redirects successfully and maintains the query string" do
+          expect(subject).to be(301)
+          expect(response).to redirect_to(build_url(to, query_string))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/dxfsiiwE/1313-record-of-all-redirects-that-we-need-to-put-in-place-from-the-bau-site-on-get-into-teaching-private-beta

### Context and changes

When this site replaces the BAU site there will still be plenty of links in the wild that point to pages that no longer exist. We're going to add some redirect rules to `redirects.yml` to intercept many of these but we need to maintain the `utm` codes and any other query params.

[Rails' redirect method](https://api.rubyonrails.org/v6.1.0/classes/ActionDispatch/Routing/Redirection.html#method-i-redirect) will redirect entirely, losing the query params, when passed a single path argument.

Thankfully, when passed a keyword argument for a specific part of the URL - e.g., `path:`, only that part is substituted and the rest of the URL is left as-is.

Here we use that functionality to our advantage and replace only the path, this keeps the query string in place and should allow our tracking params to be maintained even when redirecting legacy pages to their new counterparts.