### PR TITLE
Make markdown h3 headings bigger than h4

### DIFF
--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -21,7 +21,7 @@
     <%= render Navigation::BreadcrumbComponent.new %>
 
     <main role="main" id="main-content">
-      <section class="container">
+      <section class="container events">
         <article class="markdown<%= " fullwidth" if @before_search_fullwidth %> ">
           <%= yield :before_search %>
         </article>
@@ -29,7 +29,7 @@
       <div class="feature">
         <%= render @search_component %>
       </div>
-      <section class="container">
+      <section class="container events">
         <article class="fullwidth">
           <%= yield %>
         </article>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -30,7 +30,7 @@
         <%= render @search_component %>
       </div>
       <section class="container">
-        <article class="markdown fullwidth">
+        <article class="fullwidth">
           <%= yield %>
         </article>
       </section>

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -1,219 +1,226 @@
-.types-of-event__header__icon {
-  margin-bottom: 5px;
-}
-
-.event-type-descriptions {
-  text-align: left;
-  padding-bottom: 60px;
-
-  .event-type-descriptions__content {
-    @include cards-grid;
-    padding: $indent-amount $indent-amount 0 $indent-amount;
-    margin-bottom: 0;
-  }
-}
-
-.search-for-events-results {
-  display: flex;
-  flex-wrap: wrap;
-
-  > a {
-    width: 33.333%;
-    margin-bottom: 30px;
-    padding: 0 15px;
-    box-sizing: border-box;
-    text-decoration: none;
-  }
-
-  .event-box {
-    height: 100%;
-  }
-}
-
-.events-featured {
-  background: $grey;
-  position: relative;
-  padding: $indent-amount;
-  width: 100%;
-  margin-top: 30px;
-  box-sizing: border-box;
-
-  + .events-featured {
-    margin-top: 30px;
-  }
-
-  .no-results {
-    width: 66.6%;
-
-    @include mq($until: tablet) {
-      width: 100%;
-    }
-  }
-
-  &--with-logo {
-    margin-top: 90px;
-  }
-
-  &__heading {
-    > h3 {
-      font-size: size("medium");
-      margin: 0 0 $indent-amount 0;
-      line-height: 1.25;
-    }
-  }
-
-  &__text {
-    max-width: 70%;
-    margin-bottom: 30px;
-  }
-
-  &__list {
-    padding: 0;
-    @include cards-grid;
-
-    &__item {
-
-      list-style: none;
-      display: flex;
-      text-decoration: none;
-    }
-  }
-
-  .call-to-action-button {
+.events {
+  h2 {
+    @include content-heading;
     margin-top: 1.5em;
-    white-space: normal;
   }
 
-  &__logo {
-    position: absolute;
-    top: 0;
-    left: 100%;
-    transform: translate(-100%, -65%);
-  }
-}
-
-.event-pagination {
-  &.content {
-    overflow: inherit;
+  .types-of-event__header__icon {
+    margin-bottom: 5px;
   }
 
-  .pagination {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-
-    @mixin pagination-item {
-      font-weight: bold;
-      font-size: size("xsmall");
-      padding: .8em;
-      text-decoration: none;
-      margin: 1em 0;
-    }
-
-    // kaminari selectors
-    * {
-      display: block;
-      line-height: 1;
-    }
-
-    a {
-      @include pagination-item;
-      border: 2px solid $pink-dark;
-      color: $pink-dark;
-    }
-
-    .page {
-      text-align: center;
-      min-width: .8em;
-
-      &.current,
-      &.gap {
-        padding: .8em .6em;
-      }
-
-      &.current {
-        @include pagination-item;
-        background-color: $pink-dark;
-        color: $white;
-        border: 2px solid $pink-dark;
-      }
-    }
-
-    .prev {
-      margin-right: .2em;
-    }
-
-    .prev + .page,
-    .page + .page {
-      margin-left: .2em;
-      margin-right: .2em;
-    }
-  }
-}
-
-@include mq($until: tablet) {
   .event-type-descriptions {
-    padding-bottom: 0;
-  }
+    text-align: left;
+    padding-bottom: 60px;
 
-  .types-of-event {
-    &__left {
-
-      padding-left: 0;
-      padding-right: 0;
-      display: block;
-      width: 100%;
-      margin-right: 40px;
-    }
-
-    &__right {
-      margin: 0;
-      padding: 0;
-      display: block;
-      width: 100%;
+    .event-type-descriptions__content {
+      @include cards-grid;
+      padding: $indent-amount $indent-amount 0 $indent-amount;
+      margin-bottom: 0;
     }
   }
 
   .search-for-events-results {
+    display: flex;
+    flex-wrap: wrap;
+
     > a {
-      width: 50%;
+      width: 33.333%;
+      margin-bottom: 30px;
+      padding: 0 15px;
+      box-sizing: border-box;
+      text-decoration: none;
+    }
+
+    .event-box {
+      height: 100%;
     }
   }
 
   .events-featured {
-    &__text {
-      max-width: 100%;
+    background: $grey;
+    position: relative;
+    padding: $indent-amount;
+    width: 100%;
+    margin-top: 30px;
+    box-sizing: border-box;
+
+    + .events-featured {
+      margin-top: 30px;
     }
 
-    &--with-logo {
-      margin-top: 60px;
+    .no-results {
+      width: 66.6%;
 
       @include mq($until: tablet) {
-        margin-top: 30px;
+        width: 100%;
       }
     }
 
+    &--with-logo {
+      margin-top: 90px;
+    }
+
     &__heading {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+      > h3 {
+        font-size: size("medium");
+        margin: 0 0 $indent-amount 0;
+        line-height: 1.25;
+      }
+    }
+
+    &__text {
+      max-width: 70%;
+      margin-bottom: 30px;
+    }
+
+    &__list {
+      padding: 0;
+      @include cards-grid;
+
+      &__item {
+
+        list-style: none;
+        display: flex;
+        text-decoration: none;
+      }
+    }
+
+    .call-to-action-button {
+      margin-top: 1.5em;
+      white-space: normal;
     }
 
     &__logo {
-      position: relative;
-      top: auto;
-      left: auto;
-      transform: scale(.7);
-      margin-right: -58px;
+      position: absolute;
+      top: 0;
+      left: 100%;
+      transform: translate(-100%, -65%);
     }
   }
-}
 
-@include mq($until: mobile) {
-  .search-for-events-results {
-    > a {
-      width: 100%;
-      padding: 0;
+  .event-pagination {
+    &.content {
+      overflow: inherit;
+    }
+
+    .pagination {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+
+      @mixin pagination-item {
+        font-weight: bold;
+        font-size: size("xsmall");
+        padding: .8em;
+        text-decoration: none;
+        margin: 1em 0;
+      }
+
+      // kaminari selectors
+      * {
+        display: block;
+        line-height: 1;
+      }
+
+      a {
+        @include pagination-item;
+        border: 2px solid $pink-dark;
+        color: $pink-dark;
+      }
+
+      .page {
+        text-align: center;
+        min-width: .8em;
+
+        &.current,
+        &.gap {
+          padding: .8em .6em;
+        }
+
+        &.current {
+          @include pagination-item;
+          background-color: $pink-dark;
+          color: $white;
+          border: 2px solid $pink-dark;
+        }
+      }
+
+      .prev {
+        margin-right: .2em;
+      }
+
+      .prev + .page,
+      .page + .page {
+        margin-left: .2em;
+        margin-right: .2em;
+      }
+    }
+  }
+
+  @include mq($until: tablet) {
+    .event-type-descriptions {
+      padding-bottom: 0;
+    }
+
+    .types-of-event {
+      &__left {
+
+        padding-left: 0;
+        padding-right: 0;
+        display: block;
+        width: 100%;
+        margin-right: 40px;
+      }
+
+      &__right {
+        margin: 0;
+        padding: 0;
+        display: block;
+        width: 100%;
+      }
+    }
+
+    .search-for-events-results {
+      > a {
+        width: 50%;
+      }
+    }
+
+    .events-featured {
+      &__text {
+        max-width: 100%;
+      }
+
+      &--with-logo {
+        margin-top: 60px;
+
+        @include mq($until: tablet) {
+          margin-top: 30px;
+        }
+      }
+
+      &__heading {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      &__logo {
+        position: relative;
+        top: auto;
+        left: auto;
+        transform: scale(.7);
+        margin-right: -58px;
+      }
+    }
+  }
+
+  @include mq($until: mobile) {
+    .search-for-events-results {
+      > a {
+        width: 100%;
+        padding: 0;
+      }
     }
   }
 }

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -41,6 +41,14 @@
     margin-top: 1.5em;
   }
 
+  h3 {
+    font-size: size(large);
+  }
+
+  h4 {
+    font-size: size(medium);
+  }
+
   a {
     &[href*="//"] {
       &:after {


### PR DESCRIPTION
A couple of our guidance pages need some distinction. To stop this from bleeding into the events pages the .markdown class has been removed from the event list container.

Here's a `h3` followed by a `h4`:

![Screenshot from 2021-03-10 15-42-15](https://user-images.githubusercontent.com/128088/110655808-49aced00-81b7-11eb-87e8-25a1720ce9e1.png)
