### PR TITLE
Scribble form

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -7,7 +7,7 @@ module Internal
     DEFAULT_EVENT_TYPE = "provider".freeze
 
     def index
-      @event_type = set_event_type(params[:event_type])
+      @event_type = determine_event_type(params[:event_type])
 
       load_pending_events(@event_type)
       @no_results = @events.blank?
@@ -24,7 +24,7 @@ module Internal
     end
 
     def new
-      @event_type = set_event_type(params[:event_type])
+      @event_type = determine_event_type(params[:event_type])
       @event = Event.new(venue_type: Event::VENUE_TYPES[:existing], type_id: @event_type)
       @event.building = EventBuilding.new
     end
@@ -55,7 +55,7 @@ module Internal
 
   private
 
-    def set_event_type(type)
+    def determine_event_type(type)
       event_types[type] || event_types[:provider]
     end
 

--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -17,13 +17,14 @@ module Internal
     attribute :name, :string
     attribute :summary, :string
     attribute :description, :string
-    attribute :is_online, :boolean
+    attribute :is_online, :boolean, default: nil
     attribute :start_at, :datetime
     attribute :end_at, :datetime
-    attribute :provider_contact_email, :string
-    attribute :provider_organiser, :string
-    attribute :provider_target_audience, :string
-    attribute :provider_website_url, :string
+    attribute :provider_contact_email, :string, default: nil
+    attribute :provider_organiser, :string, default: nil
+    attribute :provider_target_audience, :string, default: nil
+    attribute :provider_website_url, :string, default: nil
+    attribute :scribble_id, :string, default: nil
     attribute :building
     attribute :venue_type, default: VENUE_TYPES[:none]
 
@@ -31,18 +32,18 @@ module Internal
     validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }
     validates :summary, presence: true, allow_blank: false, length: { maximum: 1000 }
     validates :description, presence: true, allow_blank: false, length: { maximum: 2000 }
-    validates :summary, presence: true, allow_blank: false
-    validates :is_online, inclusion: { in: [true, false] }
+    validates :is_online, inclusion: { in: [true, false] }, if: -> { provider_event? }
     validates :start_at, presence: true, allow_blank: false
     validates :end_at, presence: true
     validates :provider_contact_email,
               presence: true,
               allow_blank: false,
               email_format: true,
-              length: { maximum: 100 }
-    validates :provider_organiser, presence: true, allow_blank: false, length: { maximum: 300 }
-    validates :provider_target_audience, presence: true, allow_blank: false, length: { maximum: 500 }
-    validates :provider_website_url, presence: true, allow_blank: false, length: { maximum: 300 }
+              length: { maximum: 100 }, if: -> { provider_event? }
+    validates :provider_organiser, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { provider_event? }
+    validates :provider_target_audience, presence: true, allow_blank: false, length: { maximum: 500 }, if: -> { provider_event? }
+    validates :provider_website_url, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { provider_event? }
+    validates :scribble_id, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { online_event? }
     validates :venue_type, inclusion: { in: VENUE_TYPES.values }
     validates_each :start_at, :end_at do |record, attr, value|
       unless value.nil?
@@ -108,6 +109,14 @@ module Internal
     def invalid?
       invalid_building = building.present? && building.invalid?
       super || invalid_building
+    end
+
+    def provider_event?
+      type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+    end
+
+    def online_event?
+      type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
     end
 
   private

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -61,7 +61,7 @@
   <br />
   <% end %>
 
-  <% if event_status_open?(@event) %>
+  <% if event_status_open?(@event) || event_status_pending?(@event) %>
     <% if can_sign_up_online?(@event) %>
       <h2>How to attend</h2>
       <p>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -22,7 +22,9 @@
   <h1 class="pending-title">Pending <%= event_type_name %> events</h1>
 
   <%= button_to "Submit #{event_type_name} event for review",
