### PR TITLE
Ensure the 404 is rendered in HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ private
   end
 
   def render_not_found
-    render template: "errors/not_found", layout: "application", status: :not_found
+    render template: "errors/not_found", layout: "application", status: :not_found, formats: %i[html]
   end
 
   def render_too_many_requests


### PR DESCRIPTION
We've seen an influx of bots poking around for pages that don't exist.

These cause a ActionView::MissingTemplate error because we're trying to serve a 404 in the format they requested the docuemnt in, so `/some-file.md` is expecting us to have a `errors/not_found.md` file, which we don't.

![Screenshot from 2021-03-17 12-13-58](https://user-images.githubusercontent.com/128088/111465694-50d57d00-871a-11eb-8068-4f09e8072274.png)
