### PR TITLE
Hide original images when JS disabled

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -8,6 +8,7 @@
   <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' %>
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+  <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>
 

--- a/app/webpacker/packs/application_no_js.js
+++ b/app/webpacker/packs/application_no_js.js
@@ -1,0 +1,1 @@
+import '../styles/application-no-js.scss';

--- a/app/webpacker/styles/application-no-js.scss
+++ b/app/webpacker/styles/application-no-js.scss
@@ -1,0 +1,3 @@
+img.lazyload {
+  display: none;
+}


### PR DESCRIPTION
When JS is disabled the original `img` tag would be `visibility: hidden` but as it has an explicit width/height it still takes up space (if we use `display: none` it would result in content shift when the image is set and the selector no longer applies).

Instead, this adds a new pack with CSS for when JS is disabled that will `display: none` on the original image (as JS is disabled the content shift will never happen as the lazy image loading will be working and a default `noscript img` is shown).


