### PR TITLE
Switch to using new Sentry gem to notify of Bans

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -69,7 +69,7 @@ module Rack
             if should_ban
               obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
 
-              Raven.capture_message <<~BAN_MESSAGE
+              Sentry.capture_message <<~BAN_MESSAGE
                 Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
                 accessing #{req.path} with '#{req.query_string}'
               BAN_MESSAGE


### PR DESCRIPTION
### Trello card

https://trello.com/c/CvoMhTUe

### Context

This was a port from TTA but GiT is using the new Sentry gem

### Changes proposed in this pull request

1. Use Sentry gem for notifying of exceptions



