### PR TITLE
Speed up content checks by not repeating requests

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -1,7 +1,20 @@
 require "rails_helper"
 
+class StoredPage
+  attr_accessor :path, :status_code, :body
+
+  def initialize(path, status_code, body)
+    @path        = path
+    @status_code = status_code
+    @body        = body
+  end
+end
+
 RSpec.feature "content pages check", type: :feature, content: true do
   include_context "stub types api"
+
+  let(:other_paths) { %w[/ /search /tta-service /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }
+  let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}] }
 
   before do
     # we don't care about the contents of the events pages here, just
@@ -12,49 +25,74 @@ RSpec.feature "content pages check", type: :feature, content: true do
   end
 
   let(:document) { Nokogiri.parse(page.body) }
-  let(:statuses_deemed_successful) { Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently) }
 
-  PageLister.content_urls.each do |url|
-    describe "visiting #{url}" do
-      let(:url) { url }
-      before { visit(url) }
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
+    statuses_deemed_successful = Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently)
 
-      scenario "checking that #{url} responds with success" do
-        expect(page).to have_http_status :success
-      end
+    @stored_pages = PageLister.content_urls.map do |path|
+      visit(path)
 
-      scenario "the anchor links reference existing IDs" do
-        document
+      fail unless page.status_code.in?(statuses_deemed_successful)
+
+      StoredPage.new(path, page.status_code, Nokogiri.parse(page.body))
+    end
+
+    @stored_pages_by_path = @stored_pages.index_by(&:path)
+  end
+
+  after(:all) { @stored_pages = nil }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  describe "content checks" do
+    scenario "responds with success" do
+      expect(@stored_pages.map(&:status_code)).to all(be(200))
+    end
+
+    scenario "the anchor links reference existing IDs" do
+      @stored_pages.each do |sp|
+        sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
           .select { |href| href.start_with?("#") }
           .reject { |href| href == "#" }
           .each do |href|
-            expect(page).to have_css(href)
+            expect(sp.body).to have_css(href)
           end
       end
+    end
 
