### PR TITLE
Re-raise non 400 errors

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -90,8 +90,12 @@ module Internal
       GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event(to_api_event)
       true
     rescue GetIntoTeachingApiClient::ApiError => e
-      map_api_errors_to_attributes(e) if e.code == 400
-      false
+      if e.code == 400
+        map_api_errors_to_attributes(e)
+        false
+      else
+        raise
+      end
     end
 
     def buildings


### PR DESCRIPTION
### Context
When the API throws an error, the events provider form should direct to an error page. Currently, it fails silently, which has resulted in users unknowingly resubmitting bad events.

### Changes proposed in this pull request
- Re-raise non-404 errors