### PR TITLE
Correct ordering of picture sources

### DIFF
--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -1,7 +1,7 @@
 class NextGenImages
   # As we control the conversion we only need to look for
   # a subset of all the possible extensions.
-  NEXT_GEN_IMAGE_EXTS = %w[.jp2 .webp].freeze
+  NEXT_GEN_IMAGE_EXTS = %w[.webp .jp2].freeze
 
   def initialize(page)
     @page = page
@@ -22,12 +22,12 @@ private
     src = img.attribute("src").value
 
     Nokogiri::XML::Node.new("picture", doc) do |picture|
-      picture.add_child(img.dup)
-      source_exts = [File.extname(src)] + NEXT_GEN_IMAGE_EXTS
+      source_exts = NEXT_GEN_IMAGE_EXTS + [File.extname(src)]
       source_exts.each do |ext|
         source = source(src, ext, doc)
         picture.add_child(source) if source.present?
       end
+      picture.add_child(img.dup)
     end
   end
 

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -16,7 +16,7 @@ describe NextGenImages do
       let(:original_src) { "path/to/image.jpg" }
 
       context "when there are no next-gen images" do
-        it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/jpeg')}</picture>") }
+        it { is_expected.to include("<picture>#{source(original_src, 'image/jpeg')}<img src=\"#{original_src}\"></picture>") }
       end
 
       context "when the image is already in a picture tag" do
@@ -28,9 +28,9 @@ describe NextGenImages do
       context "when there are next-gen images" do
         let(:next_gen_imgs) do
           {
-            "image/jpeg" => original_src,
-            "image/jp2" => original_src.gsub(original_ext, ".jp2"),
             "image/webp" => original_src.gsub(original_ext, ".webp"),
+            "image/jp2" => original_src.gsub(original_ext, ".jp2"),
+            "image/jpeg" => original_src,
           }
         end
 
@@ -42,7 +42,7 @@ describe NextGenImages do
 
         it do
           sources = next_gen_imgs.map { |mime_type, src| source(src, mime_type) }.join
-          is_expected.to include("<picture><img src=\"#{original_src}\">#{sources}</picture>")
+          is_expected.to include("<picture>#{sources}<img src=\"#{original_src}\"></picture>")
         end
       end
     end
@@ -50,13 +50,13 @@ describe NextGenImages do
     context "when the original image is a png" do
       let(:original_src) { "path/to/image.png" }
 
-      it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/png')}</picture>") }
+      it { is_expected.to include("<picture>#{source(original_src, 'image/png')}<img src=\"#{original_src}\"></picture>") }
     end
 
     context "when the original image is an svg" do
       let(:original_src) { "path/to/image.svg" }
 
-      it { is_expected.to include("<picture><img src=\"#{original_src}\">#{source(original_src, 'image/svg+xml')}</picture>") }
+      it { is_expected.to include("<picture>#{source(original_src, 'image/svg+xml')}<img src=\"#{original_src}\"></picture>") }
     end
   end
 

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -14,7 +14,7 @@ describe "Next Gen Images" do
 
     it do
       is_expected.to match(
-        /<picture><img alt="Department for education" src=".*\.svg"><source srcset=".*\.svg" type="image\/svg\+xml"><\/source><\/picture>/,
+        /<picture><source srcset=".*\.svg" type="image\/svg\+xml"><\/source><img alt="Department for education" src=".*\.svg"><\/picture>/,
       )
     end
   end


### PR DESCRIPTION
It turns out the order of the sources and img inside the `picture` element is important - we want to put the next-gen formats first and the `img` tag last, so that the browser correctly serves the next-gen image with priority over the jpeg/png.

I've put `webp` first as that seems to have the broadest support.