-      scenario "there are no localhost links" do
-        document
+    scenario "there are no localhost links" do
+      @stored_pages.each do |sp|
+        sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
           .each { |href| expect(href).not_to match(%r{https?://(localhost|127\.0\.0\.1|::1)}) }
       end
+    end
 
-      scenario "the internal images exist" do
-        document
+    scenario "the internal images exist" do
+      images = []
+      @stored_pages.each do |sp|
+        sp.body
           .css("img")
           .map { |img| img["data-src"] || img["src"] }
           .reject { |src| src.start_with?("http") }
           .uniq
           .each do |src|
+            next unless src.in?(images)
+
             visit(src)
-            expect(page).to have_http_status(:success), "invalid image src on #{url} - #{src}"
+            expect(page).to have_http_status(:success), "invalid image src on #{sp.path} - #{src}"
+            images.push(src)
           end
       end
+    end
 
-      scenario "the internal links reference existing pages" do
-        document
+    scenario "the internal links reference existing pages" do
+      paths = other_paths.concat(@stored_pages.map(&:path))
+      @stored_pages.each do |sp|
+        sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
           .reject { |href| href.start_with?(Regexp.union("http:", "https:", "tel:", "mailto:")) }
@@ -62,56 +100,60 @@ RSpec.feature "content pages check", type: :feature, content: true do
           .select { |href| href.start_with?(Regexp.union("/", /\w+/)) }
           .uniq
           .each do |href|
-            visit(href)
+            next if ignored_path_patterns.any? { |p| p.match?(href) }
 
-            expect(page.status_code).to(be_in(statuses_deemed_successful), "#{href} resulted in #{page.status_code}")
+            uri = URI.parse(href)
 
-            if (fragment = URI.parse(href).fragment)
-              expect(page).to(have_css("#" + fragment), "invalid link on #{url} - #{href}, (missing fragment #{fragment})")
+            expect(paths).to include(uri.path)
+
+            if (fragment = uri.fragment)
+              expect(@stored_pages_by_path[uri.path].body).to(have_css("#" + fragment), "invalid link on #{sp.path} - #{href}, (missing fragment #{fragment})")
             end
           end
       end
+    end
 
-      scenario "there are no internal links that contain the site's domain" do
-        document
+    scenario "there are no internal links that contain the site's domain" do
+      @stored_pages.each do |sp|
+        sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
           .each do |href|
-            expect(href).not_to start_with("https://getintoteaching.education.gov.uk")
-            expect(href).not_to start_with("http://getintoteaching.education.gov.uk")
-          end
+          expect(href).not_to start_with("https://getintoteaching.education.gov.uk")
+          expect(href).not_to start_with("http://getintoteaching.education.gov.uk")
+        end
+      end
+    end
+  end
+end
+
+describe "navbar" do
+  subject { page }
+
+  before { visit "/" }
+
+  let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
+
+  scenario "navigable pages appear in desktop navbar" do
+    navigation_pages.each do |url, frontmatter|
+      page.within "nav .navbar__desktop" do
+        is_expected.to have_link frontmatter[:title], href: url
       end
     end
   end
 
-  describe "navbar" do
-    subject { page }
-
-    before { visit "/" }
-
-    let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
-
-    scenario "navigable pages appear in desktop navbar" do
-      navigation_pages.each do |url, frontmatter|
-        page.within "nav .navbar__desktop" do
-          is_expected.to have_link frontmatter[:title], href: url
-        end
+  scenario "navigable pages appear in mobile navbar" do
+    navigation_pages.each do |url, frontmatter|
+      page.within "nav .navbar__mobile" do
+        is_expected.to have_link frontmatter[:title], href: url
       end
     end
+  end
 
-    scenario "navigable pages appear in mobile navbar" do
-      navigation_pages.each do |url, frontmatter|
-        page.within "nav .navbar__mobile" do
-          is_expected.to have_link frontmatter[:title], href: url
-        end
-      end
-    end
-
-    scenario "mobile nav matches desktop nav" do
-      document.css("nav .navbar__desktop a").each do |desktop_link|
-        page.within "nav .navbar__mobile" do
-          is_expected.to have_link desktop_link.text, href: desktop_link["href"]
-        end
+  scenario "mobile nav matches desktop nav" do
+    document.css("nav .navbar__desktop a").each do |desktop_link|
+      page.within "nav .navbar__mobile" do
+        is_expected.to have_link desktop_link.text, href: desktop_link["href"]
       end
     end
   end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -24,8 +24,6 @@ RSpec.feature "content pages check", type: :feature, content: true do
       .and_return([])
   end
 
-  let(:document) { Nokogiri.parse(page.body) }
-
   # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do
     statuses_deemed_successful = Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently)
@@ -125,35 +123,36 @@ RSpec.feature "content pages check", type: :feature, content: true do
       end
     end
   end
-end
 
-describe "navbar" do
-  subject { page }
+  describe "navbar" do
+    subject { page }
 
-  before { visit "/" }
+    before { visit "/" }
+    let(:document) { Nokogiri.parse(page.body) }
 
-  let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
+    let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }
 
-  scenario "navigable pages appear in desktop navbar" do
-    navigation_pages.each do |url, frontmatter|
-      page.within "nav .navbar__desktop" do
-        is_expected.to have_link frontmatter[:title], href: url
+    scenario "navigable pages appear in desktop navbar" do
+      navigation_pages.each do |url, frontmatter|
+        page.within "nav .navbar__desktop" do
+          is_expected.to have_link frontmatter[:title], href: url
+        end
       end
     end
-  end
 
-  scenario "navigable pages appear in mobile navbar" do
-    navigation_pages.each do |url, frontmatter|
-      page.within "nav .navbar__mobile" do
-        is_expected.to have_link frontmatter[:title], href: url
+    scenario "navigable pages appear in mobile navbar" do
+      navigation_pages.each do |url, frontmatter|
+        page.within "nav .navbar__mobile" do
+          is_expected.to have_link frontmatter[:title], href: url
+        end
       end
     end
-  end
 
-  scenario "mobile nav matches desktop nav" do
-    document.css("nav .navbar__desktop a").each do |desktop_link|
-      page.within "nav .navbar__mobile" do
-        is_expected.to have_link desktop_link.text, href: desktop_link["href"]
+    scenario "mobile nav matches desktop nav" do
+      document.css("nav .navbar__desktop a").each do |desktop_link|
+        page.within "nav .navbar__mobile" do
+          is_expected.to have_link desktop_link.text, href: desktop_link["href"]
+        end
       end
     end
   end


### PR DESCRIPTION
Previously every single page and link check used `visit` to load the page, this creates lots of duplicate (identical) requests.

Now the loops are run _inside_ the `scenario`, so it looks like there are fewer tests but there should be an equal number of assertions.

Some benchmarks:

```
 .../get-into-teaching-app speed-up-content-checks[8e217dd8] ✔ $
 ❯ time bundle exec rspec --tag content
Run options:
  include {:content=>true}
  exclude {:onschedule=>true}

Randomized with seed 48196
.............................................................................................................................................................................................................................................................................................................................................................................................

Finished in 3 minutes 51.4 seconds (files took 1.83 seconds to load)
381 examples, 0 failures

Randomized with seed 48196

bundle exec rspec --tag content  213.33s user 18.82s system 99% cpu 3:53.74 total

 .../get-into-teaching-app master[5eaeee71] ✔ $
 ❯ git switch speed-up-content-checks
Switched to branch 'speed-up-content-checks'

 .../get-into-teaching-app speed-up-content-checks[8e217dd8] ✔ $
 ❯ time bundle exec rspec --tag content
Use the new slots API (https://viewcomponent.org/guide/slots.html) instead. (called from <class:AccordionComponent> at /home/peter/projects/department-for-education/current/get-into-teaching-app/app/components/content/accordion_component.rb:6)
Run options:
  include {:content=>true}
  exclude {:onschedule=>true}

Randomized with seed 49356
......

Finished in 11.86 seconds (files took 1.83 seconds to load)
6 examples, 0 failures

Randomized with seed 49356

bundle exec rspec --tag content  13.02s user 1.06s system 99% cpu 14.160 total
```

From 213 seconds to 13 seconds. Not bad.
