### PR TITLE
Add support for responsive images

### DIFF
--- a/app/components/sections/hero_component.rb
+++ b/app/components/sections/hero_component.rb
@@ -22,7 +22,7 @@ module Sections
     end
 
     def background_image
-      tag.div(class: "hero__img", style: "background-image: url(#{image_path})")
+      tag.img(src: image_path, data: { "lazy-disable": true })
     end
 
     def show_subtitle?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 require "next_gen_images"
 require "lazy_load_images"
+require "responsive_images"
 
 class ApplicationController < ActionController::Base
   include UtmCodes
@@ -36,6 +37,7 @@ private
     return unless response_is_html?
 
     response.body = NextGenImages.new(response.body).html
+    response.body = ResponsiveImages.new(response.body).html
     response.body = LazyLoadImages.new(response.body).html
   end
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -41,7 +41,7 @@ $mobile-cutoff: 800px;
     }
   }
 
-  &__img {
+  > picture {
     float: right;
     max-width: 50%;
     display: none;
@@ -99,7 +99,7 @@ $mobile-cutoff: 800px;
       }
     }
 
-    &__img {
+    > picture {
       min-height: 10em;
       grid-area: -5 / -4 / -3 / -1;
     }
@@ -124,7 +124,7 @@ $mobile-cutoff: 800px;
         grid-area: 5 / 1 / 7 / 4;
       }
 
-      &__img {
+      > picture {
         grid-area: -6 / -6 / -1 / -1;
       }
     }
@@ -190,12 +190,15 @@ $mobile-cutoff: 800px;
     }
   }
 
