### PR TITLE
Fix early exit from http_basic block

### DIFF
--- a/app/controllers/internal_controller.rb
+++ b/app/controllers/internal_controller.rb
@@ -3,13 +3,11 @@ class InternalController < ApplicationController
   skip_before_action :site_wide_authentication
   helper_method :publisher?
 
-protected
+private
 
   def publisher?
     session[:role] == :publisher
   end
-
-private
 
   def set_account_role(role_type)
     session[:role] = role_type
@@ -17,17 +15,19 @@ private
 
   def authenticate
     authenticate_or_request_with_http_basic do |username, password|
-      return false if username.blank? || password.blank?
+      authenticated = false
 
-      if username == publisher[:username] && password == publisher[:password]
-        set_account_role(:publisher)
-        return true
-      elsif username == author[:username] && password == author[:password]
-        set_account_role(:author)
-        return true
+      unless username.blank? || password.blank?
+        if username == publisher[:username] && password == publisher[:password]
+          set_account_role(:publisher)
+          authenticated = true
+        elsif username == author[:username] && password == author[:password]
+          set_account_role(:author)
+          authenticated = true
+        end
       end
 
-      false
+      authenticated
     end
   end
 


### PR DESCRIPTION
### Context
Bug fix - using `return` in the `authenticate_or_request_with_http_basic` block is actually returning from the enclosing `authenticate` method. This is causing some unusual behaviour.

### Changes proposed in this pull request
- Fix early exit from http_basic block