### PR TITLE
Add mockup of how a condensed ML signup might look

### DIFF
--- a/app/views/mailing_list_signups/new.html.erb
+++ b/app/views/mailing_list_signups/new.html.erb
@@ -14,29 +14,32 @@
 
     <%= f.govuk_email_field(:email) %>
 
-    <%= f.govuk_collection_select(
-      :consideration_journey_stage_id,
-      f.object.consideration_journey_stages,
-      :id,
-      :value,
-    ) %>
-
-    <%= f.govuk_collection_select(
-      :degree_status_id,
-      f.object.degree_status_options,
-      :id,
-      :value,
-    ) %>
-
-    <%= f.govuk_collection_select(
-      :preferred_teaching_subject_id,
-      f.object.teaching_subjects,
-      :id,
-      :value,
-      options: { prompt: "Please select" },
-    ) %>
-
     <%= f.govuk_text_field(:address_postcode, width: 10) %>
+
+    <details>
+      <summary>Personalise your emails</summary>
+      <%= f.govuk_collection_select(
+        :consideration_journey_stage_id,
+        f.object.consideration_journey_stages,
+        :id,
+        :value,
+      ) %>
+
+      <%= f.govuk_collection_select(
+        :degree_status_id,
+        f.object.degree_status_options,
+        :id,
+        :value,
+      ) %>
+
+      <%= f.govuk_collection_select(
+        :preferred_teaching_subject_id,
+        f.object.teaching_subjects,
+        :id,
+        :value,
+        options: { prompt: "Please select" },
+      ) %>
+    </details>
 
     <%= f.govuk_check_boxes_fieldset(:accept_privacy_policy, multiple: false, legend: { text: "Terms and conditions" }) do %>
       <%= f.govuk_check_box :accept_privacy_policy, 1, 0, multiple: false, link_errors: true %>

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -19,6 +19,18 @@
     h2 {
       @include font-size("medium");
     }
+
+    details {
+      margin: 2em 0;
+
+      summary {
+        margin: 1em 0;
+      }
+
+      * {
+        margin-left: 0.5em;
+      }
+    }
   }
 
   .registration__event {


### PR DESCRIPTION
This is a throwaway prototype exploring how shortening the single page 'register your interest' page might make the page less daunting.

Example:


https://user-images.githubusercontent.com/128088/118836545-d95bcf80-b8bb-11eb-8c96-24b49bbd2ebd.mp4