-  &__img {
+  > picture {
     height: 100%;
     width: 100%;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
+
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
 
     @include safari-only {
       max-height: 30em;

--- a/lib/responsive_images.rb
+++ b/lib/responsive_images.rb
@@ -1,0 +1,67 @@
+# Responsive images are automatically loaded according to
+# the convention:
+#
+# /path/to/image--<breakpoint>.ext
+#
+# For example, if a default image exists:
+#
+# /path/to/image.png
+#
+# You can ensure a tablet version is displayed on all devices
+# that have a viewport < 768px by creating the file:
+#
+# /path/to/image--tablet.png
+class ResponsiveImages
+  BREAKPOINTS = {
+    mobile: "500px",
+    tablet: "768px",
+    desktop: "1000px",
+    wide: "1500px",
+  }.freeze
+
+  def initialize(page)
+    @page = page
+  end
+
+  def html
+    doc = Nokogiri::HTML(@page)
+
+    doc.css("picture source").each do |source|
+      BREAKPOINTS.each do |breakpoint, max_width|
+        prepend_responsive_source(source, breakpoint, max_width)
+      end
+    end
+
+    doc.to_html(encoding: "UTF-8", indent: 2)
+  end
+
+private
+
+  def prepend_responsive_source(source, breakpoint, max_width)
+    responsive_src = responsive_src(source["srcset"], breakpoint)
+    return if responsive_src.blank?
+
+    responsive_source = source.dup
+    responsive_source["srcset"] = responsive_src
+    responsive_source["media"] = "(max-width: #{max_width})"
+
+    source.add_previous_sibling(responsive_source)
+  end
+
+  def responsive_src(src, breakpoint)
+    file = responsive_file(src, breakpoint)
+    file&.sub(Rails.public_path.to_s, "")
+  end
+
+  def responsive_file(src, breakpoint)
+    ext = File.extname(src)
+
+    basename = if Rails.env.development?
+                 src.sub(/#{ext}$/, "")
+               else
+                 src.sub(/\-[^-]*#{ext}$/, "")
+               end
+
+    Dir.glob("#{Rails.public_path}#{basename}--#{breakpoint}*#{ext}").first
+  end
+end

--- a/spec/components/sections/hero_component_spec.rb
+++ b/spec/components/sections/hero_component_spec.rb
@@ -57,7 +57,7 @@ describe Sections::HeroComponent, type: "component" do
 
       context "when an image is present in the front matter" do
         specify "the hero renders it" do
-          expect(page).to have_css(%(div.hero__img))
+          expect(page).to have_css("img[data-lazy-disable=true]")
           expect(rendered_component).to match(/images\/hero-home-dt-[0-9a-f]+\.jpg/)
         end
       end

--- a/spec/lib/responsive_images_spec.rb
+++ b/spec/lib/responsive_images_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+require "responsive_images"
+
+describe ResponsiveImages do
+  describe "#html" do
+    let(:fingerprint) { "-fingerprint1" }
+    let(:src) { "/assets/images/an-image#{fingerprint}.jpg" }
+    let(:body) do
+      "<picture>
+        <source srcset=\"#{src}\" type=\"image/jpeg\"></source>
+        <img src=\"#{src}\">
+      </picture>"
+    end
+    let(:instance) { described_class.new(body) }
+
+    before { allow(Dir).to receive(:glob).and_call_original }
+
+    subject { instance.html }
+
+    it { is_expected.to include(body) }
+
+    described_class::BREAKPOINTS.each do |breakpoint, max_width|
+      context "when a #{breakpoint} image exists" do
+        let!(:responsive_src) { setup_responsive_img(breakpoint) }
+
+        it do
+          is_expected.to include(
+            "<source srcset=\"#{responsive_src}\" type=\"image/jpeg\" media=\"(max-width: #{max_width})\"></source>",
+          )
+        end
+      end
+    end
+
+    context "when multiple responsive images exist" do
+      let!(:tablet_src) { setup_responsive_img(:tablet) }
+      let!(:mobile_src) { setup_responsive_img(:mobile) }
+
+      it "renders smallest <source> first" do
+        is_expected.to include(
+          "<source srcset=\"#{mobile_src}\" type=\"image/jpeg\" media=\"(max-width: 500px)\"></source>" \
+          "<source srcset=\"#{tablet_src}\" type=\"image/jpeg\" media=\"(max-width: 768px)\"></source>",
+        )
+      end
+    end
+
+    context "when fingerprinting is disabled (in development)" do
+      let(:fingerprint) { "" }
+      let!(:responsive_src) { setup_responsive_img(:mobile) }
+
+      before { allow(Rails).to receive(:env) { "development".inquiry } }
+
+      it do
+        is_expected.to include(
+          "<source srcset=\"#{responsive_src}\" type=\"image/jpeg\" media=\"(max-width: 500px)\"></source>", \
+        )
+      end
+    end
+  end
+
+  def setup_responsive_img(breakpoint)
+    fingerprint = "1234abc"
+    responsive_src = "/assets/images/an-image--#{breakpoint}-#{fingerprint}.jpg"
+    responsive_file = "#{Rails.public_path}#{responsive_src}"
+    responsive_pattern = "#{Rails.public_path}/assets/images/an-image--#{breakpoint}*.jpg"
+
+    allow(Dir).to receive(:glob).with(responsive_pattern) { [responsive_file] }
+
+    responsive_src
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1538](https://trello.com/c/4Pt8xMys/1538-create-and-deploy-responsive-hero-images-ensure-consistency-in-size-dimensions)

### Context

Currently we don't have an easy way of displaying different images to different devices. Ideally, we want to be able to serve a different image depending on the device being used (mobile, tablet, desktop, etc).

### Changes proposed in this pull request

- Switch hero background images for img tags

We want to serve these responsively, so we need to use an `img` tag within a `picture` tag that will enable us to set `srcset` and `size` attributes.

- Support responsive images

Add `ResponsiveImages` lib that will generate the appropriate `source` tags for any responsive images that it finds present in the filesystem. The images must take a specific format to be used:

```
/path/to/image--<breakpoint>.ext
```

If a responsive image is found, it will be displayed for the device specified in the `breakpoint` and all smaller viewports (unless a specific image exists for a smaller breakpoint):

```
mobile: "500px"
tablet: "768px"
desktop: "1000px"
wide: "1500px"
```

For example, if a default image exists:

```
/path/to/image.png
```

You can ensure a tablet version is displayed on all devices that have a viewport < 768px by creating the file:

```
/path/to/image--tablet.png
```

### Guidance to review

I've included a test mobile version of the story photo on [this page](https://review-get-into-teaching-app-1215.london.cloudapps.digital/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching) to make reviewing easier. I'll remove the test image before the PR is merged down.

| Mobile      | Tablet |
| ----------- | ----------- |
| <img width="497" alt="Screenshot 2021-05-05 at 13 47 46" src="https://user-images.githubusercontent.com/29867726/117143196-7bea5d80-ada8-11eb-9930-f57cb131951c.png"> | <img width="730" alt="Screenshot 2021-05-05 at 13 48 04" src="https://user-images.githubusercontent.com/29867726/117143240-86a4f280-ada8-11eb-88db-984c748b7520.png"> |

Lazy loading has been disabled for the hero images to avoid a flicker when the page initially loads (its not noticeable on content images but the hero images are all in the same location so it can be a bit off-putting).