### PR TITLE
Replacing broken Teach North link

### DIFF
--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -66,7 +66,7 @@ providers:
       name:  Susan Ingram
       email:  susan.ingram@shottonhallacademy.co.uk
     - header: Teach North with Outwood Grange Academies Trust
-      link: "https://teachnorth.com/internships"
+      link: "https://teachnorth.com/latest-news/2020/2/11/applications-open-for-oie-teaching-internship-programme?rq=internships"
       name: Emma Sikora
       email: e.sikora@outwood.com
   North West:


### PR DESCRIPTION
### Trello card
N/A

### Context
We received info from Paul Keene that we have a broken link on the Teaching Internships page - we are replacing it with a working one.

### Changes proposed in this pull request
Replace Teach North link on `app/views/content/teaching-internship-providers.md` with updated link `https://teachnorth.com/latest-news/2020/2/11/applications-open-for-oie-teaching-internship-programme?rq=internships`

### Guidance to review
- check the link works and makes sense
