### PR TITLE
Small fixes to aid development of new ways to train page

### DIFF
--- a/app/components/content/feature_table_component.html.erb
+++ b/app/components/content/feature_table_component.html.erb
@@ -1,5 +1,5 @@
 <% if title? %>
-  <h2 class="always-indent"><%= title %></h2>
+  <%= tag.h2(title, class: "always-indent", id: title.parameterize.concat("-table")) %>
 <% end %>
 
 <div class="<%= wrapper_class %>">

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,8 +88,8 @@ module ApplicationHelper
     link_to text, path, **options
   end
 
-  def chat_link(text = "Chat to us")
-    link_to(text, "#", data: { controller: "talk-to-us", action: "talk-to-us#startChat" })
+  def chat_link(text = "Chat to us", classes: nil)
+    link_to(text, "#", class: classes, data: { controller: "talk-to-us", action: "talk-to-us#startChat" })
   end
 
   def internal_referer

--- a/spec/components/content/feature_table_component_spec.rb
+++ b/spec/components/content/feature_table_component_spec.rb
@@ -16,7 +16,7 @@ describe Content::FeatureTableComponent, type: "component" do
   end
 
   it { is_expected.to have_css(".feature-table") }
-  it { is_expected.to have_css("h2", text: title) }
+  it { is_expected.to have_css("h2##{title.parameterize}-table", text: title) }
   it { is_expected.to have_css("dl") }
 
   describe "within the definition list" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -205,7 +205,8 @@ describe ApplicationHelper do
 
   describe "#chat_link" do
     let(:text) { "Chat with us" }
-    subject { helper.chat_link(text) }
+    let(:extra_class) { "button" }
+    subject { helper.chat_link(text, classes: extra_class) }
 
     it %(generates a hyperlink) do
       expect(subject).to have_css("a")
@@ -217,6 +218,10 @@ describe ApplicationHelper do
 
     it %(has the right data action) do
       expect(subject).to have_css(%(a[data-action="talk-to-us#startChat"]))
+    end
+
+    it %(applies the correct class) do
+      expect(subject).to have_css(%(a.button))
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/8HB2AjKg/1525-content-ways-to-train-redevelop-page-to-focus-more-on-user-considerations

### Context and changes

- Allow the chat_link helper to take extra classes
- Add an id to each feature table
