### PR TITLE
Internal show

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -25,7 +25,7 @@ class EventsController < ApplicationController
 
   def show
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
-    raise_not_found if @event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+    raise_not_found if @event.status_id == pending_event_status_id
 
     @page_title = @event.name
     @front_matter = { "description" => @event.summary }
@@ -79,5 +79,9 @@ private
 
     (params[Events::Search.model_name.param_key] || defaults)
       .permit(:type, :distance, :postcode, :month)
+  end
+
+  def pending_event_status_id
+    GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -25,6 +25,7 @@ class EventsController < ApplicationController
 
   def show
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
+    raise_not_found if @event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
 
     @page_title = @event.name
     @front_matter = { "description" => @event.summary }

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -17,21 +17,21 @@ module Internal
   private
 
     def load_pending_events
-      opts = {
-        type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-        status_ids: [pending_event_status_id],
-        quantity_per_type: 1_000,
-      }
-
       search_results = GetIntoTeachingApiClient::TeachingEventsApi
                          .new
-                         .search_teaching_events_grouped_by_type(opts)
+                         .search_teaching_events_grouped_by_type(events_search_params)
 
       @group_presenter = Events::GroupPresenter.new(search_results)
       @events = @group_presenter.paginated_events_of_type(
         GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
         params[:page],
       )
+    end
+
+    def events_search_params
+      { type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+        status_ids: [pending_event_status_id],
+        quantity_per_type: 1_000 }
     end
 
     def pending_event_status_id

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -1,8 +1,40 @@
 module Internal
   class EventsController < ::InternalController
+    layout "internal"
+
     def index
-      # stubbed for now
-      head :ok
+      @no_results = load_pending_events.blank?
+    end
+
+    def show
+      @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
+      raise_not_found unless @event.status_id == pending_event_status_id
+
+      @page_title = @event.name
+    end
+
+  private
+
+    def load_pending_events
+      opts = {
+        type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+        status_ids: [pending_event_status_id],
+        quantity_per_type: 1_000,
+      }
+
+      search_results = GetIntoTeachingApiClient::TeachingEventsApi
+                         .new
+                         .search_teaching_events_grouped_by_type(opts)
+
+      @group_presenter = Events::GroupPresenter.new(search_results)
+      @events = @group_presenter.paginated_events_of_type(
+        GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+        params[:page],
+      )
+    end
+
+    def pending_event_status_id
+      GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
     end
   end
 end

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -1,9 +1,10 @@
 module Internal
   class EventsController < ::InternalController
     layout "internal"
+    before_action :load_pending_events, only: %i[index]
 
     def index
-      @no_results = load_pending_events.blank?
+      @no_results = @events.blank?
     end
 
     def show

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -25,6 +25,10 @@ module EventsHelper
     event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
   end
 
+  def event_status_pending?(event)
+    event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+  end
+
   def can_sign_up_online?(event)
     event.web_feed_id && event_status_open?(event) && !is_event_type?(event, "School or University event")
   end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -3,7 +3,7 @@
 
   <p class="event-info__date"><%= format_event_date(@event, stacked: false) %></p>
 
-  <% unless event_status_open?(@event) %>
+  <% unless event_status_open?(@event) || event_status_pending?(@event) %>
     <div class="content-alert content-alert--fullwidth">
       <p>This event is now closed. Search <%= link_to("here", events_path) %> for our other events.</p>
     </div>

--- a/app/views/internal/_event.html.erb
+++ b/app/views/internal/_event.html.erb
@@ -1,0 +1,3 @@
+<%= link_to internal_event_path(id: event.readable_id), class: "events-featured__list__item" do %>
+  <%= render(Events::EventBoxComponent.new(event)) %>
+<% end %>

--- a/app/views/internal/_provider_event.html.erb
+++ b/app/views/internal/_provider_event.html.erb
@@ -1,0 +1,3 @@
+<%= link_to internal_event_path(id: provider_event.readable_id), class: "events-featured__list__item" do %>
+  <%= render(Events::EventBoxComponent.new(provider_event)) %>
+<% end %>

