### PR TITLE
Add fail2ban

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -10,3 +10,4 @@ GOOGLE_TAG_MANAGER_ID=GTM-P2WKCWR
 BAM_ID=1
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.cloudapps.digital/"
+FAIL2BAN=3

--- a/.env.preprod
+++ b/.env.preprod
@@ -10,4 +10,5 @@ GOOGLE_TAG_MANAGER_ID=GTM-P2WKCWR
 BAM_ID=1
 VWO_ID=524595
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.cloudapps.digital/"
+SKIP_REQ_LIMITS=true
 FAIL2BAN=3

--- a/.env.rolling
+++ b/.env.rolling
@@ -2,3 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 BAM_ID=1
 VWO_ID=524595
+SKIP_REQ_LIMITS=true

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -5,6 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
-
-  Rack::Attack.enabled = false
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -5,6 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
-
-  Rack::Attack.enabled = false
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,15 @@
 module Rack
   class Attack
+    FAIL2BAN_LIST = %w[
+      /etc/passwd
+      wp-admin
+      wp-login
+      wp-includes
+      .php
+    ].freeze
+
+    FAIL2BAN_REGEX = Regexp.union(FAIL2BAN_LIST).freeze
+
     # Throttle /csp_reports requests by IP (5rpm)
     throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
       req.ip if req.path == "/csp_reports"
@@ -43,6 +53,28 @@ module Rack
       end
 
       req.ip if (req.patch? || req.put?) && path_performs_event_sign_up
+    end
+
+    if ENV["FAIL2BAN"].to_s.match? %r{\A\d+\z}
+      FAIL2BAN_TIME = ENV["FAIL2BAN"].to_s.to_i.minutes.freeze
+
+      blocklist("block hostile bots") do |req|
+        Fail2Ban.filter("hostile-bots-#{req.ip}", maxretry: 0, findtime: 1.second, bantime: FAIL2BAN_TIME) do
+          (
+            FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
+            FAIL2BAN_REGEX.match?(req.path)
+          ).tap do |should_ban|
+            if should_ban
+              obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
+
+              Raven.capture_message <<~BAN_MESSAGE
+                Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
+                accessing #{req.path} with '#{req.query_string}'
+              BAN_MESSAGE
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

We want to ban bots which poke around the site

### Changes proposed in this pull request

1. Made the request limits configurable independantly from Rack::Attack itself
2. Added fail2ban configuration

### Guidance to review

Port from similar changes on the TTA app, note this will only work correctly when the cloudfront ip filtering is merged - see https://github.com/DFE-Digital/get-into-teaching-app/pull/994
