### PR TITLE
Update API cache store

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,6 @@ Rails.application.configure do
     Rails.application.credentials.author_username.presence
   config.x.author_password = ENV["AUTHOR_PASSWORD"].presence || \
     Rails.application.credentials.author_password.presence
+
+  config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,6 +116,8 @@ Rails.application.configure do
   config.x.author_password = ENV["AUTHOR_PASSWORD"].presence || \
     Rails.application.credentials.author_password.presence
 
+  config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-HTTP")
+
   # Configure Semantic Logging for production environments
   # This cannot be conditionally loaded so we use it all the time in production
   # like environments.

--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -13,7 +13,7 @@ GetIntoTeachingApiClient.configure do |config|
     config.base_path = parsed.path.gsub(%r{\A/api}, "")
   end
 
-  config.cache_store = Rails.cache
+  config.cache_store = Rails.application.config.x.api_client_cache_store
 
   config.circuit_breaker = {
     enabled: true,

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -46,9 +46,7 @@ describe "Instrumentation" do
   end
 
   describe "cache_read.active_support" do
-    include_context "stub latest privacy policy api"
-
-    after { get privacy_policy_path }
+    after { Rails.cache.read("test") }
 
     it "observes the :app_cache_read_total metric" do
       metric = registry.get(:app_cache_read_total)


### PR DESCRIPTION
### Context

Currently, when a teaching event is posted to the API, it will not be immediately available on the hosted environments because of HTTP caching.

The cache will be cleared when events are posted in the API client Gem. However, we only want to clear the API cache, so here we update the API client cache store to use a new Redis namespace.

### Changes proposed in this pull request
-Update the API client cache store

### Guidance to review
Linked to this [PR](https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/49)
