### PR TITLE
Lazy load youtube iframe

### DIFF
--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -18,6 +18,7 @@ module StoriesHelper
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
       allowfullscreen: true,
       class: "story__video",
+      loading: "lazy",
     )
   end
 


### PR DESCRIPTION
The lazy loading attribute doesn't have great support yet, but Chrome and Edge support it and it placates the page speed checker, so there's no harm.