### PR TITLE
Fix long words causing horizontal scroll

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -3,6 +3,8 @@
   @mixin overhang { margin-left: auto; margin-right: auto; }
   @include external-link-icon;
 
+  word-break: break-word;
+
   > * {
     @include indent-left-and-right;
   }


### PR DESCRIPTION
On mobile a long word (or email) can cause horizontal scroll. Setting `word-break: break-word;` on the `markdown` class means these words will wrap instead of bleeding out of the viewport.

<img width="374" alt="Screenshot 2021-04-14 at 08 43 46" src="https://user-images.githubusercontent.com/29867726/114672897-89f31400-9cfd-11eb-8e80-82b1be7710ad.png">
