### PR TITLE
Exclude partials from the Frontmatter.list

### DIFF
--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -65,6 +65,8 @@ module Pages
     def preload
       content_dirs.reverse.each do |content_dir|
         Dir.glob(content_pattern(content_dir)) do |found|
+          next if File.basename(found).starts_with? "_"
+
           add path(content_dir, found), found
         end
       end

--- a/spec/fixtures/files/markdown_content/_partial.md
+++ b/spec/fixtures/files/markdown_content/_partial.md
@@ -1,0 +1,1 @@
+Some content

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Pages::Frontmatter do
     it { expect(subject.keys).to include "/page1" }
     it { expect(subject.keys).to include "/subfolder/page2" }
     it { expect(subject["/page1"]).to include title: "Hello World 1" }
+    it { expect(subject.keys).to_not include "/_partial" }
   end
 
   describe ".perform_caching" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/lKMwd0XH

### Context
The current sitemap file includes URLs of partials, giving false indications to search engines when crawling the site.

### Changes proposed in this pull request
This change will exclude partials when the Page::Frontmatter.list is populated.
