### PR TITLE
Remove explicit icon-external classes

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -32,7 +32,7 @@
   <h2>Venue information</h2>
   <p><%= @event.building.venue %>, <%= event_address(@event) %>.</p>
   <% if @event.provider_website_url %>
-    <p><%= link_to("Visit venue website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
+    <p><%= link_to("Visit venue website", @event.provider_website_url, { target: "blank" }) %><i class="icon"></i></p>
   <%end %>
   <p><%= event_location_map(@event) %></p>
   <% end %>
@@ -40,7 +40,7 @@
   <% if event_has_provider_info?(@event) %>
     <h2>Provider information</h2>
     <% if @event.provider_website_url %>
-      <p><strong>Event website</strong><br /><%= link_to(@event.provider_website_url, @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i></p>
+      <p><strong>Event website</strong><br /><%= link_to(@event.provider_website_url, @event.provider_website_url, { target: "blank" }) %><i class="icon"></i></p>
     <% end %>
     <% if @event.provider_target_audience %>
       <p><strong>Target audience</strong><br /><%= @event.provider_target_audience %></p>


### PR DESCRIPTION
This styling gets applied implicitly from the URL being external. It was causing duplicate icons:

<img width="501" alt="Screenshot 2021-04-06 at 12 38 36" src="https://user-images.githubusercontent.com/29867726/113705165-0457de80-96d5-11eb-8b69-da9d0abaed7b.png">
