### PR TITLE
New steps layout

### DIFF
--- a/app/components/calls_to_action/next_steps_component.html.erb
+++ b/app/components/calls_to_action/next_steps_component.html.erb
@@ -1,5 +1,4 @@
 <%= tag.div(class: %w[call-to-action call-to-action--next-steps]) do %>
-  <%= icon %>
 
   <div class="call-to-action__content">
     <%= tag.span("Get support from an adviser", class: "call-to-action__heading") %>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,6 +6,7 @@ class PagesController < ApplicationController
   PAGE_LAYOUTS = [
     "layouts/home",
     "layouts/accordion",
+    "layouts/steps",
     "layouts/stories/landing",
     "layouts/stories/list",
     "layouts/stories/story",

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -32,7 +32,7 @@
           <% @front_matter.key?("steps") && @front_matter.dig("steps").tap do |steps_fm| %>
 
             <div class="steps">
-              <% steps_fm.each.with_index do |(title, contents), i| %>
+              <% steps_fm.each.with_index(1) do |(title, contents), i| %>
                 <section class="step">
                   <div class="step__number">
                     <%= i %>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html> 
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
@@ -34,12 +34,12 @@
             <div class="steps">
               <% steps_fm.each.with_index(1) do |(title, contents), i| %>
                 <section class="step">
-                  <div class="step__number">
-                    <%= i %>
-                  </div>
 
                   <header class="step__header">
-                    <%= tag.h3(title) %>
+                    <div class="step__number">
+                      <%= i %>
+                    </div>
+                    <%= tag.h2(title) %>
                   </header>
 
                   <div class="step__content">
@@ -51,8 +51,9 @@
 
           <% end %>
 
-          <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
+
         <% end %>
+        <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
       </section>
     </main>
 

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+    <%= render "sections/head" %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+      </div>
+    </div>
+
+    <%= render "sections/header" %>
+    <%= render Sections::HeroComponent.new(@front_matter) %>
+    <%= render Navigation::BreadcrumbComponent.new %>
+
+    <main role="main" id="main-content">
+      <section class="container">
+        <% if !@front_matter["image"] %>
+          <header>
+            <% if @front_matter["title_caption"].present? %>
+              <%= tag.span(@front_matter["title_caption"], class: "caption") %>
+            <% end %>
+
+            <%= tag.h1(@front_matter["title"]) %>
+          </header>
+        <% end %>
+
+        <%= tag.article(class: article_classes(@front_matter)) do %>
+
+          <%= yield %>
+
+          <% @front_matter.key?("steps") && @front_matter.dig("steps").tap do |steps_fm| %>
+
+            <div class="steps">
+              <% steps_fm.each.with_index do |(title, contents), i| %>
+                <section class="step">
+                  <div class="step__number">
+                    <%= i %>
+                  </div>
+
+                  <header class="step__header">
+                    <%= tag.h3(title) %>
+                  </header>
+
+                  <div class="step__content">
+                    <%= render(partial: contents["partial"]) %>
+                  </div>
+                </section>
+              <% end %>
+            </ul>
+
+          <% end %>
+
+          <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
+        <% end %>
+      </section>
+    </main>
+
+    <%= render "sections/footer" %>
+    <%= render "components/videoplayer" %>
+    <%= render "sections/cookie-acceptance" %>
+    <%= render "components/analytics" %>
+    <% end %>
+</html>
+

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -51,21 +51,14 @@
 
           <% end %>
 
+          <div class="supplementary steps-cta">
+            <%= render CallsToAction::NextStepsComponent.new%>
+          </div>
+
         <% end %>
-
+        
       </section>
 
-      <section class="container">
-        <div class="supplementary steps-cta">
-            <%= render CallsToAction::SimpleComponent.new(
-              icon: "icon-person",
-              title: "Get support from an adviser",
-              text: "Our Teacher Training Advisers can help you select a provider, prepare for interviews and complete your application successfully. ",
-              link_text: "Sign up",
-              link_target: "/tta-service"
-            )%>
-        </div>
-      </section>
     </main>
 
     <%= render "sections/footer" %>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -1,4 +1,4 @@
-<!doctype html> 
+<!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
@@ -51,9 +51,20 @@
 
           <% end %>
 
-
         <% end %>
-        <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
+
+      </section>
+
+      <section class="container">
+        <div class="supplementary steps-cta">
+            <%= render CallsToAction::SimpleComponent.new(
+              icon: "icon-person",
+              title: "Get support from an adviser",
+              text: "Our Teacher Training Advisers can help you select a provider, prepare for interviews and complete your application successfully. ",
+              link_text: "Sign up",
+              link_target: "/tta-service"
+            )%>
+        </div>
       </section>
     </main>
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -199,4 +199,39 @@
       .call-to-action__image { grid-area: 1 / 2 / 2 / 3; }
     }
   }
