### PR TITLE
Add get school experience page

### DIFF
--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -46,7 +46,7 @@ They're not obliged to offer experience and may be limiting visitors due to coro
 
 They also need to be careful about allowing visitors into the school for the safety of children and young people.
 
-You may also be asked to have a DBS check to ensure you're safe to work with children.
+You may be asked to have a DBS check to ensure you're safe to work with children.
 
 Be flexible with your availability if possible and persevere with your search.
 

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -7,8 +7,8 @@ description: |-
 date: "2021-05-04"
 right_column:
   ctas:
-    - title: Find school experience
-      link_text: "Request early years, primary or secondary experience."
+    - title: Get school experience
+      link_text: "Request early years, primary or secondary experience"
       link_target: "https://schoolexperience.education.gov.uk/"
       icon: "icon-person"
       hide_on_mobile: Yes
@@ -40,11 +40,7 @@ To find experience you can:
 
 It's normal to have to try a few schools before you find one that can help.
 
-They're not obliged to offer experience and may be limiting visitors due to coronavirus (COVID-19).
-
-They also need to be careful about allowing visitors into the school for the safety of children and young people.
-
-You may be asked to have a DBS check to ensure you're safe to work with children.
+They may be limiting visitors due to coronavirus (COVID-19) and may need to organise a DBS check to ensure you're safe to work with children.
 
 Be flexible with your availability if possible and persevere with your search.
 

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -7,10 +7,10 @@ description: |-
 date: "2021-05-04"
 right_column:
   ctas:
-    - title: Get school experience
-      link_text: "Request early years, primary or secondary experience"
+    - title: Organise school experience
+      link_text: "Request school experience"
       link_target: "https://schoolexperience.education.gov.uk/"
-      icon: "icon-person"
+      icon: "icon-calendar"
       hide_on_mobile: Yes
       hide_on_tablet: Yes
 keywords:
