### PR TITLE
Add includes polyfill for IE11

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,5 +1,6 @@
 import '@stimulus/polyfills';
 import '../styles/application.scss';
+import 'polyfills/includes.js';
 import 'polyfills/ie11-foreach.js';
 import 'polyfills/ie8.js';
 import 'polyfills/objectFitPolyfill.basic.min.js';

--- a/app/webpacker/polyfills/ie11-foreach.js
+++ b/app/webpacker/polyfills/ie11-foreach.js
@@ -1,5 +1,4 @@
 if ('NodeList' in window && !NodeList.prototype.forEach) {
-  console.info('polyfill for IE11');
   NodeList.prototype.forEach = function (callback, thisArg) {
     thisArg = thisArg || window;
     for (var i = 0; i < this.length; i++) {

--- a/app/webpacker/polyfills/includes.js
+++ b/app/webpacker/polyfills/includes.js
@@ -1,0 +1,11 @@
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    'use strict';
+
+    if (search instanceof RegExp) {
+      throw TypeError('first argument must not be a RegExp');
+    }
+    if (start === undefined) { start = 0; }
+    return this.indexOf(search, start) !== -1;
+  };
+}


### PR DESCRIPTION
IE11 complains as `include` is not available; this polyfills it. At some point (or if there's many more of these!) I'll have a look at setting up webpacker to transpile JS so its compatible for IE.