+
+  &--next-steps {
+    position: relative;
+    background: transparent;
+    @include mq($until: tablet) {
+      max-width: calc(100% - 1.25em);
+    }
+    .call-to-action__heading {
+      color: white;
+      background: $purple;
+      transform: rotate(-3deg);
+      display: inline-block;
+      padding: 0.625em 1.25em;
+      margin-left: -22px;
+      margin-bottom: 0.5em;
+    }
+    .call-to-action__content {
+      background-color: $grey;
+      overflow: hidden;
+      position: relative;
+    }
+    .call-to-action__text {
+      margin-bottom: 1.4em;
+    }
+    &:before {
+      content: "";
+      display: block;
+      width: calc(50% + 1.25em);
+      height: calc(50% + 1.25em);
+      position: absolute;
+      bottom: -1.25em;
+      right: -1.25em;
+      background-color: $purple;
+    }
+  }
 }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -208,7 +208,7 @@
     }
     .call-to-action__heading {
       color: white;
-      background: $purple;
+      background: $green;
       transform: rotate(-3deg);
       display: inline-block;
       padding: 0.625em 1.25em;
@@ -231,7 +231,7 @@
       position: absolute;
       bottom: -1.25em;
       right: -1.25em;
-      background-color: $purple;
+      background-color: $green;
     }
   }
 }

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -27,6 +27,7 @@
 @import 'blocks';
 @import 'search-page' ;
 @import 'eligibility-checker' ;
+@import 'steps' ;
 
 @import './sections/hero';
 @import './sections/hero/content';

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -52,6 +52,11 @@ a {
   &--unpadded {
     padding: 0;
   }
+
+  &--smaller {
+    font-size: size("xsmall");
+    padding: 8px $indent-amount;
+  }
 }
 
 .call-to-action-icon-button {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -57,6 +57,12 @@ a {
     font-size: size("xsmall");
     padding: 8px $indent-amount;
   }
+
+  &--no-external-icon {
+    &:after {
+      content: none;
+    }
+  }
 }
 
 .call-to-action-icon-button {

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -49,7 +49,7 @@
     font-size: size(small);
   }
 
