### PR TITLE
Crm form suggestions

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -116,7 +116,7 @@ module Internal
       return if end_at.blank? || start_at.blank?
 
       if end_at <= start_at
-        errors.add(:end_at, "must be after the start date")
+        errors.add(:end_at, "Must be after the start date")
       end
     end
   end

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -9,7 +9,7 @@
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :id %>
   <%= f.govuk_text_field :name, label: { text: 'Event name' } %>
-  <%= f.govuk_text_field :readable_id, label: { text: 'External event name' } %>
+  <%= f.govuk_text_field :readable_id, label: { text: 'Event partial URL' } %>
   <%= f.govuk_text_area :summary, label: { text: 'Event summary' } %>
   <%= render "form/govuk_error_message", label: "Event description", field_errors: @event.errors[:description] do %>
     <%= f.hidden_field :description, class: "event-description" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,39 @@ en:
               blank: Accept the privacy policy to continue
               accepted: Accept the privacy policy to continue
 
+        internal/event:
+          attributes:
+            name:
+              blank: Enter a name
+            readable_id:
+              blank: Enter a partial URL
+            summary:
+              blank: Enter a summary
+            description:
+              blank: Enter a description
+            provider_contact_email:
+              blank: Enter a provider email address
+              invalid: Enter a valid email address
+            provider_organiser:
+              blank: Enter a provider organiser
+            provider_target_audience:
+              blank: Enter a provider target audience
+            provider_website_url:
+              blank: Enter a provider website/registration link
+            is_online:
+              inclusion: Choose whether the event is online
+            start_at:
+              blank: Enter the date and time the event starts
+            end_at:
+              blank: Enter the date and time the event ends
+
+        internal/event_building:
+          attributes:
+            venue:
+              blank: Enter a venue name
+            address_postcode:
+              blank: Enter a postcode
+
   helpers:
     answer:
       mailing_list_steps_degree_status:

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -81,9 +81,8 @@ RSpec.feature "Internal section", type: :feature do
 
       click_button "Submit for review"
 
-      expect(page).to have_text "can't be blank"
-      expect(page).to have_text "is not included in the list"
-      expect(page).to have_text "is invalid"
+      expect(page).to have_text "Enter a name"
+      expect(page).to have_text "Enter a venue name"
     end
 
     scenario "There are validation errors on building only" do
@@ -92,14 +91,10 @@ RSpec.feature "Internal section", type: :feature do
       enter_valid_event_details
 
       choose "Add a new venue"
-      fill_in "Venue", with: "valid"
-      fill_in "Postcode", with: "invalid"
 
       click_button "Submit for review"
 
-      expect(page).to_not have_text "can't be blank"
-      expect(page).to_not have_text "is not included in the list"
-      expect(page).to have_text "is invalid"
+      expect(page).to have_text "Enter a venue name"
     end
 
     scenario "There are validation errors on event only" do
@@ -111,9 +106,7 @@ RSpec.feature "Internal section", type: :feature do
 
       click_button "Submit for review"
 
-      expect(page).to have_text "can't be blank"
-      expect(page).to have_text "is not included in the list"
-      expect(page).to_not have_text "is invalid"
+      expect(page).to have_text "Enter a name"
     end
   end
 
@@ -141,7 +134,7 @@ private
 
   def enter_valid_event_details
     fill_in "Event name", with: "test"
-    fill_in "External event name", with: "test"
+    fill_in "Event partial URL", with: "test"
     fill_in "Event summary", with: "test"
     find(:id, "internal_event_description", visible: false)
       .click


### PR DESCRIPTION
### Context
We demoed the provider events form to the CRM team who suggested that `Event partial URL` is a better name for `readable_id` than `External event name`.

### Changes proposed in this pull request
- Change label name from `External event name` to `Event partial URL`
- Add better validation messages via `locales`
- Update features specs to work with new validation messages