### PR TITLE
Show either search bar or menu on mobile

### DIFF
--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -2,17 +2,33 @@ import { Controller } from 'stimulus';
 
 export default class extends Controller {
   static targets = ['hamburger', 'label', 'links'];
+  static closedClass = 'navbar__mobile--closed';
 
   connect() {
     this.navToggle();
   }
 
   navToggle() {
-    const hide =
-      this.linksTarget.style.display === 'block' ||
-      this.linksTarget.style.display === '';
-    this.linksTarget.style.display = hide ? 'none' : 'block';
-    this.hamburgerTarget.className = hide ? 'icon-hamburger' : 'icon-close';
-    this.labelTarget.innerHTML = hide ? 'Menu' : 'Close';
+    this.visible ? this.hide() : this.show()
+  }
+
+  show() {
+    this.element.classList.remove(this.constructor.closedClass) ;
+
+    this.linksTarget.style.display = 'block';
+    this.hamburgerTarget.className = 'icon-close';
+    this.labelTarget.innerHTML = 'Close';
+  }
+
+  hide() {
+    this.element.classList.add(this.constructor.closedClass) ;
+
+    this.linksTarget.style.display = 'none';
+    this.hamburgerTarget.className = 'icon-hamburger';
+    this.labelTarget.innerHTML = 'Menu';
+  }
+
+  get visible() {
+    return !this.element.classList.contains(this.constructor.closedClass)
   }
 }

