### PR TITLE
Set @image_description for story cards

### DIFF
--- a/app/components/stories/card_component.rb
+++ b/app/components/stories/card_component.rb
@@ -5,10 +5,17 @@ module Stories
     def initialize(card:)
       super(card: card)
       @name = card["name"]
+      @image_description = "A photograph of #{image_description_name}"
     end
 
     def link_text
       "Read #{name}'s story"
+    end
+
+  private
+
+    def image_description_name
+      name || "a teacher"
     end
   end
 end

--- a/spec/components/stories/card_component_spec.rb
+++ b/spec/components/stories/card_component_spec.rb
@@ -25,6 +25,10 @@ describe Stories::CardComponent, type: "component" do
     end
   end
 
+  specify "the image has descriptive alt text" do
+    expect(subject).to have_css(%(img[alt="A photograph of #{story['name']}"]))
+  end
+
   specify "includes the snippet" do
     is_expected.to have_content(story["snippet"])
   end


### PR DESCRIPTION

### Trello card

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### Context and changes

Without an `@image_description` being set the alt text isn't present, this was flagged by our SEO audit. This change sets it to the teacher's name. There is a fall back to `"A photograph of a teacher" if ever we manage to add a story without a name.