### PR TITLE
Enable image processing in all environments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :add_home_breadcrumb
   before_action :toggle_vwo
 
-  after_action :process_images, if: -> { Rails.env.preprod? }
+  after_action :process_images
 
   def raise_not_found
     raise ActionController::RoutingError, "Not Found"

--- a/spec/requests/lazy_load_images_spec.rb
+++ b/spec/requests/lazy_load_images_spec.rb
@@ -2,22 +2,10 @@ require "rails_helper"
 
 describe "Lazy Load Images" do
   before do
-    allow(Rails.env).to receive(:preprod?) { preprod }
     get root_path
   end
   subject { response.body }
 
-  context "when running in preprod" do
-    let(:preprod) { true }
-
-    it { is_expected.to include("data-src") }
-    it { is_expected.to include("lazyload") }
-  end
-
-  context "when not running in preprod" do
-    let(:preprod) { false }
-
-    it { is_expected.to_not include("data-src") }
-    it { is_expected.to_not include("lazyload") }
-  end
+  it { is_expected.to include("data-src") }
+  it { is_expected.to include("lazyload") }
 end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -2,26 +2,15 @@ require "rails_helper"
 
 describe "Next Gen Images" do
   before do
-    allow(Rails.env).to receive(:preprod?) { preprod }
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with(/.*\.svg/) { true }
     get root_path
   end
   subject { response.body }
 
-  context "when running in preprod" do
-    let(:preprod) { true }
-
-    it do
-      is_expected.to match(
-        /<picture><source .*><\/source><img .*><noscript><img .*><\/noscript><\/picture>/,
-      )
-    end
-  end
-
-  context "when not running in preprod" do
-    let(:preprod) { false }
-
-    it { is_expected.to_not include("<picture>") }
+  it do
+    is_expected.to match(
+      /<picture><source .*><\/source><img .*><noscript><img .*><\/noscript><\/picture>/,
+    )
   end
 end


### PR DESCRIPTION
We have image processing that serves next-gen images and lazy loads the images running in the preprod environment. Its been well tested now and appears to function properly, so we can enable in production.