### PR TITLE
Add preset labels to all custom metrics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ GIT_API_TOKEN=test
 GIT_API_ENDPOINT=https://host.api/endpoint
 TTA_SERVICE_URL=http://tta-service.test
 PREVIEW_PAGES=1
+VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"

--- a/config/initializers/01_vcap.rb
+++ b/config/initializers/01_vcap.rb
@@ -1,0 +1,7 @@
+if ENV["VCAP_SERVICES"].present?
+  Rails.application.config.x.vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+end
+
+if ENV["VCAP_APPLICATION"].present?
+  Rails.application.config.x.vcap_app = JSON.parse(ENV["VCAP_APPLICATION"])
+end

--- a/config/initializers/01_vcap_services.rb
+++ b/config/initializers/01_vcap_services.rb
@@ -1,3 +1,0 @@
-if ENV["VCAP_SERVICES"].present?
-  Rails.application.config.x.vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
-end

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -1,65 +1,83 @@
 module Prometheus
   module Metrics
+    def self.preset_labels
+      {
+        app: Rails.application.config.x.vcap_app["application_name"],
+        organisation: Rails.application.config.x.vcap_app["organization_name"],
+        space: Rails.application.config.x.vcap_app["space_name"],
+      }
+    end
+
     prometheus = Prometheus::Client.registry
 
     prometheus.counter(
       :app_requests_total,
       docstring: "A counter of requests",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :app_request_duration_ms,
       docstring: "A histogram of request durations",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :app_request_view_runtime_ms,
       docstring: "A histogram of request view runtimes",
-      labels: %i[path method status],
+      labels: %i[path method status] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :app_render_view_ms,
       docstring: "A histogram of view rendering times",
-      labels: %i[identifier],
+      labels: %i[identifier] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.histogram(
       :app_render_partial_ms,
       docstring: "A histogram of partial rendering times",
-      labels: %i[identifier],
+      labels: %i[identifier] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :app_cache_read_total,
       docstring: "A counter of cache reads",
-      labels: %i[key hit],
+      labels: %i[key hit] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.counter(
       :app_csp_violations_total,
       docstring: "A counter of CSP violations",
-      labels: %i[blocked_uri document_uri violated_directive],
+      labels: %i[blocked_uri document_uri violated_directive] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.gauge(
       :app_page_speed_score_performance,
       docstring: "Google page speed scores (performance)",
-      labels: %i[strategy path],
+      labels: %i[strategy path] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.gauge(
       :app_page_speed_score_accessibility,
       docstring: "Google page speed scores (accessibility)",
-      labels: %i[strategy path],
+      labels: %i[strategy path] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
 
     prometheus.gauge(
       :app_page_speed_score_seo,
       docstring: "Google page speed scores (seo)",
-      labels: %i[strategy path],
+      labels: %i[strategy path] + preset_labels.keys,
+      preset_labels: preset_labels,
     )
   end
 end

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -9,6 +9,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of requests") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_csp_violations_total" do
@@ -17,6 +18,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of CSP violations") }
     it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_request_duration_ms" do
@@ -25,6 +27,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_request_view_runtime_ms" do
@@ -33,6 +36,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_render_view_ms" do
@@ -41,6 +45,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
     it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_render_partial_ms" do
@@ -49,6 +54,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
     it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_cache_read_total" do
@@ -57,6 +63,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of cache reads") }
     it { expect { subject.get(labels: %i[key hit]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_performance" do
@@ -65,6 +72,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (performance)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_accessibility" do
@@ -73,6 +81,7 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (accessibility)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_seo" do
@@ -81,5 +90,14 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (seo)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
+  end
+
+  def expected_preset_labels
+    {
+      app: "app-name",
+      organisation: "org-name",
+      space: "space-name",
+    }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1404](https://trello.com/c/9UOVcX50/1404-improve-metrics-output-to-prometheus)

### Context

We want to be able to differentiate all metrics against preset labels:

- Application
- Organization
- Space

This will enable us to tailor alerts more suitably to the specific environment running.

### Changes proposed in this pull request

- Add preset labels to all custom metrics

### Guidance to review

