### PR TITLE
updating email for sheffield scitt

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -419,7 +419,7 @@ providers:
   Yorkshire and the Humber:
   - header: The Sheffield SCITT
     link: https://www.sheffieldscitt.org.uk/
-    email: kbarna@hallamtsa.org.uk
+    email: admin@sheffieldscitt.org.uk
   - header: Bradford College
     link: https://www.bradfordcollege.ac.uk/courses/course/qualified-teacher-status-qts-assessment-only-programme/
     name: Lee Parsell

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -223,9 +223,6 @@ providers:
     name: Neil Dixon
     telephone: 0151 426 6869
     email: neil.dixon@knowsley.gov.uk
-  - header: Merseyside, Cheshire & Greater Manchester Teacher Training Consortium
-    link: https://www.teachertrainingconsortium.info
-    email: admin@teachertrainingconsortium.org.uk
   - header: North Manchester ITT Partnership
     link: https://www.teachnorthmanchester.com/assessment-only
     name: Carrie Carvell

--- a/app/views/content/assessment-only-providers/_listing.html.erb
+++ b/app/views/content/assessment-only-providers/_listing.html.erb
@@ -1,5 +1,5 @@
 <h2>Select the region of the provider</h2>
 
-<section>
+<section class="assessment-only-providers">
   <%= render GroupedCards::ListingComponent.new @front_matter["providers"] %>
 </section>

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -42,3 +42,9 @@
     }
   }
 }
+
+.assessment-only-providers {
+  .group__card {
+    min-height: 12em;
+  }
+}


### PR DESCRIPTION
### Trello card
N/A
### Context
Received request from The Sheffield SCITT for an update to the contact email on `https://getintoteaching.education.gov.uk/assessment-only-providers`

Also removing Merseyside, Cheshire & Greater Manchester Teacher Training Consortium completely from A/O as per provider request
### Changes proposed in this pull request
update email for The Sheffield SCITT to `admin@sheffieldscitt.org.uk` in `app/views/content/assessment-only-providers.md`

Also removed the whole section for Merseyside Consortium
### Guidance to review
- check the contact email contains no typos
- check the tile still looks fine
- check Merseyside removed successfully
