### PR TITLE
Update content specs to work with image processing code

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
       scenario "the internal images exist" do
         document
           .css("img")
-          .map { |img| img["src"] }
+          .map { |img| img["data-src"] || img["src"] }
           .reject { |src| src.start_with?("http") }
           .uniq
           .each do |src|


### PR DESCRIPTION
The lazy loaded images will have a `data-src` set instead of `src` attribute initially; the content specs need to check for this with presedence over `src` or they fail as they try and load a `nil` `src`.
