### PR TITLE
Prevent abbreviations from being placed in links

### DIFF
--- a/lib/acronyms.rb
+++ b/lib/acronyms.rb
@@ -30,6 +30,7 @@ private
   def replace_acronyms(document)
     document.traverse do |node|
       next unless node.text?
+      next if node.parent.name == "a"
 
       replacements = 0
       replacement = node.content.gsub(ABBR_REGEXP) do |acronym|

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -3,16 +3,16 @@ require "acronyms"
 
 describe Acronyms, type: :helper do
   let(:content) { "All prices include VAT except where marked exVAT" }
-  let(:acronyms) { { "VAT" => "Value added tax" } }
+  let(:acronyms) { { "VAT" => "Value added tax", "HMRC" => "Her Majesty's Revenue and Customs" } }
 
   subject { described_class.new(content, acronyms).render }
   it { is_expected.to match "marked exVAT" }
   it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
 
   context "with HTML content" do
-    let(:content) { "<a href=\"#vat\" title=\"VAT information\">VAT</a>" }
-    it { is_expected.to have_css "a abbr[title=\"Value added tax\"]", text: "VAT" }
-    it { is_expected.to have_css "a[title=\"VAT information\"]" }
+    let(:content) { "<span id=\"#vat\" title=\"VAT information\">VAT</span>" }
+    it { is_expected.to have_css "span abbr[title=\"Value added tax\"]", text: "VAT" }
+    it { is_expected.to have_css "span[title=\"VAT information\"]" }
   end
 
   context "with unknown acronym" do
@@ -36,5 +36,11 @@ describe Acronyms, type: :helper do
     it "remains unchanged" do
       is_expected.to match(content)
     end
+  end
+
+  context "when the acronym is within a hyperlink" do
+    let(:content) { "<span><a href=\"#hmrc\" title=\"Her Majesty's Revenue and Customs\">HMRC</a> have a new VAT system</span>" }
+    it { is_expected.to have_css("abbr", count: 1) }
+    it { is_expected.not_to have_css("abbr", text: "HMRC") }
   end
 end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -121,7 +121,7 @@ describe TemplateHandlers::Markdown, type: :view do
 
         All prices include VAT unless marked as exVAT
 
-        Find out more about <a href="#vat" title="VAT">VAT</a>
+        Find out more about <span id="vat" title="VAT">VAT</a>
       MARKDOWN
     end
 
@@ -135,7 +135,7 @@ describe TemplateHandlers::Markdown, type: :view do
 
     it do
       is_expected.to have_css \
-        "a[title=\"VAT\"] abbr[title=\"Value added tax\"]", text: "VAT"
+        "span[title=\"VAT\"] abbr[title=\"Value added tax\"]", text: "VAT"
     end
   end
 


### PR DESCRIPTION
It's confusing for users as the links are already either underlined or styled like buttons.
