### PR TITLE
Add configurable quote component

### DIFF
--- a/app/components/content/quote_component.html.erb
+++ b/app/components/content/quote_component.html.erb
@@ -1,0 +1,25 @@
+<%= tag.blockquote(class: quote_class) do %>
+  <p><%= text_sans_last_word %><span><%= text_last_word %></span></p>
+  <% if show_footer? %>
+    <%= tag.footer(class: footer_class) do %>
+      <div class="author">
+        <% if image.present? %>
+          <%= image_pack_tag(image) %>
+        <% end %>
+        <div>
+          <% if name.present? %>
+            <cite class="name"><%= name %></cite>
+          <% end %>
+          <% if job_title.present? %>
+            <cite class="job-title"><%= job_title %></cite>
+          <% end %>
+        </div>
+      </div>
+      <% if cta.present? %>
+        <%= link_to(cta[:link], class: "button button--smaller") do %>
+          <%= cta_title_sans_last_word %> <span><%= cta_title_last_word %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/content/quote_component.rb
+++ b/app/components/content/quote_component.rb
@@ -1,0 +1,63 @@
+module Content
+  class QuoteComponent < ViewComponent::Base
+    attr_reader :text, :name, :job_title, :cta, :image, :hang, :inline
+
+    def initialize(
+      text:,
+      name: nil,
+      job_title: nil,
+      cta: nil,
+      image: nil,
+      hang: :left,
+      inline: false
+    )
+      @text = text
+      @name = name
+      @job_title = job_title
+      @cta = cta
+      @image = image
+      @hang = hang
+      @inline = inline
+
+      fail(ArgumentError, "text must be present") if text.blank?
+
+      cta_malformed = cta.present? && cta.values_at(:title, :link).any?(&:blank?)
+      fail(ArgumentError, "cta must contain a title and link") if cta_malformed
+
+      fail(ArgumentError, "hang must be :right or :left") unless %i[right left].any?(hang)
+    end
+
+    def show_footer?
+      footer_attrs = [name, job_title, cta, image]
+      footer_attrs.any?(&:present?)
+    end
+
+    def cta_title_last_word
+      cta[:title].split.last
+    end
+
+    def cta_title_sans_last_word
+      cta[:title].split[0...-1].join(" ")
+    end
+
+    def text_last_word
+      text.split.last
+    end
+
+    def text_sans_last_word
+      text.split[0...-1].join(" ")
+    end
+
+    def footer_class
+      %w[footer].tap do |c|
+        c << "footer--with-image" if image.present?
+      end
+    end
+
+    def quote_class
+      ["quote", "quote--hang-#{hang}"].tap do |c|
+        c << "quote--inline" if inline
+      end
+    end
+  end
+end

--- a/app/webpacker/styles/components/mixins/quote.scss
+++ b/app/webpacker/styles/components/mixins/quote.scss
@@ -1,0 +1,36 @@
+@mixin quote-icon($quote-size) {
+  @include icon;
+  background-image: url('../images/white-quote.svg');
+  width: $quote-size;
+  height: $quote-size;
+  fill: $white;
+  content: "";
+}
+
+@mixin quote {
+  background-color: $yellow;
+  position: relative;
+
+  p {
+    font-weight: bold;
+  }
+}
+
+$quote-size: 17px;
+
+@mixin fancy-quotes-before {
+  &:before {
+    @include quote-icon($quote-size);
+    position: absolute;
+    left: 1em;
+  }
+}
+
+@mixin fancy-quotes-after {
+  &:after {
+    @include quote-icon($quote-size);
+    position: inline;
+    transform: rotate(180deg);
+    margin-left: 7px;
+  }
+}

