### PR TITLE
Add rel='noopener noreferrer' to outbound links

### DIFF
--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -20,11 +20,12 @@ export default class extends Controller {
   }
 
   openExternalContentLinksInNewWindow() {
-    const links = this.contentTarget.querySelectorAll('.content a');
+    const links = this.contentTarget.querySelectorAll('a');
 
     links.forEach((l) => {
       if (l.getAttribute('href')?.startsWith('http')) {
         l.setAttribute('target', '_blank');
+        l.setAttribute('rel', 'noopener noreferrer');
 
         // add hidden text to inform screen reader users that
         // link will open in a new window

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -67,7 +67,16 @@ describe('LinkController', () => {
         const contentExternalLink = document.getElementById(
           'content-external-link'
         );
-        expect(contentExternalLink.hasAttribute('target')).toBe(true);
+        expect(contentExternalLink.getAttribute('target')).toEqual('_blank');
+      });
+
+      it("adds rel='noopener noreferrer' to the content external link", () => {
+        const contentExternalLink = document.getElementById(
+          'content-external-link'
+        );
+        expect(contentExternalLink.getAttribute('rel')).toEqual(
+          'noopener noreferrer'
+        );
       });
 
       it('adds a description of where the link will open for screen reader users', () => {


### PR DESCRIPTION
### Trello card

https://trello.com/c/trRjn2j7/542-consider-the-security-implications-of-applying-targetblank-to-all-external-links

### Context

This is probably not a risk for users of newer browsers but adds a layer of security for users of out-of-date ones. It can prevent the pages we link to from gaining 'partial access' to our page; this could allow an attacker who has gained control of a page we link to to cause mischeif by modifying the `window.opener.location`, etc.  

More info here:
* https://dev.to/ben/the-targetblank-vulnerability-by-example
* https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c#.disn238f9

### Changes proposed in this pull request

As well as adding `target='_blank'` to external links, add `rel='noopener noreferrer'`
