### PR TITLE
Bring the feedback_bar back

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -1,6 +1,7 @@
 <%= render "sections/mailing-list-popup" %>
 <footer class="site-footer">
   <%= render "sections/talk-to-us" %>
+  <%= render "sections/feedback_bar" %>
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">


### PR DESCRIPTION
The feedback bar was removed from the footer by mistake. This PR brings it back.
