### PR TITLE
Add spacing beneath buttons in markdown paragraphs

### DIFF
--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -1,7 +1,7 @@
 @mixin content-heading {
   display: inline-block;
   margin-top: 0;
-  margin-bottom: .2rem;
+  margin-bottom: .1rem;
   padding: .4rem $indent-amount;
   background: $blue;
   @include font-size("medium");

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -23,6 +23,10 @@
     @include content-heading;
   }
 
+  p > .button {
+    margin-bottom: 1.5em;
+  }
+
   .accordions,
   .stories-feature,
   .feature-table,

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -23,8 +23,31 @@
     @include content-heading;
   }
 
-  p > .button {
-    margin-bottom: 1.5em;
+  h2:not(:first-child),
+  .call-to-action {
+    margin-top: 1.5em;
+  }
+
+  h3 {
+    @include font-size(medium);
+    margin-bottom: 0.2em;
+  }
+
+  h4 {
+    @include font-size(small);
+    margin-bottom: 0.2em;
+  }
+
+  p,
+  table {
+    > .button {
+      margin-bottom: 1.5em;
+    }
+
+    + h3,
+    + h4 {
+      margin-top: 1.5em;
+    }
   }
 
   .accordions,
@@ -41,19 +64,6 @@
 
   .content-alert--left {
     margin-left: 0;
-  }
-
-  h2:not(:first-child),
-  .call-to-action {
-    margin-top: 1.5em;
-  }
-
-  h3 {
-    @include font-size(medium);
-  }
-
-  h4 {
-    @include font-size(small);
   }
 
   // stop the external icon from appearing inside CTA 'button' style links


### PR DESCRIPTION
This gives the button a little more breathing room and makes documents
flow more nicely.

![Screenshot from 2021-04-22 15-42-20](https://user-images.githubusercontent.com/128088/115744643-aa207400-a38a-11eb-83cc-2b1158c6be68.png)

Also improve the spacing around headers so there's more above than below. Old on left, new on right.

![Screenshot from 2021-04-22 16-57-50](https://user-images.githubusercontent.com/128088/115746957-b86f8f80-a38c-11eb-8d8d-037b6cdf2c71.png)

