### PR TITLE
Always keep Rubocop Output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
             rubocop --format json --out=/app/out/rubocop-result.json
 
       - name: Keep Rubocop output
+        if: always() 
         uses: actions/upload-artifact@v2
         with:
           name: Rubocop_results


### PR DESCRIPTION
Regardless if Rubocop passes or fails keep any output as an artefact.


