### PR TITLE
Move mailing list promotion bar outside of footer

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,6 +1,6 @@
+<%= render "sections/mailing-list-bar" %>
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
-  <%= render "sections/mailing-list-bar" %>
   <%= render "sections/feedback_bar" %>
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">

--- a/app/views/sections/_mailing-list-bar.html.erb
+++ b/app/views/sections/_mailing-list-bar.html.erb
@@ -1,7 +1,7 @@
 <div class="mailing-list-bar" data-controller="mailing-list" data-banner-name="MailingList">
   <section class="mailing-list-bar__inner limit-content-width">
     <div class="mailing-list-bar__left">
-      Get personalised information and advice about getting into teaching
+      Whether you're ready to apply, or simply exploring teaching as an option, we'll send you all the information you need
     </div>
     <div class="mailing-list-bar__right">
       <a href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>

--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -1,6 +1,7 @@
 .mailing-list-bar {
   background-color: $green;
   padding: 1em;
+  margin: 1em 0 3em;
   position: sticky;
   bottom: 0;
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/NEEjWVrz/1562-create-a-banner-with-a-link-to-the-register-your-interest-thats-stays-visible-at-the-bottom-of-the-page

### Context and context

Now the mailing list promotion bar will follow users right up the page instead of politely stopping at the top of the footer.

* [Preview on desktop](https://user-images.githubusercontent.com/128088/117685024-77111980-b1ad-11eb-8558-b74d8939b009.mp4)
* [Preview on mobile](https://user-images.githubusercontent.com/128088/117685067-7d9f9100-b1ad-11eb-96fd-a962e2f28555.mp4)




