### PR TITLE
Remove temporary stop on production deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build ${{github.ref}}
+    name: Build 
     runs-on: ubuntu-latest
     outputs:
       DOCKER_IMAGE: ${{ steps.docker.outputs.DOCKER_IMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -507,7 +507,6 @@ jobs:
     name: Production Deployment
     runs-on: ubuntu-latest
     needs: [ cypress, development ]
-    if: github.ref == 'NEVER_NEVER_NEVER'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
While testing workflows, we stopped deployment to Production. This re-enables the full deployment using a single REPOSITORY for application and content