-                new_internal_event_path, method: :get,
+                new_internal_event_path,
+                params: { event_type: event_type_name },
+                method: :get,
                 class: "button submit-button no-left-margin" %>
 
   <% if @no_results %>

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -3,7 +3,7 @@
             method: :get,
             class: "govuk-back-link" %>
 
-<h1>Provider Event Details</h1>
+<h1><%= event_type_name.capitalize %> event details</h1>
 
 <%= govuk_form_for @event,
                    url: internal_events_path,
@@ -11,6 +11,7 @@
                    html: { data: { "controller": "internal-events" } } do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :id %>
+  <%= f.hidden_field :type_id %>
   <%= f.govuk_text_field :name,
                          label: { text: 'Event name' },
                          data: { "internal-events-target": "name" } %>
@@ -21,15 +22,20 @@
                  input="internal_event_description">
     </trix-editor>
   <% end %>
-  <%= f.govuk_email_field :provider_contact_email, label: { text: 'Provider email address' } %>
-  <%= f.govuk_text_field :provider_organiser, label: { text: 'Provider organiser' } %>
-  <%= f.govuk_text_field :provider_target_audience, label: { text: 'Target audience' } %>
-  <%= f.govuk_url_field :provider_website_url, label: { text: 'Provider website/registration link' } %>
-  <%= f.govuk_radio_buttons_fieldset(:is_online, inline: true,
-                                     legend: { size: 'm', text: 'Online event?' }) do %>
-    <%= f.govuk_radio_button :is_online, true, label: { text: 'Yes' } %>
-    <%= f.govuk_radio_button :is_online, false, label: { text: 'No' } %>
+
+  <% if @event.provider_event? %>
+    <%= f.govuk_email_field :provider_contact_email, label: { text: 'Provider email address' } %>
+    <%= f.govuk_text_field :provider_organiser, label: { text: 'Provider organiser' } %>
+    <%= f.govuk_text_field :provider_target_audience, label: { text: 'Target audience' } %>
+    <%= f.govuk_url_field :provider_website_url, label: { text: 'Provider website/registration link' } %>
+
+    <%= f.govuk_radio_buttons_fieldset(:is_online, inline: true,
+                                       legend: { size: 'm', text: 'Online event?' }) do %>
+      <%= f.govuk_radio_button :is_online, true, label: { text: 'Yes' } %>
+      <%= f.govuk_radio_button :is_online, false, label: { text: 'No' } %>
+    <% end %>
   <% end %>
+
   <%= render "form/govuk_error_message", label: "Start at", field_errors: @event.errors[:start_at] do %>
     <%= f.datetime_field :start_at,
                          class: class_names("datetime", "govuk-input", { "govuk-input--error": @event.errors[:start_at].any? }),
@@ -53,29 +59,35 @@
                type: "button",
                data: { action: "click->internal-events#populatePartialUrl" } %>
 
