### PR TITLE
Forward request_id to the API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: ea07b478ff51a4238c8f32e40859b2c6f890275b
+  revision: 5f070ec0a71e9dd470a129536ed0c499d303efe8
   specs:
     get_into_teaching_api_client (1.1.13)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.18)
+    get_into_teaching_api_client_faraday (0.1.19)
       activesupport
       faraday
       faraday-encoding

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pages::Page::PageNotFoundError, with: :render_not_found
 
   before_action :http_basic_authenticate
+  before_action :set_api_client_request_id
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
 
@@ -14,6 +15,12 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def set_api_client_request_id
+    # The request_id is passed to the ApiClient via Thread.current
+    # so we don't have to set it explicitly on every usage.
+    GetIntoTeachingApiClient::Current.request_id = request.uuid
+  end
 
   def add_home_breadcrumb
     return if request.path == root_path

--- a/spec/requests/api_client_request_id_spec.rb
+++ b/spec/requests/api_client_request_id_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "API client request_id", type: :request do
+  it "passes the request_id to the API client" do
+    uuid = "56b2d75b-2407-4131-bb5c-83e2d8ee0cf1"
+    expect_any_instance_of(ActionDispatch::Request).to receive(:uuid) { uuid }
+    expect_any_instance_of(GetIntoTeachingApiClient::Current).to receive(:request_id=).with(uuid).once
+    get root_path
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1412](https://trello.com/c/65tZmUeb/1412-add-correlation-ids-to-rails-apps-and-api)

### Context

The GetIntoTeachingApiClient is configured to pick up on a request_id set on Thread.current (indirectly via ActiveSupport::CurrentAttributes). This PR updates the app to set the Rails request_id on GetIntoTeachingApiClient::Current so it gets sent as part of all requests to the API.

### Changes proposed in this pull request

- Forward request_id to the API

### Guidance to review

