### PR TITLE
Target abbr styles to only paragraphs and lists

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -64,7 +64,8 @@
     }
   }
 
-  ul {
+  ul,
+  ol {
     @include mq($until: tablet) {
       padding-left: 1.2em;
     }
@@ -76,15 +77,19 @@
     text-decoration: underline dotted $grey-dark;
   }
 
-  abbr {
-    @include abbr-styles;
-    cursor: help;
-  }
+  p,
+  ol,
+  ul {
+    abbr {
+      @include abbr-styles;
+      cursor: help;
+    }
 
-  .abbr-replacement {
-    // nothing here yet, but we could use this to show
-    // that we've expanded an abbreviation
-    // @include abbr-styles;
+    // .abbr-replacement {
+    //   nothing here yet, but we could use this to show
+    //   that we've expanded an abbreviation
+    //   @include abbr-styles;
+    // }
   }
 
   table {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -28,7 +28,8 @@ h4 {
 }
 
 p,
-ul {
+ul,
+ol {
   @include font;
   @include font-size("small");
   line-height: 1.5;


### PR DESCRIPTION
This should prevent acronyms from appearing in buttons, headings etc where you wouldn't expect to find them.

Example of what we _don't_ want:

![Screenshot from 2021-04-21 10-14-07](https://user-images.githubusercontent.com/128088/115528885-562e6600-a28a-11eb-9bc9-155c479db4bb.png)

