### PR TITLE
Add @front_matter to events for meta descriptions

### DIFF
--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -13,6 +13,7 @@ class EventCategoriesController < ApplicationController
 
     @category_name = helpers.pluralised_category_name(@type.id)
     @page_title = @category_name
+    @front_matter = { "description" => "Get your questions answered at a #{@category_name} event." }
 
     load_events(:future)
   end
@@ -21,7 +22,9 @@ class EventCategoriesController < ApplicationController
     raise_not_found unless has_archive?(@type)
 
     @category_name = helpers.past_category_name(@type.id)
+
     @page_title = @category_name
+    @front_matter = { "description" => "See past #{@category_name} events." }
 
     load_events(:past)
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,17 +11,23 @@ class EventsController < ApplicationController
 
   def index
     @page_title = "Find an event near you"
+    @front_matter = { "description" => "Get your questions answered at an event." }
+
     render layout: "events"
   end
 
   def search
     @page_title = "Find an event near you"
+    @front_matter = { "description" => "Get your questions answered at an event." }
+
     render "index", layout: "events"
   end
 
   def show
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
+
     @page_title = @event.name
+    @front_matter = { "description" => @event.summary }
 
     breadcrumb "events.search", :events_path
     category_name = t("event_types.#{@event.type_id}.name.plural")

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -6,6 +6,7 @@ describe EventsController do
   describe "#index" do
     include_context "stub upcoming events by category api", EventsController::UPCOMING_EVENTS_PER_TYPE
     let(:parsed_response) { Nokogiri.parse(response.body) }
+    let(:expected_description) { "Get your questions answered at an event." }
 
     subject! do
       get(events_path)
@@ -13,6 +14,18 @@ describe EventsController do
     end
 
     it { is_expected.to have_http_status :success }
+
+    it "has a meta description" do
+      actual_description = parsed_response.at_css("head meta[name='description']")["content"]
+
+      expect(actual_description).to eql(expected_description)
+    end
+
+    it "has a meta og:description" do
+      actual_description = parsed_response.at_css("head meta[name='og:description']")["content"]
+
+      expect(actual_description).to eql(expected_description)
+    end
 
     specify "all events should be rendered" do
       expect(parsed_response.css(".events-featured__list__item").count).to eql(events.count)
@@ -65,12 +78,25 @@ describe EventsController do
           type_id: event_type,
         }
       end
+      let(:expected_description) { "Get your questions answered at an event." }
 
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes media_type: "text/html" }
 
-      specify "all events should be rendered" do
+      it "renders all events" do
         expect(parsed_response.css(".events-featured__list__item").count).to eql(events.count)
+      end
+
+      it "has a meta description" do
+        actual_description = parsed_response.at_css("head meta[name='description']")["content"]
+
+        expect(actual_description).to eql(expected_description)
+      end
+
+      it "has a meta og:description" do
+        actual_description = parsed_response.at_css("head meta[name='og:description']")["content"]
+
+        expect(actual_description).to eql(expected_description)
       end
     end
 
@@ -104,6 +130,7 @@ describe EventsController do
 
       describe "the response body" do
         subject { response.body }
+        let(:parsed_response) { Nokogiri.parse(response.body) }
 
         it { is_expected.to include(event.name) }
         it { is_expected.to include(event.description) }
@@ -171,6 +198,18 @@ describe EventsController do
 
           it { is_expected.to match(%r{To register for this event, follow the instructions in the event information section}) }
           it { is_expected.not_to match(%r{Sign up for this}) }
+        end
+
+        it "has a meta description" do
+          actual_description = parsed_response.at_css("head meta[name='description']")["content"]
+
+          expect(actual_description).to eql(event.summary)
+        end
+
+        it "has a meta og:description" do
+          actual_description = parsed_response.at_css("head meta[name='og:description']")["content"]
+
+          expect(actual_description).to eql(event.summary)
         end
       end
     end


### PR DESCRIPTION
### Trello card

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### Context and changes

The meta descriptions provide search engines with more contextual information about a page.

![Screenshot from 2021-04-01 12-13-24](https://user-images.githubusercontent.com/128088/113288165-7d76c080-92e6-11eb-9e3a-452a524581d1.png)


