### PR TITLE
Lazy load images correctly with Turbolinks

### DIFF
--- a/app/components/navigation/navbar_component.html.erb
+++ b/app/components/navigation/navbar_component.html.erb
@@ -11,12 +11,12 @@
             </ul>
 
             <div class="navbar__desktop__search">
-              <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50"),
+              <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50", data: { "lazy-disable": true }),
                           search_path,
                           class: "searchbox__search",
                           data: { action: "searchbox#toggle" } %>
 
-              <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50"),
+              <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50", data: { "lazy-disable": true }),
                           search_path,
                           class: "searchbox__close",
                           data: { action: "searchbox#toggle" } %>
@@ -30,12 +30,12 @@
                     <div data-navigation-target="hamburger" id='hamburger' class="icon-close"></div>
                 </a>
 
-                <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50"),
+                <%= link_to image_pack_tag("icon-site-search.svg", alt: "Search", size: "50x50", data: { "lazy-disable": true }),
                             search_path,
                             class: "searchbox__search",
                             data: { action: "searchbox#toggle" } %>
 
-                <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50"),
+                <%= link_to image_pack_tag("icon-site-search-close.svg", alt: "Close search", size: "50x50", data: { "lazy-disable": true }),
                             search_path,
                             class: "searchbox__close",
                             data: { action: "searchbox#toggle" } %>

--- a/app/views/components/_logo.html.erb
+++ b/app/views/components/_logo.html.erb
@@ -1,10 +1,10 @@
 <div class="logo-wrapper">
   <div class="logo">
     <a href="/" class="logo__image">
-      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "140x48" %>
+      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "140x48", data: { "lazy-disable": true } %>
     </a>
   </div>
   <div class="dfe-logo">
-      <%= image_pack_tag 'media/images/dfelogo-black.svg', alt: "Department for education", size: "92x54" %>
+      <%= image_pack_tag 'media/images/dfelogo-black.svg', alt: "Department for education", size: "92x54", data: { "lazy-disable": true } %>
   </div>
 </div>

--- a/app/webpacker/javascript/lazy_images.js
+++ b/app/webpacker/javascript/lazy_images.js
@@ -1,7 +1,8 @@
-import 'lazysizes';
+import lazySizes from 'lazysizes';
+lazySizes.cfg.init = false;
 
-// By default lazy-loaded images are hidden (to support JS
-// being disabled). If JS is enabled, we show them.
-document.querySelectorAll(".lazyload").forEach((img) => {
-  img.classList.add("visible");
+lazySizes.init();
+
+document.addEventListener('turbolinks:load', function () {
+  lazySizes.init();
 });

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -137,6 +137,6 @@ $chevron-direction-map: (
   clear: both;
 }
 
-img[data-src]:not(.visible) {
-  display: none;
+img.lazyload:not([src]) {
+  visibility: hidden;
 }

--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -7,16 +7,24 @@ class LazyLoadImages
     doc = Nokogiri::HTML(@page)
 
     doc.css("img").each do |img|
+      next if img["data-lazy-disable"].present?
+
       img.after(noscript_image(img, doc))
-      img.set_attribute("data-src", img.attribute("src"))
+
+      img["data-src"] = img.attribute("src")
       img.remove_attribute("src")
+
       img["class"] ||= ""
       img["class"] = img["class"] << " lazyload"
     end
 
-    doc.css("picture source").each do |source|
-      source.set_attribute("data-srcset", source.attribute("srcset"))
-      source.remove_attribute("srcset")
+    doc.css("picture").each do |picture|
+      next if picture.css("img[data-lazy-disable]").any?
+
+      picture.css("source").each do |source|
+        source["data-srcset"] = source.attribute("srcset")
+        source.remove_attribute("srcset")
+      end
     end
 
     doc.to_html(encoding: "UTF-8", indent: 2)

--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -9,14 +9,14 @@ class LazyLoadImages
     doc.css("img").each do |img|
       img.after(noscript_image(img, doc))
       img.set_attribute("data-src", img.attribute("src"))
-      img.set_attribute("src", nil)
+      img.remove_attribute("src")
       img["class"] ||= ""
       img["class"] = img["class"] << " lazyload"
     end
 
     doc.css("picture source").each do |source|
       source.set_attribute("data-srcset", source.attribute("srcset"))
-      source.set_attribute("srcset", nil)
+      source.remove_attribute("srcset")
     end
 
     doc.to_html(encoding: "UTF-8", indent: 2)

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -19,7 +19,7 @@ class NextGenImages
 private
 
   def picture(img, doc)
-    src = img.attribute("src").value
+    src = img["src"]
 
     Nokogiri::XML::Node.new("picture", doc) do |picture|
       source_exts = NEXT_GEN_IMAGE_EXTS + [File.extname(src)]
@@ -37,8 +37,8 @@ private
     return nil unless File.exist?("#{Rails.public_path}/#{src}")
 
     Nokogiri::XML::Node.new("source", doc) do |source|
-      source.set_attribute("srcset", src)
-      source.set_attribute("type", mime_type(src))
+      source["srcset"] = src
+      source["type"] = mime_type(src)
     end
   end
 

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -12,9 +12,15 @@ describe LazyLoadImages do
     subject { instance.html }
 
     it do
-      lazy_image = "<img class=\"test lazyload\" src=\"\" data-src=\"#{original_src}\">"
-      lazy_source = "<source srcset=\"\" data-srcset=\"#{original_src}\"></source>"
+      lazy_image = "<img class=\"test lazyload\" data-src=\"#{original_src}\">"
+      lazy_source = "<source data-srcset=\"#{original_src}\"></source>"
       is_expected.to include("<picture>#{lazy_image}<noscript>#{img}</noscript>#{lazy_source}</picture>")
+    end
+
+    context "when lazy-loading is disabled on the image" do
+      let(:img) { "<img class=\"test\" src=\"#{original_src}\" data-lazy-disable=\"true\">" }
+
+      it { is_expected.to include(picture) }
     end
   end
 end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -14,7 +14,7 @@ describe "Next Gen Images" do
 
     it do
       is_expected.to match(
-        /<picture><source type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" width=\"92\" height=\"54\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
+        /<picture><source .*><\/source><img .*><noscript><img .*><\/noscript><\/picture>/,
       )
     end
   end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -14,7 +14,7 @@ describe "Next Gen Images" do
 
     it do
       is_expected.to match(
-        /<picture><source srcset=\"\" type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" src=\"\" width=\"92\" height=\"54\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
+        /<picture><source type="image\/svg\+xml" data-srcset=".*\.svg"><\/source><img alt="Department for education" width=\"92\" height=\"54\" data-src=".*\.svg" class=" lazyload"><noscript>.*<\/noscript><\/picture>/,
       )
     end
   end


### PR DESCRIPTION
- Lazy load images correctly with Turbolinks

The lazy images weren't being correctly loaded on page change due to the library not being initialised on `turbolinks:load`.

Also improves the code around making the images visible once the `src` is set.

- Disable lazy loading header images

The images in the navigation don't benefit from being lazy loaded and there is a very slight flash when transitioning between pages because of the lazy loading. Its only noticeable on these images as they are present/in the same place on every page.

Cleans up some of the Nokogiri syntax to be consistent.
