### PR TITLE
Fix "selectElement is not defined" console error

### DIFF
--- a/app/webpacker/packs/internal.js
+++ b/app/webpacker/packs/internal.js
@@ -9,9 +9,11 @@ document.body.className = document.body.className
   ? document.body.className + ' js-enabled'
   : 'js-enabled';
 
-const selectId = '#internal-event-building-id-field';
+const selectId = document.querySelector('#internal-event-building-id-field');
 
-enhanceSelectElement({
-  selectElement: document.querySelector(selectId),
-  placeholder: 'E.g., M1 7JA',
-});
+if (selectId) {
+  enhanceSelectElement({
+    selectElement: selectId,
+    placeholder: 'E.g., M1 7JA',
+  });
+}


### PR DESCRIPTION
### Context
`enhanceSelectElement` is running on every page that includes the `internal` layout. This is resulting in a console error on pages that do not have the select element (pages other than the provider form). 

### Changes proposed in this pull request
- Only call enhanceSelectElement if select element is present 