### PR TITLE
Ignore cloudfront ip ranges when calculating client IP addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "redis"
 gem "kaminari", "~> 1.2"
 gem "view_component"
 
+# Ignore cloudfront IPs when getting customer IP address
+gem "actionpack-cloudfront"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-cloudfront (1.0.8)
+      rails (>= 4.2)
     actiontext (6.1.3)
       actionpack (= 6.1.3)
       activerecord (= 6.1.3)
@@ -369,6 +371,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-cloudfront
   addressable
   amazing_print
   bootsnap (>= 1.1.0)

--- a/config/initializers/exclude_cloudfront_ips.rb
+++ b/config/initializers/exclude_cloudfront_ips.rb
@@ -1,0 +1,6 @@
+# Don't load in dev or test environments
+# Mirrors behaviour of actionpack-cloudfront
+unless Rails.env.development? || Rails.env.test?
+  require "cloud_front_ip_filter"
+  CloudFrontIpFilter.configure!
+end

--- a/lib/cloud_front_ip_filter.rb
+++ b/lib/cloud_front_ip_filter.rb
@@ -1,0 +1,25 @@
+class CloudFrontIpFilter
+  def self.configure!
+    Rack::Request.ip_filter = new(Rack::Request.ip_filter)
+  end
+
+  def initialize(original_filter = nil)
+    @original_filter = original_filter
+  end
+
+  def call(ip)
+    @original_filter.call(ip) || cloudfront_ip?(ip)
+  end
+
+private
+
+  def cloudfront_ip?(ip)
+    cloudfront_proxies.any? do |range|
+      range.include? ip
+    end
+  end
+
+  def cloudfront_proxies
+    ActionPack::Cloudfront::IpRanges.cloudfront_proxies
+  end
+end

--- a/spec/lib/cloud_front_ip_filter_spec.rb
+++ b/spec/lib/cloud_front_ip_filter_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "cloud_front_ip_filter"
+
+RSpec.describe CloudFrontIpFilter do
+  before do
+    stub_request(:get, "https://ip-ranges.amazonaws.com/ip-ranges.json")
+      .to_return(status: 401) # will fallback to copy in Gem
+  end
+
+  subject { described_class.new original }
+
+  let(:original) { ->(ip) { /192\.168\.1\./.match?(ip) } }
+
+  describe "#call" do
+    context "with private ips" do
+      it { expect(subject.call("192.168.1.10")).to be true }
+      it { expect(subject.call("192.168.2.10")).to be false }
+      it { expect(subject.call("192.168.1.1")).to be true }
+      it { expect(subject.call("192.168.1.254")).to be true }
+    end
+
+    context "with other ips" do
+      it { expect(subject.call("51.8.222.98")).to be false }
+    end
+
+    context "with cloudfront ips" do
+      it { expect(subject.call("15.207.13.128")).to be true }
+      it { expect(subject.call("15.207.13.254")).to be true }
+    end
+
+    context "with ips just outside cloudfronts ranges" do
+      it { expect(subject.call("15.207.13.1")).to be false }
+      it { expect(subject.call("15.207.13.127")).to be false }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We want to use fail2ban to temporarily ban bots from the website - this requires knowledge of the users IP address to be as correct as possible. Currently we are mistakenly recognising the CDNs exit node IP as the end users IP address.

### Changes proposed in this pull request

1. Ignore cloudfront ip ranges when calculating client IP addresses

### Guidance to review

1. Port from equivalent changes in TTA - also includes the change to apply to `production` as well as `rolling` and `preprod` environments