### PR TITLE
Bug fix hide original img when JS disabled

### DIFF
--- a/app/webpacker/styles/application-no-js.scss
+++ b/app/webpacker/styles/application-no-js.scss
@@ -1,3 +1,3 @@
-img.lazyload {
+img.lazyload:not([src]) {
   display: none;
 }


### PR DESCRIPTION
The old selector was not specific enough and was being overridden by the `visibility: hidden` applied by the original selector still.
