### PR TITLE
Add length validation to match CRM

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -27,10 +27,10 @@ module Internal
     attribute :building
     attribute :venue_type, type: VENUE_TYPES, default: VENUE_TYPES[:none]
 
-    validates :name, presence: true, allow_blank: false
-    validates :readable_id, presence: true, allow_blank: false
-    validates :summary, presence: true, allow_blank: false
-    validates :description, presence: true, allow_blank: false
+    validates :name, presence: true, allow_blank: false, length: { maximum: 300 }
+    validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }
+    validates :summary, presence: true, allow_blank: false, length: { maximum: 1000 }
+    validates :description, presence: true, allow_blank: false, length: { maximum: 2000 }
     validates :summary, presence: true, allow_blank: false
     validates :is_online, inclusion: { in: [true, false] }
     validates :start_at, presence: true, allow_blank: false
@@ -40,9 +40,9 @@ module Internal
               allow_blank: false,
               email_format: true,
               length: { maximum: 100 }
-    validates :provider_organiser, presence: true, allow_blank: false
-    validates :provider_target_audience, presence: true, allow_blank: false
-    validates :provider_website_url, presence: true, allow_blank: false
+    validates :provider_organiser, presence: true, allow_blank: false, length: { maximum: 300 }
+    validates :provider_target_audience, presence: true, allow_blank: false, length: { maximum: 500 }
+    validates :provider_website_url, presence: true, allow_blank: false, length: { maximum: 300 }
     validates_each :start_at, :end_at do |record, attr, value|
       unless value.nil?
         record.errors.add attr, "Must be in the future" if value <= Time.zone.now

--- a/app/models/internal/event_building.rb
+++ b/app/models/internal/event_building.rb
@@ -12,8 +12,12 @@ module Internal
     attribute :address_city, :string
     attribute :address_postcode, :string
 
-    validates :venue, presence: true, allow_blank: false
-    validates :address_postcode, presence: true, postcode: true, allow_blank: false
+    validates :venue, presence: true, allow_blank: false, length: { maximum: 100 }
+    validates :address_line1, length: { maximum: 255 }
+    validates :address_line2, length: { maximum: 255 }
+    validates :address_line3, length: { maximum: 255 }
+    validates :address_city, length: { maximum: 100 }
+    validates :address_postcode, presence: true, postcode: true, allow_blank: false, length: { maximum: 100 }
 
     def self.initialize_with_api_building(building)
       hash = convert_attributes_from_api_model(building)

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -16,6 +16,23 @@ describe Internal::EventBuilding do
       it { is_expected.to allow_value("test").for :venue }
       it { is_expected.to_not allow_value("").for :venue }
       it { is_expected.to_not allow_value(nil).for :venue }
+      it { is_expected.to validate_length_of(:venue).is_at_most(100) }
+    end
+
+    describe "#address_line1" do
+      it { is_expected.to validate_length_of(:address_line1).is_at_most(255) }
+    end
+
+    describe "#address_line2" do
+      it { is_expected.to validate_length_of(:address_line2).is_at_most(255) }
+    end
+
+    describe "#address_line3" do
+      it { is_expected.to validate_length_of(:address_line3).is_at_most(255) }
+    end
+
+    describe "#address_city" do
+      it { is_expected.to validate_length_of(:address_city).is_at_most(100) }
     end
 
     describe "#address_postcode" do
@@ -23,6 +40,7 @@ describe Internal::EventBuilding do
       it { is_expected.to_not allow_value("not a postcode").for :address_postcode }
       it { is_expected.to_not allow_value("").for :address_postcode }
       it { is_expected.to_not allow_value(nil).for :address_postcode }
+      it { is_expected.to validate_length_of(:address_postcode).is_at_most(100) }
     end
   end
 

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -4,6 +4,7 @@ describe Internal::Event do
   describe "attributes" do
     it { is_expected.to respond_to :id }
     it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :readable_id }
     it { is_expected.to respond_to :summary }
     it { is_expected.to respond_to :description }
     it { is_expected.to respond_to :building }
@@ -22,16 +23,25 @@ describe Internal::Event do
     describe "#name" do
       it { is_expected.to allow_value("test").for :name }
       it { is_expected.to_not allow_values("", nil).for :name }
+      it { is_expected.to validate_length_of(:name).is_at_most(300) }
+    end
+
+    describe "#readable_id" do
+      it { is_expected.to allow_value("test").for :readable_id }
+      it { is_expected.to_not allow_values("", nil).for :readable_id }
+      it { is_expected.to validate_length_of(:readable_id).is_at_most(300) }
     end
 
     describe "#summary" do
       it { is_expected.to allow_value("test").for :summary }
       it { is_expected.to_not allow_values("", nil).for :summary }
+      it { is_expected.to validate_length_of(:summary).is_at_most(1000) }
     end
 
     describe "#description" do
       it { is_expected.to allow_value("test").for :description }
       it { is_expected.to_not allow_values("", nil).for :description }
+      it { is_expected.to validate_length_of(:description).is_at_most(2000) }
     end
 
     describe "#is_online" do
@@ -73,16 +83,19 @@ describe Internal::Event do
     describe "#provider organiser" do
       it { is_expected.to allow_value("test").for :provider_organiser }
       it { is_expected.to_not allow_value("", nil).for :provider_organiser }
+      it { is_expected.to validate_length_of(:provider_organiser).is_at_most(300) }
     end
 
     describe "#provider target audience" do
       it { is_expected.to allow_value("test").for :provider_target_audience }
       it { is_expected.to_not allow_value("", nil).for :provider_target_audience }
+      it { is_expected.to validate_length_of(:provider_target_audience).is_at_most(500) }
     end
 
     describe "#provider website url" do
       it { is_expected.to allow_value("test").for :provider_website_url }
       it { is_expected.to_not allow_value("", nil).for :provider_website_url }
+      it { is_expected.to validate_length_of(:provider_website_url).is_at_most(300) }
     end
   end
 


### PR DESCRIPTION
### Context
The fields of Teaching events and Teaching event buildings have maximum character count in the CRM. If an event/building field that exceed that character count is posted, the API will throw an error.

### Changes proposed in this pull request
- Add maximum character counts to the field of events/buildings, so that bad events/buildings are not posted.