### PR TITLE
Update mailing list links to point at first page

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/tta-service">Get an adviser</a></li>
         <li><a href="/events">Go to an event</a></li>
-        <li><a href="/mailinglist/signup">Sign up for personalised updates</a></li>
+        <li><a href="/mailinglist/signup/name">Sign up for personalised updates</a></li>
       </ul>
     <% end %>
   </aside>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -31,7 +31,7 @@
           <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
         <% end %>
         <%= link_to "Find an event near you", events_path %>
-        <%= link_to "Sign up for the mailing list", mailing_list_steps_path %>
+        <%= link_to "Sign up for updates", mailing_list_steps_path %>
         <%= link_to("Three things to help you get into teaching", page_path(page: "three-things-to-help-you-get-into-teaching")) %>
         <%= link_to("COVID-19", page_path(page: "covid-19")) %>
       </div>

--- a/app/views/sections/_mailing-list-bar.html.erb
+++ b/app/views/sections/_mailing-list-bar.html.erb
@@ -4,7 +4,7 @@
       Get personalised information and advice about getting into teaching
     </div>
     <div class="mailing-list-bar__right">
-      <a href="/mailinglist/signup" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
+      <a href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
       <a href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
     </div>
   </section>


### PR DESCRIPTION
### Trello card

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### Context and changes.

Changing the links from `/mailinglist/signup` to `/mailinglist/signup/name` prevents us from linking to a route that immediately 301's the user, something that can affect our SEO.