--- a/app/webpacker/styles/components/quote.scss
+++ b/app/webpacker/styles/components/quote.scss
@@ -1,0 +1,121 @@
+.quote {
+  @include quote;
+  margin: 0;
+
+  p {
+    @include fancy-quotes-before;
+    margin: 0;
+    font-size: 1.2em;
+
+    span {
+      @include fancy-quotes-after;
+      white-space: nowrap;
+    }
+  }
+
+  p, .footer {
+    padding: $indent-amount 25px $indent-amount 48px;
+  }
+
+  .footer {
+    padding-top: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .author {
+      display: inline-flex;
+      gap: 1em;
+      font-size: 1em;
+    }
+
+    .name, .job-title {
+      display: block;
+      font-style: normal;
+    }
+
+    .job-title {
+      font-weight: bold;
+      margin-top: 0.5rem;
+    }
+
+    .button {
+      margin-top: $indent-amount;
+    }
+
+    img {
+      max-width: 50%;
+    }
+  }
+}
+
+@include mq($from: tablet) {
+  .quote p {
+    font-size: 1.4em;
+  }
+
+  .quote--inline {
+    max-width: 50%;
+    float: left;
+    margin-right: $indent-amount;
+    margin-bottom: $indent-amount;
+  }
+
+  .quote:not(.quote--inline) {
+    &.quote--hang-right {
+      .footer {
+        flex-direction: row-reverse;
+
+        &--with-image {
+          .author {
+            margin-right: 185px;
+          }
+        }
+
+        .author {
+          margin-left: 0;
+          text-align: right;
+        }
+
+        img {
+          left: auto;
+          right: 0;
+        }
+
+        .button {
+          right: auto;
+          left: 1em;
+        }
+      }
+    }
+  }
+
+  .quote:not(.quote--inline) {
+    .footer {
+      flex-direction: row;
+      justify-content: space-between;
+
+      &--with-image {
+        .author {
+          margin-left: 170px;
+        }
+      }
+
+      .button {
+        margin-top: 0;
+        position: absolute;
+        right: $indent-amount;
+        bottom: 0;
+        transform: translate(0, 50%);
+      }
+
+      img {
+        position: absolute;
+        left: 0;
+        border: 1em solid $yellow;
+        border-top: 0;
+        width: 175px;
+      }
+    }
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -3,6 +3,7 @@
 
 @import './components/mixins/cards-grid';
 @import './components/mixins/headings';
+@import './components/mixins/quote';
 
 @import 'icons';
 @import 'breakpoints';
@@ -41,6 +42,7 @@
 @import './components/content-alert';
 @import './components/feature-table';
 @import './components/link-block';
+@import './components/quote';
 @import './components/search';
 @import './components/colored-stripe';
 @import './components/type-description';

--- a/app/webpacker/styles/markdown-figures-and-quotes.scss
+++ b/app/webpacker/styles/markdown-figures-and-quotes.scss
@@ -1,48 +1,16 @@
 .markdown {
-  @mixin quote-icon($quote-size) {
-    @include icon;
-    background-image: url('../images/white-quote.svg');
-    width: $quote-size;
-    height: $quote-size;
-    fill: $white;
-    content: "";
-  }
-
-  @mixin quote {
-    background-color: $yellow;
-    float: left;
-    max-width: 340px;
-    position: relative;
-  }
-
-  @mixin fancy-quotes {
-    $quote-size: 17px;
-
-    padding: 15px 44px;
-    font-weight: bold;
-
-    &:before {
-      @include quote-icon($quote-size);
-      position: absolute;
-      left: .4em;
-    }
-
-    &:after {
-      @include quote-icon($quote-size);
-      position: inline;
-      transform: rotate(180deg);
-      margin-left: 7px;
-    }
-  }
-
   > blockquote {
     @include quote;
+    float: left;
+    max-width: 340px;
     margin: 0 25px 0 0;
 
     p {
-      @include fancy-quotes;
+      @include fancy-quotes-before;
+      @include fancy-quotes-after;
       margin: 0;
       padding: 1em 1.6em;
+      padding: 15px 44px;
     }
 
     @include mq($until: mobile) {
@@ -56,6 +24,8 @@
 
   figure {
     @include quote;
+    float: left;
+    max-width: 340px;
 
     @include mq($until: tablet) {
       max-width: inherit;
@@ -69,10 +39,10 @@
     }
 
     blockquote {
-      margin: 1em 2rem;
-
       p {
-        @include fancy-quotes;
+        @include fancy-quotes-before;
+        @include fancy-quotes-after;
+        padding: 15px 44px;
         @include reset;
       }
     }

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -6,4 +6,6 @@ Rails.application.configure do
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
   config.x.enable_beta_redirects = false
+
+  config.view_component.show_previews = true
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -6,4 +6,6 @@ Rails.application.configure do
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
   config.x.enable_beta_redirects = false
+
+  config.view_component.show_previews = true
 end

--- a/spec/components/content/quote_component_spec.rb
+++ b/spec/components/content/quote_component_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+describe Content::QuoteComponent, type: :component do
+  let(:component) do
+    described_class.new(
+      text: text,
+      name: name,
+      job_title: job_title,
+      cta: cta,
+      image: image,
+      hang: hang,
+      inline: inline,
+    )
+  end
+  let(:text) { "text goes here" }
+  let(:name) { "name" }
+  let(:job_title) { "job-title" }
+  let(:cta) { { title: "click this", link: "/cta" } }
+  let(:image) { "media/images/featured-3.jpg" }
+  let(:hang) { :left }
+  let(:inline) { false }
+
+  subject do
+    render_inline(component)
+    page
+  end
+
+  describe "quote classes" do
+    it { is_expected.to have_css(".quote.quote--hang-#{hang}") }
+    it { is_expected.not_to have_css(".quote--inline") }
+  end
+
+  describe "quote text" do
+    it { is_expected.to have_css("p", text: text.split[0...-1].join(" ")) }
+    it { is_expected.to have_css("span", text: text.split.last) }
+  end
+
+  describe "footer" do
+    it { is_expected.to have_css(".footer.footer--with-image") }
+
+    describe "author" do
+      it { is_expected.to have_css("img") }
+      it { is_expected.to have_css("cite", text: name) }
+      it { is_expected.to have_css("cite", text: job_title) }
+    end
+
+    describe "call to action" do
+      it { is_expected.to have_link(cta[:title], href: cta[:link]) }
+      it { is_expected.to have_css("a span", text: cta[:title].split.last) }
+    end
+  end
+
+  context "when name is not specified" do
+    let(:name) { nil }
+    it { is_expected.not_to have_css(".author cite.name") }
+  end
+
+  context "when job_title is not specified" do
+    let(:job_title) { nil }
+    it { is_expected.not_to have_css(".author cite.job-title") }
+  end
+
+  context "when cta is not specified" do
+    let(:cta) { nil }
+    it { is_expected.not_to have_link }
+  end
+
+  context "when image is not specified" do
+    let(:image) { nil }
+    it { is_expected.not_to have_css("img") }
+  end
+
+  context "when inline" do
+    let(:inline) { true }
+    it { is_expected.to have_css(".quote--inline") }
+  end
+
+  context "when no footer elements are present" do
+    let(:name) { nil }
+    let(:job_title) { nil }
+    let(:image) { nil }
+    let(:cta) { nil }
+    it { is_expected.not_to have_css(".footer") }
+  end
+
+  describe "argument checks" do
+    it do
+      expect { described_class.new(text: nil) }.to \
+        raise_error(ArgumentError, "text must be present")
+    end
+
+    it do
+      expect { described_class.new(text: "  ") }.to \
+        raise_error(ArgumentError, "text must be present")
+    end
+
+    it do
+      expect { described_class.new(text: text, hang: nil) }.to \
+        raise_error(ArgumentError, "hang must be :right or :left")
+    end
+
+    it do
+      expect { described_class.new(text: text, hang: :up) }.to \
+        raise_error(ArgumentError, "hang must be :right or :left")
+    end
+
+    it do
+      expect { described_class.new(text: text, cta: { title: "", link: "" }) }.to \
+        raise_error(ArgumentError, "cta must contain a title and link")
+    end
+  end
+end

--- a/spec/components/previews/content/quote_component_preview.rb
+++ b/spec/components/previews/content/quote_component_preview.rb
@@ -1,0 +1,174 @@
+class Content::QuoteComponentPreview < ViewComponent::Preview
+  def default
+    component = Content::QuoteComponent.new(text)
+    render(component)
+  end
+
+  def with_inline
+    component = Content::QuoteComponent.new(
+      text
+        .merge(inline),
+    )
+
+    render_with_template(
+      template: "content/quote_component_preview/inline",
+      locals: { component: component },
+    )
+  end
+
+  def with_author
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author),
+    )
+    render(component)
+  end
+
+  def with_name
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author.slice(:name)),
+    )
+    render(component)
+  end
+
+  def with_job_title
+    component = Content::QuoteComponent.new(
+      text
+      .merge(author.slice(:job_title)),
+    )
+    render(component)
+  end
+
+  def with_cta
+    component = Content::QuoteComponent.new(
+      text
+        .merge(cta),
+    )
+    render(component)
+  end
+
+  def with_author_and_cta
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta),
+    )
+    render(component)
+  end
+
+  def with_author_image_and_cta
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta)
+        .merge(image),
+    )
+    render(component)
+  end
+
+  def with_author_image_and_cta_inline
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta)
+        .merge(image)
+        .merge(inline),
+    )
+
+    render_with_template(
+      template: "content/quote_component_preview/inline",
+      locals: { component: component },
+    )
+  end
+
+  def with_author_hanging_right
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(hang_right),
+    )
+    render(component)
+  end
+
+  def with_author_and_cta_hanging_right
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta)
+        .merge(hang_right),
+    )
+    render(component)
+  end
+
+  def with_author_image_and_cta_hanging_right
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta)
+        .merge(image)
+        .merge(hang_right),
+    )
+    render(component)
+  end
+
+  def with_author_image_and_cta_hanging_right_inline
+    component = Content::QuoteComponent.new(
+      text
+        .merge(author)
+        .merge(cta)
+        .merge(image)
+        .merge(hang_right)
+        .merge(inline),
+    )
+
+    render_with_template(
+      template: "content/quote_component_preview/inline",
+      locals: { component: component },
+    )
+  end
+
+private
+
+  def text
+    {
+      text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "\
+      "Praesent a nisl semper, efficitur velit ac, tincidunt arcu. "\
+      "Morbi non nisl eu arcu molestie lacinia quis quis libero.",
+    }
+  end
+
+  def author
+    {
+      name: "John Doe",
+      job_title: "Trainee English teacher",
+    }
+  end
+
+  def cta
+    {
+      cta: {
+        title: "Call to Action",
+        link: "/",
+      },
+    }
+  end
+
+  def image
+    {
+      image: "media/images/featured-3.jpg",
+    }
+  end
+
+  def hang_right
+    {
+      hang: :right,
+    }
+  end
+
+  def inline
+    {
+      inline: true,
+    }
+  end
+end

