### PR TITLE
Stub event API calls in content specs

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.feature "content pages check", type: :feature, content: true do
+  include_context "stub types api"
+
+  before do
+    # we don't care about the contents of the events pages here, just
+    # that they exist.
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+      .to(receive(:search_teaching_events_grouped_by_type))
+      .and_return([])
+  end
+
   let(:document) { Nokogiri.parse(page.body) }
   let(:statuses_deemed_successful) { Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently) }
 


### PR DESCRIPTION
### Context

DFE-Digital/get-into-teaching-content/pull/421 is currently blocked because a link to the events page is causing an API-related error.

### Changes

There's now a link in our content that, when the content specs run, cause the events page to be rendered. This fails as external API requests are disallowed during testing, so here we avoid the call by just having the API client return an empty array.
