### PR TITLE
Mailing list popups

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,3 +1,4 @@
+<%= render "sections/mailing-list-popup" %>
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
   <%= render "sections/mailing-list-bar" %>

--- a/app/views/sections/_mailing-list-popup.html.erb
+++ b/app/views/sections/_mailing-list-popup.html.erb
@@ -17,7 +17,7 @@
 
 
             <div class="dialog__buttons">
-              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept" id="cookies-agree">
+              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
                   <span>Register your interest</span>
               </a>
               <a class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">

--- a/app/views/sections/_mailing-list-popup.html.erb
+++ b/app/views/sections/_mailing-list-popup.html.erb
@@ -17,10 +17,11 @@
 
 
             <div class="dialog__buttons">
-              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
+              <a id="mailing-list-popup-accept" href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
                   <span>Register your interest</span>
               </a>
-              <a class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
+
+              <a id="mailing-list-popup-dismiss" class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
                   <span>No thanks</span>
               </a>
             </div>

--- a/app/views/sections/_mailing-list-popup.html.erb
+++ b/app/views/sections/_mailing-list-popup.html.erb
@@ -17,10 +17,10 @@
 
 
             <div class="dialog__buttons">
-              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept" data-mailing-list-popup-target="agree" id="cookies-agree">
+              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept" id="cookies-agree">
                   <span>Register your interest</span>
               </a>
-              <a class="button button--secondary" href="#" data-mailing-list-popup-target="disagree" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
+              <a class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
                   <span>No thanks</span>
               </a>
             </div>

--- a/app/views/sections/_mailing-list-popup.html.erb
+++ b/app/views/sections/_mailing-list-popup.html.erb
@@ -1,0 +1,29 @@
+<div data-controller="mailing-list-popup" data-mailing-list-popup-target="modal" role="complementary">
+    <div class="dialog" data-mailing-list-popup-target="dialog">
+        <div class="dialog__background"></div>
+        <div class="dialog__content">
+            <div>
+                <div class="logo__image">
+                    <span href="/">
+                        <%= image_pack_tag "media/images/getintoteachinglogo.svg", alt: "Get Into Teaching", size: "140x48" %>
+                    </span>
+                </div>
+                <h2>Before you go&#8230;</h2>
+            </div>
+            <p>
+              Whether you’re ready to apply, or simply exploring teaching as an
+              option, we can send you the information you need.
+            </p>
+
+
+            <div class="dialog__buttons">
+              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept" data-mailing-list-popup-target="agree" id="cookies-agree">
+                  <span>Register your interest</span>
+              </a>
+              <a class="button button--secondary" href="#" data-mailing-list-popup-target="disagree" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
+                  <span>No thanks</span>
+              </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/sections/_mailing-list-popup.html.erb
+++ b/app/views/sections/_mailing-list-popup.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="mailing-list-popup" data-mailing-list-popup-target="modal" role="complementary">
-    <div class="dialog" data-mailing-list-popup-target="dialog">
+    <div id="mailing-list-popup" class="dialog" data-mailing-list-popup-target="dialog">
         <div class="dialog__background"></div>
         <div class="dialog__content">
             <div>

