### PR TITLE
Skip site wide authentication in internal section

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   rescue_from GetIntoTeachingApiClient::ApiError, with: :handle_api_error
   rescue_from Pages::Page::PageNotFoundError, with: :render_not_found
 
-  before_action :http_basic_authenticate
+  before_action :site_wide_authentication
   before_action :set_api_client_request_id
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
@@ -74,7 +74,7 @@ private
     render_error :too_many_requests
   end
 
-  def http_basic_authenticate
+  def site_wide_authentication
     return true if ENV["HTTPAUTH_USERNAME"].blank?
 
     authenticate_or_request_with_http_basic do |name, password|

--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -1,5 +1,5 @@
 class HealthchecksController < ApplicationController
-  skip_before_action :http_basic_authenticate
+  skip_before_action :site_wide_authentication
 
   def show
     @healthcheck = Healthcheck.new

--- a/app/controllers/internal_controller.rb
+++ b/app/controllers/internal_controller.rb
@@ -1,5 +1,6 @@
 class InternalController < ApplicationController
   before_action :authenticate
+  skip_before_action :site_wide_authentication
   helper_method :publisher?
 
 protected
@@ -20,11 +21,13 @@ private
 
       if username == publisher[:username] && password == publisher[:password]
         set_account_role(:publisher)
+        return true
       elsif username == author[:username] && password == author[:password]
         set_account_role(:author)
+        return true
       end
 
-      session[:role].present?
+      false
     end
   end
 


### PR DESCRIPTION
### Context
There are two implementations of HTTP Basic Authentication:
- Site wide which is used to protect the Dev and Test environments
- In the `internal` section (`/internal/events`). This section is accessible on the live site by permitted people only.

However, these don't work together when both active (which they will be on the Dev and Test environments)

### Changes proposed in this pull request
- Skip site wide auth in internal controller
- Rename to `site_wide_authentication` to state more explicitly what it does
 
### Guidance to review
To see this working set the following in `.env.develpment`
```
HTTPAUTH_USERNAME = something
HTTPAUTH_PASSWORD = something
```

You will be prompted to authenticate when first accessing either section, or when swapping from one section to another, which I think is the behaviour we want?