### PR TITLE
Instantiate Faraday client with a URL

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -69,8 +69,8 @@ private
     links.select { |href| href.starts_with? %r{https?://} }
   end
 
-  def faraday
-    ::Faraday.new do |f|
+  def faraday(link)
+    ::Faraday.new(link) do |f|
       f.request :retry, max: 2
       f.use ::FaradayMiddleware::FollowRedirects
     end
@@ -78,9 +78,9 @@ private
 
   def check(link)
     if needs_get?(link)
-      faraday.get(link).status
+      faraday(link).get.status
     else
-      faraday.head(link).status
+      faraday(link).head.status
     end
   rescue ::Faraday::Error
     nil


### PR DESCRIPTION
### Context and changes

When links are provided via `#get`, Faraday actually treats the argument as the 'suffix' to whatever was provided when initialised. As a result, the trailing slash is dropped. This causes one of our link tests to fail as the site 301s from `https://example.com` to `https://example.com/`.

https://github.com/lostisland/faraday/issues/212
