### PR TITLE
Allow AhrefsSiteAudit crawler to audit the site

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,6 @@ Disallow: /
 
 User-agent: SemrushBot-SA
 Allow: /
+
+User-agent: AhrefsSiteAudit
+Allow: /


### PR DESCRIPTION
Similar to Semrush, allow Ahrefs to do an SEO audit.
