### PR TITLE
Add tabbed navigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 9e1ee278207b6c3499ca969c8d2e10bc2bb30a97
+  revision: c0bf769898ceabbaaa74790381a44c1e316e4b60
   specs:
-    get_into_teaching_api_client (1.1.15)
+    get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.29)
+    get_into_teaching_api_client_faraday (0.1.32)
       activesupport
       faraday
       faraday-encoding

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -2,11 +2,14 @@ module Internal
   class EventsController < ::InternalController
     layout "internal"
     before_action :authorize_publisher, only: %i[approve]
+    helper_method :event_type_name
+
+    DEFAULT_EVENT_TYPE = "provider".freeze
 
     def index
-      event_type = event_types[params[:event_type]] || event_types[:provider]
+      @event_type = event_types[params[:event_type]] || event_types[:provider]
 
-      load_pending_events(event_type)
+      load_pending_events(@event_type)
       @no_results = @events.blank?
 
       @success = params[:success]
@@ -50,6 +53,10 @@ module Internal
     end
 
   private
+
+    def event_type_name
+      params[:event_type] || DEFAULT_EVENT_TYPE
+    end
 
     def authorize_publisher
       render_forbidden unless publisher?

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -10,7 +10,6 @@
     </div>
   <% end %>
 
-
   <div class="tab-bar">
     <%= link_to "Provider events",
                 internal_events_path(event_type: "provider"),
@@ -19,7 +18,6 @@
                 internal_events_path(event_type: "online"),
                 class: class_names("tab-link", "tab", { "active-tab": event_type_name == "online" }) %>
   </div>
-
 
   <h1 class="pending-title">Pending <%= event_type_name %> events</h1>
 

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -1,6 +1,6 @@
 <div class="markdown events-index">
   <% if @success %>
-    <div class="govuk-panel govuk-panel--confirmation">
+    <div class="govuk-panel govuk-panel--confirmation confirmation-panel">
       <h1 class="govuk-panel__title">
         Event submitted
         <% if @pending %>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -1,4 +1,4 @@
-<div class="markdown">
+<div class="markdown events-index">
   <% if @success %>
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
@@ -10,9 +10,20 @@
     </div>
   <% end %>
 
-  <h1 class="pending-title">Pending Provider Events</h1>
 
-  <%= button_to "Submit a provider event for review",
+  <div class="tab-bar">
+    <%= link_to "Provider events",
+                internal_events_path(event_type: "provider"),
+                class: class_names("tab-link", "tab", { "active-tab": event_type_name == "provider" }) %>
+    <%= link_to "Online events",
+                internal_events_path(event_type: "online"),
+                class: class_names("tab-link", "tab", { "active-tab": event_type_name == "online" }) %>
+  </div>
+
+
+  <h1 class="pending-title">Pending <%= event_type_name %> events</h1>
+
+  <%= button_to "Submit #{event_type_name} event for review",
                 new_internal_event_path, method: :get,
                 class: "button submit-button no-left-margin" %>
 

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -9,8 +9,8 @@
   </div>
 
 
-  <main role="main" id="main-content">
-    <section class="container">
+  <main role="main" id="main-content" class=<%= class_names({ "listing": current_page?(action: 'index') }) %>>
+    <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>
       </article>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -9,7 +9,7 @@
   </div>
 
 
-  <main role="main" id="main-content" class=<%= class_names({ "listing": current_page?(action: 'index') }) %>>
+  <main role="main" id="main-content" class="<%= class_names("internal", { "index": current_page?(action: 'index') }) %>">
     <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -26,11 +26,15 @@ $govuk-include-default-font-face: false;
 }
 
 .form-button {
-  margin: 0 0 30px;
+  margin-bottom: 30px;
 }
 
 .hidden {
   display: none;
+}
+
+.confirmation-panel {
+  margin: 0;
 }
 
 // Tab navigation
