### PR TITLE
Add a basic sitemap generator

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,46 @@
+class SitemapController < ApplicationController
+  DEFAULT_LASTMOD = "2021-03-01".freeze
+
+  ALIASES = {
+    "/home" => "/",
+  }.freeze
+
+  OTHER_PATHS = %w[
+    /events
+    /event-categories/train-to-teach-events
+    /event-categories/online-q-as
+    /event-categories/school-and-university-events
+  ].freeze
+
+  def show
+    render xml: build.to_xml
+  end
+
+private
+
+  def build
+    Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+      xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
+        Pages::Frontmatter.list.each do |path, metadata|
+          xml.url do
+            xml.loc(request.base_url + page_location(path))
+            xml.lastmod(metadata.fetch("date") { DEFAULT_LASTMOD })
+            xml.priority(metadata.fetch("priority")) if metadata.key?("priority")
+          end
+        end
+
+        OTHER_PATHS.each do |events_path|
+          xml.url do
+            xml.loc(request.base_url + events_path)
+            xml.lastmod(DEFAULT_LASTMOD)
+            xml.change_frequency("daily")
+          end
+        end
+      end
+    end
+  end
+
+  def page_location(path)
+    ALIASES.fetch(path) { path }
+  end
+end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -10,6 +10,7 @@ class SitemapController < ApplicationController
     /event-categories/train-to-teach-events
     /event-categories/online-q-as
     /event-categories/school-and-university-events
+    /mailinglist/signup
   ].freeze
 
   def show
@@ -33,7 +34,6 @@ private
           xml.url do
             xml.loc(request.base_url + events_path)
             xml.lastmod(DEFAULT_LASTMOD)
-            xml.change_frequency("daily")
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
+  get "/sitemap.xml", to: "sitemap#show", via: :all
 
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
     redirect_rules.each { |from, to| get from, to: redirect(path: to) }

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe SitemapController do
+  subject { Nokogiri::XML(response.body) }
+
+  let(:nodes) do
+    {
+      "/ways-to-train" => {
+        "name" => "Ways to train",
+        "priority" => 0.8,
+        "date" => "2020-11-11",
+      },
+      "/salaries-and-benfits" => {
+        "name" => "Salaries and benefits",
+        "priority" => 0.7,
+      },
+      "/my-story-into-teaching/what-a-great-story" => {
+        "name" => "What a great story",
+        "priority" => 0.7,
+        "date" => "2020-10-10",
+      },
+    }
+  end
+
+  before { allow(Pages::Frontmatter).to receive(:list) { nodes } }
+
+  before { get("/sitemap.xml") }
+
+  describe "#show" do
+    let(:sitemap_namespace) { "http://www.sitemaps.org/schemas/sitemap/0.9" }
+    specify "the document should have the correct namespace" do
+      expect(subject.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
+    end
+
+    describe "nodes" do
+      let(:expected) { SitemapController::OTHER_PATHS.count + nodes.count }
+      let(:paths) { nodes.keys.concat(SitemapController::OTHER_PATHS) }
+
+      specify "should have the right number of nodes" do
+        expect(expected).to eql(subject.xpath("/xmlns:urlset/xmlns:url").size)
+      end
+
+      specify "the nodes should have the correct paths" do
+        expect(
+          subject
+            .xpath("xmlns:urlset/xmlns:url/xmlns:loc")
+            .map { |node| URI(node.text).path },
+        ).to match_array(paths)
+      end
+    end
+
+    describe "priority" do
+      specify "priority should be assinged from frontmatter" do
+        nodes.each do |path, data|
+          importance = subject.at_xpath(
+            %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:priority),
+          ).text
+
+          expect(importance).to eql(data["priority"].to_s)
+        end
+      end
+    end
+
+    describe "lastmod" do
+      specify "last modified date should be assinged from frontmatter" do
+        nodes.each do |path, data|
+          last_modified = subject.at_xpath(
+            %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:lastmod),
+          ).text
+
+          expect(last_modified).to eql((data["date"] || SitemapController::DEFAULT_LASTMOD).to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SitemapController do
   subject { Nokogiri::XML(response.body) }
 
-  let(:nodes) do
+  let(:content_pages) do
     {
       "/ways-to-train" => {
         "name" => "Ways to train",
@@ -22,7 +22,7 @@ RSpec.describe SitemapController do
     }
   end
 
-  before { allow(Pages::Frontmatter).to receive(:list) { nodes } }
+  before { allow(Pages::Frontmatter).to receive(:list) { content_pages } }
 
   before { get("/sitemap.xml") }
 
@@ -32,15 +32,15 @@ RSpec.describe SitemapController do
       expect(subject.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
     end
 
-    describe "nodes" do
-      let(:expected) { SitemapController::OTHER_PATHS.count + nodes.count }
-      let(:paths) { nodes.keys.concat(SitemapController::OTHER_PATHS) }
+    describe "content_pages" do
+      let(:expected) { SitemapController::OTHER_PATHS.count + content_pages.count }
+      let(:paths) { content_pages.keys.concat(SitemapController::OTHER_PATHS) }
 
-      specify "should have the right number of nodes" do
+      specify "should have the right number of content_pages" do
         expect(expected).to eql(subject.xpath("/xmlns:urlset/xmlns:url").size)
       end
 
-      specify "the nodes should have the correct paths" do
+      specify "the content_pages should have the correct paths" do
         expect(
           subject
             .xpath("xmlns:urlset/xmlns:url/xmlns:loc")
@@ -51,7 +51,7 @@ RSpec.describe SitemapController do
 
     describe "priority" do
       specify "priority should be assinged from frontmatter" do
-        nodes.each do |path, data|
+        content_pages.each do |path, data|
           importance = subject.at_xpath(
             %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:priority),
           ).text
@@ -63,7 +63,7 @@ RSpec.describe SitemapController do
 
     describe "lastmod" do
       specify "last modified date should be assinged from frontmatter" do
-        nodes.each do |path, data|
+        content_pages.each do |path, data|
           last_modified = subject.at_xpath(
             %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:lastmod),
           ).text


### PR DESCRIPTION
### Trello card

https://trello.com/c/CEFa8IGk/1401-create-or-update-our-sitemap

### Context and changes

It uses both the combined frontmatter from all content (via `Pages::Frontmatter`) and a hard-coded list of extra paths, which aren't generated from markdown files (like /events) to build a [sitemap](https://www.sitemaps.org/protocol.html).

### Guidance to review

Find it at `/sitemap.xml`
