### PR TITLE
Make image dimensions explicit

### DIFF
--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -36,7 +36,7 @@ private
   end
 
   def thumbnail_image_tag
-    helpers.image_tag(image, data: { "object-fit" => "cover" }, **thumbnail_image_alt_attribute)
+    helpers.image_tag(image, data: { "object-fit" => "cover" }, size: "128x128", **thumbnail_image_alt_attribute)
   end
 
   def thumbnail_image_alt_attribute
@@ -47,7 +47,7 @@ private
 
   def video_link
     link_to(video, class: "card__thumb", data: { action: "click->video#play", "video-target": "link" }) do
-      safe_join([tag.div(helpers.fas_icon("play"), class: "card__thumb--play-icon"), image_tag(image, **thumbnail_image_alt_attribute)])
+      safe_join([tag.div(helpers.fas_icon("play"), class: "card__thumb--play-icon"), image_tag(image, size: "128x128", **thumbnail_image_alt_attribute)])
     end
   end
 

--- a/app/components/content/generic_block_component.rb
+++ b/app/components/content/generic_block_component.rb
@@ -2,16 +2,17 @@ module Content
   class GenericBlockComponent < ViewComponent::Base
     attr_reader :title, :classes
 
-    def initialize(title:, icon_image:, icon_alt:, classes: [])
+    def initialize(title:, icon_image:, icon_alt:, icon_size: nil, classes: [])
       @title      = title
       @icon_image = icon_image
       @icon_alt   = icon_alt
+      @icon_size  = icon_size
       @classes    = classes
     end
 
     def icon
       tag.div(class: "blocks__icon") do
-        image_pack_tag(@icon_image, alt: @icon_alt)
+        image_pack_tag(@icon_image, alt: @icon_alt, size: @icon_size)
       end
     end
   end

--- a/app/components/navigation/navbar_component.html.erb
+++ b/app/components/navigation/navbar_component.html.erb
@@ -11,12 +11,12 @@
             </ul>
 
             <div class="navbar__desktop__search">
-              <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search"),
+              <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50"),
                           search_path,
                           class: "searchbox__search",
                           data: { action: "searchbox#toggle" } %>
 
-              <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search"),
+              <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50"),
                           search_path,
                           class: "searchbox__close",
                           data: { action: "searchbox#toggle" } %>
@@ -30,12 +30,12 @@
                     <div data-navigation-target="hamburger" id='hamburger' class="icon-close"></div>
                 </a>
 
-                <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search"),
+                <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50"),
                             search_path,
                             class: "searchbox__search",
                             data: { action: "searchbox#toggle" } %>
 
-                <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search"),
+                <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50"),
                             search_path,
                             class: "searchbox__close",
                             data: { action: "searchbox#toggle" } %>

--- a/app/views/components/_logo.html.erb
+++ b/app/views/components/_logo.html.erb
@@ -1,10 +1,10 @@
 <div class="logo-wrapper">
   <div class="logo">
     <a href="/" class="logo__image">
-      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page" %>
+      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "140x48" %>
     </a>
   </div>
   <div class="dfe-logo">
-      <%= image_pack_tag 'media/images/dfelogo-black.svg', alt: "Department for education" %>
+      <%= image_pack_tag 'media/images/dfelogo-black.svg', alt: "Department for education", size: "92x54" %>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -26,6 +26,7 @@
       title: "Life as a teacher",
       icon_image: "icon-school-black.svg",
       icon_alt: "mortarboard icon",
+      icon_size: "40x30",
       classes: "blocks__directory"
     ) do %>
       <ul>
@@ -39,6 +40,7 @@
       title: "Your training",
       icon_image: "icon-doc-black.svg",
       icon_alt: "icon containing learning materials",
+      icon_size: "40x35",
       classes: "blocks__directory"
     ) do %>
       <ul>
@@ -53,6 +55,7 @@
       title: "Take the next step",
       icon_image: "icon-git-black.svg",
       icon_alt: "site icon logo checkmark",
+      icon_size: "33x33",
       classes: "blocks__directory"
     ) do %>
       <ul>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -37,6 +37,7 @@
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
     icon_alt: "mortarboard icon",
+    icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -50,6 +51,7 @@
     title: "Your next steps",
     icon_image: "icon-doc-black.svg",
     icon_alt: "icon containing learning materials",
+    icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -63,10 +65,11 @@
     title: "Sign up to get a Teacher Training Adviser",
     icon_image: "icon-git-black.svg",
     icon_alt: "site icon logo checkmark",
+    icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>
     <p class="block__text">
-      If you're ready to get into teaching, you can get free, one-to-one, support from a dedicated, experienced teaching professional to guide you through the process. 
+      If you're ready to get into teaching, you can get free, one-to-one, support from a dedicated, experienced teaching professional to guide you through the process.
     </p>
 
     <%= link_to "Get an adviser", "/tta-service", class: "button button--white button--unpadded" %>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -8,7 +8,7 @@
 
       <% if with_logo %>
       <div class="events-featured__logo">