--- a/app/views/internal/_provider_event.html.erb
+++ b/app/views/internal/_provider_event.html.erb
@@ -1,3 +1,0 @@
-<%= link_to internal_event_path(id: provider_event.readable_id), class: "events-featured__list__item" do %>
-  <%= render(Events::EventBoxComponent.new(provider_event)) %>
-<% end %>

--- a/app/views/internal/index.html.erb
+++ b/app/views/internal/index.html.erb
@@ -1,9 +1,9 @@
 <div class="markdown">
-  <% if params[:success] %>
+  <% if @success %>
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
         Event submitted
-        <% if params[:success] == "pending" %>
+        <% if @pending %>
           for review
         <% end %>
       </h1>

--- a/app/views/internal/index.html.erb
+++ b/app/views/internal/index.html.erb
@@ -1,0 +1,35 @@
+<div class="markdown">
+  <% if params[:success] %>
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Event submitted
+        <% if params[:success] == "pending" %>
+          for review
+        <% end %>
+      </h1>
+    </div>
+  <% end %>
+
+  <h1 class="pending-title">Pending Provider Events</h1>
+  
+  <% if @no_results %>
+    <div class="pending-no-results">
+      <%= render(Events::NoResultsComponent.new) do %>
+        No pending events for review
+      <% end %>
+    </div>
+  <% else %>
+    <div class="events container">
+      <section class="types-of-event">
+        <div class="events-featured">
+          <div class="events-featured__list">
+            <%= render partial: "provider_event", collection: @events %>
+          </div>
+        </div>
+        <div class="event-pagination">
+          <%= paginate @events %>
+        </div>
+      </section>
+    </div>
+  <% end %>
+</div>

--- a/app/views/internal/index.html.erb
+++ b/app/views/internal/index.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <h1 class="pending-title">Pending Provider Events</h1>
-  
+
   <% if @no_results %>
     <div class="pending-no-results">
       <%= render(Events::NoResultsComponent.new) do %>
@@ -23,7 +23,7 @@
       <section class="types-of-event">
         <div class="events-featured">
           <div class="events-featured__list">
-            <%= render partial: "provider_event", collection: @events %>
+            <%= render partial: "event", collection: @events %>
           </div>
         </div>
         <div class="event-pagination">

--- a/app/views/internal/show.html.erb
+++ b/app/views/internal/show.html.erb
@@ -1,0 +1,9 @@
+<div>
+  <%= link_to "Return to pending events",
+              internal_events_path, method: :get,
+              class: "govuk-back-link" %>
+
+  <div class="markdown">
+    <%= render template:"events/show" %>
+  </div>
+</div>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en" class="govuk-template">
+<%= render "sections/head" %>
+<%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <div id="skiplink-container">
+    <div>
+      <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>
+    </div>
+  </div>
+
+
+  <main role="main" id="main-content">
+    <section class="container">
+      <article class="fullwidth">
+        <%= yield %>
+      </article>
+    </section>
+  </main>
+
+  <%= render "components/videoplayer" %>
+  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
+<% end %>
+</html>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -18,6 +18,5 @@
   </main>
 
   <%= render "components/videoplayer" %>
-  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
 <% end %>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
   end
 
   namespace :internal do
-    resources :events, only: %i[index]
+    resources :events, only: %i[index show]
   end
 
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -17,6 +17,7 @@ module GetIntoTeachingApiClient
       {
         "Open" => 222_750_000,
         "Closed" => 222_750_001,
+        "Pending" => 222_750_003,
       }.freeze
 
     # This is not a complete list.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ActiveSupport::Testing::TimeHelpers
   config.include SpecHelpers::Events
+  config.include SpecHelpers::Internal
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -200,6 +200,12 @@ describe EventsController do
           it { is_expected.not_to match(%r{Sign up for this}) }
         end
 
