### PR TITLE
Quotes around Trello Body

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -24,6 +24,6 @@ jobs:
         uses: DFE-Digital/github-actions/AddTrelloComment@master
         with:
           MESSAGE:      ${{ github.event.pull_request.html_url }} 
-          CARD:         ${{ github.event.pull_request.body }}           
+          CARD:         "${{ github.event.pull_request.body }}"           
           TRELLO-KEY:   ${{ steps.azSecret.outputs.TRELLO-KEY}}
           TRELLO-TOKEN: ${{ steps.azSecret.outputs.TRELLO-TOKEN }}


### PR DESCRIPTION
[Attachments in Github PRs cause trello failure](https://trello.com/b/lRXllOHK/get-into-teaching-private-beta)

### Context
Error when scanning a github pull request with attachments, maybe caused by lack of quotes


### Guidance to review
|Before|After|
|---|---|
|<img width="694" alt="before" src="https://user-images.githubusercontent.com/951947/113711008-54866f00-96dc-11eb-8587-2dbe9ea837ac.png">|<img width="700" alt="after" src="https://user-images.githubusercontent.com/951947/113711023-5a7c5000-96dc-11eb-8238-9c41b16833d8.png">