--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -5,7 +5,15 @@ export default class extends Controller {
   static closedClass = 'navbar__mobile--closed';
 
   connect() {
-    this.navToggle();
+    this.navToggle()
+
+    this.searchHandler = this.hide.bind(this)
+    document.addEventListener('navigation:search', this.searchHandler)
+  }
+
+  disconnect() {
+    if (document && this.searchHandler)
+      document.removeEventListener('navigation:menu', this.searchHandler)
   }
 
   navToggle() {
@@ -18,6 +26,8 @@ export default class extends Controller {
     this.linksTarget.style.display = 'block';
     this.hamburgerTarget.className = 'icon-close';
     this.labelTarget.innerHTML = 'Close';
+
+    this.notify()
   }
 
   hide() {
@@ -30,5 +40,11 @@ export default class extends Controller {
 
   get visible() {
     return !this.element.classList.contains(this.constructor.closedClass)
+  }
+
+  notify() {
+    const showingMenuEvent = new CustomEvent('navigation:menu');
+
+    document.dispatchEvent(showingMenuEvent);
   }
 }

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -22,10 +22,27 @@ export default class extends Controller {
 
   toggle(ev) {
     ev.preventDefault()
-    this.element.classList.toggle(this.constructor.openedClass)
 
-    if (this.element.classList.contains(this.constructor.openedClass) && this.inputField)
-      this.inputField.focus() ;
+    this.visible ? this.hide() : this.show()
+  }
+
+  get visible() {
+    return this.element.classList.contains(this.constructor.openedClass)
+  }
+
+  show() {
+    if (this.visible) return
+
+    this.element.classList.add(this.constructor.openedClass)
+
+    if (this.inputField)
+      this.inputField.focus()
+  }
+
+  hide() {
+    if (!this.visible) return
+
+    this.element.classList.remove(this.constructor.openedClass)
   }
 
   get autocompleteWrapper() {

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -11,6 +11,9 @@ export default class extends Controller {
 
   connect() {
     this.setupAccessibleAutocomplete()
+
+    this.mobileMenuHandler = this.hide.bind(this)
+    document.addEventListener('navigation:menu', this.mobileMenuHandler)
   }
 
   disconnect() {
@@ -18,6 +21,9 @@ export default class extends Controller {
       this.autocompleteWrapper.remove()
 
     this.clearAnalyticsSubmitter() ;
+
+    if (document && this.mobileMenuHandler)
+      document.removeEventListener('navigation:menu', this.mobileMenuHandler)
   }
 
   toggle(ev) {
@@ -37,6 +43,8 @@ export default class extends Controller {
 
     if (this.inputField)
       this.inputField.focus()
+
+    this.notify()
   }
 
   hide() {
@@ -143,5 +151,11 @@ export default class extends Controller {
 
     window.clearTimeout(this.analyticsSubmitter)
     this.analyticsSubmitter = null
+  }
+
+  notify() {
+    const showingSearchEvent = new CustomEvent('navigation:search');
+
+    document.dispatchEvent(showingSearchEvent);
   }
 }

--- a/spec/javascript/controllers/navigation_controller_spec.js
+++ b/spec/javascript/controllers/navigation_controller_spec.js
@@ -2,7 +2,7 @@ import { Application } from 'stimulus';
 import NavigationController from 'navigation_controller.js';
 
 describe('NavigationController', () => {
-  document.body.innerHTML = `<div class="navbar__mobile" data-controller="navigation">
+  const navigationTemplate = `<div class="navbar__mobile" data-controller="navigation">
         <div class="navbar__mobile__buttons">
             <a data-action="click->navigation#navToggle" href="javascript:void(0);" class="icon">
                 <div data-navigation-target="hamburger" id='hamburger' class="icon-close"></div>
@@ -25,47 +25,66 @@ describe('NavigationController', () => {
   const application = Application.start();
   application.register('navigation', NavigationController);
 
+  beforeEach(() => document.body.innerHTML = navigationTemplate)
+
   describe('when first loaded', () => {
     it('hides the mobile navigation', () => {
       const themobilenav = document.getElementById('navbar-mobile-links');
       expect(themobilenav.style.display).toBe('none');
     });
-  });
 
-  describe('when first loaded', () => {
     it('sets the icon to a hamburger', () => {
       const theicon = document.getElementById('hamburger');
       expect(theicon.className).toBe('icon-hamburger');
     });
-  });
 
-  describe('when first loaded', () => {
     it("sets the label to read 'Menu'", () => {
       const thelabel = document.getElementById('navbar-label');
       expect(thelabel.innerHTML).toBe('Menu');
     });
   });
 
-  describe('once clicked', () => {
+  describe('once clicked to open', () => {
+    beforeEach(() => document.getElementById('hamburger').click())
+
     it('shows the mobile navigation', () => {
-      const theicon = document.getElementById('hamburger');
-      theicon.click();
       const themobilenav = document.getElementById('navbar-mobile-links');
       expect(themobilenav.style.display).toBe('block');
     });
-  });
 
-  describe('once clicked', () => {
     it('sets the icon to a cross', () => {
       const theicon = document.getElementById('hamburger');
       expect(theicon.className).toBe('icon-close');
     });
-  });
 
-  describe('once clicked', () => {
     it("sets the label to read 'Close'", () => {
       const thelabel = document.getElementById('navbar-label');
       expect(thelabel.innerHTML).toBe('Close');
     });
   });
+
+  describe('search bar opening', () => {
+    describe('when mobile menu already open', () => {
+      beforeEach(() => {
+        document.getElementById('hamburger').click()
+        document.dispatchEvent(new CustomEvent('navigation:search'))
+      })
+
+      it("hides the mobile navigation", () => {
+        const themobilenav = document.getElementById('navbar-mobile-links');
+        expect(themobilenav.style.display).toBe('none');
+      })
+    })
+
+    describe('when mobile menu closed', () => {
+      beforeEach(() => {
+        document.dispatchEvent(new CustomEvent('navigation:search'))
+      })
+
+      it("leaves the mobile navigation closed", () => {
+        const themobilenav = document.getElementById('navbar-mobile-links');
+        expect(themobilenav.style.display).toBe('none');
+      })
+    })
+  })
 });

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -2,7 +2,7 @@ import { Application } from 'stimulus' ;
 import SearchboxController from 'searchbox_controller.js' ;
 
 describe('SearchboxController', () => {
-  document.body.innerHTML = `
+  const searchboxTemplate = `
     <div data-controller="searchbox" class="searchbox">
       <a href="#" data-action="searchbox#toggle">
         Toggle
@@ -15,6 +15,8 @@ describe('SearchboxController', () => {
 
   const application = Application.start()
   application.register('searchbox', SearchboxController) ;
+
+  beforeEach(() => document.body.innerHTML = searchboxTemplate)
 
   describe("initialising autocomplete", () => {
     it("should create autocomplete-wrapper div", () => {
@@ -37,6 +39,29 @@ describe('SearchboxController', () => {
 
       document.querySelector('.searchbox a[data-action]').click()
       expect(searchBar().length).toBe(0)
+    })
+  })
+
+  describe("mobile menu opening", () => {
+    describe('when searchbox already open', () => {
+      beforeEach(() => {
+        document.querySelector('.searchbox a[data-action]').click()
+        document.dispatchEvent(new CustomEvent('navigation:menu'))
+      })
+
+      it("hides the search box", () => {
+        expect(document.querySelectorAll('.searchbox--opened').length).toBe(0)
+      })
+    })
+
+    describe('when searchbox is hidden', () => {
+      beforeEach(() => {
+        document.dispatchEvent(new CustomEvent('navigation:menu'))
+      })
+
+      it("leaves the search box hidden", () => {
+        expect(document.querySelectorAll('.searchbox--opened').length).toBe(0)
+      })
     })
   })
 })


### PR DESCRIPTION
### Trello card

https://trello.com/c/Nj1GdT7d

### Context

To avoid confusion when we open a searchbar, we should hide the mobile menu and vice versa.

### Changes proposed in this pull request

1. Hide mobile menu when opening the search bar
2. Hide search bar when opening the mobile menu

