### PR TITLE
Add button to generate partial URL

### DIFF
--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -13,7 +13,7 @@
   <%= f.hidden_field :id %>
   <%= f.govuk_text_field :name,
                          label: { text: 'Event name' },
-                         data: { "internal-events-target": "name"  } %>
+                         data: { "internal-events-target": "name" } %>
   <%= f.govuk_text_area :summary, label: { text: 'Event summary' } %>
   <%= render "form/govuk_error_message", label: "Event description", field_errors: @event.errors[:description] do %>
     <%= f.hidden_field :description, class: "event-description" %>
@@ -43,7 +43,11 @@
   <%= f.govuk_text_field :readable_id,
                          label: { text: 'Event partial URL' },
                          hint: { text: 'You can generate the partial URL from the event name and start at date' },
-                         data: { target: "internal-events.partialUrl" } %>
+                         data: { "internal-events-target": "partialUrl" } %>
+
+  <span class="govuk-error-message hidden" id="internal-generate-url-error" data-internal-events-target="errorMessage" }>
+    <span class="govuk-visually-hidden">Error: </span>Name and Start at fields must have values in order to generate partial URL
+  </span>
   <%= f.button "Generate partial URL",
                class: "button form-button",
                type: "button",

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -45,7 +45,7 @@
                          hint: { text: 'You can generate the partial URL from the event name and start at date' },
                          data: { target: "internal-events.partialUrl" } %>
   <%= f.button "Generate partial URL",
-               class: "call-to-action-button button form-button",
+               class: "button form-button",
                data: { action: "click->internal-events#generateButtonClicked" } %>
 
   <div class="no-left-margin">
@@ -72,5 +72,5 @@
       <% end %>
     <% end %>
   </div>
-  <%= f.button "Submit for review", class: "call-to-action-button button form-button" %>
+  <%= f.button "Submit for review", class: "button form-button" %>
 <% end %>

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -13,7 +13,7 @@
   <%= f.hidden_field :id %>
   <%= f.govuk_text_field :name,
                          label: { text: 'Event name' },
-                         data: { target: "internal-events.name" } %>
+                         data: { "internal-events-target": "name"  } %>
   <%= f.govuk_text_area :summary, label: { text: 'Event summary' } %>
   <%= render "form/govuk_error_message", label: "Event description", field_errors: @event.errors[:description] do %>
     <%= f.hidden_field :description, class: "event-description" %>
@@ -33,7 +33,7 @@
   <%= render "form/govuk_error_message", label: "Start at", field_errors: @event.errors[:start_at] do %>
     <%= f.datetime_field :start_at,
                          class: class_names("datetime", "govuk-input", { "govuk-input--error": @event.errors[:start_at].any? }),
