### PR TITLE
Remove JS `link_controller` from `internal` layout

### DIFF
--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
 <%= render "sections/head" %>
-<%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link internal-events", "link-target": "content" }, id: "body" do %>
+<%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video internal-events", "link-target": "content" }, id: "body" do %>
   <div id="skiplink-container">
     <div>
       <a href="#main-content" class="skiplink govuk-link">Skip to main content</a>


### PR DESCRIPTION
### Context
The JS `link` controller creates a hidden node for outbound links. The most recent change to the link controller targets all `a` tags.

This is not working well with the Trix editor, where new links are being created for each link in that field. These appear as `(Link opens in new window)` when an event is duplicated or edited. Removing the link controller from the internal layout to fix.

![image](https://user-images.githubusercontent.com/47089130/119337775-20b0da00-bc87-11eb-9e8d-ecb481c35139.png)

### Changes proposed in this pull request
- Remove `link` controller from `internal` layout

### Guidance to review

