### PR TITLE
Add link to presentations on TTT hub page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
           <li>how to submit a successful application</li>
           <li>what a career in teaching is really like</li>
         </ul>
+        <p>
+        The presentations used at these events can be found <a href="/presentations">here</a>.
+        </p>
       222750008: |-
         <p>
           Ask a panel of specialists the questions that matter to you in one of our real-time Q&A online events.


### PR DESCRIPTION
### Trello card
https://trello.com/c/NYfdwR0Q/1374-add-link-to-presentations-from-events-landing-page

### Context

Business request - add link to presentations for TTT events. I've added this to the Hub page so as not to overcrowd the main events homepage. 


