### PR TITLE
External link checker

### DIFF
--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.feature "external links check", :onschedule do
+  describe "all pages" do
+    it "will have no broken links" do
+      results = {}
+      faraday = Faraday.new do |f|
+        f.request :retry, max: 2
+        f.use FaradayMiddleware::FollowRedirects
+      end
+
+      PageLister.content_urls.each do |current_page|
+        puts "\nCHECKING #{current_page}"
+        visit(current_page)
+        document = Nokogiri.parse(page.body)
+        links = document
+                  .css("a")
+                  .pluck("href")
+                  .select { |href| href.starts_with? %r{https?://} }
+
+        WebMock.enable_net_connect!
+
+        links.each do |external_link|
+          if results.key? external_link
+            puts "-> [CACHED] #{external_link}"
+            # page already checked so just adding to list of pages with broken link
+            results[external_link][:pages] << current_page
+            next
+          else
+            puts "-> #{external_link}"
+          end
+
+          begin
+            faraday_response = faraday.get(external_link)
+
+            results[external_link] = {
+              status: faraday_response.status,
+              pages: [current_page],
+            }
+          rescue Faraday::Error
+            results[external_link] = {
+              status: nil,
+              pages: [current_page],
+            }
+          end
+        end
+
+        WebMock.disable_net_connect!
+      end
+
+      failures = results.reject do |_page, response|
+        (200..299).include? response[:status]
+      end
+
+      # comparing to hash instead of checking .empty? so the failures dump
+      # the difference in the hashes
+      expect(failures).to eql({})
+    end
+  end
+end

--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -3,48 +3,14 @@ require "rails_helper"
 RSpec.feature "external links check", :onschedule do
   describe "all pages" do
     it "will have no broken links" do
-      results = {}
-      faraday = Faraday.new do |f|
-        f.request :retry, max: 2
-        f.use FaradayMiddleware::FollowRedirects
-      end
+      results = LinkChecker::Results.new
 
       PageLister.content_urls.each do |current_page|
-        puts "\nCHECKING #{current_page}"
         visit(current_page)
-        document = Nokogiri.parse(page.body)
-        links = document
-                  .css("a")
-                  .pluck("href")
-                  .select { |href| href.starts_with? %r{https?://} }
+        checker = LinkChecker.new(current_page, page.body)
 
         WebMock.enable_net_connect!
-
-        links.each do |external_link|
-          if results.key? external_link
-            puts "-> [CACHED] #{external_link}"
-            # page already checked so just adding to list of pages with broken link
-            results[external_link][:pages] << current_page
-            next
-          else
-            puts "-> #{external_link}"
-          end
-
-          begin
-            faraday_response = faraday.get(external_link)
-
-            results[external_link] = {
-              status: faraday_response.status,
-              pages: [current_page],
-            }
-          rescue Faraday::Error
-            results[external_link] = {
-              status: nil,
-              pages: [current_page],
-            }
-          end
-        end
-
+        checker.check_links(results)
         WebMock.disable_net_connect!
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,4 +112,6 @@ RSpec.configure do |config|
   #   Kernel.srand config.seed
 
   config.raise_errors_for_deprecations!
+
+  config.filter_run_excluding :onschedule
 end

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -35,6 +35,8 @@ class PageLister
 end
 
 class LinkChecker
+  IGNORE = %w[127.0.0.1 localhost ::1 www.linkedin.com linkedin.com].freeze
+
   attr_reader :page, :document
 
   class Results < Hash; end
@@ -52,6 +54,8 @@ class LinkChecker
 
   def check_links(results = Results.new)
     external_links.each do |link|
+      next if ignored?(link)
+
       results[link] ||= Result.new(check(link), [])
       results[link].pages << page
     end
@@ -80,5 +84,11 @@ private
     faraday.get(link).status
   rescue ::Faraday::Error
     nil
+  end
+
+  def ignored?(link)
+    IGNORE.any? do |ignore|
+      link.starts_with? %r{https?://#{ignore}/}
+    end
   end
 end

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -38,7 +38,12 @@ class LinkChecker
   attr_reader :page, :document
 
   class Results < Hash; end
-  Result = Struct.new(:status, :pages)
+
+  Result = Struct.new(:status, :pages) do
+    def inspect
+      "Status code: #{status}" + pages.map { |p| "\n        -> #{p}" }.join
+    end
+  end
 
   def initialize(page, body)
     @page = page


### PR DESCRIPTION
### Trello card

https://trello.com/c/pUu6GogQ

### Context

We want a script to check all the external links within the site.

### Changes proposed in this pull request

1. Added an rspec test, it is tagged as part of the `onschedule` specs and excluded from runs by default - this can be subsequently run from CI.

### Guidance to review

I've used an RSpec test because I needed a mechanism to render the internal pages we are scanning for links. Its in a single test because we want to share the results across pages though this could potentially be achieved via a singleton.

The checker tries to 'behave well' - it uses HEAD requests, follows redirects, handles connection failures and only queries any given link once per run. The output is just a hash of the failure results but it lists the status code returned (or nil if no response). It also lists the pages which the broken link appears on.

There are several broken links on the assessment providers page it seems.

LinkedIn responds with a status code 999 so I've just excluded it the checks. There is also an (empty) array of domains to use GET requests for if that proves necessary.

I'll add a corresponding PR to content to run this on a schedule once its passed review and been merged

