### PR TITLE
Allow YouTube's privacy-enhanced service iframes

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -21,7 +21,7 @@ SecureHeaders::Configuration.default do |config|
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self' tr.snapchat.com www.facebook.com www.gov.uk dev.visualwebsiteoptimizer.com],
     frame_ancestors: %w['self'],
-    frame_src: %w['self' embed.scribblelive.com tr.snapchat.com www.facebook.com www.youtube.com *.hotjar.com *.doubleclick.net dev.visualwebsiteoptimizer.com],
+    frame_src: %w['self' embed.scribblelive.com tr.snapchat.com www.facebook.com www.youtube.com www.youtube-nocookie.com *.hotjar.com *.doubleclick.net dev.visualwebsiteoptimizer.com],
     img_src: %w['self' linkbam.uk *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com *.visualwebsiteoptimizer.com ad.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels,
     manifest_src: %w['self'],
     media_src: %w['self'],


### PR DESCRIPTION
### Trello card

https://trello.com/c/hd43j3IM/1485-add-return-to-teaching-adviser-video-to-page

### Context and changes

See DFE-Digital/get-into-teaching-content/pull/413

Without this change videos are blocked:

> Content Security Policy: The page's settings blocked the loading of a
> resource at https://www.youtube-nocookie.com/embed/2NrLm_XId4k ("frame-src").

Fixed by adding a frame_src CSP entry.
