### PR TITLE
Add timeout to pagespeed call

### DIFF
--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -23,3 +23,4 @@ jobs:
         method: 'POST'
         username: ${{ secrets.HTTP-USERNAME }}
         password: ${{ secrets.HTTP-PASSWORD }}
+        timeout: 1800000 # 30 minutes in ms


### PR DESCRIPTION
The pagespeed task takes about 20 minutes, so it needs a long timeout.