### PR TITLE
Update Sentry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,8 @@ gem "loaf"
 
 gem "prometheus-client"
 
-gem "sentry-raven"
+gem "sentry-rails"
+gem "sentry-ruby"
 
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,8 +299,16 @@ GEM
     semantic_logger (4.7.4)
       concurrent-ruby (~> 1.0)
     semantic_range (2.3.1)
-    sentry-raven (3.1.1)
+    sentry-rails (4.3.0)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simplecov (0.17.1)
@@ -392,7 +400,8 @@ DEPENDENCIES
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk (~> 3.14.0)
   secure_headers
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   simplecov (~> 0.17.1)
   spring

--- a/app/components/cards/latest_event_component.rb
+++ b/app/components/cards/latest_event_component.rb
@@ -46,7 +46,7 @@ module Cards
     def fetch_event
       @event = @page_data.latest_event_for_category(category)
     rescue Events::Category::UnknownEventCategory => e
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       @event = nil
     end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,9 @@ Sentry.init do |config|
   if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
     config.dsn = Rails.application.credentials.sentry_dsn
   end
+
+  # Sentry::BackgroundWorker requires ActiveRecord, but we don't use it so
+  # we have to manually override async and send events synchronously (or they
+  # just disappear with no error!).
+  config.async = ->(event, hint) { Sentry.send(event, hint) }
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-Raven.configure do |config|
+Sentry.init do |config|
   if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
     config.dsn = Rails.application.credentials.sentry_dsn
   end

--- a/spec/components/cards/latest_event_component_spec.rb
+++ b/spec/components/cards/latest_event_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     let(:card) { { "category" => "unknown" } }
 
-    before { expect(Raven).to receive(:capture_exception).and_call_original }
+    before { expect(Sentry).to receive(:capture_exception).and_call_original }
 
     it { is_expected.to have_css ".card header", text: find_events_header }
   end
@@ -55,7 +55,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     let(:card) { {} }
 
-    before { expect(Raven).to receive(:capture_exception).and_call_original }
+    before { expect(Sentry).to receive(:capture_exception).and_call_original }
 
     it { is_expected.to have_css ".card header", text: find_events_header }
   end


### PR DESCRIPTION
The sentry-raven gem we were using is deprecated/in maintenance mode. Sentry now have two gems that replace it (sentry-ruby and sentry-rails).

Update to new gems and migrate existing code (migration guide: https://docs.sentry.io/platforms/ruby/guides/rails/migration/)

The `Sentry::BackgroundWorker` sends events to Sentry async by default, using `ActiveRecord::Base.connection_pool`. We don't use `ActiveRecord` in the app, so this was failing silently with an `unrecognized constant ActiveRecord`. Instead of pulling in `ActiveRecord` just for this (which has its own difficulties as it tries to connect to a DB by default) we override the `async` handler to just send everything synchronously (which is how `sentry-raven` was working).