### PR TITLE
Smooth transformed elements on mobile Safari

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -39,6 +39,12 @@
 @mixin rotated-block($degrees: -3deg, $blur: 4px) {
   transform: rotate($degrees);
   backdrop-filter: blur($blur);
+
+  // On mobile Safari using backdrop-filter results in alisaing
+  // when the element is also transformed.
+  @supports (-webkit-touch-callout: none) {
+    backdrop-filter: none;
+  }
 }
 
 @mixin chevron-icon($color, $dimensions, $rotate: 45deg) {


### PR DESCRIPTION
On iOS mobile Safari the rotated blocks end up with pixelated edges due to the use of `backdrop-filter: blur()`. I can't find a way of retaining the blur and anti-aliasing the edges, so removing it only for mobile Safari (the blur is a nice to have and was more important when we had rotated blocks that mostly overlapped images, which I don't think we have any more).

| Before      | After |
| ----------- | ----------- |
| ![IMG_13D2AB416536-1](https://user-images.githubusercontent.com/29867726/114513105-be999980-9c31-11eb-94d3-6db93a3f0a97.jpeg)      | ![IMG_946E3B598F60-1](https://user-images.githubusercontent.com/29867726/114513114-c0fbf380-9c31-11eb-8b99-b4a42314bc16.jpeg)       |



