### PR TITLE
Fix breadcrumb error when page has no title

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -33,7 +33,7 @@ class PagesController < ApplicationController
     @page = Pages::Page.find content_template
 
     (@page.ancestors.reverse + [@page]).each do |page|
-      breadcrumb page.title, page.path
+      breadcrumb page.title, page.path if @page.title.present?
     end
 
     render template: @page.template, layout: page_layout

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -35,6 +35,12 @@ RSpec.feature "Breadcrumbs", type: :feature do
     end
   end
 
+  context "when visiting a content page without a title" do
+    let(:path) { page_path("no-title") }
+
+    it { is_expected.to have_http_status(:success) }
+  end
+
   context "when visiting a disclaimer page" do
     let(:path) { page_path("disclaimer") }
 

--- a/spec/support/views/content/no-title.md
+++ b/spec/support/views/content/no-title.md
@@ -1,0 +1,6 @@
+---
+layout: "layouts/content"
+title: "  "
+---
+
+Some content


### PR DESCRIPTION
It a content page does not have a title we try and add a breadcrumb with a `nil` name, which throws an exception.

Update to skip pages without a title (omitting them from the breadcrumbs).