### PR TITLE
Log to Sentry when CircuitBrokenError is thrown in client Gem

### DIFF
--- a/app/controllers/concerns/circuit_breaker.rb
+++ b/app/controllers/concerns/circuit_breaker.rb
@@ -4,7 +4,10 @@ module CircuitBreaker
   extend ActiveSupport::Concern
 
   included do
-    rescue_from GetIntoTeachingApiClient::CircuitBrokenError, with: :redirect_to_not_available
+    rescue_from GetIntoTeachingApiClient::CircuitBrokenError do |exception|
+      Sentry.capture_exception(exception)
+      redirect_to_not_available
+    end
   end
 
 protected

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -14,6 +14,8 @@ describe "Circuit breaker" do
   end
 
   context "when the API returns a CircuitBrokenError" do
+    before { expect(Sentry).to receive(:capture_exception).with(error) }
+
     it "the EventsController redirects to an error page" do
       get event_path("event-id")
       expect(response).to redirect_to(events_not_available_path)


### PR DESCRIPTION
### Trello card
https://trello.com/c/Z9YPUZ5Q

### Context
The API client will raise a CircuitBrokenError if there are repeated API failures. See PR [here](https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/37)

When this happens, the error should be logged to Sentry

### Changes proposed in this pull request
- Log to Sentry when CircuitBrokenError is raised in the client Gem

### Guidance to review
This was tested by going into the client Gem and raising a CircuitBrokenError on any request, see the Sentry log that was produced [here](https://sentry.io/organizations/dfe-bat/issues/2340553013/?project=5276949&query=is%3Aunresolved). The app still navigates to not available pages such as `/events/not-available` as it should, see [here](https://github.com/DFE-Digital/get-into-teaching-app/pull/947).

If this is a suitable solution, I will do the same in the TTA app.
