### PR TITLE
Prevent mailing list bar from blocking content

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,6 @@
 
     <%= render "sections/footer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/videoplayer" %>
   <% end %>
 </html>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -31,7 +31,6 @@
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/analytics" %>
   <% end %>
 </html>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -97,7 +97,6 @@
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>
-        <%= render "sections/mailing-list-bar" %>
         <%= render "components/analytics" %>
     <% end %>
 </html>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -35,7 +35,6 @@
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/analytics" %>
   <% end %>
 </html>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -38,7 +38,6 @@
 
     <%= render "sections/footer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/videoplayer" %>
   <% end %>
 </html>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -21,7 +21,6 @@
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/analytics" %>
   <% end %>
 </html>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -19,7 +19,6 @@
 
     <%= render "sections/footer" %>
     <%= render "sections/cookie-acceptance" %>
-    <%= render "sections/mailing-list-bar" %>
     <%= render "components/videoplayer" %>
   <% end %>
 </html>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -46,7 +46,6 @@
         </article>
       </main>
       <%= render "sections/footer" %>
-      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -17,7 +17,6 @@
         </section>
       </main>
       <%= render "sections/footer" %>
-      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -10,7 +10,6 @@
         <% end %>
       </main>
       <%= render "sections/footer" %>
-      <%= render "sections/mailing-list-bar" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>
     <% end %>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,5 +1,6 @@
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
+  <%= render "sections/mailing-list-bar" %>
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">

--- a/app/views/sections/_mailing-list-bar.html.erb
+++ b/app/views/sections/_mailing-list-bar.html.erb
@@ -1,13 +1,11 @@
 <div class="mailing-list-bar" data-controller="mailing-list" data-banner-name="MailingList">
-  <section class="container">
-      <div class="mailing-list-bar__inner">
-          <div class="mailing-list-bar__left">
-            Get personalised information and advice about getting into teaching
-          </div>
-          <div class="mailing-list-bar__right">
-            <a href="/mailinglist/signup" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
-            <a href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
-          </div>
-      </div>
+  <section class="mailing-list-bar__inner limit-content-width">
+    <div class="mailing-list-bar__left">
+      Get personalised information and advice about getting into teaching
+    </div>
+    <div class="mailing-list-bar__right">
+      <a href="/mailinglist/signup" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
+      <a href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
+    </div>
   </section>
 </div>

--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -1,13 +1,8 @@
 .mailing-list-bar {
   background-color: $green;
-  max-width: $content-max-width;
-  margin: 0 auto;
-
+  padding: 1em;
   position: sticky;
   bottom: 0;
-  padding: 1em;
-
-  flex-direction: row;
 
   // will be enabled via JS
   display: none;
@@ -15,6 +10,7 @@
   &__inner {
     align-items: center;
     display: flex;
+    margin: 0 auto;
 
     @include mq($until: tablet) {
       flex-direction: column;
@@ -59,9 +55,5 @@
       color: $white;
       text-decoration: none;
     }
-  }
-
-  > .container {
-    @include reset;
   }
 }


### PR DESCRIPTION
### Context

The mailing list bar floating at the bottom of the page allowed it to encroach too far up. When the COVID-19 banner is present it made the page really difficult to see and the hero image obscured the "Not now" link to disable it. [Example here](https://user-images.githubusercontent.com/128088/110769735-6d704180-8250-11eb-941f-8210853f4cbb.jpeg).


### Changes proposed in this pull request

Make the mailing list signup bar ['sticky'](https://developer.mozilla.org/en-US/docs/Web/CSS/position) and move it to the footer. This will allow the mailing list to float up the footer but not over actual content.

#### Mobile

https://user-images.githubusercontent.com/128088/110769879-942e7800-8250-11eb-937a-1f11a4bbc9d9.mp4

#### Desktop

https://user-images.githubusercontent.com/128088/110770027-bfb16280-8250-11eb-84ba-a5430e71d951.mp4