-  <div class="no-left-margin">
-    <%= f.fields_for :building, @event.building do |b| %>
-      <%= b.govuk_error_summary unless @event.building.nil? %>
-      <%= f.govuk_radio_buttons_fieldset(:venue_type, legend: { size: 'm', text: 'Event venue' }) do %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:none], label: { text: 'No venue' }, link_errors: true %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' } do %>
-          <%= b.govuk_collection_select :id,
-                                        f.object.buildings,
-                                        :id,
-                                        ->(building) { "#{building.venue}, #{building.address_postcode}" },
-                                        label: { text: 'Search for existing buildings' },
-                                        options: { include_blank: "" } %>
-        <% end %>
-        <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:add], label: { text: 'Add a new venue' } do %>
-          <%= b.govuk_text_field :venue, label: { text: 'Venue' } %>
-          <%= b.govuk_text_field :address_line1, label: { text: 'Address line 1' } %>
-          <%= b.govuk_text_field :address_line2, label: { text: 'Address line 2' } %>
-          <%= b.govuk_text_field :address_line3, label: { text: 'Address line 3' } %>
-          <%= b.govuk_text_field :address_city, label: { text: 'City' } %>
-          <%= b.govuk_text_field :address_postcode, label: { text: 'Postcode' } %>
+  <% if @event.online_event? %>
+    <%= f.govuk_url_field :scribble_id, label: { text: 'Scribble ID' } %>
+  <% end %>
+
+  <% if @event.provider_event? %>
+    <div class="no-left-margin">
+      <%= f.fields_for :building, @event.building do |b| %>
+        <%= b.govuk_error_summary unless @event.building.nil? %>
+        <%= f.govuk_radio_buttons_fieldset(:venue_type, legend: { size: 'm', text: 'Event venue' }) do %>
+          <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:none], label: { text: 'No venue' }, link_errors: true %>
+          <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:existing], label: { text: 'Search existing venues' } do %>
+            <%= b.govuk_collection_select :id,
+                                          f.object.buildings,
+                                          :id,
+                                          ->(building) { "#{building.venue}, #{building.address_postcode}" },
+                                          label: { text: 'Search for existing buildings' },
+                                          options: { include_blank: "" } %>
+          <% end %>
+          <%= f.govuk_radio_button :venue_type, Internal::Event::VENUE_TYPES[:add], label: { text: 'Add a new venue' } do %>
+            <%= b.govuk_text_field :venue, label: { text: 'Venue' } %>
+            <%= b.govuk_text_field :address_line1, label: { text: 'Address line 1' } %>
+            <%= b.govuk_text_field :address_line2, label: { text: 'Address line 2' } %>
+            <%= b.govuk_text_field :address_line3, label: { text: 'Address line 3' } %>
+            <%= b.govuk_text_field :address_city, label: { text: 'City' } %>
+            <%= b.govuk_text_field :address_postcode, label: { text: 'Postcode' } %>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
+  <% end %>
   </div>
   <%= f.button "Submit for review", class: "button form-button" %>
 <% end %>

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -31,7 +31,7 @@
 
     <%= f.govuk_radio_buttons_fieldset(:is_online, inline: true,
                                        legend: { size: 'm', text: 'Online event?' }) do %>
-      <%= f.govuk_radio_button :is_online, true, label: { text: 'Yes' } %>
+      <%= f.govuk_radio_button :is_online, true, label: { text: 'Yes' }, link_errors: true %>
       <%= f.govuk_radio_button :is_online, false, label: { text: 'No' } %>
     <% end %>
   <% end %>

--- a/app/views/internal/events/show.html.erb
+++ b/app/views/internal/events/show.html.erb
@@ -12,11 +12,11 @@
     <div class="govuk-notification-banner__content">
       <p class="govuk-notification-banner__heading">
         This is a pending event.
-        <%= button_to "Edit this provider event",
+        <%= button_to "Edit this event",
                       edit_internal_event_path(@event.readable_id), method: :get,
                       class: "button notification-button" %>
         <% if publisher? %>
-          <%= button_to "Submit this provider event",
+          <%= button_to "Set event status to Open",
                         internal_approve_path, params: { id: @event.readable_id }, method: :put,
                         class: "button notification-button" %>
         <% end %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -13,6 +13,7 @@
     <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>
+        <%= yield(:feature) %>
       </article>
     </section>
   </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,8 @@ en:
               blank: Enter the date and time the event starts
             end_at:
               blank: Enter the date and time the event ends
+            scribble_id:
+              blank: Enter a Scribble ID
 
         internal/event_building:
           attributes:

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -3,13 +3,22 @@ require "action_text/system_test_helper"
 
 RSpec.feature "Internal section", type: :feature do
   let(:types) { Events::Search.available_event_type_ids }
