### PR TITLE
Add test to prevent internal links with the domain

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -61,6 +61,16 @@ RSpec.feature "content pages check", type: :feature, content: true do
             end
           end
       end
+
+      scenario "there are no internal links that contain the site's domain" do
+        document
+          .css("a")
+          .map { |fragment| fragment["href"] }
+          .each do |href|
+            expect(href).not_to start_with("https://getintoteaching.education.gov.uk")
+            expect(href).not_to start_with("http://getintoteaching.education.gov.uk")
+          end
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/b91wQipe/1516-add-a-content-spec-to-ensure-we-dont-have-full-urls-in-internal-links

### Context

This is just a safety net to prevent people from accidentally creating internal links with the protocol and domain. This will break in our test environments and is generally a bit of a nuisance.
