### PR TITLE
Add the file that identifies us to Ahrefs

### DIFF
--- a/public/ahrefs_fedc417d95bed03087d3e11cb889a31773021b87ffd7ec039c8b80ac97c74f71
+++ b/public/ahrefs_fedc417d95bed03087d3e11cb889a31773021b87ffd7ec039c8b80ac97c74f71
@@ -1,0 +1,1 @@
+ahrefs-site-verification_fedc417d95bed03087d3e11cb889a31773021b87ffd7ec039c8b80ac97c74f71


### PR DESCRIPTION
### Trello

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### context and changes

This proof-of-ownership routine would normally be carried out via Google Search Console but we don't have that enabled for the beta site yet.