### PR TITLE
Create redirect for old GSE page route

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -17,6 +17,9 @@ redirects:
   "/international-teachers": "/international-candidates"
   "/international-students": "/international-candidates"
 
+  # Old GSE Page
+  "/get-school-experience/get-school-experience": "/get-school-experience"
+
   # Campaign landing pages
   "/helping-you-become-a-teacher": "/three-things-to-help-you-get-into-teaching"
 


### PR DESCRIPTION
### Context
SEMrush report shows that this URL returns a 404. It used to be a page for our GSE page. We shifted it up one level.

### Changes proposed in this pull request
Added a redirect in the .yml file to prevent any potential 404s when someone navigates to `/get-school-experience/get-school-experience`

### Guidance to review
Does the redirect work?