+        context "when the event is a 'Pending event'" do
+          let(:event) { build(:event_api, web_feed_id: nil, status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]) }
+
+          it { expect(response).to have_http_status :not_found }
+        end
+
         it "has a meta description" do
           actual_description = parsed_response.at_css("head meta[name='description']")["content"]
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -1,21 +1,15 @@
 require "rails_helper"
 
 describe Internal::EventsController do
-  let(:types) { Events::Search.available_event_type_ids }
-  let(:events) do
-    2.times.collect do |index|
-      start_at = Time.zone.today.at_end_of_month - index.days
-      type_id = types[index % types.count]
-      build(:event_api, :with_provider_info, name: "Event #{index + 1}", start_at: start_at, type_id: type_id)
-    end
+  let(:pending_event) do
+    build(:event_api,
+          name: "Pending event",
+          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
+          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
   end
-  let(:events_by_type) { group_events_by_type(events) }
-  let(:provider_events_by_type) { group_events_by_type([events[0]]) }
-
-  before do
-    events[0].status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
-    events[0].type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
-  end
+  let(:open_event) { build(:event_api, name: "Open event") }
+  let(:events) { [pending_event, open_event] }
+  let(:provider_events_by_type) { group_events_by_type([pending_event]) }
 
   describe "#index" do
     context "when any user type" do
@@ -42,8 +36,8 @@ describe Internal::EventsController do
         it "shows pending events" do
           assert_response :success
           expect(response.body).not_to include("No pending events")
-          expect(response.body).to include("<h4>Event 1</h4>")
-          expect(response.body).not_to include("<h4>Event 2</h4>")
+          expect(response.body).to include("<h4>Pending event</h4>")
+          expect(response.body).not_to include("<h4>Open event</h4>")
         end
       end
     end
@@ -61,7 +55,7 @@ describe Internal::EventsController do
         end
         it "shows pending events" do
           assert_response :success
-          expect(response.body).to include("<h1>Event 1</h1>")
+          expect(response.body).to include("<h1>Pending event</h1>")
         end
       end
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -79,22 +79,4 @@ describe Internal::EventsController do
       end
     end
   end
-
-private
-
-  def generate_auth_headers(user_type)
-    if user_type == :publisher
-      username = ENV["PUBLISHER_USERNAME"]
-      password = ENV["PUBLISHER_PASSWORD"]
-    elsif user_type == :author
-      username = ENV["AUTHOR_USERNAME"]
-      password = ENV["AUTHOR_PASSWORD"]
-    end
-
-    { "HTTP_AUTHORIZATION" =>
-        ActionController::HttpAuthentication::Basic.encode_credentials(
-          username,
-          password,
-        ) }
-  end
 end

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+describe Internal::EventsController do
+  let(:types) { Events::Search.available_event_type_ids }
+  let(:events) do
+    2.times.collect do |index|
+      start_at = Time.zone.today.at_end_of_month - index.days
+      type_id = types[index % types.count]
+      build(:event_api, :with_provider_info, name: "Event #{index + 1}", start_at: start_at, type_id: type_id)
+    end
+  end
+  let(:events_by_type) { group_events_by_type(events) }
+  let(:provider_events_by_type) { group_events_by_type([events[0]]) }
+
+  before do
+    events[0].status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+    events[0].type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+  end
+
+  describe "#index" do
+    context "when any user type" do
+      context "when there are no pending events" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+            .to receive(:search_teaching_events_grouped_by_type) { [] }
+
+          get internal_events_path, headers: generate_auth_headers(:author)
+        end
+        it "shows a no events banner" do
+          assert_response :success
+          expect(response.body).to include("No pending events")
+        end
+      end
+
+      context "when there are pending events" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+            .to receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
+
+          get internal_events_path, headers: generate_auth_headers(:author)
+        end
+        it "shows pending events" do
+          assert_response :success
+          expect(response.body).not_to include("No pending events")
+          expect(response.body).to include("<h4>Event 1</h4>")
+          expect(response.body).not_to include("<h4>Event 2</h4>")
+        end
+      end
+    end
+  end
+
+  describe "#show" do
+    let(:event_to_get_readable_id) { "1" }
+    context "when any user type" do
+      context "when the event is pending" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+            .to receive(:get_teaching_event).with(event_to_get_readable_id) { events[0] }
+
+          get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:author)
+        end
+        it "shows pending events" do
+          assert_response :success
+          expect(response.body).to include("<h1>Event 1</h1>")
+        end
+      end
+
+      context "when the event is not pending" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+            .to receive(:get_teaching_event).with(event_to_get_readable_id) { events[1] }
+
+          get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:author)
+        end
+        it "redirects to not found" do
+          assert_response :not_found
+          expect(response.body).to include "Page not found"
+        end
+      end
+    end
+  end
+
+private
+
+  def generate_auth_headers(user_type)
+    if user_type == :publisher
+      username = ENV["PUBLISHER_USERNAME"]
+      password = ENV["PUBLISHER_PASSWORD"]
+    elsif user_type == :author
+      username = ENV["AUTHOR_USERNAME"]
+      password = ENV["AUTHOR_PASSWORD"]
+    end
+
+    { "HTTP_AUTHORIZATION" =>
+        ActionController::HttpAuthentication::Basic.encode_credentials(
+          username,
+          password,
+        ) }
+  end
+end