-  let(:event) do
+  let(:provider_event) do
     build(:event_api,
           :with_provider_info,
-          name: "Pending event",
-          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"])
+          name: "Pending provider event",
+          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
+          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
   end
-  let(:events_by_type) { group_events_by_type([event]) }
+  let(:online_event) do
+    build(:event_api,
+          :with_provider_info,
+          name: "Pending online event",
+          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
+          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
+  end
+  let(:provider_events_by_type) { group_events_by_type([provider_event]) }
+  let(:online_events_by_type) { group_events_by_type([online_event]) }
 
   before do
     allow(Rails.application.config.x).to receive(:publisher_username) { "publisher" }
@@ -19,9 +28,6 @@ RSpec.feature "Internal section", type: :feature do
       page.driver.browser.authorize("publisher", "password")
     end
 
-    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_grouped_by_type) { events_by_type }
-
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi).to \
       receive(:get_teaching_event_buildings) { [] }
 
@@ -29,123 +35,207 @@ RSpec.feature "Internal section", type: :feature do
       receive(:upsert_teaching_event) { [] }
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_teaching_event) { event }
+      receive(:get_teaching_event) { provider_event }
+
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
   end
 
-  scenario "Submit a new form" do
-    navigate_to_new_submission
+  shared_examples "pending events" do |event_type|
+    scenario "submit a new form" do
+      navigate_to_new_submission(event_type)
 
-    enter_valid_event_details
-
-    click_button "Submit for review"
-    expect(page).to have_text "Event submitted for review"
-  end
-
-  scenario "Edit a pending event with no building" do
-    event.building = nil
-
-    navigate_to_edit_form
-
-    expect(page).to have_checked_field("No venue")
-
-    click_button "Submit for review"
-    expect(page).to have_text "Event submitted for review"
-  end
-
-  scenario "Edit a pending event with building" do
-    navigate_to_edit_form
-
-    expect(page).to have_checked_field("Search existing venues")
-  end
-
-  scenario "Final submit" do
-    visit internal_events_path
-    expect(page).to have_text "Pending provider events"
-
-    click_link "Pending event"
-    expect(page).to have_text("This is a pending event")
-
-    click_button "Submit this provider event"
-    expect(page).to have_text("Event submitted")
-  end
-
-  describe "validations" do
-    scenario "There are validation errors on event and building" do
-      navigate_to_new_submission
-
-      fill_in "internal_event[start_at]", with: 1.day.ago
-      fill_in "internal_event[end_at]", with: 1.day.ago
-
-      choose "Add a new venue"
-      fill_in "Postcode", with: "invalid"
+      enter_valid_provider_event_details if event_type == "provider"
+      enter_valid_online_event_details if event_type == "online"
 
       click_button "Submit for review"
-
-      expect(page).to have_text "Enter a name"
-      expect(page).to have_text "Enter a venue name"
+      expect(page).to have_text "Event submitted for review"
     end
 
-    scenario "There are validation errors on building only" do
-      navigate_to_new_submission
+    scenario "final submit" do
+      visit internal_events_path(event_type: event_type)
+      expect(page).to have_text "Pending #{event_type} events"
 
-      enter_valid_event_details
+      click_link "Pending #{event_type} event"
+      expect(page).to have_text("This is a pending event")
 
-      choose "Add a new venue"
+      click_button "Set event status to Open"
+      expect(page).to have_text("Event submitted")
+    end
+  end
 
-      click_button "Submit for review"
-
-      expect(page).to have_text "Enter a venue name"
+  context "when provider event type" do
+    include_examples "pending events", "provider" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+          receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
+      end
     end
 
-    scenario "There are validation errors on event only" do
-      navigate_to_new_submission
+    scenario "edit a pending event with no building" do
+      provider_event.building = nil
 
-      choose "Add a new venue"
-      fill_in "Venue", with: "valid"
-      fill_in "Postcode", with: "M1 7AX"
+      navigate_to_edit_form
+
+      expect(page).to have_checked_field("No venue")
 
       click_button "Submit for review"
+      expect(page).to have_text "Event submitted for review"
+    end
 
