### PR TITLE
Add ids to mailing list bar for tracking purposes

### DIFF
--- a/app/views/sections/_mailing-list-bar.html.erb
+++ b/app/views/sections/_mailing-list-bar.html.erb
@@ -4,8 +4,8 @@
       Get personalised information and advice about getting into teaching
     </div>
     <div class="mailing-list-bar__right">
-      <a href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
-      <a href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
+      <a id="mailing-list-bar-accept" href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
+      <a id="mailing-list-bar-dismiss" href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
     </div>
   </section>
 </div>

--- a/spec/requests/mailing_list/calls_to_action_spec.rb
+++ b/spec/requests/mailing_list/calls_to_action_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe "Mailing list calls to action" do
+  describe "banner" do
+    before { get root_path }
+    subject { Nokogiri.parse(response.body) }
+
+    it "the mailing list banner has a close link" do
+      link = subject.at_css("#mailing-list-bar-dismiss")
+
+      expect(link).to be_truthy
+    end
+
+    it "the mailing list banner has an accept link" do
+      link = subject.at_css("#mailing-list-bar-accept")
+
+      expect(link).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

N/A

### Context

The IDs are to make interactions trackable via GA.
