### PR TITLE
more specificity on Steps

### DIFF
--- a/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
@@ -1,15 +1,15 @@
-<p>If you already have a degree, or equivalent qualification, you’re ready for postgraduate primary or secondary initial teacher training.</p>
+<p>Once you have a degree or equivalent qualification you’re ready for postgraduate primary or secondary initial teacher training.</p>
 
-<p>You also need the following or equivalents:</p>
+<p>You also need the following or equivalents, or to show you can meet the same standard:</p>
 
 <ul>
   <li>English GCSE grade 4 (C) or above</li>
   <li>maths GCSE grade 4 (C) or above</li>
 </ul>
 
-<p>You also need a science GCSE grade 4 (C) or above to teach primary.</p>
+<p>To teach primary you also need a science GCSE grade 4 (C) or above.</p>
 
-<p>If you do not have a degree, you can do <a href="/ways-to-train#undergraduate-teacher-training-table">undergraduate teacher training</a>.</p>
+<p><a href="/ways-to-train#undergraduate-teacher-training-table">If you're not already studying for a degree and you do not have one</a> you can do undergraduate teacher training.</p>
 
 <p>Find out what to do <a href="/international-candidates">if you’re an international candidate with qualifications from overseas</a>.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
@@ -8,7 +8,7 @@
   <li>science if you want to teach primary</li>
 </ul>
 
-<p>You may be able to show you meet the standard in another way if you do not have these GCSEs or equivalents.</p>
+<p>You may be able to show you meet the standard in another way if you do not have these GCSEs.</p>
 
 <%= chat_link("Chat online for qualifications advice", classes: "button button--smaller") %>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
@@ -1,6 +1,6 @@
 <p>Once you have a degree or equivalent qualification you’re ready for postgraduate primary or secondary initial teacher training.</p>
 
-<p>You also need the following GCSEs at grade 4 (C) or equivalents:</p>
+<p>You also need the following GCSEs at grade 4 (C) or above, or equivalent qualifications:</p>
 
 <ul>
   <li>English</li>
@@ -8,10 +8,10 @@
   <li>science if you want to teach primary</li>
 </ul>
 
-<p>If you do not have the required GCSEs, you may be able to show you meet the standard in another way.</p>
+<p>You may be able to show you meet the standard in another way if you do not have these GCSEs or equivalents.</p>
 
 <%= chat_link("Chat online for qualifications advice", classes: "button button--smaller") %>
 
-<p><a href="/ways-to-train#undergraduate-teacher-training-table">If you're not already studying for a degree and you do not have one</a> you can do undergraduate teacher training.</p>
-
 <p>Find out what to do <a href="/international-candidates">if you’re an international candidate with qualifications from overseas</a>.</p>
+
+<p><a href="/ways-to-train#undergraduate-teacher-training-table">If you're not already studying for a degree and you do not have one</a> you can do undergraduate teacher training.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
@@ -1,16 +1,17 @@
 <p>Once you have a degree or equivalent qualification you’re ready for postgraduate primary or secondary initial teacher training.</p>
 
-<p>You also need the following or equivalents, or to show you can meet the same standard:</p>
+<p>You also need the following GCSEs at grade 4 (C) or equivalents:</p>
 
 <ul>
-  <li>English GCSE grade 4 (C) or above</li>
-  <li>maths GCSE grade 4 (C) or above</li>
+  <li>English</li>
+  <li>maths</li>
+  <li>science if you want to teach primary</li>
 </ul>
 
-<p>To teach primary you also need a science GCSE grade 4 (C) or above.</p>
+<p>If you do not have the required GCSEs, you may be able to show you meet the standard in another way.</p>
+
+<%= chat_link("Chat online for qualifications advice", classes: "button button--smaller") %>
 
 <p><a href="/ways-to-train#undergraduate-teacher-training-table">If you're not already studying for a degree and you do not have one</a> you can do undergraduate teacher training.</p>
 
 <p>Find out what to do <a href="/international-candidates">if you’re an international candidate with qualifications from overseas</a>.</p>
-
-<%= chat_link("Chat online for qualifications advice", classes: "button button--smaller") %>


### PR DESCRIPTION
* make it clearer who should click on the link to the undergraduate content
* prevent 'false pessimism' about the need for certain GCSEs, following BAT/GIT data sharing UR playback 
* tweak language so it's more geared to people who are studying for a degree 
* remove repetition of 'GCSE grade 4 (C) or above' through bullet lead-in sentence
* move undergrad link to the bottom as we think this content doesn't apply to a large part of our audience
* link from the "if" statement rather than "undergraduate teacher training" so it's more screen reader friendly and so there's less potential to click there when it doesn't apply to you

![Screenshot 2021-05-19 at 12 04 53](https://user-images.githubusercontent.com/56349171/118802742-6db53a80-b89a-11eb-847f-5fc881928eb6.png)
