### PR TITLE
Hack fix to make assessment providers grid work

### DIFF
--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -6,18 +6,20 @@
   <% end %>
 </ul>
 
-<% for group in groups %>
-<div class="events-featured" id="<%= group_link_anchor(group) %>">
-  <div class="events-featured__heading">
-    <h3>
-      <%= group %>
-    </h3>
-  </div>
+<div class="events">
+  <% for group in groups %>
+  <div class="events-featured" id="<%= group_link_anchor(group) %>">
+    <div class="events-featured__heading">
+      <h3>
+        <%= group %>
+      </h3>
+    </div>
 
-  <div class="events-featured__list">
-  <% for item in items(group) %>
-    <%= render GroupedCards::CardComponent.new item %>
-  <% end %>
+    <div class="events-featured__list">
+    <% for item in items(group) %>
+      <%= render GroupedCards::CardComponent.new item %>
+    <% end %>
+    </div>
   </div>
+  <% end %>
 </div>
-<% end %>


### PR DESCRIPTION
This broke as a result of the encapsulation of events styles within the `.events` class. This is a short-term fix to make it render correctly, a [better fix will follow](https://trello.com/c/JHLDbbWK/1411-refactor-groupedcards-components) that will remove anything event-specific from the grouped cards styles