-      expect(page).to have_text "Enter a name"
+    scenario "edit a pending event with building" do
+      navigate_to_edit_form
+
+      expect(page).to have_checked_field("Search existing venues")
+    end
+
+    context "when the event submission is invalid" do
+      scenario "there are validation errors on event and building" do
+        navigate_to_new_submission("provider")
+
+        enter_bad_start_end_dates
+
+        choose "Add a new venue"
+        fill_in "Postcode", with: "invalid"
+
+        click_button "Submit for review"
+
+        expect_provider_validation_errors
+      end
+
+      scenario "there are validation errors on building only" do
+        navigate_to_new_submission("provider")
+
+        enter_valid_provider_event_details
+
+        choose "Add a new venue"
+
+        click_button "Submit for review"
+
+        expect_building_validation_errors
+      end
+
+      scenario "there are validation errors on event only" do
+        navigate_to_new_submission("provider")
+
+        enter_bad_start_end_dates
+
+        choose "Add a new venue"
+        fill_in "Venue", with: "valid"
+        fill_in "Postcode", with: "M1 7AX"
+
+        click_button "Submit for review"
+
+        expect_provider_validation_errors
+      end
+    end
+  end
+
+  context "when online event type" do
+    include_examples "pending events", "online" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+          receive(:search_teaching_events_grouped_by_type) { online_events_by_type }
+      end
+    end
+
+    context "when the event submission is invalid" do
+      scenario "there are validation errors on event" do
+        navigate_to_new_submission("online")
+
+        enter_bad_start_end_dates
+
+        click_button "Submit for review"
+
+        expect_online_validation_errors
+      end
     end
   end
 
 private
 
-  def navigate_to_new_submission
-    visit internal_events_path(event_type: "provider")
-    expect(page).to have_text "Pending provider events"
+  def enter_bad_start_end_dates
+    fill_in "internal_event[start_at]", with: 1.day.ago
+    fill_in "internal_event[end_at]", with: 1.day.ago
+  end
 
-    click_button "Submit provider event for review"
-    expect(page).to have_text("Provider Event Details")
-    expect(page).to have_checked_field("Search existing venues")
+  def expect_building_validation_errors
+    expect(page).to have_text "Enter a venue name"
+    expect(page).to have_text "Enter a postcode"
+  end
+
+  def expect_online_validation_errors
+    expect_common_validation_errors
+
+    expect(page).to have_text "Enter a Scribble ID"
+  end
+
+  def expect_provider_validation_errors
+    expect_common_validation_errors
+
+    expect(page).to have_text "Choose whether the event is online"
+    expect(page).to have_text "Enter a provider email address"
+    expect(page).to have_text "Enter a provider organiser"
+    expect(page).to have_text "Enter a provider target audience"
+    expect(page).to have_text "Enter a provider website/registration link"
+  end
+
+  def expect_common_validation_errors
+    expect(page).to have_text "Enter a name"
+    expect(page).to have_text "Enter a summary"
+    expect(page).to have_text "Enter a description"
+    expect(page).to have_text "Enter a partial URL"
+    # start_at and end_at in error summary and field message
+    expect(page).to have_text "Must be in the future", count: 4
+  end
+
+  def navigate_to_new_submission(event_type)
+    visit internal_events_path(event_type: event_type)
+    expect(page).to have_text "Pending #{event_type} events"
+
+    click_button "Submit #{event_type} event for review"
+
+    expect(page).to have_text("#{event_type.capitalize} event details")
+
+    expect(page).to have_checked_field("Search existing venues") if event_type == "provider"
   end
 
   def navigate_to_edit_form
     visit internal_events_path(event_type: "provider")
     expect(page).to have_text "Pending provider events"
 
-    click_link "Pending event"
+    click_link "Pending provider event"
     expect(page).to have_text("This is a pending event")
 
-    click_button "Edit this provider event"
-    expect(page).to have_text("Provider Event Details")
+    click_button "Edit this event"
+    expect(page).to have_text("Provider event details")
   end
 
