### PR TITLE
Make sitemap mailing list page not redirect

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -10,7 +10,7 @@ class SitemapController < ApplicationController
     /event-categories/train-to-teach-events
     /event-categories/online-q-as
     /event-categories/school-and-university-events
-    /mailinglist/signup
+    /mailinglist/signup/name
   ].freeze
 
   def show


### PR DESCRIPTION
### Trello card

https://trello.com/c/3VUoO7Fg/1467-fix-minor-seo-issues

### Context and changes

The mailing list signup entry in the sitemap causes a redirect to the
name stage of the wizard. This reflects badly in our sitemap where we
shouldn't have any pages that redirect.
