### PR TITLE
Run specs in random order

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  #   config.order = :random
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
At the moment if we hit a flakey spec in the CI pipeline we have no way to recreate the same test order locally in order to debug it.

By running in a random order RSpec will print out the `seed` value used for the run, which we can then use to perform an identical run locally.