### PR TITLE
Don't suppress review apps for draft pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,6 @@ jobs:
           release_name: Release ${{ steps.tag_version.outputs.pr_number }}
           commitish: ${{ github.sha}}
           prerelease: false
-          draft: false
 
       - name: Copy PR Info to Release
         if: steps.release.outputs.id


### PR DESCRIPTION
We should really have review apps for draft PRs in the same way as for regular ones.
