### PR TITLE
Keep Artefacts Even on Failure 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,12 +89,14 @@ jobs:
         run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/.resultset.json
 
       - name:  Keep Code Coverage Report
+        if:  always()
         uses: actions/upload-artifact@v2
         with:
           name: Code_Coverage
           path: ${{ github.workspace }}/coverage/*
 
       - name:  Keep Unit Tests Results
+        if:  always()
         uses: actions/upload-artifact@v2
         with:
           name: unit_tests
@@ -111,6 +113,7 @@ jobs:
             rubocop --format json --out=/app/out/rubocop-result.json
 
       - name: Keep Rubocop output
+        if:  always()
         uses: actions/upload-artifact@v2
         with:
           name: Rubocop_results


### PR DESCRIPTION
### Trello card
[Keep Lint Failure Outputs ](https://trello.com/c/C2jiSt2r/1394-keep-lint-failure-output)

### Context
When a LINT fails the following step to save  the results does not run, changed the process to always try to save the results.

### Changes proposed in this pull request
added ``` If: failure() ```

### Guidance to review
No changes to the application