@@ -31,7 +31,7 @@ It can also really help [your teacher training application](/tips-on-applying-fo
 
 To find experience you can:
 
-* [request early years, primary or secondary experience on GOV.UK](https://schoolexperience.education.gov.uk/) - not all schools advertise experience here and some only offer online experience due to coronavirus (COVID-19) restrictions
+* [find a school offering experience through GOV.UK](https://schoolexperience.education.gov.uk/) - not all schools advertise experience here and some only offer online experience due to coronavirus (COVID-19) restrictions
 * approach schools yourself
 
 ## Approach schools yourself

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -3,7 +3,7 @@ title: Get school experience
 image: "/assets/images/international-dt.jpg"
 mobileimage: "/assets/images/steps-hero-mob.jpg"
 description: |-
-  School experience can help your teacher training application. Here's how to get school experience.
+  School experience can help you talk to teachers and get an insight into day-to-day school life. Here's how to get school experience.
 date: "2021-05-04"
 right_column:
   ctas:
@@ -26,8 +26,6 @@ Spending some time in a school allows you to:
 * observe lessons and other teacher responsibilities
 * talk to teachers
 * get an insight into day-to-day school life
-
-It can also really help [your teacher training application](/tips-on-applying-for-teacher-training), although it’s not a training entry requirement.
 
 To find experience you can:
 

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -50,7 +50,7 @@ Be flexible with your availability if possible and persevere with your search.
 
 ## Maths or physics teaching internships
 
-[Find a paid teaching internship if you’re doing an undergraduate degree in science, technology, engineering or maths (STEM)](https://getintoteaching.education.gov.uk/teaching-internship-providers).
+[Find a paid teaching internship if you’re doing an undergraduate degree in science, technology, engineering or maths (STEM)](/teaching-internship-providers).
 
 ## If you cannot get into the classroom right now
 
@@ -58,4 +58,4 @@ Be flexible with your availability if possible and persevere with your search.
 
 These videos are not a claim of best practice but can help you get to know teaching better.
 
-[Events](https://getintoteaching.education.gov.uk/events) can also give you an insight into teaching.
+[Events](/events) can also give you an insight into teaching.

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -52,7 +52,7 @@ Be flexible with your availability if possible and persevere with your search.
 
 ## Maths or physics teaching internships
 
-[Find a paid teaching internship if you’re doing a STEM undergraduate degree](https://getintoteaching.education.gov.uk/teaching-internship-providers).
+[Find a paid teaching internship if you’re doing an undergraduate degree in science, technology, engineering or maths (STEM)](https://getintoteaching.education.gov.uk/teaching-internship-providers).
 
 ## If you cannot get into the classroom right now
 

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -1,0 +1,63 @@
+---
+title: Get school experience
+image: "/assets/images/international-dt.jpg"
+mobileimage: "/assets/images/steps-hero-mob.jpg"
+description: |-
+  School experience can help your teacher training application. Here's how to get school experience.
+date: "2021-05-04"
+right_column:
+  ctas:
+    - title: Find school experience
+      text: |
+       Request early years, primary or secondary experience.
+      link_text: "Find school experience"
+      link_target: "https://schoolexperience.education.gov.uk/"
+      icon: "icon-person"
+      hide_on_mobile: Yes
+      hide_on_tablet: Yes
+keywords:
+  - School experience
+  - Teaching experience
+  - Teacher experience
+---
+
+School experience can help you decide whether teaching is right for you.
+
+Spending some time in a school allows you to:
+
+* observe lessons and other teacher responsibilities
+* talk to teachers
+* get an insight into day-to-day school life
+
+It can also really help your teacher training application, although it’s not a training entry requirement.
+
+To find experience you can:
+
+* [request early years, primary or secondary experience on GOV.UK](https://schoolexperience.education.gov.uk/) - not all schools advertise experience here and some only offer online experience due to coronavirus (COVID-19) restrictions
+* approach schools yourself
+
+## Approach schools yourself
+
+[Find schools near you](https://get-information-schools.service.gov.uk/) and give them a ring to find out who to talk to about getting school experience.
+
+It's normal to have to try a few schools before you find one that can help.
+
+They're not obliged to offer experience and may be limiting visitors due to coronavirus (COVID-19).
+
+They also need to be careful about allowing visitors into the school for the safety of children and young people.
+
+You may also be asked to have a DBS check to ensure you're safe to work with children.
+
+Be flexible with your availability if possible and persevere with your search.
+
+## Maths or physics teaching internships
+
+[Find a paid teaching internship if you’re doing a STEM undergraduate degree](https://getintoteaching.education.gov.uk/teaching-internship-providers).
+
+## If you cannot get into the classroom right now
+
+[Observe teachers’ lessons and analysis of their lessons on the Oak National Academy website](https://teachers.thenational.academy/lessons-for-itt).
+
+These videos are not a claim of best practice but can help you get to know teaching better.
+
+[Events](https://getintoteaching.education.gov.uk/events) can also help you get to know teaching.

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -8,9 +8,7 @@ date: "2021-05-04"
 right_column:
   ctas:
     - title: Find school experience
-      text: |
-       Request early years, primary or secondary experience.
-      link_text: "Find school experience"
+      link_text: "Request early years, primary or secondary experience."
       link_target: "https://schoolexperience.education.gov.uk/"
       icon: "icon-person"
       hide_on_mobile: Yes

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -58,4 +58,4 @@ Be flexible with your availability if possible and persevere with your search.
 
 These videos are not a claim of best practice but can help you get to know teaching better.
 
-[Events](https://getintoteaching.education.gov.uk/events) can also help you get to know teaching.
+[Events](https://getintoteaching.education.gov.uk/events) can also give you an insight into teaching.

--- a/app/views/content/get-school-experience/get-school-experience.md
+++ b/app/views/content/get-school-experience/get-school-experience.md
@@ -29,7 +29,7 @@ Spending some time in a school allows you to:
 * talk to teachers
 * get an insight into day-to-day school life
 
-It can also really help your teacher training application, although it’s not a training entry requirement.
+It can also really help [your teacher training application](/tips-on-applying-for-teacher-training), although it’s not a training entry requirement.
 
 To find experience you can:
 


### PR DESCRIPTION
The new Steps iteration won't include a section on school experience so we need a space for Get school experience content.

Need some formatting help - have temporarily used the 'get an adviser' call to action side bar component but think that icon is reserved for getting an adviser content. 

Have also used an existing banner that's used elsewhere - we may want to use something different.

