### PR TITLE
Downgrade view component to quieten warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem "redis"
 
 gem "kaminari", "~> 1.2"
-gem "view_component"
+gem "view_component", "~> 2.29.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (1.7.0)
-    view_component (2.31.1)
+    view_component (2.29.0)
       activesupport (>= 5.0.0, < 7.0)
     web-console (4.1.0)
       actionview (>= 6.0.0)
@@ -470,7 +470,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  view_component
+  view_component (~> 2.29.0)
   web-console (>= 3.3.0)
   webdrivers (~> 4.6)
   webmock (>= 3.12.2)


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

The one place where we're using `with_slot` is the accordion component, which is likely to be killed off in the coming weeks. Rather than re-write it to hush the warnings we'll just use a slightly-older version temporarily.
