### PR TITLE
style edits across funding and salaries

### DIFF
--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -82,13 +82,16 @@
     - Adult Dependants’ Grant
     - Disabled students
     - Disabled Students’ Allowances
-    
+
 ---
 
 
 ## Tuition fee and maintenance loans
 
-You can apply for a tuition fee loan of up to £9,250 to cover your teacher training, so you don't need to pay course fees upfront. You can also apply for a maintenance loan of up to £12,382 to help with living costs.
+To help you [train to teach](/ways-to-train), you can apply for a:
+
+* tuition fee loan of up to £9,250 to cover your teacher training, so you do not need to pay course fees upfront
+* maintenance loan of up to £12,382 to help with living costs
 
 You can still apply for a tuition fee and a maintenance loan if you already have a student loan, and regardless of whether you get a bursary or scholarship.
 
@@ -99,11 +102,20 @@ $student-finance-calculator$
 
 ## Bursaries and scholarships
 
-You may be eligible for a bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You don’t need to pay them back.
+You may be eligible for a bursary or scholarship when training to teach.
 
-You’ll need a first, 2:1, 2:2 degree or a PhD or Master's to be eligible for a bursary, as well as meeting the bursary scheme's individual terms and conditions. [Get further guidance on your eligibility for bursaries](https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2021-to-2022).
+These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.
 
