### PR TITLE
Migrate page speed task to endpoint

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,14 +47,4 @@ on_worker_boot do
     # Re-open appenders after forking the process
     SemanticLogger.reopen
   end
-
-  if Rails.env.pagespeed?
-    require "page_speed_score"
-
-    sitemap_url = "https://getintoteaching.education.gov.uk/sitemap.xml"
-    page_speed_score = PageSpeedScore.new(sitemap_url)
-    page_speed_score.fetch
-
-    PageSpeedScore.publish
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,18 @@ Rails.application.routes.draw do
     get "/assets/*missing", to: "errors#not_found", via: :all
   end
 
+  post "/pagespeed/run", constraints: -> { Rails.env.pagespeed? }, to: proc { |_env|
+    require "page_speed_score"
+
+    sitemap_url = "https://getintoteaching.education.gov.uk/sitemap.xml"
+    page_speed_score = PageSpeedScore.new(sitemap_url)
+    page_speed_score.fetch
+
+    PageSpeedScore.publish
+
+    [204, {}, []]
+  }
+
   namespace :internal do
     resources :events, only: %i[index]
   end

--- a/spec/requests/pagespeed_spec.rb
+++ b/spec/requests/pagespeed_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+require "page_speed_score"
+
+describe "Page Speed Task" do
+  let(:run_pagespeed_path) { "/pagespeed/run" }
+
+  before { allow(Rails.env).to receive(:pagespeed?) { pagespeed_env } }
+
+  context "when not in the pagespeed environment" do
+    let(:pagespeed_env) { false }
+
+    it "returns 404" do
+      expect { post run_pagespeed_path }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  context "when in the pagespeed environment" do
+    let(:pagespeed_env) { true }
+
+    before do
+      expect_any_instance_of(PageSpeedScore).to receive(:fetch)
+      expect(PageSpeedScore).to receive(:publish)
+    end
+
+    it "returns 204" do
+      post run_pagespeed_path
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
We were trying to run the task on boot but for some reason its not working. To make it easier to debug I'm moving it to its own endpoint that we can call, only available in the `pagespeed` environment.
