### PR TITLE
Fix next gen image paths

### DIFF
--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -19,7 +19,7 @@ class NextGenImages
 private
 
   def picture(img, doc)
-    src = img.attribute("src")
+    src = img.attribute("src").value
 
     Nokogiri::XML::Node.new("picture", doc) do |picture|
       picture.add_child(img.dup)
@@ -32,11 +32,9 @@ private
   end
 
   def source(original_src, ext, doc)
-    src = "#{File.basename(original_src, '.*')}#{ext}"
+    src = "#{original_src.chomp(File.extname(original_src))}#{ext}"
 
-    # File.exist? should work here but doesn't; for some reason
-    # File.file? appears to work correctly.
-    return nil unless File.file?("#{Rails.public_path}/#{src}")
+    return nil unless File.exist?("#{Rails.public_path}/#{src}")
 
     Nokogiri::XML::Node.new("source", doc) do |source|
       source.set_attribute("srcset", src)

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -7,13 +7,13 @@ describe NextGenImages do
     let(:body) { "<img src=\"#{original_src}\">" }
     let(:instance) { described_class.new(body) }
 
-    before { allow(File).to receive(:file?) { false } }
-    before { allow(File).to receive(:file?).with("#{Rails.public_path}/#{original_src}") { true } }
+    before { allow(File).to receive(:exist?) { false } }
+    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
 
     subject { instance.html }
 
     context "when the original image is a jpg" do
-      let(:original_src) { "image.jpg" }
+      let(:original_src) { "path/to/image.jpg" }
 
       context "when there are no next-gen images" do
         it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/jpeg')}</picture>") }
@@ -36,7 +36,7 @@ describe NextGenImages do
 
         before do
           next_gen_imgs.values.each do |src|
-            allow(File).to receive(:file?).with("#{Rails.public_path}/#{src}") { true }
+            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}") { true }
           end
         end
 
@@ -48,13 +48,13 @@ describe NextGenImages do
     end
 
     context "when the original image is a png" do
-      let(:original_src) { "image.png" }
+      let(:original_src) { "path/to/image.png" }
 
       it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/png')}</picture>") }
     end
 
     context "when the original image is an svg" do
-      let(:original_src) { "image.svg" }
+      let(:original_src) { "path/to/image.svg" }
 
       it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/svg+xml')}</picture>") }
     end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe "Next Gen Images" do
   before do
     allow(Rails.env).to receive(:preprod?) { preprod }
-    allow(File).to receive(:file?).and_call_original
-    allow(File).to receive(:file?).with(/.*\.svg/) { true }
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with(/.*\.svg/) { true }
     get root_path
   end
   subject { response.body }


### PR DESCRIPTION
Previously I was using `File.basename` as the image `src`, but this omits the path -- the tests didn't cover an image with a path so they weren't failing.

Update tests to cover images with paths and make sure the `src` retains the full path to the image.

Swap `File.file?` back to `File.exist?` as this wasn't the problem.