### PR TITLE
Add the mailing list banner to stories layouts

### DIFF
--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -46,6 +46,7 @@
         </article>
       </main>
       <%= render "sections/footer" %>
+      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -17,6 +17,7 @@
         </section>
       </main>
       <%= render "sections/footer" %>
+      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -10,6 +10,7 @@
         <% end %>
       </main>
       <%= render "sections/footer" %>
+      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>


### PR DESCRIPTION
It was missing as the mailing list bars were dropped in as a replacement for the feedback ones, which were also absent from the stories pages.