--- a/spec/requests/internal_controller_spec.rb
+++ b/spec/requests/internal_controller_spec.rb
@@ -7,12 +7,7 @@ describe Internal do
   end
 
   it "should reject unauthenticated users" do
-    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
-      "wrong",
-      "wrong",
-    )
-
-    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
+    get internal_events_path, headers: generate_auth_headers(:bad_credentials)
 
     assert_response :unauthorized
   end
@@ -24,26 +19,16 @@ describe Internal do
   end
 
   it "should set the account role of publishers" do
-    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
-      ENV["PUBLISHER_USERNAME"],
-      ENV["PUBLISHER_PASSWORD"],
-    )
+    get internal_events_path, headers: generate_auth_headers(:publisher)
 
-    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
-
-    assert_response 200
+    assert_response :success
     expect(session[:role]).to be(:publisher)
   end
 
   it "should set the account role of authors" do
-    authorization = ActionController::HttpAuthentication::Basic.encode_credentials(
-      ENV["AUTHOR_USERNAME"],
-      ENV["AUTHOR_PASSWORD"],
-    )
+    get internal_events_path, headers: generate_auth_headers(:author)
 
-    get internal_events_path, headers: { "HTTP_AUTHORIZATION" => authorization }
-
-    assert_response 200
+    assert_response :success
     expect(session[:role]).to be(:author)
   end
 end

--- a/spec/support/spec_helpers/internal.rb
+++ b/spec/support/spec_helpers/internal.rb
@@ -1,0 +1,22 @@
+module SpecHelpers
+  module Internal
+    def generate_auth_headers(login_type)
+      if login_type == :publisher
+        username = ENV["PUBLISHER_USERNAME"]
+        password = ENV["PUBLISHER_PASSWORD"]
+      elsif login_type == :author
+        username = ENV["AUTHOR_USERNAME"]
+        password = ENV["AUTHOR_PASSWORD"]
+      elsif login_type == :bad_credentials
+        username = "wrong"
+        password = "wrong"
+      end
+
+      { "HTTP_AUTHORIZATION" =>
+          ActionController::HttpAuthentication::Basic.encode_credentials(
+            username,
+            password,
+          ) }
+    end
+  end
+end


### PR DESCRIPTION
# Trello card
https://trello.com/c/eDrH76ST

# Context
It was requested that the pending events should be able to be viewed as they appear on the main site, so they can be properly reviewed.

# Changes proposed in this pull request
- Add views for index and show
- Add request specs 
- Add actions for `index` and `show` to the internal events controller
- Do not show `pending` events on the main site when visiting them directly (they shouldn't be visible on index because there is a default filter on the API `get events` endpoint that returns `open` and `closed` events only)