### PR TITLE
Move green ML bar out of footer and into layouts

### DIFF
--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -28,6 +28,7 @@
       </section>
     </main>
 
+    <%= render "sections/mailing-list-bar" %>
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -92,6 +92,7 @@
       </section>
     </main>
 
+        <%= render "sections/mailing-list-bar" %>
         <%= render "sections/footer" %>
         <%= render "components/videoplayer" %>
         <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -30,6 +30,7 @@
       </section>
     </main>
 
+    <%= render "sections/mailing-list-bar" %>
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -18,6 +18,7 @@
       <% end %>
     </main>
 
+    <%= render "sections/mailing-list-bar" %>
     <%= render "sections/footer" %>
     <%= render "components/videoplayer" %>
     <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -45,6 +45,8 @@
           </section>
         </section>
       </main>
+
+      <%= render "sections/mailing-list-bar" %>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -16,6 +16,8 @@
           </section>
         </section>
       </main>
+
+      <%= render "sections/mailing-list-bar" %>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -9,6 +9,8 @@
           <%= yield %>
         <% end %>
       </main>
+
+      <%= render "sections/mailing-list-bar" %>
       <%= render "sections/footer" %>
       <%= render "components/videoplayer" %>
       <%= render "sections/cookie-acceptance" %>

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,5 +1,4 @@
 <%= render "sections/mailing-list-popup" %>
-<%= render "sections/mailing-list-bar" %>
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
   <div class="site-footer__wrapper limit-content-width">


### PR DESCRIPTION
Moving the green mailing list banner out of the footer stops it from appearing on every page (including the mailing list signup). It gives us a little more control and won't pester users who are mid-way through signing up to sign up.


https://user-images.githubusercontent.com/128088/118264141-294b2880-b4af-11eb-8eaa-129fb8aa48e3.mp4

