### PR TITLE
remove reference to "new website" - not in the user's interest

### DIFF
--- a/app/views/sections/_feedback_bar.html.erb
+++ b/app/views/sections/_feedback_bar.html.erb
@@ -12,8 +12,7 @@
         </div>
       </div>
       <div>
-        We'd like your feedback on our new Get Into Teaching website.
-        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think</a>.
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think about this service</a>
       </div>
     </div>
   </section>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -9,8 +9,7 @@
             <section class="talk-to-us__inner__table__column" data-controller="talk-to-us">
                <h3 class="talk-to-us__inner__table__column__heading">Chat online</h3>
                <p>
-                  If you have questions about getting into teaching, we can help you get the answers you need with our one-to-one live online chat service,
-                  Monday-Friday between 8.30am and 5pm.
+                  Get the answers you need through online chat, Monday to Friday between 8.30am and 5pm.
                </p>
                <a href="#" class="button" data-action="click->talk-to-us#startChat">
                  Chat online
@@ -18,9 +17,9 @@
 
             </section>
             <section class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
-               <h3 class="talk-to-us__inner__table__column__heading">Sign up to get a Teacher Training Adviser</h3>
+               <h3 class="talk-to-us__inner__table__column__heading">Sign up to get a teacher training adviser</h3>
                <p>
-                  If you're ready to get into teaching, or you're returning to teaching and qualified to teach maths, physics or languages, you can get support from a dedicated, experienced teaching professional to guide you through the process.
+                  Get support from an experienced teaching professional if you're ready to get into teaching or if you're returning to teaching and qualified to teach maths, physics or languages.
                </p>
                <a href="/tta-service" class="button">
                  Get an adviser
@@ -31,7 +30,7 @@
                <div class="talk-to-us__inner__freephone">
                   <h3 class="talk-to-us__inner__table__column__heading">Call us</h3>
                   <p>
-                     If you’d prefer, you can call us about teaching or teacher training on Freephone <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a>, Monday-Friday between 8.30am and 5pm. You can also use this number to update or amend any of your details.
+                     You can call us for free about teacher training on <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a>, Monday to Friday between 8.30am and 5pm. You can also use this number to update or amend your details.
                   </p>
                </div>
       </div>


### PR DESCRIPTION
and make 'talk to us' content a bit more concise

