### PR TITLE
Do not run if Dependabot/Snyk

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   attach-to-trello:
     name: Link Trello card to this PR
-    runs-on: ubuntu-latest
-    if: ! contains( "sfawcett dependabot[bot] snyk" , "${{github.actor}}" )  
+    runs-on: ubuntu-latest  
+    if: "!contains( 'sfawcett dependabot[bot] snyk' , github.actor )"  
     steps:
       - uses: Azure/login@v1
         with:
@@ -20,7 +20,7 @@ jobs:
            keyvault: ${{ secrets.KEY_VAULT}}
            secrets: 'TRELLO-KEY, TRELLO-TOKEN'
 
-      - name: Add Trello Comment
+      - name: Add Trello Comment 
         uses: DFE-Digital/github-actions/AddTrelloComment@master
         with:
           MESSAGE:      ${{ github.event.pull_request.html_url }} 

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -8,7 +8,7 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest
-    if: ! contains( "sfawcett dependabot[bot] snyk" , ${{github.actor}} )  
+    if: ! contains( "sfawcett dependabot[bot] snyk" , github.actor )  
     steps:
       - uses: Azure/login@v1
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,7 +1,6 @@
 name: Link Trello card
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [ opened , edited]
 
@@ -9,7 +8,7 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest
-    if: ! contains( "sfawcett dependabot[bot] snyk" , github.actor )  
+    if: ! contains( "sfawcett dependabot[bot] snyk" , "${{github.actor}}" )  
     steps:
       - uses: Azure/login@v1
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -8,7 +8,7 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest
-    environment: Development
+    if: ! contains( "sfawcett dependabot[bot] snyk" , ${{github.actor}} )  
     steps:
       - uses: Azure/login@v1
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,6 +1,7 @@
 name: Link Trello card
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [ opened , edited]
 

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -8,7 +8,7 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest  
-    if: "!contains( 'sfawcett dependabot[bot] snyk' , github.actor )"  
+    if: "!contains( 'sfawcett123 dependabot[bot] snyk' , github.actor )"  
     steps:
       - uses: Azure/login@v1
         with:

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -8,7 +8,7 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest  
-    if: "!contains( 'sfawcett123 dependabot[bot] snyk' , github.actor )"  
+    if: "!contains( 'dependabot[bot] snyk' , github.actor )"  
     steps:
       - uses: Azure/login@v1
         with:


### PR DESCRIPTION
## Problem
Snyk and Dependabot are two external applications that can raise Push Requests (PRs), these PRs will not be attached to a Trello ticket, and because Snyk and Dependabot do not have access to our secrets they will also fail. 

## Solution
On the run `trello`  workflow, the error is annoying and irrelevant. Therefore if the job is being run by one of these applications it is never going to work, so we can add a condition to prevent it trying.


