### PR TITLE
Add button to duplicate events

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -24,15 +24,13 @@ module Internal
     end
 
     def new
-      @event_type = determine_event_type(params[:event_type])
-      @event = Event.new(venue_type: Event::VENUE_TYPES[:existing], type_id: @event_type)
-      @event.building = EventBuilding.new
       if params[:duplicate]
         @event = get_event_by_id(params[:duplicate])
         @event.id = nil
         @event.readable_id = nil
       else
-        @event = Event.new(venue_type: Event::VENUE_TYPES[:existing])
+        @event_type = determine_event_type(params[:event_type])
+        @event = Event.new(venue_type: Event::VENUE_TYPES[:existing], type_id: @event_type)
         @event.building = EventBuilding.new
       end
     end

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -50,6 +50,11 @@ module Internal
     def edit
       api_event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
       @event = Event.initialize_with_api_event(api_event)
+      if params[:duplicated]
+        @event.id = nil
+        @event.readable_id = nil
+      end
+
       render :new
     end
 

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -27,6 +27,14 @@ module Internal
       @event_type = determine_event_type(params[:event_type])
       @event = Event.new(venue_type: Event::VENUE_TYPES[:existing], type_id: @event_type)
       @event.building = EventBuilding.new
+      if params[:duplicate]
+        @event = get_event_by_id(params[:duplicate])
+        @event.id = nil
+        @event.readable_id = nil
+      else
+        @event = Event.new(venue_type: Event::VENUE_TYPES[:existing])
+        @event.building = EventBuilding.new
+      end
     end
 
     def approve
@@ -48,12 +56,7 @@ module Internal
     end
 
     def edit
-      api_event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
-      @event = Event.initialize_with_api_event(api_event)
-      if params[:duplicated]
-        @event.id = nil
-        @event.readable_id = nil
-      end
+      @event = get_event_by_id(params[:id])
 
       render :new
     end
@@ -66,6 +69,11 @@ module Internal
 
     def event_type_name
       params[:event_type] || DEFAULT_EVENT_TYPE
+    end
+
+    def get_event_by_id(event_id)
+      api_event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(event_id)
+      @event = Event.initialize_with_api_event(api_event)
     end
 
     def authorize_publisher

--- a/app/views/internal/events/show.html.erb
+++ b/app/views/internal/events/show.html.erb
@@ -15,6 +15,11 @@
         <%= button_to "Edit this event",
                       edit_internal_event_path(@event.readable_id), method: :get,
                       class: "button notification-button" %>
+        <%= button_to "Duplicate this event",
+                      edit_internal_event_path(@event.readable_id), params: { duplicated: true },
+                      method: :get,
+                      class: "button notification-button",
+                      form: { target: '_blank' } %>
         <% if publisher? %>
           <%= button_to "Set event status to Open",
                         internal_approve_path, params: { id: @event.readable_id }, method: :put,

--- a/app/views/internal/events/show.html.erb
+++ b/app/views/internal/events/show.html.erb
@@ -16,7 +16,7 @@
                       edit_internal_event_path(@event.readable_id), method: :get,
                       class: "button notification-button" %>
         <%= button_to "Duplicate this event",
-                      edit_internal_event_path(@event.readable_id), params: { duplicated: true },
+                      new_internal_event_path, params: { duplicate: @event.readable_id },
                       method: :get,
                       class: "button notification-button",
                       form: { target: '_blank' } %>

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -166,48 +166,48 @@ describe Internal::EventsController do
         expect(response.body).to include("#{event_params ? event_params.capitalize : 'Provider'} event details")
       end
 
-      context "when event is duplicated" do
-        let(:event_to_duplicate_readable_id) { "1" }
+      context "when any user type" do
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
             .to receive(:get_teaching_event_buildings) { [] }
-          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-            .to receive(:get_teaching_event).with(event_to_duplicate_readable_id) { pending_online_event }
         end
 
-        it "renders the events form with populated fields" do
-          get new_internal_event_path(duplicate: event_to_duplicate_readable_id), headers: generate_auth_headers(:author)
+        context "when event is duplicated" do
+          let(:event_to_duplicate_readable_id) { "1" }
+          before do
+            allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
+              .to receive(:get_teaching_event_buildings) { [] }
+            allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+              .to receive(:get_teaching_event).with(event_to_duplicate_readable_id) { pending_online_event }
+          end
 
-          assert_response :success
-          expect(response.body).to include("value=\"Pending online event\"")
+          it "renders the events form with populated fields" do
+            get new_internal_event_path(duplicate: event_to_duplicate_readable_id), headers: generate_auth_headers(:author)
+
+            assert_response :success
+            expect(response.body).to include("value=\"Pending online event\"")
+          end
+
+          it "removes 'id' and 'partial url' values" do
+            get new_internal_event_path(duplicate: event_to_duplicate_readable_id), headers: generate_auth_headers(:author)
+
+            assert_response :success
+            expect(css_select("#internal_event_id").first[:value]).to be_nil
+            expect(css_select("#internal-event-readable-id-field").first[:value]).to be_nil
+          end
         end
 
-        it "removes 'id' and 'partial url' values" do
-          get new_internal_event_path(duplicate: event_to_duplicate_readable_id), headers: generate_auth_headers(:author)
-
-          assert_response :success
-          expect(css_select("#internal_event_id").first[:value]).to be_nil
-          expect(css_select("#internal-event-readable-id-field").first[:value]).to be_nil
+        context "when no event type parameter" do
+          include_examples "new event"
         end
-      end
-    end
 
-    context "when any user type" do
-      before do
-        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-          .to receive(:get_teaching_event_buildings) { [] }
-      end
+        context "when provider event type parameter" do
+          include_examples "new event", "provider"
+        end
 
-      context "when no event type parameter" do
-        include_examples "new event"
-      end
-
-      context "when provider event type parameter" do
-        include_examples "new event", "provider"
-      end
-
-      context "when online event type parameter" do
-        include_examples "new event", "online"
+        context "when online event type parameter" do
+          include_examples "new event", "online"
+        end
       end
     end
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -184,6 +184,13 @@ describe Internal::EventsController do
       context "when online event type parameter" do
         include_examples "new event", "online"
       end
+
+      it "removes 'id' and 'partial url' when event is duplicated" do
+        get edit_internal_event_path(event_to_edit_readable_id, duplicated: true), headers: generate_auth_headers(:author)
+        assert_response :success
+        expect(css_select("#internal_event_id").first[:value]).to be_nil
+        expect(css_select("#internal-event-readable-id-field").first[:value]).to be_nil
+      end
     end
 
     describe "#edit" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/l8pD2kl7

### Context
The CRM team requested a way to duplicate events as a time saving measure. It is very common for multiple events to have the same/similar details.

### Changes proposed in this pull request
- Add button to duplicate event

### Guidance to review
I wanted to add a features spec like this. It was a bit awkward though (I was having to turn off WebMock for a Capybara `__identify__` request), and I was getting a false positive so I abandoned it. 
 
Okay to rely on request spec only for this?

```ruby
  before do
    WebMock.allow_net_connect!
  end

  after do
    WebMock.disable_net_connect!
  end

  scenario "Duplicate event", js: true do
    navigate_to_existing_event

    new_tab = window_opened_by { click_button "Duplicate this event" }
    within_window new_tab do
      page.driver.browser.authorize("publisher", "password")
      expect(page).to have_field("Event partial URL", with: "hello")
    end
  end
end

```