### PR TITLE
Update event search radius options

### DIFF
--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -7,7 +7,7 @@ module Events
     RESULTS_PER_TYPE = 9
     FUTURE_MONTHS = 5
     PAST_MONTHS = 4
-    DISTANCES = [30, 50, 100].freeze
+    DISTANCES = [10, 25].freeze
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze
 
     delegate :available_event_type_ids, :available_distance_keys, to: :class

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -16,7 +16,7 @@ describe Events::Search do
 
   describe ".available_distance_keys" do
     subject { described_class.new.available_distance_keys }
-    it { is_expected.to eql [nil, 30, 50, 100] }
+    it { is_expected.to eql [nil, 10, 25] }
   end
 
   describe ".available_event_type_ids" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -101,7 +101,7 @@ describe "View events by category" do
 
   describe "filtering the results" do
     let(:postcode) { "TE57 1NG" }
-    let(:radius) { 30 }
+    let(:radius) { 25 }
     let(:start_after) { DateTime.now.utc.beginning_of_day }
     let(:start_before) { start_after.advance(months: 5).end_of_month }
     let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_id: nil } }


### PR DESCRIPTION
### Trello card

[Trello-1390](https://trello.com/c/C1tAJCWr/1390-dev-tweak-event-search-radius-options)

### Context

We have observed that nobody is really using the 50/100 mile radius search options and the 30 mile radius option returns a decent number of results for most people. Working on that assumption we want to make the event search more localised and monitor it going forward, in hopes that users find the tighter search radius more useful.

### Changes proposed in this pull request

- Update event search radius options

### Guidance to review

