### PR TITLE
Add pagespeed env to Gemfile group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ group :test do
   gem "webmock"
 end
 
-group :rolling, :preprod, :userresearch, :production do
+group :rolling, :preprod, :userresearch, :production, :pagespeed do
   # loading the Gem monkey patches rails logger
   # only load in prod-like environments when we actually need it
   gem "amazing_print"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The application has 2 extra Rails environments, in addition to the default 3.
 3. `production` - the 'live' production copy of the application
 4. `rolling` - 'production-like' - continuously delivered, reflects current master
 5. `preprod` - 'production-like' - stage before release to final production
+6. `pagespeed` - 'production-like' - pipes page speed metrics to Prometheus on boot
 
 **NOTE:** It is **important** if checking for the production environment to also 
 check for other 'production-like' environments unless you really intend to only

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     redirect_rules.each { |from, to| get from, to: redirect(path: to) }
   end
 
-  if Rails.env.rolling? || Rails.env.preprod? || Rails.env.production?
+  if Rails.env.rolling? || Rails.env.preprod? || Rails.env.production? || Rails.env.pagespeed?
     get "/assets/*missing", to: "errors#not_found", via: :all
   end
 


### PR DESCRIPTION
The SemanticLogger was missing due to not having `pagespeed` in the appropriate Gemfile group.

Update Readme/routes to be consistent with other prod-like environments.