-                         data: { target: "internal-events.startAt" } %>
+                         data: { "internal-events-target": "startAt" } %>
   <% end %>
   <%= render "form/govuk_error_message", label: "End at", field_errors: @event.errors[:end_at] do %>
     <%= f.datetime_field :end_at, class: class_names("datetime", "govuk-input",
@@ -46,7 +46,8 @@
                          data: { target: "internal-events.partialUrl" } %>
   <%= f.button "Generate partial URL",
                class: "button form-button",
-               data: { action: "click->internal-events#generateButtonClicked" } %>
+               type: "button",
+               data: { action: "click->internal-events#populatePartialUrl" } %>
 
   <div class="no-left-margin">
     <%= f.fields_for :building, @event.building do |b| %>

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -5,11 +5,15 @@
 
 <h1>Provider Event Details</h1>
 
-<%= govuk_form_for @event, url: internal_events_path, method: :post do |f| %>
+<%= govuk_form_for @event,
+                   url: internal_events_path,
+                   method: :post,
+                   html: { data: { "controller": "internal-events" } } do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :id %>
-  <%= f.govuk_text_field :name, label: { text: 'Event name' } %>
-  <%= f.govuk_text_field :readable_id, label: { text: 'Event partial URL' } %>
+  <%= f.govuk_text_field :name,
+                         label: { text: 'Event name' },
+                         data: { target: "internal-events.name" } %>
   <%= f.govuk_text_area :summary, label: { text: 'Event summary' } %>
   <%= render "form/govuk_error_message", label: "Event description", field_errors: @event.errors[:description] do %>
     <%= f.hidden_field :description, class: "event-description" %>
@@ -27,13 +31,22 @@
     <%= f.govuk_radio_button :is_online, false, label: { text: 'No' } %>
   <% end %>
   <%= render "form/govuk_error_message", label: "Start at", field_errors: @event.errors[:start_at] do %>
-    <%= f.datetime_field :start_at, class: class_names("datetime", "govuk-input",
-                                                       { "govuk-input--error": @event.errors[:start_at].any? }) %>
+    <%= f.datetime_field :start_at,
+                         class: class_names("datetime", "govuk-input", { "govuk-input--error": @event.errors[:start_at].any? }),
+                         data: { target: "internal-events.startAt" } %>
   <% end %>
   <%= render "form/govuk_error_message", label: "End at", field_errors: @event.errors[:end_at] do %>
     <%= f.datetime_field :end_at, class: class_names("datetime", "govuk-input",
                                                      { "govuk-input--error": @event.errors[:end_at].any? }) %>
   <% end %>
+
+  <%= f.govuk_text_field :readable_id,
+                         label: { text: 'Event partial URL' },
+                         hint: { text: 'You can generate the partial URL from the event name and start at date' },
+                         data: { target: "internal-events.partialUrl" } %>
+  <%= f.button "Generate partial URL",
+               class: "call-to-action-button button form-button",
+               data: { action: "click->internal-events#generateButtonClicked" } %>
 
   <div class="no-left-margin">
     <%= f.fields_for :building, @event.building do |b| %>
@@ -59,5 +72,5 @@
       <% end %>
     <% end %>
   </div>
-  <%= f.button "Submit for review", class: "call-to-action-button button" %>
+  <%= f.button "Submit for review", class: "call-to-action-button button form-button" %>
 <% end %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
 <%= render "sections/head" %>
-<%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+<%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link internal-events", "link-target": "content" }, id: "body" do %>
   <div id="skiplink-container">
     <div>
       <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['name', 'startAt', 'partialUrl'];
+
+  get nameValue() {
+    return this.nameTarget.value;
+  }
+
+  get startAtValue() {
+    return this.startAtTarget.value;
+  }
+
+  get partialUrlValue() {
+    return this.partialUrlTarget.value;
+  }
+
+  set partialUrlValue(value) {
+    this.partialUrlTarget.value = value;
+  }
+
+  generateButtonClicked(event) {
+    event.preventDefault();
+
+    const date = this.formatDate(this.startAtValue);
+    const name = this.formatName(this.nameValue);
+    this.partialUrlValue = this.generatePartialUrl(date, name);
+  }
+
+  generatePartialUrl(date, name) {
+    if (date === '' || name === '') return '';
+
+    return `${date}-${name}`;
+  }
+
+  formatDate(dateTimeString) {
+    if (dateTimeString === '') return '';
+
+    const date = dateTimeString.substring(0, dateTimeString.indexOf('T'));
+    const [year, month, day] = date.split('-');
+    return year.slice(-2) + month + day;
+  }
+
+  formatName(name) {
+    return name.trim().toLowerCase().split(/\s+/).join('-');
+  }
+}

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -1,23 +1,33 @@
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['name', 'startAt', 'partialUrl'];
+  static targets = ['name', 'startAt', 'partialUrl', 'errorMessage'];
 
   populatePartialUrl() {
-    const date = this.formatDate(this.startAtTarget.value);
-    const name = this.formatName(this.nameTarget.value);
+    const nameValue = this.nameTarget.value;
+    const startAtValue = this.startAtTarget.value;
+
+    if (nameValue === '' || startAtValue === '') {
+      this.partialUrlTarget.value = '';
+      this.toggleErrorMessageVisibility(true);
+      return;
+    }
+
+    this.toggleErrorMessageVisibility(false);
+    const date = this.formatDate(startAtValue);
+    const name = this.formatName(nameValue);
     this.partialUrlTarget.value = this.generatePartialUrl(date, name);
   }
 
   generatePartialUrl(date, name) {
-    if (date === '' || name === '') return '';
-
     return `${date}-${name}`;
   }
 