--- a/spec/components/previews/content/quote_component_preview/inline.html.erb
+++ b/spec/components/previews/content/quote_component_preview/inline.html.erb
@@ -1,0 +1,43 @@
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>
+<%= render(component) %>
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>
+<p>
+  Quisque dui est, fermentum at velit eget, auctor lobortis orci.
+  Aenean justo ligula, varius sed rhoncus id, ornare sit amet ex.
+  Maecenas malesuada at ante at rhoncus. Fusce quis egestas sapien.
+  Sed non semper est. Donec egestas tincidunt est.
+  Aenean a justo ac lectus tempus dignissim ut ut metus.
+</p>


### PR DESCRIPTION
### Trello card

[Trello-1541](https://trello.com/c/EEn4kHgh/1541-design-create-module-for-a-teacher-photo-headshot-and-quote-to-intersperse-through-the-site)

### Context

**As a user** browsing content on the GIT site
**I want to** be able to see people like me who have gone through the process of becoming a teacher
**So that** I can be reassured that I can become (and succeed as) a teacher

### Changes proposed in this pull request

- Add configurable quote component

Introduce a new, configurable quote component that works both inline and full width, with various options to customise presentation.

- Enable ViewComponent previews in rolling/preprod

Enable reviewing view components in the review instances.

### Guidance to review

The component previews can be [accessed here](https://review-get-into-teaching-app-1230.london.cloudapps.digital/rails/view_components/content/quote_component) - screenshots:

| Default      | With Author | With Author/CTA      | With Author/CTA/Image |
| ----------- | ----------- | ----------- | ----------- |
| <img width="768" alt="Screenshot 2021-05-07 at 12 55 26" src="https://user-images.githubusercontent.com/29867726/117446101-7ff6b680-af33-11eb-9a65-71a7ebfd4459.png"> | <img width="767" alt="Screenshot 2021-05-07 at 12 55 44" src="https://user-images.githubusercontent.com/29867726/117446144-8be27880-af33-11eb-9212-a8675eb924ac.png"> | <img width="766" alt="Screenshot 2021-05-07 at 12 56 17" src="https://user-images.githubusercontent.com/29867726/117446183-9e5cb200-af33-11eb-87f9-3db4dc2bb055.png"> | <img width="766" alt="Screenshot 2021-05-07 at 12 56 48" src="https://user-images.githubusercontent.com/29867726/117446240-b0d6eb80-af33-11eb-8b21-7ef9b56697ea.png"> |


| With Author/Image/CTA/Right      | With Inline | Mobile 1 | Mobile 2 |
| ----------- | ----------- | ----------- | ----------- |
| <img width="770" alt="Screenshot 2021-05-07 at 13 27 58" src="https://user-images.githubusercontent.com/29867726/117449565-0ca37380-af38-11eb-9ac4-74e5413342fa.png"> | <img width="706" alt="Screenshot 2021-05-07 at 13 30 03" src="https://user-images.githubusercontent.com/29867726/117449829-568c5980-af38-11eb-84a4-48a251b0d016.png"> |  <img width="484" alt="Screenshot 2021-05-07 at 13 35 10" src="https://user-images.githubusercontent.com/29867726/117450381-0f529880-af39-11eb-9fb2-f7552c8ffdca.png">  |  <img width="456" alt="Screenshot 2021-05-07 at 13 30 58" src="https://user-images.githubusercontent.com/29867726/117449937-791e7280-af38-11eb-961d-0df122624246.png">  |




