### PR TITLE
Support lazy loading images that are below the fold

### DIFF
--- a/app/webpacker/javascript/lazy_images.js
+++ b/app/webpacker/javascript/lazy_images.js
@@ -1,0 +1,7 @@
+import 'lazysizes';
+
+// By default lazy-loaded images are hidden (to support JS
+// being disabled). If JS is enabled, we show them.
+document.querySelectorAll(".lazyload").forEach((img) => {
+  img.classList.add("visible");
+});

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,6 +3,7 @@ import '../styles/application.scss';
 import 'polyfills/ie8.js';
 import 'polyfills/objectFitPolyfill.basic.min.js';
 import 'javascript/object_fit.js';
+import 'javascript/lazy_images.js';
 import Rails from 'rails-ujs';
 import Turbolinks from 'turbolinks';
 

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -136,3 +136,7 @@ $chevron-direction-map: (
 .clearfix {
   clear: both;
 }
+
+img[data-src]:not(.visible) {
+  display: none;
+}

--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -1,0 +1,32 @@
+class LazyLoadImages
+  def initialize(page)
+    @page = page
+  end
+
+  def html
+    doc = Nokogiri::HTML(@page)
+
+    doc.css("img").each do |img|
+      img.after(noscript_image(img, doc))
+      img.set_attribute("data-src", img.attribute("src"))
+      img.set_attribute("src", nil)
+      img["class"] ||= ""
+      img["class"] = img["class"] << " lazyload"
+    end
+
+    doc.css("picture source").each do |source|
+      source.set_attribute("data-srcset", source.attribute("srcset"))
+      source.set_attribute("srcset", nil)
+    end
+
+    doc.to_html(encoding: "UTF-8", indent: 2)
+  end
+
+private
+
+  def noscript_image(img, doc)
+    Nokogiri::XML::Node.new("noscript", doc) do |noscript|
+      noscript.add_child(img.dup)
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "govuk-frontend": "^3.11.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^2.2.1",
+    "lazysizes": "^5.3.2",
     "rails-ujs": "^5.2.5",
     "sass-mq": "^5.0.1",
     "serialize-javascript": "^5.0.1",

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "lazy_load_images"
+
+describe LazyLoadImages do
+  describe "#html" do
+    let(:original_src) { "image.jpg" }
+    let(:original_ext) { File.extname(original_src) }
+    let(:img) { "<img class=\"test\" src=\"#{original_src}\">" }
+    let(:picture) { "<picture>#{img}<source srcset=\"#{original_src}\"></source></picture>" }
+    let(:instance) { described_class.new(picture) }
+
+    subject { instance.html }
+
+    it do
+      lazy_image = "<img class=\"test lazyload\" src=\"\" data-src=\"#{original_src}\">"
+      lazy_source = "<source srcset=\"\" data-srcset=\"#{original_src}\"></source>"
+      is_expected.to include("<picture>#{lazy_image}<noscript>#{img}</noscript>#{lazy_source}</picture>")
+    end
+  end
+end

--- a/spec/requests/lazy_load_images_spec.rb
+++ b/spec/requests/lazy_load_images_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe "Lazy Load Images" do
+  before do
+    allow(Rails.env).to receive(:preprod?) { preprod }
+    get root_path
+  end
+  subject { response.body }
+
+  context "when running in preprod" do
+    let(:preprod) { true }
+
+    it { is_expected.to include("data-src") }
+    it { is_expected.to include("lazyload") }
+  end
+
+  context "when not running in preprod" do
+    let(:preprod) { false }
+
+    it { is_expected.to_not include("data-src") }
+    it { is_expected.to_not include("lazyload") }
+  end
+end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -14,7 +14,7 @@ describe "Next Gen Images" do
 
     it do
       is_expected.to match(
-        /<picture><source srcset=".*\.svg" type="image\/svg\+xml"><\/source><img alt="Department for education" src=".*\.svg"><\/picture>/,
+        /<picture><source srcset=\"\" type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" src=\"\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
       )
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,6 +6117,11 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+lazysizes@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/lazysizes/-/lazysizes-5.3.2.tgz#27f974c26f5fcc33e7db765c0f4930488c8a2984"
+  integrity sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"


### PR DESCRIPTION
### Trello card

[Trello-1450](https://trello.com/c/AwCyN4st/1450-page-speed-improvements)

### Context

If an image is below the fold we don't want to load it as part of the first paint. Instead, we only want to load images when the user scrolls the viewport to approach them. This will make the page load faster and give us a better page speed score.

We also want to ensure images still work when Javascript is disabled.

### Changes proposed in this pull request

- Support lazy loading images that are below the fold

Intercepts HTML before rendering and removes the `src` attribute, retaining the path in `data-src`.

Appends a `noscript` tag containing the original `img` to support when Javascript is disabled.

The original images are hidden by default, to avoid styling issues when JS disabled (we don't want to show both images as the lazy image will not have a src set).

Lazysizes picks up any img tags with a `lazyload` class and populates the `src` when the user is scrolling towards the image. It also supports lazy-loading the picture source tags with `data-srcset`.

A side-effect of this is that the webp/jp2 image sources will no longer be available if the browser has JS disabled. Whilst we could fix this I don't think its worth the effort given the % of users in this scenario.

Enabled only in preprod environment for now.

### Guidance to review


https://user-images.githubusercontent.com/29867726/113887905-c97ba680-97b9-11eb-8159-c361fcc0f50a.mov