-  a {
+  a:not(.button--no-external-icon) {
     &[href*="//"] {
       &:after {
         content: url('../images/icon-external.svg');

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -42,11 +42,11 @@
   }
 
   h3 {
-    font-size: size(large);
+    font-size: size(medium);
   }
 
   h4 {
-    font-size: size(medium);
+    font-size: size(small);
   }
 
   a {

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -74,27 +74,28 @@
       }
 
       details {
-
         summary {
           font-weight: bold;
           color: $blue-dark;
           text-decoration: underline;
           list-style: none;
           cursor: pointer;
+
           &::-webkit-details-marker {
-            display:none;
+            display: none;
           }
+
           &:hover {
             text-decoration: none;
           }
+
           &:after {
             content: "";
-            display: block;
+            display: inline-block;
             width: 10px;
             height: 10px;
-            display: inline-block;
             border: 2px solid $blue-dark;
-            border-width: 0px 3px 3px 0px;
+            border-width: 0 3px 3px 0;
             transform: rotate(45deg);
             position: relative;
             top: -2px;
@@ -105,6 +106,7 @@
         section + section {
           margin-top: 2em;
         }
+
         &[open] {
           summary {
             &:after {

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -1,0 +1,27 @@
+.steps {
+  outline: 1px dashed pink;
+  padding: 1em;
+
+  .step {
+    outline: 1px dashed lightblue;
+    padding: 1em;
+
+    &__number {
+      outline: 1px dashed peru;
+      padding: 1em;
+      margin: .2em;
+    }
+
+    &__header {
+      outline: 1px dashed coral;
+      padding: 1em;
+      margin: .2em;
+    }
+
+    &__content {
+      outline: 1px dashed chartreuse;
+      padding: 1em;
+      margin: .2em;
+    }
+  }
+}

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -5,7 +5,7 @@
 
   &:before {
     content: "";
-    width: 0px;
+    width: 0;
     height: calc(100% - 20px);
     position: absolute;
     top: 20px;
@@ -46,6 +46,7 @@
     &__header {
       display: flex;
       align-items: center;
+
       h2 {
         margin: 0;
         padding: 0;
@@ -55,8 +56,9 @@
         background: transparent;
         color: $black;
         @include mq($until: tablet) {
-        font-size: size(medium);
+          font-size: size(medium);
         }
+
         &:after {
           display: none;
         }

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -1,27 +1,74 @@
 .steps {
-  outline: 1px dashed pink;
-  padding: 1em;
+  position: relative;
+  margin: 0;
+  box-sizing: border-box;
+
+  &:before {
+    content: "";
+    width: 0px;
+    height: calc(100% - 20px);
+    position: absolute;
+    top: 20px;
+    left: 37px;
+    border-left: 6px dotted $black;
+    @include mq($until: tablet) {
+      left: 27px;
+    }
+  }
+
+  * {
+    box-sizing: border-box;
+  }
 
   .step {
-    outline: 1px dashed lightblue;
-    padding: 1em;
+    margin-bottom: 50px;
 
     &__number {
-      outline: 1px dashed peru;
-      padding: 1em;
-      margin: .2em;
+      width: 80px;
+      height: 80px;
+      padding: 4px;
+      margin-right: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-weight: bold;
+      font-size: 28px;
+      background-color: $yellow;
+      position: relative;
+      @include mq($until: tablet) {
+        width: 60px;
+        height: 60px;
+        margin-right: 15px;
+      }
     }
 
     &__header {
-      outline: 1px dashed coral;
-      padding: 1em;
-      margin: .2em;
+      display: flex;
+      align-items: center;
+      h2 {
+        margin: 0;
+        padding: 0;
+        font-size: size(large);
+        line-height: 1.25em;
+        width: calc(100% - 100px);
+        background: transparent;
+        color: $black;
+        @include mq($until: tablet) {
+        font-size: size(medium);
+        }
+        &:after {
+          display: none;
+        }
+      }
     }
 
     &__content {
-      outline: 1px dashed chartreuse;
-      padding: 1em;
-      margin: .2em;
+      padding-left: 100px;
+      @include mq($until: tablet) {
+        padding-left: 75px;
+        padding-right: 20px;
+      }
     }
   }
 }

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -55,6 +55,7 @@
         width: calc(100% - 100px);
         background: transparent;
         color: $black;
+
         @include mq($until: tablet) {
           font-size: size(medium);
         }
@@ -70,6 +71,25 @@
       @include mq($until: tablet) {
         padding-left: 75px;
         padding-right: 20px;
+      }
+
+      details {
+        border: 2px solid $pink-dark;
+
+        summary {
+          background-color: $pink-dark;
+          color: $white;
+          font-weight: bold;
+          padding: .4em 2em;
+        }
+
+        section {
+          margin: 1em;
+        }
+
+        section + section {
+          margin-top: 2em;
+        }
       }
     }
   }

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -74,21 +74,44 @@
       }
 
       details {
-        border: 2px solid $pink-dark;
 
         summary {
-          background-color: $pink-dark;
-          color: $white;
           font-weight: bold;
-          padding: .4em 2em;
-        }
-
-        section {
-          margin: 1em;
+          color: $blue-dark;
+          text-decoration: underline;
+          list-style: none;
+          cursor: pointer;
+          &::-webkit-details-marker {
+            display:none;
+          }
+          &:hover {
+            text-decoration: none;
+          }
+          &:after {
+            content: "";
+            display: block;
+            width: 10px;
+            height: 10px;
+            display: inline-block;
+            border: 2px solid $blue-dark;
+            border-width: 0px 3px 3px 0px;
+            transform: rotate(45deg);
+            position: relative;
+            top: -2px;
+            margin-left: 7px;
+          }
         }
 
         section + section {
           margin-top: 2em;
+        }
+        &[open] {
+          summary {
+            &:after {
+              transform: rotate(225deg);
+              top: 4px;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Trello

https://trello.com/c/r5EJ4jui/1359-make-steps-appear-more-linear

### Context and changes

This PR adds the styles for the new steps layout and the new variation of the CTA beneath it. Until DFE-Digital/get-into-teaching-content/pull/342 is merged, this will only change the style of the 'next steps' CTA, which is used in two places:

| At the bottom of the steps accordion | On the presentations page |
| ------ | ------ |
| ![Screenshot from 2021-03-22 12-27-46](https://user-images.githubusercontent.com/128088/111990698-6e845700-8b0b-11eb-909a-bfd9d843cca5.png) | ![Screenshot from 2021-03-22 12-29-01](https://user-images.githubusercontent.com/128088/111990717-72b07480-8b0b-11eb-8110-7f52352d58a4.png) | 

[Here's a preview of the page as it'll look once the content is merged](https://user-images.githubusercontent.com/128088/111812827-5ffe2b80-88d0-11eb-9720-0e2d59095d24.png).

