### PR TITLE
Set cookies SameSite attribute to 'Lax'

### DIFF
--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -41,6 +41,7 @@ export default class CookiePreferences {
     const serialized = JSON.stringify(categories);
     Cookies.set(CookiePreferences.cookieName, serialized, {
       expires: CookiePreferences.cookieLifetimeInDays,
+      sameSite: 'Lax',
     });
 
     this.cookieSet = true;


### PR DESCRIPTION
### Trello card
https://trello.com/c/3iFacmIh

### Context
Browsers will reject cookies which have set the SameSite attribute to "None", without also setting the Secure attribute. 

### Changes proposed in this pull request
Set the SameSite to "Lax" instead.

### Guidance to review
Firefox shouldn't display the `Some cookies are misusing the recommended “SameSite“ attribute` warning in the console.
