### PR TITLE
Tweak the mailing list bar styles

### DIFF
--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -25,7 +25,7 @@
     color: $white;
 
     @include mq($until: tablet) {
-      padding: 1em 0;
+      padding: .2em 0 1em;
     }
   }
 

--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -36,8 +36,7 @@
     flex-shrink: 0;
 
     @include mq($until: tablet) {
-      flex-direction: column;
-      align-items: flex-start;
+      justify-items: center;
     }
 
     .button {
@@ -46,6 +45,7 @@
   }
 
   &__close {
+    margin-left: 1em;
     padding: .5em;
     color: $white;
     font-weight: bold;


### PR DESCRIPTION
Some minor tweaks based on @sigmaben's feedback on #976 

* reduce the margin at the top of the mailing list bar
* keep the 'Not now' link to the side of the 'Sign up' button
* add a tiny bit more space between the button and link

| Mobile | Desktop |
| ------ | -------|
| ![Screenshot from 2021-03-11 10-26-36](https://user-images.githubusercontent.com/128088/110773445-a7dbdd80-8254-11eb-976c-a902a8400017.png) | ![Screenshot from 2021-03-11 10-27-04](https://user-images.githubusercontent.com/128088/110773497-b629f980-8254-11eb-94b1-f527e341570c.png) |