@@ -46,10 +50,9 @@ $br: 7.5px;
     background-color: $white;
 
     .tab-bar {
+      padding: 20px 0 0 50px;
       background-color: $grey-very-light;
       margin: 0;
-      padding-left: 50px;
-
       display: flex;
       align-items: center;
 

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -3,7 +3,7 @@ $govuk-include-default-font-face: false;
 @import "~govuk-frontend/govuk/all";
 @import "~trix";
 
-.internal-container {
+.internal {
   .event-description {
     resize: vertical;
     overflow: auto;
@@ -43,7 +43,7 @@ $govuk-include-default-font-face: false;
   $grey-very-light: #f3f2f1;
   $br: 7.5px;
 
-  .listing {
+  &.index {
     background-color: $grey-very-light;
     max-width: none;
 

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -32,3 +32,61 @@ $govuk-include-default-font-face: false;
 .hidden {
   display: none;
 }
+
+// Tab navigation
+
+$grey-very-light: #f3f2f1;
+$br: 7.5px;
+
+.listing {
+  background-color: $grey-very-light;
+  max-width: none;
+
+  .container {
+    background-color: $white;
+
+    .tab-bar {
+      background-color: $grey-very-light;
+      margin: 0;
+      padding-left: 50px;
+
+      display: flex;
+      align-items: center;
+
+      .tab {
+        padding: 15px 30px;
+        height: 100%;
+        list-style: none;
+        background-color: $green;
+        color: $white;
+        border-radius: $br $br 0 0;
+
+        &:not(:first-child) {
+          margin-left: 20px;
+        }
+
+        &:focus {
+          background-color: $yellow;
+          box-shadow: 0 -2px $yellow, 0 4px #1d1d1b;
+        }
+
+        &:hover:not(:focus):not(.active-tab) {
+          background: darken($green, 5%);
+        }
+      }
+
+      .active-tab {
+        background-color: $white;
+        color: $black;
+      }
+
+      .tab-link {
+        text-decoration: none;
+      }
+    }
+
+    .event-pagination {
+      min-height: 50px;
+    }
+  }
+}

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -3,93 +3,95 @@ $govuk-include-default-font-face: false;
 @import "~govuk-frontend/govuk/all";
 @import "~trix";
 
-.event-description {
-  resize: vertical;
-  overflow: auto;
-  height: 350px;
-}
+.internal-container {
+  .event-description {
+    resize: vertical;
+    overflow: auto;
+    height: 350px;
+  }
 
-.notification-button {
-  margin: 0 30px 30px 0;
-}
+  .notification-button {
+    margin: 0 30px 30px 0;
+  }
 
-.pending-title {
-  padding-top: 30px;
-}
+  .pending-title {
+    padding-top: 30px;
+  }
 
-.pending-no-results {
-  margin: 3em;
-}
+  .pending-no-results {
+    margin: 3em;
+  }
 
-.no-left-margin {
-  margin-left: 0;
-}
+  .no-left-margin {
+    margin-left: 0;
+  }
 
-.form-button {
-  margin-bottom: 30px;
-}
+  .form-button {
+    margin-bottom: 30px;
+  }
 
-.hidden {
-  display: none;
-}
+  .hidden {
+    display: none;
+  }
 
-.confirmation-panel {
-  margin: 0;
-}
+  .confirmation-panel {
+    margin: 0;
+  }
 
-// Tab navigation
+  // Tab navigation
 
-$grey-very-light: #f3f2f1;
-$br: 7.5px;
+  $grey-very-light: #f3f2f1;
+  $br: 7.5px;
 
-.listing {
-  background-color: $grey-very-light;
-  max-width: none;
+  .listing {
+    background-color: $grey-very-light;
+    max-width: none;
 
-  .container {
-    background-color: $white;
+    .container {
+      background-color: $white;
 
-    .tab-bar {
-      padding: 20px 0 0 50px;
-      background-color: $grey-very-light;
-      margin: 0;
-      display: flex;
-      align-items: center;
+      .tab-bar {
+        padding: 20px 0 0 50px;
+        background-color: $grey-very-light;
+        margin: 0;
+        display: flex;
+        align-items: center;
 
-      .tab {
-        padding: 15px 30px;
-        height: 100%;
-        list-style: none;
-        background-color: $green;
-        color: $white;
-        border-radius: $br $br 0 0;
+        .tab {
+          padding: 15px 30px;
+          height: 100%;
+          list-style: none;
+          background-color: $green;
+          color: $white;
+          border-radius: $br $br 0 0;
 
-        &:not(:first-child) {
-          margin-left: 20px;
+          &:not(:first-child) {
+            margin-left: 20px;
+          }
+
+          &:focus {
+            background-color: $yellow;
+            box-shadow: 0 -2px $yellow, 0 4px #1d1d1b;
+          }
+
+          &:hover:not(:focus):not(.active-tab) {
+            background: darken($green, 5%);
+          }
         }
 
-        &:focus {
-          background-color: $yellow;
-          box-shadow: 0 -2px $yellow, 0 4px #1d1d1b;
+        .active-tab {
+          background-color: $white;
+          color: $black;
         }
 
-        &:hover:not(:focus):not(.active-tab) {
-          background: darken($green, 5%);
+        .tab-link {
+          text-decoration: none;
         }
       }
 
-      .active-tab {
-        background-color: $white;
-        color: $black;
+      .event-pagination {
+        min-height: 50px;
       }
-
-      .tab-link {
-        text-decoration: none;
-      }
-    }
-
-    .event-pagination {
-      min-height: 50px;
     }
   }
 }

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Internal section", type: :feature do
 
   scenario "Final submit" do
     visit internal_events_path
-    expect(page).to have_text "Pending Provider Events"
+    expect(page).to have_text "Pending provider events"
 
     click_link "Pending event"
     expect(page).to have_text("This is a pending event")
@@ -113,17 +113,17 @@ RSpec.feature "Internal section", type: :feature do
 private
 
   def navigate_to_new_submission
-    visit internal_events_path
-    expect(page).to have_text "Pending Provider Events"
+    visit internal_events_path(event_type: "provider")
+    expect(page).to have_text "Pending provider events"
 
-    click_button "Submit a provider event for review"
+    click_button "Submit provider event for review"
     expect(page).to have_text("Provider Event Details")
     expect(page).to have_checked_field("Search existing venues")
   end
 
   def navigate_to_edit_form
-    visit internal_events_path
-    expect(page).to have_text "Pending Provider Events"
+    visit internal_events_path(event_type: "provider")
+    expect(page).to have_text "Pending provider events"
 
     click_link "Pending event"
     expect(page).to have_text("This is a pending event")


### PR DESCRIPTION
### Trello card
https://trello.com/c/l8pD2kl7

### Context
The CRM requested the ability to add Scribble Events (a type of online event).

This will enable users to switch between provider and online events. The form will be updated to reflect this in a later PR

### Changes proposed in this pull request
- Add tabbed navigation between provider and online event types.

### Guidance to review
- Does it look passable?
