### PR TITLE
Instagram doesn't support HEAD requests

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -36,7 +36,7 @@ end
 
 class LinkChecker
   IGNORE = %w[127.0.0.1 localhost ::1 www.linkedin.com linkedin.com].freeze
-  GET_NOT_HEAD = %w[].freeze
+  GET_NOT_HEAD = %w[www.instagram.com].freeze
 
   attr_reader :page, :document
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/pUu6GogQ

### Context

The link check uses HEAD requests by default which instagram does not support.

### Changes proposed in this pull request

1. Use GET requests instead for Instagram



