### PR TITLE
Allow non-content pages to be searched

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -10,10 +10,17 @@ class Search
     @results ||= search_frontmatter
   end
 
+  NON_CONTENT_PAGES = {
+    "/events" => {
+      title: "Find an event near you",
+      keywords: %w[events conferences presentation],
+    },
+  }.freeze
+
 private
 
   def search_frontmatter
-    Pages::Frontmatter.list.select do |_path, frontmatter|
+    searchable_pages.select do |_path, frontmatter|
       keywords_match?(frontmatter[:keywords]) || title_matches?(frontmatter[:title])
     end
   end
@@ -30,5 +37,9 @@ private
 
   def title_match_regex
     @title_match_regex ||= %r{\b#{Regexp.quote search.downcase}}
+  end
+
+  def searchable_pages
+    NON_CONTENT_PAGES.merge(Pages::Frontmatter.list)
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -13,7 +13,7 @@ class Search
   NON_CONTENT_PAGES = {
     "/events" => {
       title: "Find an event near you",
-      keywords: %w[events conferences presentation],
+      keywords: %w[event events conference presentation virtual online TTT Q&A attend training],
     },
   }.freeze
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -76,5 +76,19 @@ RSpec.describe Search do
 
       it { is_expected.to be_empty }
     end
+
+    describe "non-content pages" do
+      describe "events" do
+        Search::NON_CONTENT_PAGES.dig("/events", :keywords).each do |kw|
+          describe kw do
+            let(:search) { kw }
+
+            it "finds the events page when searching for #{kw}" do
+              expect(subject).to include "/events"
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The searching mechanism only pays attention to two fields from the frontmatter, the title and keywords. Here we're prepending a list of custom pages to the automatically-loaded frontmatter that will be included in search results.
