### PR TITLE
Re-enable turbolinks preview cache on events layout

### DIFF
--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -1,12 +1,5 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
-  <% content_for(:head) do %>
-    <!--
-    Turbolinks preview cache occasionally causes the page to jump
-    back to the top after we restore the scroll position on pagination.
-    -->
-    <meta name="turbolinks-cache-control" content="no-cache">
-  <% end %>
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
     <div id="skiplink-container">


### PR DESCRIPTION
### Trello card

[Trello-1529](https://trello.com/c/QCGh3YZ5/1529-bug-go-to-an-event-and-hit-the-browser-back-button-you-go-to-the-home-page-not-the-find-an-event-page)

### Context

To replicate (in Chrome on Mac):

- Go to home page
- Click on find an event
- Click on any event
- Press browser back button

Expected: you should be on the find an event page
Actual: you are on the home page

### Changes proposed in this pull request

- Re-enable turbolinks preview cache on events layout
 
This was originally disabled due to it not behaving with the pagination component, but its causing an issue where the page is skipped completely when you press the back button (so hitting back on an event page goes to the home page and not the find events page). Re-enabling it I can't replicate the issue with the pagination anyway.

### Guidance to review