-  formatDate(dateTimeString) {
-    if (dateTimeString === '') return '';
+  toggleErrorMessageVisibility(visible) {
+    this.errorMessageTarget.style.display = visible ? 'block' : 'none';
+  }
 
+  formatDate(dateTimeString) {
     const date = dateTimeString.substring(0, dateTimeString.indexOf('T'));
     const [year, month, day] = date.split('-');
     return year.slice(-2) + month + day;

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from 'stimulus';
+import { DateTime } from 'luxon';
 
 export default class extends Controller {
   static targets = ['name', 'startAt', 'partialUrl', 'errorMessage'];
@@ -8,18 +9,21 @@ export default class extends Controller {
     const startAtValue = this.startAtTarget.value;
 
     if (nameValue === '' || startAtValue === '') {
-      this.partialUrlTarget.value = '';
       this.toggleErrorMessageVisibility(true);
-      return;
+      this.partialUrlTarget.value = '';
+    } else {
+      this.toggleErrorMessageVisibility(false);
+      this.partialUrlTarget.value = this.generatePartialUrl(
+        startAtValue,
+        nameValue
+      );
     }
-
-    this.toggleErrorMessageVisibility(false);
-    const date = this.formatDate(startAtValue);
-    const name = this.formatName(nameValue);
-    this.partialUrlTarget.value = this.generatePartialUrl(date, name);
   }
 
-  generatePartialUrl(date, name) {
+  generatePartialUrl(startAtValue, nameValue) {
+    const date = this.formatDate(startAtValue);
+    const name = this.formatName(nameValue);
+
     return `${date}-${name}`;
   }
 
@@ -28,9 +32,7 @@ export default class extends Controller {
   }
 
   formatDate(dateTimeString) {
-    const date = dateTimeString.substring(0, dateTimeString.indexOf('T'));
-    const [year, month, day] = date.split('-');
-    return year.slice(-2) + month + day;
+    return DateTime.fromISO(dateTimeString).toFormat('yyMMdd');
   }
 
   formatName(name) {

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -3,28 +3,10 @@ import { Controller } from 'stimulus';
 export default class extends Controller {
   static targets = ['name', 'startAt', 'partialUrl'];
 
-  get nameValue() {
-    return this.nameTarget.value;
-  }
-
-  get startAtValue() {
-    return this.startAtTarget.value;
-  }
-
-  get partialUrlValue() {
-    return this.partialUrlTarget.value;
-  }
-
-  set partialUrlValue(value) {
-    this.partialUrlTarget.value = value;
-  }
-
-  generateButtonClicked(event) {
-    event.preventDefault();
-
-    const date = this.formatDate(this.startAtValue);
-    const name = this.formatName(this.nameValue);
-    this.partialUrlValue = this.generatePartialUrl(date, name);
+  populatePartialUrl() {
+    const date = this.formatDate(this.startAtTarget.value);
+    const name = this.formatName(this.nameTarget.value);
+    this.partialUrlTarget.value = this.generatePartialUrl(date, name);
   }
 
   generatePartialUrl(date, name) {

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -34,6 +34,6 @@ export default class extends Controller {
   }
 
   formatName(name) {
-    return name.trim().toLowerCase().split(/\s+/).join('-');
+    return name.trim().toLowerCase().replace(/-/g, '').split(/\s+/).join('-');
   }
 }

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -28,3 +28,7 @@ $govuk-include-default-font-face: false;
 .form-button {
   margin: 0 0 30px;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -24,3 +24,7 @@ $govuk-include-default-font-face: false;
 .no-left-margin {
   margin-left: 0;
 }
+
+.form-button {
+  margin: 0 0 30px;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "is-touch-device": "^1.0.1",
     "js-cookie": "^2.2.1",
     "lazysizes": "^5.3.2",
+    "luxon": "^1.26.0",
     "rails-ujs": "^5.2.5",
     "sass-mq": "^5.0.1",
     "serialize-javascript": "^5.0.1",

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -1,69 +1,64 @@
 import InternalEventsController from 'internal_events_controller.js';
+import { Application } from 'stimulus';
 
 describe('InternalEventsController', () => {
-  let controller;
+  document.body.innerHTML = `
+    <form class="new_internal_event" id="new_internal_event" data-controller="internal-events">
+      <input id="internal-event-name-field" class="govuk-input" data-internal-events-target="name"/>
+      <input class="datetime govuk-input" data-internal-events-target="startAt" type="datetime-local" name="internal_event[start_at]" id="internal_event_start_at"/>
+      <input id="internal-event-readable-id-field" class="govuk-input" aria-describedby="internal-event-readable-id-hint" data-internal-events-target="partialUrl" type="text" name="internal_event[readable_id]"/>
+      <button id="generate" name="button" type="button" class="button form-button" data-target="internal-events.generateButton" data-action="click->internal-events#populatePartialUrl">Generate partial <span>URL</span></button>
+    </form>
+  `;
 
-  beforeEach(() => {
-    controller = new InternalEventsController();
-  });
+  const application = Application.start();
+  application.register('internal-events', InternalEventsController);
 
-  describe('#formatDate()', () => {
-    it('returns an empty string when date an empty string', () => {
-      const result = controller.formatDate('');
+  describe('clicking "generate partial URL" button', () => {
+    describe('start at time is selected', () => {
+      beforeEach(
+        () =>
+          (document.getElementById('internal_event_start_at').value =
+            '2021-05-15T10:51')
+      );
 
-      expect(result).toBe('');
+      it('replaces name internal whitespace with hyphens', () => {
+        document.getElementById('internal-event-name-field').value =
+          'event     name';
+
+        document.getElementById('generate').click();
+
+        const partialUrlFieldValue = document.getElementById(
+          'internal-event-readable-id-field'
+        ).value;
+        expect(partialUrlFieldValue).toBe('210515-event-name');
+      });
+
+      it('trims name surrounding whitespace', () => {
+        document.getElementById('internal-event-name-field').value =
+          '  event name  ';
+
+        document.getElementById('generate').click();
+
+        const partialUrlFieldValue = document.getElementById(
+          'internal-event-readable-id-field'
+        ).value;
+        expect(partialUrlFieldValue).toBe('210515-event-name');
+      });
+
+      it('converts characters to lower case', () => {
+        document.getElementById('internal-event-name-field').value =
+          'EVENT NAME';
+
+        document.getElementById('generate').click();
+
+        const partialUrlFieldValue = document.getElementById(
+          'internal-event-readable-id-field'
+        ).value;
+        expect(partialUrlFieldValue).toBe('210515-event-name');
+      });
     });
 
-    it('returns a formatted date', () => {
-      const result = controller.formatDate('2021-05-15T10:51');
-
-      expect(result).toBe('210515');
-    });
-  });
-
-  describe('#formatName()', () => {
-    it('returns an empty string when name an empty string', () => {
-      const result = controller.formatName('');
-
-      expect(result).toBe('');
-    });
-
-    it('trims surrounding whitespace', () => {
-      const result = controller.formatName(' name ');
-
-      expect(result).toBe('name');
-    });
-
-    it('converts characters to lower case', () => {
-      const result = controller.formatName('TEST');
-
-      expect(result).toBe('test');
-    });
-
-    it('replaces internal whitespace with hyphens', () => {
-      const result = controller.formatName('event name');
-
-      expect(result).toBe('event-name');
-    });
-  });
-
-  describe('#generatePartialUrl()', () => {
-    it('returns an empty string when date is an empty string', () => {
-      const result = controller.generatePartialUrl('', 'name');
-
-      expect(result).toBe('');
-    });
-
-    it('returns an empty string when name is an empty string', () => {
-      const result = controller.generatePartialUrl('date', '');
-
-      expect(result).toBe('');
-    });
-
-    it('returns a formatted partial URL', () => {
-      const result = controller.generatePartialUrl('210515', 'event-name');
-
-      expect(result).toBe('210515-event-name');
-    });
+    describe('start at is not set', () => {});
   });
 });

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -7,6 +7,9 @@ describe('InternalEventsController', () => {
       <input id="internal-event-name-field" class="govuk-input" data-internal-events-target="name"/>
       <input class="datetime govuk-input" data-internal-events-target="startAt" type="datetime-local" name="internal_event[start_at]" id="internal_event_start_at"/>
       <input id="internal-event-readable-id-field" class="govuk-input" aria-describedby="internal-event-readable-id-hint" data-internal-events-target="partialUrl" type="text" name="internal_event[readable_id]"/>
+      <span class="govuk-error-message hidden" id="internal-generate-url-error" data-internal-events-target="errorMessage">
+        <span class="govuk-visually-hidden">Error: </span>Name and Start at fields must have values in order to generate partial URL
+      </span>
       <button id="generate" name="button" type="button" class="button form-button" data-target="internal-events.generateButton" data-action="click->internal-events#populatePartialUrl">Generate partial <span>URL</span></button>
     </form>
   `;
@@ -15,50 +18,122 @@ describe('InternalEventsController', () => {
   application.register('internal-events', InternalEventsController);
 
   describe('clicking "generate partial URL" button', () => {
-    describe('start at time is selected', () => {
+    afterEach(() => {
+      document.getElementById('internal_event_start_at').value = '';
+      document.getElementById('internal-event-name-field').value = '';
+    });
+
+    describe('event name and start at have values', () => {
       beforeEach(
         () =>
           (document.getElementById('internal_event_start_at').value =
             '2021-05-15T10:51')
       );
 
-      it('replaces name internal whitespace with hyphens', () => {
-        document.getElementById('internal-event-name-field').value =
-          'event     name';
+      describe('name', () => {
+        it('replaces internal whitespace with hyphens', () => {
+          document.getElementById('internal-event-name-field').value =
+            'event     name';
 
-        document.getElementById('generate').click();
+          document.getElementById('generate').click();
 
-        const partialUrlFieldValue = document.getElementById(
-          'internal-event-readable-id-field'
-        ).value;
-        expect(partialUrlFieldValue).toBe('210515-event-name');
+          const partialUrlFieldValue = document.getElementById(
+            'internal-event-readable-id-field'
+          ).value;
+          expect(partialUrlFieldValue).toBe('210515-event-name');
+        });
+
+        it('trims surrounding whitespace', () => {
+          document.getElementById('internal-event-name-field').value =
+            '  event name  ';
+
+          document.getElementById('generate').click();
+
+          const partialUrlFieldValue = document.getElementById(
+            'internal-event-readable-id-field'
+          ).value;
+          expect(partialUrlFieldValue).toBe('210515-event-name');
+        });
+
+        it('converts characters to lower case', () => {
+          document.getElementById('internal-event-name-field').value =
+            'EVENT NAME';
+
+          document.getElementById('generate').click();
+
+          const partialUrlFieldValue = document.getElementById(
+            'internal-event-readable-id-field'
+          ).value;
+          expect(partialUrlFieldValue).toBe('210515-event-name');
+        });
       });
 
-      it('trims name surrounding whitespace', () => {
+      it('previous error message is removed', () => {
         document.getElementById('internal-event-name-field').value =
-          '  event name  ';
+          'event name';
+        const errorMessage = document.getElementById(
+          'internal-generate-url-error'
+        );
+        errorMessage.style.display = 'block';
 
         document.getElementById('generate').click();
 
-        const partialUrlFieldValue = document.getElementById(
-          'internal-event-readable-id-field'
-        ).value;
-        expect(partialUrlFieldValue).toBe('210515-event-name');
-      });
-
-      it('converts characters to lower case', () => {
-        document.getElementById('internal-event-name-field').value =
-          'EVENT NAME';
-
-        document.getElementById('generate').click();
-
-        const partialUrlFieldValue = document.getElementById(
-          'internal-event-readable-id-field'
-        ).value;
-        expect(partialUrlFieldValue).toBe('210515-event-name');
+        expect(errorMessage.style.display).toBe('none');
       });
     });
 
-    describe('start at is not set', () => {});
+    describe('start at has no value', () => {
+      beforeEach(() => {
+        document.getElementById('internal-event-name-field').value = 'name';
+      });
+
+      it('displays error message', () => {
+        document.getElementById('generate').click();
+
+        const errorMessage = document.getElementById(
+          'internal-generate-url-error'
+        );
+        expect(errorMessage.style.display).toBe('block');
+      });
+
+      it('empties partial URL field value', () => {
+        const partialUrl = document.getElementById(
+          'internal-event-readable-id-field'
+        );
+        partialUrl.value = 'test';
+
+        document.getElementById('generate').click();
+
+        expect(partialUrl.value).toBe('');
+      });
+    });
+
+    describe('name has no value', () => {
+      beforeEach(() => {
+        document.getElementById('internal_event_start_at').value =
+          '2021-05-15T10:51';
+      });
+
+      it('displays error message', () => {
+        document.getElementById('generate').click();
+
+        const errorMessage = document.getElementById(
+          'internal-generate-url-error'
+        );
+
+        expect(errorMessage.style.display).toBe('block');
+      });
+
+      it('empties partial URL field value', () => {
+        const partialUrl = document.getElementById(
+          'internal-event-readable-id-field'
+        );
+        partialUrl.value = 'test';
+
+        document.getElementById('generate').click();
+
+        expect(partialUrl.value).toBe('');
+      });
+    });
   });
 });

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -66,6 +66,18 @@ describe('InternalEventsController', () => {
           ).value;
           expect(partialUrlFieldValue).toBe('210515-event-name');
         });
+
+        it('removes extra hyphens', () => {
+          document.getElementById('internal-event-name-field').value =
+            'event - name - with - hyphens';
+
+          document.getElementById('generate').click();
+
+          const partialUrlFieldValue = document.getElementById(
+            'internal-event-readable-id-field'
+          ).value;
+          expect(partialUrlFieldValue).toBe('210515-event-name-with-hyphens');
+        });
       });
 
       it('previous error message is removed', () => {

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -1,0 +1,69 @@
+import InternalEventsController from 'internal_events_controller.js';
+
+describe('InternalEventsController', () => {
+  let controller;
+
+  beforeEach(() => {
+    controller = new InternalEventsController();
+  });
+
+  describe('#formatDate()', () => {
+    it('returns an empty string when date an empty string', () => {
+      const result = controller.formatDate('');
+
+      expect(result).toBe('');
+    });
+
+    it('returns a formatted date', () => {
+      const result = controller.formatDate('2021-05-15T10:51');
+
+      expect(result).toBe('210515');
+    });
+  });
+
+  describe('#formatName()', () => {
+    it('returns an empty string when name an empty string', () => {
+      const result = controller.formatName('');
+
+      expect(result).toBe('');
+    });
+
+    it('trims surrounding whitespace', () => {
+      const result = controller.formatName(' name ');
+
+      expect(result).toBe('name');
+    });
+
+    it('converts characters to lower case', () => {
+      const result = controller.formatName('TEST');
+
+      expect(result).toBe('test');
+    });
+
+    it('replaces internal whitespace with hyphens', () => {
+      const result = controller.formatName('event name');
+
+      expect(result).toBe('event-name');
+    });
+  });
+
+  describe('#generatePartialUrl()', () => {
+    it('returns an empty string when date is an empty string', () => {
+      const result = controller.generatePartialUrl('', 'name');
+
+      expect(result).toBe('');
+    });
+
+    it('returns an empty string when name is an empty string', () => {
+      const result = controller.generatePartialUrl('date', '');
+
+      expect(result).toBe('');
+    });
+
+    it('returns a formatted partial URL', () => {
+      const result = controller.generatePartialUrl('210515', 'event-name');
+
+      expect(result).toBe('210515-event-name');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,6 +6312,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
+  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
+
 make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
### Trello card
https://trello.com/c/l8pD2kl7

### Context
The CRM team requested a way to generate partial URLs based on the event name and start date.

### Changes proposed in this pull request
- Add button to generate partial URL

### Guidance to review
- I originally did this on name/date change. But I thought that could be annoying if you choose a custom name, then change name or date.
- Tested this by testing the individual methods, do I need to set up the HTML template like some of the other controllers instead/as well?
- Should this have some feedback when name or date is not set? Would this just be an error message (suppose I could just hide the button until they are set)?
- I replace whitespace with hyphens to match the other events, are there any other characters that shouldn't appear in a URL?