### PR TITLE
Increase height of new event description field

### DIFF
--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -6,6 +6,7 @@ $govuk-include-default-font-face: false;
 .event-description {
   resize: vertical;
   overflow: auto;
+  height: 350px;
 }
 
 .notification-button {


### PR DESCRIPTION
The CRM team would like this field to be taller by default.