### PR TITLE
Add rule as fallback for unsupported browsers

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -15,6 +15,7 @@
 @mixin _external-link-icon-style {
   &[href*="//"] {
     &:after {
+      content: url('../images/icon-external.svg');
       content: url('../images/icon-external.svg') / "External link icon";
       margin-left: .2em;
       display: inline-block;


### PR DESCRIPTION
Firefox doesn't support the `/` syntax yet so this rule will provide a fallback if the one after it isn't recognised.

