### PR TITLE
Add width to stories element to fix IE

### DIFF
--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -35,6 +35,7 @@
   display: flex;
   flex-direction: column;
   margin-bottom: 2em;
+  width: 100%;
 
   @include mq($from: tablet) {
     flex-direction: row;


### PR DESCRIPTION
The element collapses to be nearly invisible on IE 11, but adding a `width: 100%` attribute corrects it.

| Before      | After  |
| ----------- | ----------- |
|   <img width="1588" alt="Screenshot 2021-04-12 at 11 31 24" src="https://user-images.githubusercontent.com/29867726/114381068-9f8ffe80-9b82-11eb-842a-c23e966700f5.png">   | <img width="1519" alt="Screenshot 2021-04-12 at 11 31 05" src="https://user-images.githubusercontent.com/29867726/114381011-93a43c80-9b82-11eb-952b-fc0122d4ce59.png">        |


