### PR TITLE
Fix CSS img selector

### DIFF
--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -14,7 +14,7 @@
   }
 
   &__photo {
-    > picture img {
+    > picture img, > img {
       width: 8em;
     }
   }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -155,7 +155,7 @@
     .card__thumb {
       flex: 0 1 45%;
 
-      > picture img {
+      > picture img, > img {
         width: 100%;
         object-fit: contain;
         height: auto;


### PR DESCRIPTION
This was udpated to check inside `picture` for the next gen asset changes, but as these are not in prod yet its lost the styling against the `img` in that environment.

Update to target both selectors so it works in prod and test.

| Before        | After          |
| ------------- |-------------|
|  <img width="376" alt="Screenshot 2021-04-08 at 10 51 18" src="https://user-images.githubusercontent.com/29867726/114006449-5a08c400-9858-11eb-8507-627d0807be58.png"> | <img width="363" alt="Screenshot 2021-04-08 at 10 51 43" src="https://user-images.githubusercontent.com/29867726/114006514-68ef7680-9858-11eb-996d-db7073c6a73c.png">|