-For a scholarship, each professional scholarship body sets its own criteria. These bodies include the [Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry), [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing), [Mathematics Teacher Training Scholarship](https://ima.org.uk/support/mathematics-teacher-training-scholarship/) (maths) and the [Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics).
+You’ll need a first, 2:1, 2:2 degree or a PhD or master's degree to be eligible for a bursary, as well as meeting the bursary scheme's individual terms and conditions.
+
+[Find out more about your eligibility for bursaries](https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2021-to-2022).
+
+For a scholarship, each professional scholarship body sets its own criteria. These bodies include:
+
+* the [Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry)
+* [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
+* [Mathematics Teacher Training Scholarship](https://ima.org.uk/support/mathematics-teacher-training-scholarship/) (maths)
+* [Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
 
 ### Check which subjects have bursaries and scholarships
 
@@ -123,15 +135,25 @@ below. You cannot receive both a bursary and a scholarship.
 
 ### Non-graduate bursaries
 
-If you're a final year undergraduate student, you may be eligible for a [training bursary of £9,000](https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#undergraduate-bursary). The bursary is available if you're studying a Qualified Teacher Status (QTS) course in secondary maths or physics, or you're studying an opt-in QTS course in secondary undergraduate computing, languages, mathematics or physics.
+#### If you're a final year undergraduate student
 
-There are [Troops to Teachers](https://www.ucas.com/teaching-option/troops-teachers) tax-free bursaries of £40,000 for former military personel  undertaking  undergraduate degrees leading to QTS in England. You may be eligible for the bursary if you train to teach secondary biology, physics, chemistry, computing, maths or modern foreign languages.
+You may be eligible for a [training bursary of £9,000](https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#undergraduate-bursary) if you're on a secondary maths or physics course leading to '[qualified teacher status](/ways-to-train)' (QTS).
+
+You may also be eligible if you're studying an opt-in QTS course in secondary undergraduate computing, languages, mathematics or physics.
+
+#### If you're a former military personel
+
+You may be eligible for a [Troops to Teachers](https://www.ucas.com/teaching-option/troops-teachers) tax-free bursary of £40,000 if you're:
+
+* training to teach secondary biology, physics, chemistry, computing, maths or modern foreign languages
+* doing an undergraduate degree leading to QTS in England
+
 
 $chat$
 
 ## Extra financial support for parents and carers
 
-You may be able to get extra financial support if you have children or other caring responsibilities.
+ If you have children or other caring responsibilities you may be able to get extra financial support through the following schemes:
 
 * [Childcare Grant](https://www.gov.uk/childcare-grant)
 * [Parents Learning Allowance](https://www.gov.uk/parents-learning-allowance)

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -74,9 +74,13 @@
     - Troops to Teachers
     - Army
     - Air Force
+    - RAF
     - Navy
+    - Military
+    - Former
     - Parents
     - Parents’ Learning Allowance
+    - PLA
     - Childcare
     - Childcare Grant
     - Adult Dependants’ Grant

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -118,8 +118,8 @@ For a scholarship, each professional scholarship body sets its own criteria. The
 
 * the [Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry)
 * [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
-* [Mathematics Teacher Training Scholarship](https://ima.org.uk/support/mathematics-teacher-training-scholarship/) (maths)
-* [Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
+* the [Institute of Mathematics and its Applications](https://ima.org.uk/support/mathematics-teacher-training-scholarship/) (maths)
+* the [Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
 
 ### Check which subjects have bursaries and scholarships
 
@@ -160,7 +160,7 @@ $chat$
  If you have children or other caring responsibilities you may be able to get extra financial support through the following schemes:
 
 * [Childcare Grant](https://www.gov.uk/childcare-grant)
-* [Parents Learning Allowance](https://www.gov.uk/parents-learning-allowance)
+* [Parents' Learning Allowance](https://www.gov.uk/parents-learning-allowance)
 * [Adult Dependants’ Grant](https://www.gov.uk/adult-dependants-grant)
 
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -9,6 +9,16 @@ image: "/assets/images/salaries-hero-dt.jpg"
 backlink: "../../"
 navigation: 40
 lid_pixel_event: "SalaryBenefits"
+right_column:
+  ctas:
+    - title: How to train to teach
+      text: |
+       Find out how to train to become a qualified primary or secondary teacher in England.
+      link_text: "Ways to train"
+      link_target: "/ways-to-train"
+      icon: "icon-person"
+      hide_on_mobile: Yes
+      hide_on_tablet: Yes
 keywords:
   - Salary
   - Pay
@@ -36,7 +46,9 @@ keywords:
   - ECF
 ---
 
-Schools develop their own pay policies to attract and retain teachers that have the greatest impact on their pupils' learning. What you're paid will be linked to performance, not length of service - meaning your salary can move forward in line with your career.
+Schools develop their own pay policies to attract and retain teachers that have the greatest impact on their pupils' learning.
+
+What you're paid will be linked to performance, not length of service - meaning your salary can move forward in line with your career.
 
 ## Qualified teachers
 
@@ -52,28 +64,30 @@ As you progress in your teaching career, it's possible to move up through these 
 | The rest of England and Wales | £25,714 | £41,604 |
 
 ### Newly qualified teacher benefits
- 
-A new 2-year package to support teachers at the start of their career, based on the [Early Career Framework](https://www.gov.uk/government/publications/supporting-early-career-teachers), launches nationally in September 2021.
- 
+
+A 2-year package to support teachers at the start of their career, based on the [early career framework](https://www.gov.uk/government/publications/supporting-early-career-teachers), launches nationally in September 2021.
+
 The support package includes:
- 
+
 * funded 5% time off timetable in the second year of teaching, in addition to the existing 10% in the first year
-* a range of high-quality, freely available curricula and training materials underpinned by the Early Career Framework
+* a range of high-quality, freely available curricula and training materials underpinned by the early career framework
 * funded training for mentors of early career teachers
-* funded time for mentors to support early career teachers 
+* funded time for mentors to support early career teachers
 
 ### Teaching and learning responsibility (TLR) payments
 
 If you take on extra ongoing responsibilities in your role, you could get a salary uplift.
 
-There are two main ranges for these (TLR 1 and TLR 2), depending on the category your duties come under:
+There are 2 main ranges for these (TLR 1 and TLR 2), depending on the category your duties come under:
 
 | Level   | Minimum | Maximum |
 | ------- | -----   | -----   |
 | TLR 1   | £8,291  | £14,030 |
 | TLR 2   | £2,873  | £7,017  |
 
-Factors that apply to awarding TLRs include impact on educational progress beyond the teacher’s assigned pupils. It may also involve leading, developing and enhancing the teaching practice of others.
+Factors that apply to awarding TLRs include impact on educational progress beyond the teacher’s assigned pupils.
+
+It may also involve leading, developing and enhancing the teaching practice of others.
 
 ### Holidays
 
@@ -87,15 +101,17 @@ The Teachers’ Pension Scheme gives you a regular source of income when you ret
 * registered with HM Revenue and Customs - so your contributions are tax-free
 * flexible and allows you to take some of it as a tax-free lump sum
 
-[Find out more from Teachers’ Pensions](https://www.teacherspensions.co.uk/members/new-starter.aspx)
+[Find out more about the Teachers’ Pension Scheme](https://www.teacherspensions.co.uk/members/new-starter.aspx)
 
 ## Career progression
 
 ### Leading practitioners
 
-A Leading Practitioner is an excellent and highly skilled teacher who consistently demonstrates the highest standards of classroom practice. They share their skills and experience through the coaching, mentoring and induction of teachers, including trainees and newly qualified teachers (NQTs). 
+A 'leading practitioner' is an excellent and highly skilled teacher who consistently demonstrates the highest standards of classroom practice.
 
-In this role you could earn between £42,402 and £72,480 depending on where you teach.
+They share their skills and experience through the coaching, mentoring and induction of teachers, including trainees and newly qualified teachers (NQTs).
+
+You could earn between £42,402 and £72,480 depending on where you teach.
 
 | Area                          | Minimum | Maximum |
 | -------                       | -----   | -----   |
@@ -106,7 +122,9 @@ In this role you could earn between £42,402 and £72,480 depending on where you
 
 ### Headteachers
 
-Headteachers lead, motivate and manage staff. In this role you will earn between £47,735 to £125,098 depending on where you teach.
+Headteachers lead, motivate and manage staff.
+
+You will earn between £47,735 to £125,098 depending on where you teach.
 
 | Area                          | Minimum | Maximum  |
 | -------                       | -----   | -----    |
@@ -117,7 +135,9 @@ Headteachers lead, motivate and manage staff. In this role you will earn between
 
 #### Other leadership team positions
 
-Headteachers work with other leadership teachers. The average salary for leadership teachers (excluding headteachers) in 2019 was £54,911.
+Headteachers work with other leadership teachers.
+
+The average salary for leadership teachers (excluding headteachers) in 2019 was £54,911.
 
 ### Unqualified teachers
 


### PR DESCRIPTION

mainly adding more spacing, breaking text into bullets or adding extra headings 
putting early career framework in lower case in line with gov.uk
add a call to action to 'Ways to train' from Salaries as it feels that there's no clear way to go after that page 