### PR TITLE
Bug fix check if public asset exists

### DIFF
--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -34,7 +34,9 @@ private
   def source(original_src, ext, doc)
     src = "#{File.basename(original_src, '.*')}#{ext}"
 
-    return nil unless File.exist?("#{Rails.public_path}/#{src}")
+    # File.exist? should work here but doesn't; for some reason
+    # File.file? appears to work correctly.
+    return nil unless File.file?("#{Rails.public_path}/#{src}")
 
     Nokogiri::XML::Node.new("source", doc) do |source|
       source.set_attribute("srcset", src)

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -7,8 +7,8 @@ describe NextGenImages do
     let(:body) { "<img src=\"#{original_src}\">" }
     let(:instance) { described_class.new(body) }
 
-    before { allow(File).to receive(:exist?) { false } }
-    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
+    before { allow(File).to receive(:file?) { false } }
+    before { allow(File).to receive(:file?).with("#{Rails.public_path}/#{original_src}") { true } }
 
     subject { instance.html }
 
@@ -36,7 +36,7 @@ describe NextGenImages do
 
         before do
           next_gen_imgs.values.each do |src|
-            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}") { true }
+            allow(File).to receive(:file?).with("#{Rails.public_path}/#{src}") { true }
           end
         end
 

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "Next Gen Images" do
   before do
     allow(Rails.env).to receive(:preprod?) { preprod }
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with(/.*\.svg/) { true }
+    allow(File).to receive(:file?).and_call_original
+    allow(File).to receive(:file?).with(/.*\.svg/) { true }
     get root_path
   end
   subject { response.body }


### PR DESCRIPTION
I'm not yet sure why, but `File.exist?` is returning `false` for assets in `/public`. When I test locally `File.file?` returns correctly.

Updating to see if this also works in the hosted environments.