### PR TITLE
Remove markdown classes from story card lists

### DIFF
--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -22,7 +22,7 @@
             </section>
           <% end %>
 
-          <article class="markdown fullwidth">
+          <section class="feature">
             <% @front_matter["sections"]&.each do |name, section| %>
               <% if section["stories"].present? %>
                 <div class="story-landing__stories">
@@ -43,7 +43,7 @@
               <% end %>
             <% end %>
           </section>
-        </article>
+        </section>
       </main>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -7,13 +7,13 @@
       <%= render Navigation::BreadcrumbComponent.new %>
       <main role="main" id="main-content">
         <section class="container">
-          <article class="markdown fullwidth">
+          <section class="feature">
             <%= yield %>
 
             <div class="cards stories">
               <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
             </div>
-          </article>
+          </section>
         </section>
       </main>
       <%= render "sections/footer" %>

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -118,7 +118,8 @@ section.container {
   // supplementary: content that's not directly related to the main article but might be of interest
   > .feature,
   > .supplementary {
-    flex: 0 0 100%;
+    flex: 0 1 100%;
+    @include indent-left-and-right;
   }
 
   >.page-helpful {


### PR DESCRIPTION
### Context and changes

Using the `markdown` class for things that aren't markdown has the side-effect
of applying some styles intended only for body text to other items, like the
lists of events or stories.

This change updates the story landing and index pages so the list of cards is
surrounded by a `section.feature` instead of `article.markdown`.
