### PR TITLE
Enable circuit breaker

### DIFF
--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -14,4 +14,10 @@ GetIntoTeachingApiClient.configure do |config|
   end
 
   config.cache_store = Rails.cache
+
+  config.circuit_breaker = {
+    enabled: true,
+    threshold: 5,
+    timeout: 5.minutes,
+  }
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/e9vBMLJE

### Context
Circuit breaker middleware has been added to the API Client Gem. It is enabled via the following configuration:
```rb
GetIntoTeachingApiClient.configure do |config|
  config.circuit_breaker = {
    enabled: true, # Enables the circuit breaker middleware
    threshold: 5, # Number of failures that will cause the circuit breaker to trip
    timeout: 5.minutes # Amount of time until the circuit breaker will attempt to recover
  }
end
```

### Changes proposed in this pull request
- Enable circuit breaker

### Guidance to review

