### PR TITLE
Increase cache TTL to 1 year

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{15.minutes.to_i}",
-    "Expires" => 15.minutes.from_now.to_formatted_s(:rfc822),
+    "Cache-Control" => "public, max-age=#{365.days.to_i}",
+    "Expires" => 365.days.from_now.to_formatted_s(:rfc822),
   }
 
   # Compress CSS using a preprocessor.


### PR DESCRIPTION
### Trello card

[Trello-1450](https://trello.com/c/AwCyN4st/1450-page-speed-improvements)

### Context

We now fingerprint all the assets in the content repository as well as in the Rails app, so its safe to have them cached
indefinitely going forward (as the fingerprint will change when the contents of the asset changes).

### Changes proposed in this pull request

- Increase cache TTL to 1 year

### Guidance to review

