### PR TITLE
Feature/feedback UI component

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
         <section class="feature">
           <%= yield :feature %>
         </section>
-        <%= render "sections/page_helpful" unless @hide_page_helpful_question %>
       </section>
     </main>
 

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -88,8 +88,6 @@
               ) %>
             <% end %>
           <% end %>
-
-          <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
         <% end %>
       </section>
     </main>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -26,8 +26,6 @@
           <% @front_matter["content"]&.each do |partial| %>
             <%= render(partial) %>
           <% end %>
-
-          <%= render "sections/page_helpful" unless @front_matter["hide_page_helpful_question"] %>
         </article>
       </section>
     </main>
@@ -38,4 +36,3 @@
     <%= render "components/analytics" %>
   <% end %>
 </html>
-

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -13,7 +13,6 @@
     <main role="main" id="main-content">
       <section class="feature registration container">
         <%= yield %>
-        <%= render "sections/page_helpful" unless @hide_page_helpful_question %>
       </section>
     </main>
 

--- a/app/views/sections/_feedback_bar.html.erb
+++ b/app/views/sections/_feedback_bar.html.erb
@@ -1,0 +1,20 @@
+<div class="feedback-bar">
+  <section class="feedback-bar__inner limit-content-width">
+    <div class="feedback-bar__left">
+      <h2 class="blue small">FEEDBACK</h2>
+    </div>
+    <div class="feedback-bar__right">
+      <div id="page-helpful" data-controller="page-helpful">
+        <div>
+          <strong data-page-helpful-target="text">Is this page helpful?</strong>
+          <a href="javascript:void(0)" class="page-question__answer strong" data-page-helpful-target="link" data-action="page-helpful#answer">Yes</a>
+          <a href="javascript:void(0)" class="page-question__answer strong" data-page-helpful-target="link" data-action="page-helpful#answer">No</a>
+        </div>
+      </div>
+      <div>
+        We'd like your feedback on our new Get into teaching website.
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think</a>
+      </div>
+    </div>
+  </section>
+</div>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,6 +1,7 @@
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
   <%= render "sections/mailing-list-bar" %>
+  <%= render "sections/feedback_bar" %>
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">

--- a/app/webpacker/styles/feedback-bar.scss
+++ b/app/webpacker/styles/feedback-bar.scss
@@ -1,0 +1,61 @@
+.feedback-bar {
+  background-color: $white;
+  padding: 40px;
+  bottom: 0;
+
+  @include mq($until: tablet) {
+    padding: 1.5em;
+  }
+
+
+  &__inner {
+    align-items: center;
+    display: flex;
+    margin: 0 auto;
+
+    h2 {
+      @include content-heading;
+      max-width: 100%;
+
+      &:after {
+        content: "";
+      }
+    }
+
+    @include mq($until: tablet) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+
+  &__left {
+    margin-right: 1em;
+    font-size: size(small);
+    font-weight: bold;
+
+    @include mq($until: tablet) {
+      padding: .2em 0 1em;
+    }
+  }
+
+  &__right {
+    justify-items: left;
+    align-items: left;
+    display: flex;
+    flex-direction: column;
+
+    #page-helpful {
+      a {
+        margin-left: 0.5em;
+      }
+    }
+
+    @include mq($until: tablet) {
+      padding: .2em 0 1em;
+
+      #page-helpful {
+        margin-bottom: 0.5em;
+      }
+    }
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -15,6 +15,7 @@
 @import 'markdown-figures-and-quotes';
 @import 'feature';
 @import 'featured';
+@import 'feedback-bar';
 @import 'forms';
 @import 'video';
 @import 'header';
@@ -25,9 +26,9 @@
 @import 'call-to-action';
 @import 'accordion';
 @import 'blocks';
-@import 'search-page' ;
-@import 'eligibility-checker' ;
-@import 'steps' ;
+@import 'search-page';
+@import 'eligibility-checker';
+@import 'steps';
 
 @import './sections/hero';
 @import './sections/hero/content';

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -76,3 +76,7 @@ a {
 .telephone-number:hover {
   text-decoration: none;
 }
+
+.strong {
+  font-weight: bold
+}

--- a/spec/views/sections/_feeback_bar.html.erb_spec.rb
+++ b/spec/views/sections/_feeback_bar.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "sections/_feedback_bar.html.erb", type: :view do
+  before { render partial: "sections/feedback_bar" }
+  subject { rendered }
+
+  it { is_expected.to have_link("Tell us what you think") }
+
+  # Targetted by GTM event.
+  it { is_expected.to match(/class=\"page-question__answer strong\".*>Yes</) }
+  it { is_expected.to match(/class=\"page-question__answer strong\".*>No</) }
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/v2QcGzbb/699-move-is-this-page-useful-out-of-the-way

### Context
The 'is this page useful?' is of limited use and not the tidiest of components. We want to replacing it with a new one that will be display across the site.

### Changes proposed in this pull request
Create a new feedback section, place it below the 'Talk to us' and stop rendering the 'is this page useful?' component.

### Guidance to review
|Before|After|
|---|---|
|<img width="694" alt="before" src="https://user-images.githubusercontent.com/951947/113711008-54866f00-96dc-11eb-8587-2dbe9ea837ac.png">|<img width="700" alt="after" src="https://user-images.githubusercontent.com/951947/113711023-5a7c5000-96dc-11eb-8238-9c41b16833d8.png">

