### PR TITLE
light copy edit of maths and physics internships page 

### DIFF
--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Providers offering maths and physics teaching internships
+title: Maths and physics teaching internships
 description: |-
   A number of accredited providers have been approved to offer Teaching
   Internships. You can find them listed on this page.

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,13 +1,19 @@
 
-<p>If you are an undergraduate on a STEM related degree and you are interested in teaching secondary maths or physics, 
-you may be eligible for a paid Teaching Internship. This provides an opportunity to experience the teaching profession, 
-gain new skills and be paid £300 per week for your time.</p>
+<p>You may be eligible for a paid teaching internship if you're:</p>
 
-<p>You will need to apply directly to participating schools and be an undergraduate in any year of study of a STEM related degree. To find out if you meet the eligibility criteria, check with participating schools before submitting your application. 
- 
-To get the best chance of succeeding in your application, <a href='/tta-service'>get an adviser</a> for support from our teaching experts.</p>
+<ul>
+  <li>in any year of a science, technology, engineering or maths (STEM) undergraduate degree</li>
+  <li>interested in teaching secondary maths or physics</li>
+</ul>
 
-<h4>This programme is only available to those wishing to teach secondary maths or physics.</h4>
+<p>You'll experience the teaching profession, get new skills and be paid £300 per week.</p>
+
+<p>Check you meet the eligibility criteria with participating schools before you apply.</p>
+
+<p><a href='/tta-service'>Get an adviser</a> to have the best chance succeeding in your application.</p>
+
+<p>Apply directly to participating schools in the following regions:</p>
+
 <section>
   <%= render GroupedCards::ListingComponent.new @front_matter["providers"] %>
 </section>


### PR DESCRIPTION
* remove repeated content and bold text 
* highlight important eligibility criteria through bullets instead 
* make title more user centred 

before:

![Screenshot 2021-05-07 at 16 00 29](https://user-images.githubusercontent.com/56349171/117469203-5d719700-af4d-11eb-915c-2fb6d31fe94a.png)

after:

![Screenshot 2021-05-07 at 16 01 18](https://user-images.githubusercontent.com/56349171/117469298-77ab7500-af4d-11eb-9ffc-ce7033db0715.png)

