### PR TITLE
Use lowercase for 'teacher training adviser'

### DIFF
--- a/app/components/calls_to_action/next_steps_component.html.erb
+++ b/app/components/calls_to_action/next_steps_component.html.erb
@@ -5,11 +5,11 @@
 
     <div class="call-to-action__action">
       <p class="call-to-action__text">
-        Our Teacher Training Advisers can help you select a provider, prepare for interviews and complete your application successfully.
+        Our teacher training advisers can help you select a provider, prepare for interviews and complete your application successfully.
       </p>
 
       <%= link_to("/tta-service", class: "button") do %>
-        Sign up for a Teacher Training Adviser
+        Sign up for a teacher training adviser
       <% end %>
     </div>
   </div>

--- a/app/views/eligibility_checker/show.html.erb
+++ b/app/views/eligibility_checker/show.html.erb
@@ -58,7 +58,7 @@
   <p>
     You can <%= link_to("attend an event", "/events_path") %>, gain
     <%= link_to("school experience", "https://schoolexperience.education.gov.uk/") %>, or
-    <%= link_to("speak to a Teacher Training Adviser", "/tta-service") %>
+    <%= link_to("speak to a teacher training adviser", "/tta-service") %>
     to help you with the whole process of finding, funding and applying for a course.
   </p>
 
@@ -68,7 +68,7 @@
   <p>
     If you want to teach in a secondary school you can <%= link_to("attend an event", "/events_path") %>, gain
     <%= link_to("school experience", "https://schoolexperience.education.gov.uk/") %>, or
-    <%= link_to("speak to a Teacher Training Adviser", "/tta-service") %>
+    <%= link_to("speak to a teacher training adviser", "/tta-service") %>
     to help you with the whole process of finding, funding and applying for a course.
   </p>
 
@@ -81,7 +81,7 @@
   <h3>Next steps:</h3>
 
   <p>
-    If you want to teach at a secondary school speak to a <%= link_to("Teacher Training Adviser", "/tta-service") %>.
+    If you want to teach at a secondary school speak to a <%= link_to("teacher training adviser", "/tta-service") %>.
     They'll help you understand your options.
   </p>
 
@@ -138,6 +138,6 @@
 
 <p>
   <strong>Similar qualifications:</strong> If you think you have what you need, but your
-  qualifications are not on this list, <%= link_to "a Teacher Training Adviser", "/tta-service" %> can let you
+  qualifications are not on this list, <%= link_to "a teacher training adviser", "/tta-service" %> can let you
   know if your qualifications are equivalent and that you're ready to apply.
 </p>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -62,7 +62,7 @@
   <% end %>
 
   <%= render Content::GenericBlockComponent.new(
-    title: "Sign up to get a Teacher Training Adviser",
+    title: "Sign up to get a teacher training adviser",
     icon_image: "icon-git-black.svg",
     icon_alt: "site icon logo checkmark",
     icon_size: "33x33",

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -18,7 +18,7 @@
 
             </section>
             <section class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
-               <h3 class="talk-to-us__inner__table__column__heading">Sign up to get a Teacher Training Adviser</h3>
+               <h3 class="talk-to-us__inner__table__column__heading">Sign up to get a teacher training adviser</h3>
                <p>
                   If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
                </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,7 @@ en:
         plural: "Online Q&As"
         past: "Past online Q&As"
       description: |-
-        In these online sessions, our Teacher Training Advisers answer questions on specific topics, such as funding or ways to train.
+        In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
         Get fast answers to your questions so you can take the next step to becoming a teacher.
     222750009:
       name:


### PR DESCRIPTION
### Context and changes

The term 'teacher training adviser' doesn't refer to a service so should be lowercased throughout. We recently made the corresponding change in the content repo and are applying it here too.
