### PR TITLE
Serve images in next-gen image formats where possible

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require "next_gen_images"
+
 class ApplicationController < ActionController::Base
   include UtmCodes
 
@@ -10,11 +12,19 @@ class ApplicationController < ActionController::Base
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
 
+  after_action :insert_next_gen_images, if: -> { Rails.env.preprod? }
+
   def raise_not_found
     raise ActionController::RoutingError, "Not Found"
   end
 
 private
+
+  def insert_next_gen_images
+    return unless response.headers["Content-Type"]&.include?("text/html")
+
+    response.body = NextGenImages.new(response.body).html
+  end
 
   def set_api_client_request_id
     # The request_id is passed to the ApiClient via Thread.current

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -46,7 +46,7 @@
                   </div>
                 <% end %>
               <% end %>
-            </ul>
+            </div>
 
           <% end %>
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -14,7 +14,7 @@
   }
 
   &__photo {
-    > img {
+    > picture img {
       width: 8em;
     }
   }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -155,7 +155,7 @@
     .card__thumb {
       flex: 0 1 45%;
 
-      > img {
+      > picture img {
         width: 100%;
         object-fit: contain;
         height: auto;

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -47,6 +47,7 @@ private
 
     case ext
     when ".webp"
+      # Rack::Mime.mime_type is returning the wrong mime type for webp.
       "image/webp"
     else
       Rack::Mime.mime_type(ext)

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -1,0 +1,55 @@
+class NextGenImages
+  # As we control the conversion we only need to look for
+  # a subset of all the possible extensions.
+  NEXT_GEN_IMAGE_EXTS = %w[.jp2 .webp].freeze
+
+  def initialize(page)
+    @page = page
+  end
+
+  def html
+    doc = Nokogiri::HTML(@page)
+    doc.css("img").each do |img|
+      img.replace(picture(img, doc)) unless img.parent.name == "picture"
+    end
+
+    doc.to_html(encoding: "UTF-8", indent: 2)
+  end
+
+private
+
+  def picture(img, doc)
+    src = img.attribute("src")
+
+    Nokogiri::XML::Node.new("picture", doc) do |picture|
+      picture.add_child(img.dup)
+      source_exts = [File.extname(src)] + NEXT_GEN_IMAGE_EXTS
+      source_exts.each do |ext|
+        source = source(src, ext, doc)
+        picture.add_child(source) if source.present?
+      end
+    end
+  end
+
+  def source(original_src, ext, doc)
+    src = "#{File.basename(original_src, '.*')}#{ext}"
+
+    return nil unless File.exist?("#{Rails.public_path}/#{src}")
+
+    Nokogiri::XML::Node.new("source", doc) do |source|
+      source.set_attribute("srcset", src)
+      source.set_attribute("type", mime_type(src))
+    end
+  end
+
+  def mime_type(src)
+    ext = File.extname(src)
+
+    case ext
+    when ".webp"
+      "image/webp"
+    else
+      Rack::Mime.mime_type(ext)
+    end
+  end
+end

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+require "next_gen_images"
+
+describe NextGenImages do
+  describe "#html" do
+    let(:original_ext) { File.extname(original_src) }
+    let(:body) { "<img src=\"#{original_src}\">" }
+    let(:instance) { described_class.new(body) }
+
+    before { allow(File).to receive(:exist?) { false } }
+    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
+
+    subject { instance.html }
+
+    context "when the original image is a jpg" do
+      let(:original_src) { "image.jpg" }
+
+      context "when there are no next-gen images" do
+        it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/jpeg')}</picture>") }
+      end
+
+      context "when the image is already in a picture tag" do
+        let(:body) { "<picture><img src=\"#{original_src}\"></picture>" }
+
+        it { is_expected.to include(body) }
+      end
+
+      context "when there are next-gen images" do
+        let(:next_gen_imgs) do
+          {
+            "image/jpeg" => original_src,
+            "image/jp2" => original_src.gsub(original_ext, ".jp2"),
+            "image/webp" => original_src.gsub(original_ext, ".webp"),
+          }
+        end
+
+        before do
+          next_gen_imgs.values.each do |src|
+            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}") { true }
+          end
+        end
+
+        it do
+          sources = next_gen_imgs.map { |mime_type, src| source(src, mime_type) }.join
+          is_expected.to include("<picture><img src=\"#{original_src}\">#{sources}</picture>")
+        end
+      end
+    end
+
+    context "when the original image is a png" do
+      let(:original_src) { "image.png" }
+
+      it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/png')}</picture>") }
+    end
+
+    context "when the original image is an svg" do
+      let(:original_src) { "image.svg" }
+
+      it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/svg+xml')}</picture>") }
+    end
+  end
+
+  def source(src, mime_type)
+    "<source srcset=\"#{src}\" type=\"#{mime_type}\"></source>"
+  end
+end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Next Gen Images" do
+  before do
+    allow(Rails.env).to receive(:preprod?) { preprod }
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with(/.*\.svg/) { true }
+    get root_path
+  end
+  subject { response.body }
+
+  context "when running in preprod" do
+    let(:preprod) { true }
+
+    it do
+      is_expected.to match(
+        /<picture><img alt="Department for education" src=".*\.svg"><source srcset=".*\.svg" type="image\/svg\+xml"><\/source><\/picture>/,
+      )
+    end
+  end
+
+  context "when not running in preprod" do
+    let(:preprod) { false }
+
+    it { is_expected.to_not include("<picture>") }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1450](https://trello.com/c/AwCyN4st/1450-page-speed-improvements)

### Context

We use basic JPEG/PNG images for the most part; a recommendation is to use newer image formats that enable better compression, which improves the page load speed. Instead of manually saving each image in the various formats, we can generate the different formats during the Docker build process and dynamically serve them when they exist from Rails.

We should be able to build on this with a couple of further optimisations; only loading images 'above the fold' on the first paint and serving device-appropriate images (so smaller images for mobile, for example).

It would be nice to serve background images in the different formats as well, but I'm not sure how possible that is without relying on JS - I'll investigate in another PR.

### Changes proposed in this pull request

- Add NextGenImages class

Introduces a class that replaces `<img>` tags with `<picture>` tags and applicable `<source>` tags for any next-gen images that exist with the same file name as the original image.

This will allow us to generate next-gen images as part of the Docker build process and then Rails will introduce them into the responses dynamically. As most of our pages are static and cached it shouldn't have a big performance overhead.

- Add next-gen images to all HTML responses

Any HTML responses are intercepted and the next-gen images are introduced when they exist.

Enabled only in preprod initially.

- Tweak CSS to support picture instead of img tags

Some of the CSS targets a specific `img` tag with the `>` selector; these need updating to target the `img` within the new `picture` tag.

- Correct HTML closing tag

It was getting messed up running through Nokogiri (even though it rendered fine by browsers like this).

### Guidance to review

As it stands the existing images will be wrapped in a `<picture>` tag with a single `<source>` for the original image. When we update the content Docker build process to generate images in next-gen formats it should start serving those as well.

I've tested this locally with a decent amount of clicking about and it doesn't seem to break anything. Its only enabled in preprod for now so that I can get some other people to give it a decent smoke test.