-        <%= image_pack_tag "media/images/getintoteachinglogo-with-bg-purple.svg", alt: "" %>
+        <%= image_pack_tag "media/images/getintoteachinglogo-with-bg-purple.svg", alt: "", size: "250x125" %>
       </div>
       <% end %>
     </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -27,7 +27,7 @@
 <% unless @performed_search %>
   <div class="content-alert content-alert--left">
     <div class="content-alert__icon">
-      <%= image_pack_tag "media/images/icon-moved-online-purple.svg", alt: "" %>
+      <%= image_pack_tag "media/images/icon-moved-online-purple.svg", alt: "", size: "40x26" %>
     </div>
     <div>
       <h4>Some events have moved online</h4>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -6,7 +6,7 @@
   <p>You'll receive a welcome email shortly.</p>
 
   <p>
-    You’ll get emails that we think are relevant to you. 
+    You’ll get emails that we think are relevant to you.
     If your circumstances change, you can let us know at any time.
   </p>
 
@@ -41,6 +41,7 @@
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
     icon_alt: "mortarboard icon",
+    icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -54,6 +55,7 @@
     title: "Your next steps",
     icon_image: "icon-doc-black.svg",
     icon_alt: "icon containing learning materials",
+    icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -67,6 +69,7 @@
     title: "Speak to teachers",
     icon_image: "icon-git-black.svg",
     icon_alt: "site icon logo checkmark",
+    icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>
     <p class="block__text">

--- a/app/views/sections/_cookie-acceptance.html.erb
+++ b/app/views/sections/_cookie-acceptance.html.erb
@@ -5,7 +5,7 @@
             <div>
                 <div class="logo__image">
                     <span href="/">
-                        <%= image_pack_tag "media/images/getintoteachinglogo.svg", alt: "Get Into Teaching" %>
+                        <%= image_pack_tag "media/images/getintoteachinglogo.svg", alt: "Get Into Teaching", size: "140x48" %>
                     </span>
                 </div>
                 <h2>Tell us whether you accept cookies</h2>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -39,7 +39,7 @@
     </div>
     <div class="site-footer-bottom">
       <div class="site-footer-bottom__logo-container">
-        <%= image_pack_tag 'media/images/dfelogo-white.svg', alt: "Department for Education" %>
+        <%= image_pack_tag 'media/images/dfelogo-white.svg', alt: "Department for Education", size: "124x73" %>
       </div>
       <div class="site-footer-bottom__links-container">
         <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Feedback</a>

--- a/spec/components/content/generic_block_component_spec.rb
+++ b/spec/components/content/generic_block_component_spec.rb
@@ -6,9 +6,10 @@ describe Content::GenericBlockComponent, type: "component" do
   let(:icon_image) { "icon-school-black.svg" }
   let(:icon_alt) { "description of image" }
   let(:custom_class) { "purple" }
+  let(:icon_size) { "30x50" }
 
   subject! do
-    render_inline(described_class.new(title: title, icon_image: icon_image, icon_alt: icon_alt, classes: Array.wrap(custom_class))) do
+    render_inline(described_class.new(title: title, icon_image: icon_image, icon_alt: icon_alt, icon_size: icon_size, classes: Array.wrap(custom_class))) do
       content
     end
     page
@@ -18,4 +19,13 @@ describe Content::GenericBlockComponent, type: "component" do
   it { is_expected.to have_css("h3", text: title) }
   it { is_expected.to have_content(content) }
   it { is_expected.to have_css(%(img[alt="#{icon_alt}"])) }
+  it { is_expected.to have_css(%(img[width="30"])) }
+  it { is_expected.to have_css(%(img[height="50"])) }
+
+  context "when icon_size is nil" do
+    let(:icon_size) { nil }
+
+    it { is_expected.not_to have_css(%(img[width])) }
+    it { is_expected.not_to have_css(%(img[height])) }
+  end
 end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -14,7 +14,7 @@ describe "Next Gen Images" do
 
     it do
       is_expected.to match(
-        /<picture><source srcset=\"\" type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" src=\"\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
+        /<picture><source srcset=\"\" type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" src=\"\" width=\"92\" height=\"54\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
       )
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-1450](https://trello.com/c/AwCyN4st/1450-page-speed-improvements)

### Context

One of the page speed criteria checks for content shift, which is caused by images loading and resulting in other content moving due to not having the image size explicitly set.

Set image sizes explicitly to avoid content shift.

### Changes proposed in this pull request

- Make image dimensions explicit

### Guidance to review

A PR for the content repo will follow that updates a few uses of the `GenericBlockComponent` to have `icon_size`, but this allows size to be optional so will work in the interim.

