### PR TITLE
Remove event-specific styles from grouped cards

### DIFF
--- a/app/components/grouped_cards/card_component.html.erb
+++ b/app/components/grouped_cards/card_component.html.erb
@@ -1,20 +1,16 @@
-<div class="events-featured__list__item grouped-cards">
-  <div class="event-box">
-    <div class="event-box__header grouped-cards__header">
-      <%= linked_header %>
-    </div>
+<div class="group__card">
+  <div class="group__card__heading">
+    <%= linked_header %>
+  </div>
 
-    <hr class="event-box__divider event-box__divider--online-event" />
+  <hr class="group__card__divider" />
 
-    <div class="event-box__datetime">
-      <p>
-      <% for field, value in fields %>
-        <div class="grouped-cards__fields">
-          <span><%= field.humanize %>:</span>
-          <span><%= linked_value(value) %></span>
-        </div>
-      <% end %>
-      </p>
-    </div>
+  <div class="group__card__content">
+    <% for field, value in fields %>
+      <div class="group__card__fields">
+        <span><%= field.humanize %>:</span>
+        <span><%= linked_value(value) %></span>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -6,20 +6,18 @@
   <% end %>
 </ul>
 
-<div class="events">
-  <% for group in groups %>
-  <div class="events-featured" id="<%= group_link_anchor(group) %>">
-    <div class="events-featured__heading">
-      <h3>
-        <%= group %>
-      </h3>
-    </div>
-
-    <div class="events-featured__list">
-    <% for item in items(group) %>
-      <%= render GroupedCards::CardComponent.new item %>
-    <% end %>
-    </div>
+<% for group in groups %>
+<div class="group" id="<%= group_link_anchor(group) %>">
+  <div class="group__heading">
+    <h3>
+      <%= group %>
+    </h3>
   </div>
+
+  <div class="group__cards">
+  <% for item in items(group) %>
+    <%= render GroupedCards::CardComponent.new item %>
   <% end %>
+  </div>
 </div>
+<% end %>

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -1,18 +1,44 @@
-.grouped-cards {
-  &__header {
-    a {
-      [href*="//"] {
-        display: block;
-      }
-    }
+.group {
+  display: flex;
+  min-width: 100%;
+  flex-direction: column;
+  box-sizing: border-box;
+  background: $grey;
+  padding: 1em;
+  margin: 1em auto;
 
-    &:after {
-      display: none;
-      content: "";
-    }
+  h3 {
+    margin: .2em auto 1em;
   }
 
-  .grouped-cards__fields + .grouped-cards__fields {
-    margin-top: .5em;
+  .group__cards {
+    @include cards-grid;
+
+    .group__card {
+      box-sizing: border-box;
+      padding: 1em;
+      background: $white;
+
+      &__heading {
+        h4 {
+          font-size: size(small);
+          display: inline;
+        }
+      }
+
+      &__divider {
+        border: none;
+        height: 4px;
+        background-color: $blue;
+        margin: 1em 0;
+      }
+
+      &__fields {
+        font-size: size(xsmall);
+        white-space: normal;
+
+        a { overflow-wrap: break-word; }
+      }
+    }
   }
 }

--- a/app/webpacker/styles/components/mixins/cards-grid.scss
+++ b/app/webpacker/styles/components/mixins/cards-grid.scss
@@ -12,7 +12,7 @@
   @supports (display: grid) {
     display: grid;
     align-items: stretch;
-    grid-template-columns: repeat($columns, 1fr);
+    grid-template-columns: repeat($columns, minmax(0, 1fr));
     grid-gap: $gap;
   }
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -49,6 +49,7 @@ main {
 
 section.container {
   display: flex;
+  flex-grow: 0;
   flex-wrap: wrap;
   flex-direction: column;
 

--- a/spec/components/grouped_cards/card_component_spec.rb
+++ b/spec/components/grouped_cards/card_component_spec.rb
@@ -14,8 +14,8 @@ describe GroupedCards::CardComponent, type: "component" do
   end
 
   it { is_expected.to have_css "h4", text: "First organisation" }
-  it { is_expected.to have_css ".event-box__datetime span", text: "Name" }
-  it { is_expected.to have_css ".event-box__datetime span", text: "Joe Bloggs" }
+  it { is_expected.to have_css ".group__card__fields span", text: "Name" }
+  it { is_expected.to have_css ".group__card__fields span", text: "Joe Bloggs" }
   it { is_expected.to have_link "joe.bloggs@first.org", href: "mailto:joe.bloggs@first.org" }
 
   it { is_expected.not_to have_css "a h4" }

--- a/spec/components/grouped_cards/listing_component_spec.rb
+++ b/spec/components/grouped_cards/listing_component_spec.rb
@@ -26,5 +26,5 @@ describe GroupedCards::ListingComponent, type: "component" do
   it { is_expected.to have_css "h3", text: "Region 1" }
   it { is_expected.to have_css "h3", text: "Region 2" }
 
-  it { is_expected.to have_css ".event-box", count: 3 }
+  it { is_expected.to have_css ".group__card", count: 3 }
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/JHLDbbWK/1411-refactor-groupedcards-components

### Context and changes

A bug was introduced where namespacing the event styles in `.event` broke the display of another page that doesn't contain event info. The grouped cards are now generic and can be used to display anything; the styles have been updated and detached from the event-specific ones.

I've also updated the styles a bit to make the page look a little nicer.

Here are some screengrabs, old on the left, new on the right:

![Screenshot from 2021-03-12 16-26-59](https://user-images.githubusercontent.com/128088/110970542-c4117480-8351-11eb-99b7-59ac3ee3972a.png)

![Screenshot from 2021-03-12 16-27-09](https://user-images.githubusercontent.com/128088/110970689-e5726080-8351-11eb-8ec5-18e50b6997c3.png)

And to demo the other user of card styles is still intact, events:

![Screenshot from 2021-03-12 16-35-59](https://user-images.githubusercontent.com/128088/110970720-f0c58c00-8351-11eb-999f-e7bcc08b6573.png)