-  def enter_valid_event_details
+  def enter_valid_provider_event_details
+    enter_common_event_details
+
+    fill_in "Provider email address", with: "test@test.com"
+    fill_in "Provider organiser", with: "test"
+    fill_in "Target audience", with: "test"
+    fill_in "Provider website/registration link", with: "test"
+    choose "Yes"
+    choose "No venue"
+  end
+
+  def enter_valid_online_event_details
+    enter_common_event_details
+
+    fill_in "Scribble ID", with: "test"
+  end
+
+  def enter_common_event_details
     fill_in "Event name", with: "test"
     fill_in "Event partial URL", with: "test"
     fill_in "Event summary", with: "test"
     find(:id, "internal_event_description", visible: false)
       .click
       .set "test"
-    fill_in "Provider email address", with: "test@test.com"
-    fill_in "Provider organiser", with: "test"
-    fill_in "Target audience", with: "test"
-    fill_in "Provider website/registration link", with: "test"
-    choose "Yes"
     fill_in "internal_event[start_at]", with: Time.zone.now + 1.day
     fill_in "internal_event[end_at]", with: Time.zone.now + 2.days
-    choose "No venue"
   end
 end

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -44,11 +44,6 @@ describe Internal::Event do
       it { is_expected.to validate_length_of(:description).is_at_most(2000) }
     end
 
-    describe "#is_online" do
-      it { is_expected.to allow_values(true, false).for :is_online }
-      it { is_expected.to_not allow_value(nil).for :is_online }
-    end
-
     describe "#start_at" do
       it { is_expected.to_not allow_values(nil, now - 1.minute, now).for :start_at }
       it { is_expected.to allow_value(Time.zone.now + 1.minute).for :start_at }
@@ -74,28 +69,47 @@ describe Internal::Event do
       end
     end
 
-    describe "#provider contact email" do
-      it { is_expected.to allow_value("test@test.com").for :provider_contact_email }
-      it { is_expected.to_not allow_values("test", "", nil).for :provider_contact_email }
-      it { is_expected.to validate_length_of(:provider_contact_email).is_at_most(100) }
+    context "when online event" do
+      before { allow(subject).to receive(:online_event?).and_return(true) }
+
+      describe "#scribble_id" do
+        it { is_expected.to allow_value("test").for :scribble_id }
+        it { is_expected.to_not allow_values("", nil).for :scribble_id }
+        it { is_expected.to validate_length_of(:scribble_id).is_at_most(300) }
+      end
     end
 
-    describe "#provider organiser" do
-      it { is_expected.to allow_value("test").for :provider_organiser }
-      it { is_expected.to_not allow_value("", nil).for :provider_organiser }
-      it { is_expected.to validate_length_of(:provider_organiser).is_at_most(300) }
-    end
+    context "when provider event" do
+      before { allow(subject).to receive(:provider_event?).and_return(true) }
 
-    describe "#provider target audience" do
-      it { is_expected.to allow_value("test").for :provider_target_audience }
-      it { is_expected.to_not allow_value("", nil).for :provider_target_audience }
-      it { is_expected.to validate_length_of(:provider_target_audience).is_at_most(500) }
-    end
+      describe "#is_online" do
+        it { is_expected.to allow_values(true, false).for :is_online }
+        it { is_expected.to_not allow_value(nil).for :is_online }
+      end
 
