### PR TITLE
Add list of providers to event page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: b1504f3d672f9109b91bfba67cd56fb2e1755b01
+  revision: 629a558e1f360c33c8b75a01555541f05420c167
   specs:
-    get_into_teaching_api_client (1.1.13)
+    get_into_teaching_api_client (1.1.14)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.21)
+    get_into_teaching_api_client_faraday (0.1.22)
       activesupport
       faraday
       faraday-encoding

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -88,6 +88,14 @@
     <% end %>
   <% end %>
 
+  <% if @event.providers_list %>
+    <%= render Content::AccordionComponent.new do |accordion| %>
+      <%= accordion.slot(:step, title: "Training providers at this event") do %>
+        <%= safe_html_format(@event.providers_list) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% content_for :feature do %>
     <% if @event.scribble_id %>
     <p>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -150,6 +150,13 @@ describe EventsController do
           it { is_expected.to match(/data-controller="scribble" data-scribble-id="123"/) }
         end
 
+        context "when the event has a providers_list" do
+          let(:event) { build(:event_api, providers_list: "<b><script type=\"malicious\"></script>a provider</b>", readable_id: event_readable_id) }
+
+          it { is_expected.to match(/Training providers at this event/) }
+          it { is_expected.to match(/<b>a provider<\/b>/) }
+        end
+
         context "when the event is online" do
           let(:event) { build(:event_api, is_online: true) }
 


### PR DESCRIPTION
### Trello card

[Trello-1440](https://trello.com/c/iydAl0Dm/1440-test-and-implement-ability-to-render-bullet-point-list-of-providers-for-ttt-events)

### Context

The API now exposes a `providers_list` as part of a `TeachingEvent`. If the event has this set, we want to render them at the bottom of the event page inside an accordion (as the list is usually very long).

### Changes proposed in this pull request

- Bump get_into_teaching_api_client_faraday gem

Include the image_url and providers_list fields.

- Add list of providers to event page

Adds a list of providers in an accordion to the bottom of the event page.

### Guidance to review

<img width="772" alt="Screenshot 2021-03-22 at 13 45 26" src="https://user-images.githubusercontent.com/29867726/112000493-f4a59b00-8b15-11eb-9b69-896bade23292.png">

