### PR TITLE
Post cutover: Update .env.production to reflect new TTA service URL (without beta-)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -10,4 +10,4 @@ BAM_ID=1
 LID_ID=1
 HOTJAR_ID=1871524
 VWO_ID=524595
-TTA_SERVICE_URL="https://beta-adviser-getintoteaching.education.gov.uk/"
+TTA_SERVICE_URL="https://adviser-getintoteaching.education.gov.uk/"


### PR DESCRIPTION
### Trello card
N/A
### Context
Updating our TTA service URL so that our links on the site point to the new site.

### Changes proposed in this pull request
Update `TTA_SERVICE_URL` to remove 'beta-'

### Guidance to review
Do the specs need updating?
