### PR TITLE
Increase page speed action timeout

### DIFF
--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -23,4 +23,4 @@ jobs:
         method: 'POST'
         username: ${{ secrets.HTTP-USERNAME }}
         password: ${{ secrets.HTTP-PASSWORD }}
-        timeout: 1800000 # 30 minutes in ms
+        timeout: 3600000 # 1hr in ms


### PR DESCRIPTION
It timed out on the last run; it takes ~20mins locally but hit the 30min threshold in the GitHub action. Updating to give it a bit more headroom.
