### PR TITLE
Improve abbreviation usability

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -55,7 +55,7 @@
         </aside>
         <% end %>
 
-        <%= tag.article(class: article_classes(@front_matter)) do %>
+        <%= tag.article(class: article_classes(@front_matter), data: { controller: 'abbreviation' }) do %>
 
           <% if @front_matter["alert"].present? %>
             <%= tag.div(tag.p(@front_matter["alert"]), class: "content-alert content-alert--fullwidth") %>

--- a/app/webpacker/controllers/abbreviation_controller.js
+++ b/app/webpacker/controllers/abbreviation_controller.js
@@ -9,12 +9,12 @@ export default class extends Controller {
     const abbrs = this.element.querySelectorAll('abbr');
 
     const replace = (event) => {
-      // get the abbr element and pull it's name from title
+      // get the abbr element and pull its name from title
       const abbr = event.currentTarget;
       const name = abbr.getAttribute('title');
 
       // create a span with appropriate class that we can use
-      // to replce the <abbr>. This would be easier with jQuery 😢
+      // to replce the <abbr>. This would be easier with jQuery
       const replacementSpan = document.createElement('span');
       const replacementText = document.createTextNode(name);
       replacementSpan.appendChild(replacementText);

--- a/app/webpacker/controllers/abbreviation_controller.js
+++ b/app/webpacker/controllers/abbreviation_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  connect() {
+    this.addClickHandlersToAbbrElements();
+  }
+
+  addClickHandlersToAbbrElements() {
+    const abbrs = this.element.querySelectorAll('abbr');
+
+    const replace = (event) => {
+      // get the abbr element and pull it's name from title
+      const abbr = event.currentTarget;
+      const name = abbr.getAttribute('title');
+
+      // create a span with appropriate class that we can use
+      // to replce the <abbr>. This would be easier with jQuery 😢
+      const replacementSpan = document.createElement('span');
+      const replacementText = document.createTextNode(name);
+      replacementSpan.appendChild(replacementText);
+      replacementSpan.setAttribute('class', 'abbr-replacement');
+
+      // finally replace the abbr element with the new span
+      abbr.replaceWith(replacementSpan);
+    };
+
+    abbrs.forEach((abbr) => {
+      abbr.addEventListener('click', replace, { once: true });
+    });
+  }
+}

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -70,6 +70,23 @@
     }
   }
 
+  @mixin abbr-styles {
+    text-underline-offset: .2em;
+    text-decoration-thickness: 2em;
+    text-decoration: underline dotted $grey-dark;
+  }
+
+  abbr {
+    @include abbr-styles;
+    cursor: help;
+  }
+
+  .abbr-replacement {
+    // nothing here yet, but we could use this to show
+    // that we've expanded an abbreviation
+    // @include abbr-styles;
+  }
+
   table {
     $table-spacing: .5em;
     border-spacing: 0 $table-spacing;

--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -1,4 +1,15 @@
 class Acronyms
+  # This should match:
+  #
+  #  * uppercase strings,
+  #  * that are longer than 2+ characters long
+  #  * that aren't surrounded by parens
+  #
+  #  e.g., given the string:
+  #
+  #  > "A Postgraduate Certificate in Education (PGCE) will help you get QTS."
+  #
+  # QTS _should_ match but PGCE _shouldn't_.
   ABBR_REGEXP = %r{(?<!\()\b([A-Z][A-Z]+)\b(?![\w\s]*[)])}.freeze
 
   def initialize(content, acronyms)

--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -1,5 +1,5 @@
 class Acronyms
-  ABBR_REGEXP = %r{\b([A-Z][A-Z]+)\b}.freeze
+  ABBR_REGEXP = %r{(?<!\()\b([A-Z][A-Z]+)\b(?![\w\s]*[)])}.freeze
 
   def initialize(content, acronyms)
     @document = parse_html(content)

--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -10,7 +10,7 @@ class Acronyms
   #  > "A Postgraduate Certificate in Education (PGCE) will help you get QTS."
   #
   # QTS _should_ match but PGCE _shouldn't_.
-  ABBR_REGEXP = %r{(?<!\()\b([A-Z][A-Z]+)\b(?![\w\s]*[)])}.freeze
+  ABBR_REGEXP = %r{(?!\()\b([A-Z]{2,})\b(?![\w\s]*\))}.freeze
 
   def initialize(content, acronyms)
     @document = parse_html(content)

--- a/spec/javascript/controllers/abbreviation_controller_spec.js
+++ b/spec/javascript/controllers/abbreviation_controller_spec.js
@@ -1,0 +1,33 @@
+import { Application } from 'stimulus';
+import AbbreviationController from 'abbreviation_controller.js';
+
+describe('AccordionController', () => {
+  const original = `
+    <article data-controller="abbreviation">
+      <p>You need a <abbr id="abbr-1" title="Postgraduate Certificate in Education">PGCE</abbr> to get <abbr title="Qualified Teacher Status">QTS<abbr>.</p>
+    </article>
+  `;
+
+  document.body.innerHTML = original;
+
+  const application = Application.start();
+  application.register('abbreviation', AbbreviationController);
+
+  describe('when loaded', () => {
+    it('should not do anything by default', () => {
+      const abbr = document.querySelector('abbr#abbr-1');
+      expect(abbr.textContent).toEqual('PGCE');
+    });
+  });
+
+  describe('when clicked', () => {
+    it('replaces the abbr element with the title value', () => {
+      document.querySelector('abbr').click();
+      // note the first is expanded but not the second
+      const p = document.querySelector('p');
+      expect(p.textContent).toEqual(
+        'You need a Postgraduate Certificate in Education to get QTS.'
+      );
+    });
+  });
+});

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -30,4 +30,11 @@ describe Acronyms, type: :helper do
     it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
     it { is_expected.to match "and PAYE" }
   end
+
+  context "when the acronym is surrounded by brackets" do
+    let(:content) { "Taxes you may encounter include Value Added Tax (VAT) and Pay as you earn (PAYE)." }
+    it "remains unchanged" do
+      is_expected.to match(content)
+    end
+  end
 end


### PR DESCRIPTION
### Context and changes

Currently our abbreviations aren't usable for people on mobile. The way abbr tags usually work is that the content of the `title` attribute is displayed in a 'popover' window when hovering over an abbreviation. Mobile users don't have a cursor so can't really hover. They _can_ trigger the title to display by long pressing, on Android/Chrome at least, but the behaviour isn't exactly intuitive.

Here, when an abbr is clicked, we replace the content with the explanation. This should make the sentence more explicit without changing its meaning.

The regex that detects abbreviations to be abbreviated has been amended so it won't target those surrounded by parentheses, ensuring we don't end up with text like:

> Postgraduate Certificate in Education (Postgraduate Certificate in Education), lorem ipsum...


https://user-images.githubusercontent.com/128088/114697372-bf0b6080-9d15-11eb-80b0-224aeeda9810.mp4


