### PR TITLE
Add alt text for external link icons via CSS

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -17,7 +17,7 @@
 @mixin _external-link-icon-style {
   &[href*="//"] {
     &:after {
-      content: url('../images/icon-external.svg');
+      content: url('../images/icon-external.svg') / "External link icon";
       margin-left: .2em;
       display: inline-block;
       background-repeat: no-repeat;


### PR DESCRIPTION
### Trello

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### Context

I think these are being flagged by our various SEO tools

https://developer.mozilla.org/en-US/docs/Web/CSS/content
