### PR TITLE
Update trello.yml

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -26,4 +26,4 @@ jobs:
           MESSAGE:      ${{ github.event.pull_request.html_url }} 
           CARD:         ${{ github.event.pull_request.body }}           
           TRELLO-KEY:   ${{ steps.azSecret.outputs.TRELLO-KEY}}
-          TRELLO-TOKEN: ${{ steps.azSecret.outputs.TRELLO-TOKEN }
+          TRELLO-TOKEN: ${{ steps.azSecret.outputs.TRELLO-TOKEN }}


### PR DESCRIPTION
Missing bracket in workflow, causing workflow failure.
No impact on delivery as this was just the link between GitHub and Trello

