### PR TITLE
Rename telephone to address_telephone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: fdcee355185dfb8981f44e92aaa9cb24a43312e1
+  revision: 9e1ee278207b6c3499ca969c8d2e10bc2bb30a97
   specs:
-    get_into_teaching_api_client (1.1.14)
+    get_into_teaching_api_client (1.1.15)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.28)
+    get_into_teaching_api_client_faraday (0.1.29)
       activesupport
       faraday
       faraday-encoding
@@ -244,7 +244,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.2.2)
+    puma (5.3.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -453,7 +453,7 @@ DEPENDENCIES
   prometheus-client
   pry-byebug
   pry-rails
-  puma (~> 5.2)
+  puma (~> 5.3, >= 5.3.1)
   rack-attack
   rails (~> 6.1.3)
   rails_semantic_logger

--- a/app/models/events/steps/contact_details.rb
+++ b/app/models/events/steps/contact_details.rb
@@ -1,11 +1,11 @@
 module Events
   module Steps
     class ContactDetails < ::Wizard::Step
-      attribute :telephone
-      validates :telephone, telephone: true, allow_blank: true
+      attribute :address_telephone
+      validates :address_telephone, telephone: true, allow_blank: true
 
-      before_validation if: :telephone do
-        self.telephone = telephone.to_s.strip.presence
+      before_validation if: :address_telephone do
+        self.address_telephone = address_telephone.to_s.strip.presence
       end
 
       def optional?

--- a/app/views/event_steps/_contact_details.html.erb
+++ b/app/views/event_steps/_contact_details.html.erb
@@ -1,2 +1,2 @@
-<%= f.govuk_text_field :telephone %>
+<%= f.govuk_text_field :address_telephone %>
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,8 +7,10 @@ Rails.application.config.filter_parameters += %i[
   last_name
   password
   telephone
+  address_telephone
   timed_one_time_password
   firstName
   lastName
   timedOneTimePassword
+  addressTelephone
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
               invalid: Enter a valid email address
         events/steps/contact_details:
           attributes:
-            telephone:
+            address_telephone:
               invalid: Enter a valid phone number
         events/steps/further_details:
           attributes:
@@ -260,7 +260,7 @@ en:
         last_name: Last name
         email: Email address
       events_steps_contact_details:
-        telephone: Phone number (optional)
+        address_telephone: Phone number (optional)
       events_steps_personalised_updates:
         address_postcode: What is your postcode? (optional)
         degree_status_id: What stage are you at with your degree?

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Event wizard", type: :feature do
     response = GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
       eventId: "abc-123",
       addressPostcode: "TE57 1NG",
-      telephone: "1234567890",
+      addressTelephone: "1234567890",
     )
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:exchange_access_token_for_teaching_event_add_attendee).with("123456", anything).and_return(response)

--- a/spec/lib/attribute_filter_spec.rb
+++ b/spec/lib/attribute_filter_spec.rb
@@ -3,8 +3,8 @@ require "attribute_filter"
 
 describe AttributeFilter, type: :helper do
   describe ".filtered_json" do
-    let(:model) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", telephone: "1234567") }
-    let(:expected_json) { { "candidateId" => "123", "telephone" => "[FILTERED]" }.to_json }
+    let(:model) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", addressTelephone: "1234567") }
+    let(:expected_json) { { "candidateId" => "123", "addressTelephone" => "[FILTERED]" }.to_json }
 
     subject { described_class.filtered_json(input) }
 

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -5,25 +5,25 @@ describe Events::Steps::ContactDetails do
 
   it_behaves_like "a wizard step"
 
-  it { is_expected.to respond_to :telephone }
+  it { is_expected.to respond_to :address_telephone }
   it { expect(subject).to be_optional }
 
   describe "validations" do
-    it { is_expected.to allow_value("").for :telephone }
-    it { is_expected.to allow_value("01234567890").for :telephone }
-    it { is_expected.to allow_value("01234 567890").for :telephone }
-    it { is_expected.not_to allow_value("invalid").for :telephone }
-    it { is_expected.not_to allow_value("01234").for :telephone }
+    it { is_expected.to allow_value("").for :address_telephone }
+    it { is_expected.to allow_value("01234567890").for :address_telephone }
+    it { is_expected.to allow_value("01234 567890").for :address_telephone }
+    it { is_expected.not_to allow_value("invalid").for :address_telephone }
+    it { is_expected.not_to allow_value("01234").for :address_telephone }
   end
 
   describe "data cleaning" do
     it "cleans the telephone" do
-      subject.telephone = "  01234567890 "
+      subject.address_telephone = "  01234567890 "
       subject.valid?
-      expect(subject.telephone).to eq("01234567890")
-      subject.telephone = "  "
+      expect(subject.address_telephone).to eq("01234567890")
+      subject.address_telephone = "  "
       subject.valid?
-      expect(subject.telephone).to be_nil
+      expect(subject.address_telephone).to be_nil
     end
   end
 end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -54,7 +54,7 @@ describe Events::Wizard do
   describe "#exchange_access_token" do
     let(:totp) { "123456" }
     let(:request) { GetIntoTeachingApiClient::ExistingCandidateRequest.new }
-    let(:response) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", telephone: "12345") }
+    let(:response) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", addressTelephone: "12345") }
 
     before do
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -67,7 +67,7 @@ describe Events::Wizard do
     end
 
     it "logs the response model (filtering sensitive attributes)" do
-      filtered_json = { "candidateId" => "123", "telephone" => "[FILTERED]" }.to_json
+      filtered_json = { "candidateId" => "123", "addressTelephone" => "[FILTERED]" }.to_json
       expect(Rails.logger).to receive(:info).with("Events::Wizard#exchange_access_token: #{filtered_json}")
       subject.exchange_access_token(totp, request)
     end


### PR DESCRIPTION
The API currently supports both field names, but `telephone` is being deprecated in favour of `address_telephone`.
