### PR TITLE
Enable VWO in preprod on certain paths

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,6 +4,5 @@ GOOGLE_ANALYTICS_ID=GTM-K7TK4WM
 BAM_ID=1
 LID_ID=1
 HOTJAR_ID=1871524
-VWO_ID=524595
 TTA_SERVICE_URL="https://adviser-getintoteaching.education.gov.uk/"
 FAIL2BAN=1

--- a/config/vwo.yml
+++ b/config/vwo.yml
@@ -7,3 +7,6 @@
 #   - /
 
 paths:
+  - /
+  - /mailinglist/signup/name
+  - /steps-to-become-a-teacher


### PR DESCRIPTION
- Enable VWO on certain pages

We want to enable VWO on the following pages:

```
/
/steps-to-become-a-teacher
/mailinglist/signup/name
```

- Disable VWO in production

We just want to enable VWO in our preprod environment for now - once we're happy with it we will toggle it back on in production.
