### PR TITLE
Improved handling of missing non-html pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,11 +36,11 @@ private
   end
 
   def render_not_found
-    render template: "errors/not_found", layout: "application", status: :not_found
+    render_error :not_found
   end
 
   def render_too_many_requests
-    render template: "errors/too_many_requests", layout: "application", status: :too_many_requests
+    render_error :too_many_requests
   end
 
   def http_basic_authenticate
@@ -49,6 +49,25 @@ private
     authenticate_or_request_with_http_basic do |name, password|
       name == ENV["HTTPAUTH_USERNAME"].to_s &&
         password == ENV["HTTPAUTH_PASSWORD"].to_s
+    end
+  end
+
+  def render_error(status_code_symbol)
+    unless status_code_symbol.is_a?(Symbol) # Guard against incorrect usage
+      return render status: :invalid_server_error, body: nil
+    end
+
+    respond_to do |format|
+      format.html do
+        render \
+          template: "errors/#{status_code_symbol}",
+          layout: "application",
+          status: status_code_symbol
+      end
+
+      format.all do
+        render status: status_code_symbol, body: nil
+      end
     end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -13,6 +13,7 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
+      format.all { render status: :internal_server_error, body: nil }
     end
   end
 
@@ -20,6 +21,7 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :unprocessable_entity }
       format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
+      format.all { render status: :unprocessable_entity, body: nil }
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -68,6 +68,7 @@ private
       format.html do
         render \
           template: "errors/not_found",
+          layout: "application",
           status: :not_found
       end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/X2pGWgj8

### Context

Currently we trigger an unhandled exception for missing page requests when the page format is not html

### Changes proposed in this pull request

1. Added common 'error renderer' method - this ensures the layout is set to application and handles non-html formats by returning just the status code with an empty body
2. Handle unknown file types in the default error controller as well.

### Guidance to review

The `render_error` method uses the supplied parameter to select the template to render - I've tried to protect against incorrect usage - it requires a symbol, and if its not on of the status code symbols that will in turn trigger an error from the `render` method it uses.
