### PR TITLE
Reduce dependabot's npm/bundler checks to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,16 @@
+---
 version: 2
 updates:
 
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
As discussed in the tech chat, we seem to get influxes of small version bumps. Here we're reducing the frequency from weekly to monthly.

Security updates will be sent immediately regardless.