-    describe "#provider website url" do
-      it { is_expected.to allow_value("test").for :provider_website_url }
-      it { is_expected.to_not allow_value("", nil).for :provider_website_url }
-      it { is_expected.to validate_length_of(:provider_website_url).is_at_most(300) }
+      describe "#provider contact email" do
+        it { is_expected.to allow_value("test@test.com").for :provider_contact_email }
+        it { is_expected.to_not allow_values("test", "", nil).for :provider_contact_email }
+        it { is_expected.to validate_length_of(:provider_contact_email).is_at_most(100) }
+      end
+
+      describe "#provider organiser" do
+        it { is_expected.to allow_value("test").for :provider_organiser }
+        it { is_expected.to_not allow_value("", nil).for :provider_organiser }
+        it { is_expected.to validate_length_of(:provider_organiser).is_at_most(300) }
+      end
+
+      describe "#provider target audience" do
+        it { is_expected.to allow_value("test").for :provider_target_audience }
+        it { is_expected.to_not allow_value("", nil).for :provider_target_audience }
+        it { is_expected.to validate_length_of(:provider_target_audience).is_at_most(500) }
+      end
+
+      describe "#provider website url" do
+        it { is_expected.to allow_value("test").for :provider_website_url }
+        it { is_expected.to_not allow_value("", nil).for :provider_website_url }
+        it { is_expected.to validate_length_of(:provider_website_url).is_at_most(300) }
+      end
     end
 
     describe "#venue_type" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -151,43 +151,57 @@ describe Internal::EventsController do
         end
         it "should have a final submit button" do
           assert_response :success
-          expect(response.body).to include "Submit this provider event"
+          expect(response.body).to include "Set event status to Open"
         end
       end
     end
   end
 
   describe "#new" do
-    context "when any user type" do
-      before do
-        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-          .to receive(:get_teaching_event_buildings) { [] }
+    shared_examples "new event" do |event_params|
+      it "renders #{event_params || 'provider'} events form" do
+        get new_internal_event_path, headers: generate_auth_headers(:author), params: { event_type: event_params }
 
-        get new_internal_event_path, headers: generate_auth_headers(:author)
-      end
-
-      it "should have an events form" do
         assert_response :success
-        expect(response.body).to include("form")
+        expect(response.body).to include("#{event_params ? event_params.capitalize : 'Provider'} event details")
       end
     end
-  end
 
-  describe "#edit" do
-    let(:event_to_edit_readable_id) { "1" }
     context "when any user type" do
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
           .to receive(:get_teaching_event_buildings) { [] }
-        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-          .to receive(:get_teaching_event).with(event_to_edit_readable_id) { pending_provider_event }
-
-        get edit_internal_event_path(event_to_edit_readable_id), headers: generate_auth_headers(:author)
       end
 
-      it "should have an events form with populated fields" do
-        assert_response :success
-        expect(response.body).to include("value=\"Pending provider event\"")
+      context "when no event type parameter" do
+        include_examples "new event"
+      end
+
+      context "when provider event type parameter" do
+        include_examples "new event", "provider"
+      end
+
+      context "when online event type parameter" do
+        include_examples "new event", "online"
+      end
+    end
+
+    describe "#edit" do
+      let(:event_to_edit_readable_id) { "1" }
+      context "when any user type" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
+            .to receive(:get_teaching_event_buildings) { [] }
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+            .to receive(:get_teaching_event).with(event_to_edit_readable_id) { pending_provider_event }
+
+          get edit_internal_event_path(event_to_edit_readable_id), headers: generate_auth_headers(:author)
+        end
+
+        it "should have an events form with populated fields" do
+          assert_response :success
+          expect(response.body).to include("value=\"Pending provider event\"")
+        end
       end
     end
   end


### PR DESCRIPTION
### Trello card
https://trello.com/c/l8pD2kl7

### Context
The CRM requested the ability to add Scribble Events (online events).
This PR adds a "new" form for Scribble events in addition to the Provider events form.

### Changes proposed in this pull request
- Conditionally validate and render the event fields based on event type.
- Pass event type as query string to new form
- Update `events/show` view to render section if event pending. Whoever is reviewing the events must be able to accurately assess how they will appear when in an open state.
- Default optional fields to `nil`. If fields are omitted from the API request, they will not be changed in the CRM. For example, this prevents a `Scribble` event from omitting a `provider` field which would lead to it retaining its old value. This shouldn't happen anyway because it isn't possible to change an event type.
- Update some of the wording to work with either event type to reduce logic in the `internal/show` view