### PR TITLE
Make the external link mixin more modular

### DIFF
--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -55,20 +55,17 @@ $space-between-sections: 3.7em;
       list-style: none;
       padding: 0;
 
-      li {
+      li > a {
         @include suppress-external-link-icon;
+        font-size: size('xsmall');
+        color: $black;
+        line-height: 1.8em;
+        text-underline-offset: .2em;
 
-        > a {
-          font-size: size('xsmall');
-          color: $black;
-          line-height: 1.8em;
-          text-underline-offset: .2em;
-
-          &:hover {
-            color: $purple;
-            text-decoration: underline;
-            text-decoration-thickness: .12em;
-          }
+        &:hover {
+          color: $purple;
+          text-decoration: underline;
+          text-decoration-thickness: .12em;
         }
       }
     }

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -1,4 +1,5 @@
 @mixin button($bg: $green, $fg: $white) {
+  @include suppress-external-link-icon;
   display: block;
   font-weight: bold;
   background-color: $bg;

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -54,7 +54,7 @@
   // and the home page featured content video thumbnail links
   .call-to-action__action,
   .featured-content__item {
-    @include suppress-external-link-icon;
+    a { @include suppress-external-link-icon; }
 
     // this is added by Kramdown when using the ToC (table of contents) plugin
     #markdown-toc {

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -4,12 +4,10 @@
 }
 
 @mixin suppress-external-link-icon {
-  a {
-    &[href*="//"] {
-      &:after {
-        content: none !important;
-        margin-left: unset;
-      }
+  &[href*="//"] {
+    &:after {
+      content: none !important;
+      margin-left: unset;
     }
   }
 }


### PR DESCRIPTION
This allows it to be dropped in anywhere, making it easier to target buttons and other places where we never want it to appear.

![Screenshot from 2021-03-31 15-48-08](https://user-images.githubusercontent.com/128088/113163916-8741ea80-9238-11eb-9b97-2546581f5f5f.png)
![Screenshot from 2021-03-31 15-46-06](https://user-images.githubusercontent.com/128088/113163922-87da8100-9238-11eb-9a3c-bd35861cc3f4.png)

