### PR TITLE
Ensure chevron applied before external link span

### DIFF
--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -5,8 +5,8 @@ export default class extends Controller {
 
   connect() {
     this.preventTurboLinksOnJumpLinks();
-    this.openExternalContentLinksInNewWindow();
     this.prepareChevronOnButtonLinks();
+    this.openExternalContentLinksInNewWindow();
   }
 
   preventTurboLinksOnJumpLinks() {


### PR DESCRIPTION
If these happen the other way round the chevron is added to the hidden external link text and isn't displayed.
