### PR TITLE
Disable VWO except for specific pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :set_api_client_request_id
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
+  before_action :toggle_vwo
 
   after_action :insert_next_gen_images, if: -> { Rails.env.preprod? }
 
@@ -19,6 +20,16 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def toggle_vwo
+    @render_vwo = vwo_config[:paths]&.include?(request.path)
+  end
+
+  def vwo_config
+    # rubocop:disable Style/ClassVars
+    @@vwo_config ||= YAML.safe_load(File.read(Rails.root.join("config/vwo.yml"))).deep_symbolize_keys
+    # rubocop:enable Style/ClassVars
+  end
 
   def insert_next_gen_images
     return unless response.headers["Content-Type"]&.include?("text/html")

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
-  <%= render "sections/vwo_code" %>
+  <%= render "sections/vwo_code" if @render_vwo %>
   <%= csrf_meta_tags unless @cacheable_static_page %>
   <%= csp_meta_tag %>
   <%#= canonical_tag %>

--- a/app/webpacker/controllers/analytics_base_controller.js
+++ b/app/webpacker/controllers/analytics_base_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
     const cookiePrefs = new CookiePreferences();
     const cookiesAccepted = cookiePrefs.allowed(this.cookieCategory);
 
-    if (this.hasVwoCompleted && cookiesAccepted) {
+    if (!this.waitForVwo && cookiesAccepted) {
       this.triggerEvent();
     }
 
@@ -18,7 +18,7 @@ export default class extends Controller {
       );
     }
 
-    if (!this.hasVwoCompleted) {
+    if (this.waitForVwo) {
       this.vwoCompletedHandler = this.vwoCompleted.bind(this);
       document.addEventListener('vwo:completed', this.vwoCompletedHandler);
     }
@@ -62,7 +62,7 @@ export default class extends Controller {
   cookiesAcceptedChecker(event) {
     if (
       event.detail?.cookies?.includes(this.cookieCategory) &&
-      this.hasVwoCompleted
+      !this.waitForVwo
     )
       this.triggerEvent();
   }
@@ -103,6 +103,14 @@ export default class extends Controller {
     else if (this.eventName)
       this.serviceFunction(this.serviceAction, this.eventName);
     else this.serviceFunction(this.serviceAction);
+  }
+
+  get waitForVwo() {
+    return this.isVwoEnabled && !this.hasVwoCompleted;
+  }
+
+  get isVwoEnabled() {
+    return typeof window._vwo_code !== 'undefined';
   }
 
   get hasVwoCompleted() {

--- a/config/vwo.yml
+++ b/config/vwo.yml
@@ -1,0 +1,9 @@
+# Any paths listed here will have the VWO code
+# rendered on (it is disabled everywhere by default).
+# For example:
+#
+# paths:
+#   - /events
+#   - /
+
+paths:

--- a/spec/javascript/controllers/analytics_spec_helper.js
+++ b/spec/javascript/controllers/analytics_spec_helper.js
@@ -34,9 +34,12 @@ export default class {
   static describeWithCookieSet(
     name,
     controller,
-    serviceFunctionName,
-    cookieCategory
+    serviceFunctionName
   ) {
+    beforeEach(() => {
+      window._vwo_code = {};
+    });
+
     describe('with cookie already set', () => {
       beforeEach(() => {
         delete window.willRedirectionOccurByVWO;
@@ -66,6 +69,33 @@ export default class {
 
           it('Should register the service', () => {
             expect(typeof window[serviceFunctionName]).toBe('function');
+          });
+        });
+
+        describe('with VWO disabled', () => {
+          beforeEach(() => {
+            delete window._vwo_code;
+            delete window.willRedirectionOccurByVWO;
+          });
+
+          describe('with no service id', () => {
+            beforeEach(() => {
+              this.initApp(name, controller, '');
+            });
+
+            it('Should not register the service', () => {
+              expect(typeof window[serviceFunctionName]).toBe('undefined');
+            });
+          });
+
+          describe('with service id set', () => {
+            beforeEach(() => {
+              this.initApp(name, controller, '1234');
+            });
+
+            it('Should register the service', () => {
+              expect(typeof window[serviceFunctionName]).toBe('function');
+            });
           });
         });
       });
@@ -116,6 +146,30 @@ export default class {
     serviceFunctionName,
     cookieCategory
   ) {
+    beforeEach(() => {
+      window._vwo_code = {};
+    });
+
+    describe('with VWO disabled', () => {
+      beforeEach(() => {
+        delete window._vwo_code;
+        delete window.willRedirectionOccurByVWO;
+        Cookies.remove(CookiePreferences.cookieName);
+        this.initApp(name, controller, '1234');
+      });
+
+      it('should not register the service', () => {
+        expect(typeof window[serviceFunctionName]).toBe('undefined');
+      });
+
+      describe('than cookies are accepted', () => {
+        it('should register service', () => {
+          new CookiePreferences().setCategory(cookieCategory, true);
+          expect(typeof window[serviceFunctionName]).toBe('function');
+        });
+      });
+    });
+
     describe('when cookies have not yet been accepted', () => {
       beforeEach(() => {
         delete window.willRedirectionOccurByVWO;

--- a/spec/requests/vwo_spec.rb
+++ b/spec/requests/vwo_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "VWO" do
+  let(:config_path) { Rails.root.join("config/vwo.yml") }
+  let(:yaml) do
+    <<-YAML
+    paths:
+      - /vwo-test
+    YAML
+  end
+
+  before do
+    ApplicationController.class_variable_set :@@vwo_config, nil
+
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("VWO_ID").and_return("12345")
+
+    allow(File).to receive(:read).and_call_original
+    expect(File).to receive(:read).with(config_path) { yaml }
+  end
+
+  subject { response.body }
+
+  context "when the path exists in the VWO config" do
+    before { get "/vwo-test" }
+
+    it { is_expected.to include("vwo_code") }
+  end
+
+  context "when the path does not exists in the VWO config" do
+    before { get "/no-vwo-test" }
+
+    it { is_expected.not_to match("vwo_code") }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1491](https://trello.com/c/4gpMaUPW/1491-remove-vwo-after-cutover-ready-to-implement-on-individual-pages-for-a-b-testing)

### Context

By default we want to disable VWO on all pages, as we are no longer using it for redirections/splitting traffic.

We will be using VWO in the future to run a/b tests, however, so its useful to keep it around but have a mechanism to enable it on specific paths.

Updates `AnalyticsController` to work when VWO is disabled.

### Changes proposed in this pull request

- Conditionally enable VWO on pages

### Guidance to review

