### PR TITLE
Upgraded to latest simplecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
             rspec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format documentation
 
       - name: Fixup report file paths
-        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/.resultset.json
+        run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/coverage.json
 
       - name:  Keep Code Coverage Report
         uses: actions/upload-artifact@v2
@@ -129,7 +129,7 @@ jobs:
            -Dsonar.host.url=https://sonarcloud.io/
            -Dsonar.projectKey=DFE-Digital_get-into-teaching-app
            -Dsonar.testExecutionReportPaths=out/test-report.xml
-           -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/.resultset.json
+           -Dsonar.ruby.coverage.reportPaths=${PWD}/coverage/coverage.json
            -Dsonar.ruby.rubocop.reportPaths=${PWD}/out/rubocop-result.json
 
       - name: Slack Notification

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ group :development, :test do
   gem "capybara", "~> 3.35"
   gem "factory_bot_rails"
   gem "rspec-sonarqube-formatter", "~> 1.5", require: false
-  gem "simplecov", "~> 0.17.1"
+  gem "simplecov"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,11 +311,12 @@ GEM
       faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -403,7 +404,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  simplecov (~> 0.17.1)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,17 @@
 require "webmock/rspec"
 
 require "simplecov"
+require "simplecov_json_formatter"
 SimpleCov.start "rails" do
   add_filter "/app/services/get_into_teaching_api/fake_endpoints.rb"
   add_filter "/bin/"
   add_filter "/db/"
   add_filter "/spec/"
+
+  formatter SimpleCov::Formatter::MultiFormatter.new [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter,
+  ]
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Trello card

https://trello.com/c/gabkUApE

### Context

We are currently running an out of date copy of simplecov because SonarCloud is using an internal SimpleCov JSON file, and that files format got changed in SimpleCov v0.18

According to https://jira.sonarsource.com/browse/SONARSLANG-477 sonarcloud
should now support the `coverage.json` output which added in SimpleCov 0.20

### Changes proposed in this pull request

1. This change adds the new JSONFormatter to create a `coverage.json` file
2. Switches SonarCloud to use that `coverage.json` file

### Guidance to review

I wont know this is right until its merge I think but its easiest enough to revert if it breaks coverage reporting