--- a/app/webpacker/controllers/mailing-list-popup_controller.js
+++ b/app/webpacker/controllers/mailing-list-popup_controller.js
@@ -62,6 +62,7 @@ export default class extends Controller {
   accept() {
     // hook in any logging to a successful response here
     this.dismissMailingListPopup();
+    this.hide()
   }
 
   dismiss(event) {

--- a/app/webpacker/controllers/mailing-list-popup_controller.js
+++ b/app/webpacker/controllers/mailing-list-popup_controller.js
@@ -9,13 +9,9 @@ export default class extends Controller {
   topScrollMinimumDistance = 700;
 
   connect() {
-    console.debug('connected');
-
     if (isTouchDevice()) {
-      console.debug('touch device detected');
       this.setupTouchDevice();
     } else {
-      console.debug('desktop detected');
       this.setupDesktop();
     }
   }
@@ -58,10 +54,7 @@ export default class extends Controller {
   }
 
   showDialog() {
-    console.debug('showing dialog');
-
     if (this.mailingListDismissed) {
-      console.debug('already dismissed, not showing');
       return;
     }
 
@@ -74,7 +67,6 @@ export default class extends Controller {
   }
 
   dismiss(event) {
-    console.debug("dismissed");
     if (event) event.preventDefault();
 
     this.dismissMailingListPopup();
@@ -82,8 +74,6 @@ export default class extends Controller {
   }
 
   hide() {
-    console.debug("hiding");
-
     this.dialogTarget.style.display = 'none';
   }
 
@@ -98,12 +88,9 @@ export default class extends Controller {
   }
 
   monitorScrollDistance(callback) {
-    console.debug('setting up scrolling');
     let isScrolling, start, end, distance;
 
     const onScroll = () => {
-      console.debug('scrolling...');
-
       if (!start) {
         start = window.pageYOffset;
       }

--- a/app/webpacker/controllers/mailing-list-popup_controller.js
+++ b/app/webpacker/controllers/mailing-list-popup_controller.js
@@ -1,0 +1,130 @@
+import isTouchDevice from 'is-touch-device';
+import { Controller } from 'stimulus';
+const mailingListDismissedKey = 'mailingListDismissed';
+
+export default class extends Controller {
+  static targets = ['dialog'];
+  topExitSensitivity = 0;
+  topScrollEndSensitivity = 300;
+  topScrollMinimumDistance = 700;
+
+  connect() {
+    console.debug('connected');
+
+    if (isTouchDevice()) {
+      console.debug('touch device detected');
+      this.setupTouchDevice();
+    } else {
+      console.debug('desktop detected');
+      this.setupDesktop();
+    }
+  }
+
+  setupDesktop() {
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
+    document.documentElement.addEventListener(
+      'mouseleave',
+      this.handleMouseLeave
+    );
+  }
+
+  setupTouchDevice() {
+    this.monitorScrollDistance((distance, _start, end) => {
+      const scrollUp = distance < 0;
+      const atTop = end < this.topScrollEndSensitivity;
+      const longScroll = Math.abs(distance) >= this.topScrollMinimumDistance;
+
+      if (!scrollUp || !atTop || !longScroll) {
+        return;
+      }
+
+      this.showDialog();
+    });
+  }
+
+  disconnect() {
+    clearTimeout(this.delayTimeout);
+
+    if (this.handleMouseLeave) {
+      document.documentElement.removeEventListener(
+        'mouseleave',
+        this.handleMouseLeave
+      );
+    }
+
+    if (this.handleScroll) {
+      window.removeEventListener('scroll', this.handleScroll);
+    }
+  }
+
+  showDialog() {
+    console.debug('showing dialog');
+
+    if (this.mailingListDismissed) {
+      console.debug('already dismissed, not showing');
+      return;
+    }
+
+    this.dialogTarget.style.display = 'flex';
+  }
+
+  accept() {
+    // hook in any logging to a successful response here
+    this.dismissMailingListPopup();
+  }
+
+  dismiss(event) {
+    console.debug("dismissed");
+    if (event) event.preventDefault();
+
+    this.dismissMailingListPopup();
+    this.hide()
+  }
+
+  hide() {
+    console.debug("hiding");
+
+    this.dialogTarget.style.display = 'none';
+  }
+
+  dismissMailingListPopup() {
+    return window.localStorage.setItem(mailingListDismissedKey, 'true');
+  }
+
+  handleMouseLeave(e) {
+    if (e.clientY <= this.topExitSensitivity) {
+      this.showDialog();
+    }
+  }
+
+  monitorScrollDistance(callback) {
+    console.debug('setting up scrolling');
+    let isScrolling, start, end, distance;
+
+    const onScroll = () => {
+      console.debug('scrolling...');
+
+      if (!start) {
+        start = window.pageYOffset;
+      }
+
+      window.clearTimeout(isScrolling);
+
+      isScrolling = setTimeout(() => {
+        end = window.pageYOffset;
+        distance = end - start;
+
+        callback(distance, start, end);
+
+        start = end = distance = null;
+      }, 50);
+    };
+
+    this.handleScroll = onScroll.bind(this);
+    window.addEventListener('scroll', this.handleScroll, false);
+  }
+
+  get mailingListDismissed() {
+    return window.localStorage.getItem(mailingListDismissedKey) === 'true';
+  }
+}

--- a/app/webpacker/controllers/mailing-list-popup_controller.js
+++ b/app/webpacker/controllers/mailing-list-popup_controller.js
@@ -10,10 +10,8 @@ export default class extends Controller {
 
   connect() {
     if (isTouchDevice()) {
-      console.debug("setting up touch device");
       this.setupTouchDevice();
     } else {
-      console.debug("setting up desktop");
       this.setupDesktop();
     }
   }

--- a/app/webpacker/controllers/mailing-list-popup_controller.js
+++ b/app/webpacker/controllers/mailing-list-popup_controller.js
@@ -10,8 +10,10 @@ export default class extends Controller {
 
   connect() {
     if (isTouchDevice()) {
+      console.debug("setting up touch device");
       this.setupTouchDevice();
     } else {
+      console.debug("setting up desktop");
       this.setupDesktop();
     }
   }
@@ -39,10 +41,8 @@ export default class extends Controller {
   }
 
   disconnect() {
-    clearTimeout(this.delayTimeout);
-
     if (this.handleMouseLeave) {
-      document.documentElement.removeEventListener(
+      document?.documentElement.removeEventListener(
         'mouseleave',
         this.handleMouseLeave
       );

--- a/spec/javascript/controllers/mailing-list-popup_controller_spec.js
+++ b/spec/javascript/controllers/mailing-list-popup_controller_spec.js
@@ -17,10 +17,10 @@ describe('MailingListPopupController', () => {
     <div data-controller="mailing-list-popup" data-mailing-list-popup-target="modal" role="complementary">
       <div id="dialog" class="dialog" data-mailing-list-popup-target="dialog" style="display: none">
             <div class="dialog__buttons">
-              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
+              <a id="mailing-list-popup-accept" href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
                   <span>Register your interest</span>
               </a>
-              <a class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
+              <a id="mailing-list-popup-dismiss" class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
                   <span>No thanks</span>
               </a>
             </div>
@@ -104,6 +104,73 @@ describe('MailingListPopupController', () => {
         longScrollToTop(MailingListPopupController.topScrollMinimumDistance);
         jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
         expect(dialog.style.display).toContain("flex");
+      });
+
+      it("prompts according to the distance sensitivity value", () => {
+        longScrollToTop(699);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("none");
+        longScrollToTop(701);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
+      });
+
+      it("prompts according to the end sensitivity value", () => {
+        longScrollToTop(700, 301);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("none");
+        longScrollToTop(700, 299);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
+      });
+    });
+
+    describe('clicking "No thanks"', () => {
+      beforeEach(() => {
+        window.localStorage.setItem('mailingListDismissed', 'false')
+        attachController();
+      });
+
+      it('hides the mailing-list popup', () => {
+        expect(
+          window.localStorage.getItem('mailingListDismissed')
+        ).toEqual('false');
+
+        mouseLeave();
+        const closeLink = document.getElementById('mailing-list-popup-dismiss');
+        expect(dialog.style.display).toContain("flex");
+        closeLink.click();
+        expect(dialog.style.display).toContain("none");
+
+        expect(
+          window.localStorage.getItem('mailingListDismissed')
+        ).toEqual('true');
+      });
+    });
+
+    describe('clicking "Register your interest"', () => {
+      beforeEach(() => {
+        window.localStorage.setItem('mailingListDismissed', 'false')
+        attachController();
+      });
+
+      it('hides the mailing-list popup', () => {
+        expect(
+          window.localStorage.getItem('mailingListDismissed')
+        ).toEqual('false');
+
+        mouseLeave();
+        const acceptLink = document.getElementById('mailing-list-popup-accept');
+
+        expect(acceptLink.getAttribute('href')).toEqual('/mailinglist/signup/name');
+        expect(dialog.style.display).toContain("flex");
+
+        acceptLink.click();
+        expect(dialog.style.display).toContain("none");
+
+        expect(
+          window.localStorage.getItem('mailingListDismissed')
+        ).toEqual('true');
       });
     });
   });

--- a/spec/javascript/controllers/mailing-list-popup_controller_spec.js
+++ b/spec/javascript/controllers/mailing-list-popup_controller_spec.js
@@ -1,6 +1,9 @@
 import { Application } from 'stimulus' ;
 import MailingListPopupController from 'mailing-list-popup_controller.js';
 import StubLocalStorage from '../stubs/local_storage';
+import isTouchDevice from 'is-touch-device';
+
+jest.mock('is-touch-device')
 
 describe('MailingListPopupController', () => {
   beforeEach(() => {
@@ -40,25 +43,16 @@ describe('MailingListPopupController', () => {
   };
 
   const attachController = (touch = false) => {
-    jest.resetModules();
-
     if (touch) {
-      console.debug("mocking touch device");
-      jest.mock('is-touch-device', () => ({ __esModule: true, default: () => true }));
+      isTouchDevice.mockImplementation(() => true);
     } else {
-      console.debug("mocking desktop");
-      jest.mock('is-touch-device', () => ({ __esModule: true, default: () => false }));
+      isTouchDevice.mockImplementation(() => false);
     }
 
-    console.debug("mounting controller");
     const application = Application.start();
     application.register('mailing-list-popup', MailingListPopupController);
     dialog = document.getElementById('dialog');
   }
-
-  beforeEach(() => {
-    jest.resetModules();
-  });
 
   describe("when the mailing list has already been dismissed", () => {
     beforeEach(() => {
@@ -107,7 +101,7 @@ describe('MailingListPopupController', () => {
       });
 
       it("prompts on long scroll to top", () => {
-        longScrollToTop(1);
+        longScrollToTop(MailingListPopupController.topScrollMinimumDistance);
         jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
         expect(dialog.style.display).toContain("flex");
       });

--- a/spec/javascript/controllers/mailing-list-popup_controller_spec.js
+++ b/spec/javascript/controllers/mailing-list-popup_controller_spec.js
@@ -1,0 +1,116 @@
+import { Application } from 'stimulus' ;
+import MailingListPopupController from 'mailing-list-popup_controller.js';
+import StubLocalStorage from '../stubs/local_storage';
+
+describe('MailingListPopupController', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    Object.defineProperty(window, 'localStorage', {
+      value: new StubLocalStorage({ mailingListDismissed: 'false' }),
+    });
+
+    document.body.innerHTML = `
+    <div data-controller="mailing-list-popup" data-mailing-list-popup-target="modal" role="complementary">
+      <div id="dialog" class="dialog" data-mailing-list-popup-target="dialog" style="display: none">
+            <div class="dialog__buttons">
+              <a href="/mailinglist/signup/name" class="button call-to-action-button" data-action="click->mailing-list-popup#accept">
+                  <span>Register your interest</span>
+              </a>
+              <a class="button button--secondary" href="#" id="cookies-disagree" data-action="click->mailing-list-popup#dismiss">
+                  <span>No thanks</span>
+              </a>
+            </div>
+        </div>
+    </div>
+    ` ;
+  });
+
+  const mouseLeave = (clientY = 0) => {
+    var mouseEvent = document.createEvent("MouseEvents");
+    mouseEvent.initMouseEvent("mouseleave", true, false, window, 0, 0, 0, 0, clientY);
+    document.documentElement.dispatchEvent(mouseEvent);
+  };
+
+  const longScrollToTop = (distance = 700, end = 0) => {
+    window.pageYOffset = distance + end;
+    const scrollEvent = new Event('scroll');
+    window.dispatchEvent(scrollEvent);
+    window.pageYOffset = end;
+  };
+
+  const attachController = (touch = false) => {
+    jest.resetModules();
+
+    if (touch) {
+      console.debug("mocking touch device");
+      jest.mock('is-touch-device', () => ({ __esModule: true, default: () => true }));
+    } else {
+      console.debug("mocking desktop");
+      jest.mock('is-touch-device', () => ({ __esModule: true, default: () => false }));
+    }
+
+    console.debug("mounting controller");
+    const application = Application.start();
+    application.register('mailing-list-popup', MailingListPopupController);
+    dialog = document.getElementById('dialog');
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  describe("when the mailing list has already been dismissed", () => {
+    beforeEach(() => {
+      window.localStorage.setItem('mailingListDismissed', 'true');
+      attachController();
+    });
+
+    it("does not display by default", () => {
+      expect(dialog.style.display).toContain("none");
+    });
+
+    it("does not prompt on mouseleave", () => {
+      mouseLeave();
+
+      jest.advanceTimersByTime(100);
+      expect(dialog.style.display).toContain("none");
+    });
+  });
+
+  describe("when the mailing list popup has not been dismissed", () => {
+    describe("on desktop", () => {
+      beforeEach(() => {
+        window.localStorage.setItem('mailingListDismissed', 'false')
+
+        attachController();
+      });
+
+      it("prompts on mouseleave", () => {
+        mouseLeave();
+        jest.advanceTimersByTime(100);
+        expect(dialog.style.display).toContain("flex");
+      });
+
+      it("prompts according to the sensitivity value", () => {
+        mouseLeave(1);
+        expect(dialog.style.display).toContain("none");
+        mouseLeave(0);
+        expect(dialog.style.display).toContain("flex");
+      });
+    });
+
+    describe("on a touch device", () => {
+      beforeEach(() => {
+        window.localStorage.setItem('mailingListDismissed', 'false')
+        attachController(true);
+      });
+
+      it("prompts on long scroll to top", () => {
+        longScrollToTop(1);
+        jest.advanceTimersByTime(100); // Wait for timeout indicating scroll end.
+        expect(dialog.style.display).toContain("flex");
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Trello card

https://trello.com/c/ITECeTPv/1561-create-a-panel-that-pops-up-asking-users-to-register-your-interest-register-for-updates-before-the-user-leaves-the-site

### Context

Some users might accidentally try to leave the site without having signed up to our mailing list.

### Changes proposed in this pull request

Before they have chance to leave, show an informative modal popup on the page.
