### PR TITLE
Renamed DOCKERHUB to DOCKER

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for broken links
         run: |
           docker run -t --rm -e RAILS_ENV=test \
-            ${{ env.DOCKERHUB_REPOSITORY }}:sha-${{ steps.sha.outputs.short }} \
+            ${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }} \
             rspec --format documentation -t onschedule spec/features/external_links_spec.rb
 
       - name: Slack Notification


### PR DESCRIPTION
## Problem

The Link Checker was not working.
After investigation it was found the variable DOCKERHUB_REPOSITORY had not been replaced with DOCKER_REPOSITORY

## Solution
Make change in workflow