### PR TITLE
Rename the SCSS var $max-content-width to $page-max-width

### DIFF
--- a/app/webpacker/styles/breakpoints.scss
+++ b/app/webpacker/styles/breakpoints.scss
@@ -6,6 +6,6 @@ $mq-breakpoints: (
   wide: 1500px,
 );
 $mq-static-breakpoint: desktop;
-$max-content-width: 2000px;
+$page-max-width: 2000px;
 
 @import 'sass-mq';

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,5 +1,5 @@
 %content-width-limiter-shared {
-  max-width: $max-content-width;
+  max-width: $page-max-width;
   margin: auto;
 }
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/JanYj3DC

### Context
We have both `$content-max-width` and `$max-content-width` vars which look similar, but do different things. 

### Changes proposed in this pull request
Choosing better name for the latter will avoid confusion.

