### PR TITLE
Fix downward arrows in link block

### DIFF
--- a/app/webpacker/styles/components/link-block.scss
+++ b/app/webpacker/styles/components/link-block.scss
@@ -65,10 +65,11 @@
           content: "";
           display: block;
           background-image: url('../images/icon-down.svg');
+          background-repeat: no-repeat;
           width: 21px;
-          // height: size("small");
+          height: 21px;
           position: absolute;
-          top: 6px;
+          top: 10px;
           left: 15px;
         }
       }


### PR DESCRIPTION
Small fix to re-add the missing arrows from the link block.

![Screenshot from 2021-04-14 13-38-02](https://user-images.githubusercontent.com/128088/114711306-b3746580-9d26-11eb-8438-bf446a869523.png)
![Screenshot from 2021-04-14 13-37-52](https://user-images.githubusercontent.com/128088/114711309-b40cfc00-9d26-11eb-917f-c50e37f1ed07.png)

