### PR TITLE
Building must be present if venue_type is :existing

### DIFF
--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -40,7 +40,7 @@
       <%= b.govuk_error_summary unless @event.building.nil? %>
       <%= f.govuk_radio_buttons_fieldset(:venue_type, legend: { size: 'm', text: 'Event venue' }) do %>
         <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:none], label: { text: 'No venue' }, link_errors: true %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' }, link_errors: true do %>
+        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' } do %>
           <%= b.govuk_collection_select :id,
                                         f.object.buildings,
                                         :id,

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -39,8 +39,8 @@
     <%= f.fields_for :building, @event.building do |b| %>
       <%= b.govuk_error_summary unless @event.building.nil? %>
       <%= f.govuk_radio_buttons_fieldset(:venue_type, legend: { size: 'm', text: 'Event venue' }) do %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:none], label: { text: 'No venue' } %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' } do %>
+        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:none], label: { text: 'No venue' }, link_errors: true %>
+        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' }, link_errors: true do %>
           <%= b.govuk_collection_select :id,
                                         f.object.buildings,
                                         :id,

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -193,28 +193,6 @@ describe Internal::EventsController do
         end
       end
 
-      context "when \"select a venue\" is selected and a venue has not been chosen" do
-        let(:params) do
-          attributes_for :internal_event,
-                         { "venue_type": Internal::Event::VENUE_TYPES[:existing], "building": { "id": "" } }
-        end
-        it "should post no building" do
-          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-            .to receive(:get_teaching_event_buildings) { [pending_event.building] }
-
-          expected_request_body.building = nil
-
-          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-            .to receive(:upsert_teaching_event).with(expected_request_body)
-
-          post internal_events_path,
-               headers: generate_auth_headers(:author),
-               params: { internal_event: params }
-
-          expect(response).to redirect_to(internal_events_path(success: :pending))
-        end
-      end
-
       context "when \"no venue\" is selected" do
         let(:params) do
           attributes_for(:internal_event, { "venue_type": Internal::Event::VENUE_TYPES[:none], "building": { "id": "" } })


### PR DESCRIPTION
We were not showing an error/catching the scenario when a user selects an existing venue type but does not pick a building from the dropdown (instead we created the event with no building, which has been flagged as confusing by the CRM team).

Adds validation to ensure a building with an id is present if the `venue_type` is `:existing`.

Minor clean up of other tests.

<img width="1063" alt="Screenshot 2021-04-27 at 11 00 21" src="https://user-images.githubusercontent.com/29867726/116223752-c4ba6a80-a747-11eb-8eda-d5c8b9115612.png">
