### PR TITLE
Feature/fix deprecations

### DIFF
--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 describe PagesController do
   describe "#show" do
-    include_context "always render testing page"
-
     context "without caching enabled" do
       it "Should not have cache headers" do
         get "/test"
@@ -46,8 +44,7 @@ describe PagesController do
     end
 
     context "with unknown page" do
-      let(:template) { "testing/unknown" }
-      before { get "/test" }
+      before { get "/testing/unknown" }
       subject { response }
       it { is_expected.to have_http_status :not_found }
       it { is_expected.to have_attributes body: %r{Page not found} }
@@ -59,12 +56,18 @@ describe PagesController do
       it { is_expected.to have_http_status(:success) }
     end
 
-    context "with invalid page page" do
-      let(:template) { "../../secrets.txt" }
-      before { get "/test" }
+    context "with invalid page" do
+      before do
+        expect_any_instance_of(described_class).to \
+          receive(:render).with(status: :not_found, body: nil).and_call_original
+
+        get "/../../secrets.txt"
+      end
+
       subject { response }
+
       it { is_expected.to have_http_status :not_found }
-      it { is_expected.to have_attributes body: %r{Page not found} }
+      it { is_expected.to have_attributes body: "" }
     end
   end
 

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -14,14 +14,14 @@ describe EmailFormatValidator do
   end
 
   before { instance.valid? }
-  subject { instance.errors.to_h }
+  subject { instance.errors.to_hash }
 
   context "with invalid addresses" do
     %w[test.com test@@test.com test@test test@test.].each do |email|
       let(:instance) { test_model.new(email: email) }
 
       it "#{email} should not be valid" do
-        is_expected.to include email: "is invalid"
+        is_expected.to include email: ["is invalid"]
       end
     end
 
@@ -29,7 +29,7 @@ describe EmailFormatValidator do
       let(:instance) { test_model.new(email: "#{'a' * 100}@test.com") }
 
       it "is not be valid" do
-        is_expected.to include email: "is invalid"
+        is_expected.to include email: ["is invalid"]
       end
     end
   end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -14,13 +14,13 @@ describe PostcodeValidator do
   end
 
   before { instance.valid? }
-  subject { instance.errors.to_h }
+  subject { instance.errors.to_hash }
 
   context "with invalid full postcodes" do
     ["F00BAR", "123ABC", "TE57 ING"].each do |postcode|
       context "checking '#{postcode}'" do
         let(:instance) { test_model.new(postcode: postcode) }
-        it { is_expected.to include postcode: "is invalid" }
+        it { is_expected.to include postcode: ["is invalid"] }
       end
     end
   end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -15,12 +15,12 @@ describe TelephoneValidator do
   end
 
   before { instance.valid? }
-  subject { instance.errors.to_h }
+  subject { instance.errors.to_hash }
 
   %w[1234 123456789123456789123 1feg313153gewg1 random].each do |number|
     context "checking '#{number}'" do
       let(:instance) { test_model.new(telephone: number) }
-      it { is_expected.to include telephone: "is invalid" }
+      it { is_expected.to include telephone: ["is invalid"] }
     end
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/KBSuH9iG

### Context

Deprecation warnings are annoying and will become a problem in the future

### Changes proposed in this pull request

1. Switch to rails 6.1 errors format
2. Removed stubbed rendering from PagesController spec - no longer necessary now Pages::Page can find test pages
