### PR TITLE
Reduce covid banner to one line

### DIFF
--- a/app/views/sections/_header.html.erb
+++ b/app/views/sections/_header.html.erb
@@ -2,9 +2,7 @@
     <section class="covid" data-controller="banner" data-banner-name="Covid">
         <div class="limit-content-width">
             <span class="covid__header">Coronavirus (COVID-19) - <a href="/covid-19">check here for updates</a></span>
-            <p>
-                <a href="#" data-action="click->banner#hide">Hide this message</a>
-            </p>
+                <a href="#" data-action="click->banner#hide" class="covid__close"><span class="visually-hidden">Hide this message</span></a>
         </div>
     </section>
     <%= render(Navigation::NavbarComponent.new) %>

--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -245,10 +245,13 @@
   line-height: 1.25;
   background-color: $black;
   color: $white;
-  padding-top: $indent-amount;
-  padding-bottom: $indent-amount;
-  padding-left: 35px;
-  padding-right: 35px;
+  padding: 10px 20px;
+
+  .limit-content-width {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
   p {
     font-size: size("xsmall");
@@ -262,8 +265,18 @@
 
   &__header {
     display: block;
-    font-size: size("small");
     font-weight: bold;
+  }
+
+  &__close {
+    background: url(/packs/media/images/icon-close-4b00d0952ffd57a191ae46fdf62e895d.svg);
+    display: block;
+    width: 44px;
+    height: 44px;
+    background-size: 22px;
+    background-repeat: no-repeat;
+    background-position: 50%;
+    margin-left: 20px;
   }
 
   a {


### PR DESCRIPTION
Reduce the size of the covid banner to have less impact on the page on the first load. 

