### PR TITLE
Add base controller for internal authentication

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,8 @@
 # Add public visible environment variables here for the Developemnt environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 PREVIEW_PAGES=1
+
+PUBLISHER_USERNAME=publisher
+PUBLISHER_PASSWORD=password
+AUTHOR_USERNAME=author
+AUTHOR_PASSWORD=password

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,8 @@ GIT_API_TOKEN=test
 GIT_API_ENDPOINT=https://host.api/endpoint
 TTA_SERVICE_URL=http://tta-service.test
 PREVIEW_PAGES=1
+
+PUBLISHER_USERNAME=publisher
+PUBLISHER_PASSWORD=password
+AUTHOR_USERNAME=author
+AUTHOR_PASSWORD=password

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -1,0 +1,8 @@
+module Internal
+  class EventsController < ::InternalController
+    def index
+      # stubbed for now
+      head :ok
+    end
+  end
+end

--- a/app/controllers/internal_controller.rb
+++ b/app/controllers/internal_controller.rb
@@ -1,0 +1,30 @@
+class InternalController < ApplicationController
+  before_action :authenticate
+  helper_method :publisher?
+
+protected
+
+  def publisher?
+    session[:role] == :publisher
+  end
+
+private
+
+  def set_account_role(role_type)
+    session[:role] = role_type
+  end
+
+  def authenticate
+    authenticated = true
+    authenticate_or_request_with_http_basic do |username, password|
+      if username == ENV["PUBLISHER_USERNAME"] && password == ENV["PUBLISHER_PASSWORD"]
+        set_account_role(:publisher)
+      elsif username == ENV["AUTHOR_USERNAME"] && password == ENV["AUTHOR_PASSWORD"]
+        set_account_role(:author)
+      else
+        authenticated = false
+      end
+      authenticated
+    end
+  end
+end

--- a/app/controllers/internal_controller.rb
+++ b/app/controllers/internal_controller.rb
@@ -15,16 +15,14 @@ private
   end
 
   def authenticate
-    authenticated = true
     authenticate_or_request_with_http_basic do |username, password|
       if username == ENV["PUBLISHER_USERNAME"] && password == ENV["PUBLISHER_PASSWORD"]
         set_account_role(:publisher)
       elsif username == ENV["AUTHOR_USERNAME"] && password == ENV["AUTHOR_PASSWORD"]
         set_account_role(:author)
-      else
-        authenticated = false
       end
-      authenticated
+
+      session[:role].present?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
     get "/assets/*missing", to: "errors#not_found", via: :all
   end
 
+  namespace :internal do
+    resources :events, only: %i[index]
+  end
+
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/tta-service", to: "pages#tta_service", as: :tta_service

--- a/spec/requests/internal_controller_spec.rb
+++ b/spec/requests/internal_controller_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe Internal do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+      .to receive(:search_teaching_events_grouped_by_type) { [] }
+  end
+
+  it "should reject unauthenticated users" do
+    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
+      "wrong",
+      "wrong",
+    )
+
+    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
+
+    assert_response :unauthorized
+  end
+
+  it "should reject no authentication" do
+    get internal_events_path
+
+    assert_response :unauthorized
+  end
+
+  it "should set the account role of publishers" do
+    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
+      ENV["PUBLISHER_USERNAME"],
+      ENV["PUBLISHER_PASSWORD"],
+    )
+
+    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
+
+    assert_response 200
+    expect(session[:role]).to be(:publisher)
+  end
+
+  it "should set the account role of authors" do
+    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
+      ENV["AUTHOR_USERNAME"],
+      ENV["AUTHOR_PASSWORD"],
+    )
+
+    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
+
+    assert_response 200
+    expect(session[:role]).to be(:author)
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/eDrH76ST

### Context
There needs to be some internal pages only accessible by two user types:
- a third party who is able to submit events for review (author)
- A DfE member who can approve those events and publish them (publisher)

### Changes proposed in this pull request
- Add base controller for internal authentication

### Guidance to review

