### PR TITLE
Cypress started failing, boost timeout to debug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,7 +499,7 @@ jobs:
           ref: refs/heads/master
           repo: get-into-teaching-frontend-tests
           intervalSeconds: 30
-          timeoutSeconds: 300
+          timeoutSeconds: 600
 
       - name: Check for test failure
         if: steps.wait-for-tests.outputs.conclusion == 'failure'


### PR DESCRIPTION
Cypress is failing when running in CD. There is no output in the log so we can't _actually_ debug, but as it started failing on an innocuous PR it might just be that it's timing out. #stabinthedark
