### PR TITLE
Increase size of landing page numbered headings

### DIFF
--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -14,18 +14,28 @@
       background-color: $pink-dark;
       @include rotated-block;
       color: $white;
-      padding: .5em .8em;
+      padding: .6em .8em;
       font-weight: bold;
-      margin-right: 1em;
+      margin-right: .3em;
+      font-size: size(large);
     }
 
     h2 {
       margin: 0;
       background: none;
       color: $black;
+      font-size: size(large);
 
       &:after {
         content: "";
+      }
+
+      @include mq($until: tablet) {
+        font-size: size(small);
+      }
+
+      @include mq($until: desktop) {
+        font-size: size(medium);
       }
     }
   }


### PR DESCRIPTION
### Context

The pink headings are a little bit small and the page balance doesn't feel quite right.

### Changes proposed in this pull request

Increase the size of the numbered headings and tweak their margins slightly.

![Screenshot from 2021-03-31 10-19-43](https://user-images.githubusercontent.com/128088/113121738-d96c1700-920a-11eb-8394-d86766f4654e.png)

