### PR TITLE
Publish page speed scores in preprod instead of rolling

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -48,7 +48,7 @@ on_worker_boot do
     SemanticLogger.reopen
   end
 
-  if Rails.env.rolling?
+  if Rails.env.preprod?
     require "page_speed_score"
     PageSpeedScore.publish
   end


### PR DESCRIPTION
After talking to Steve we figured it would be better to use the test environment as that means we can write to the production influxdb (whilst still using the test Redis instance).