### PR TITLE
Fix the button styles for the purple box

### DIFF
--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -57,11 +57,8 @@ main.home {
     margin: 1em 0;
 
     > a {
-      @include button;
       @include chevron;
       white-space: inherit;
-
-      display: inline-block; // override the block set by button mixin
     }
   }
 
@@ -116,7 +113,6 @@ main.home {
       padding: 0 1em;
 
       a {
-        @include button;
         @include chevron;
         white-space: inherit;
       }


### PR DESCRIPTION
### Context
#1315 has broken the button styles inside the purple box

### Changes proposed in this pull request
Remove the button mixin from the `__cta` block, since the anchor tag in the purple box is already using the button class.

### Guidance to review
| Before | After |
| - | -  |
|![purplebox-button-before](https://user-images.githubusercontent.com/951947/119373081-f0c9fc80-bcaf-11eb-873b-30ec67e17650.png) |![purplebox-button-after](https://user-images.githubusercontent.com/951947/119373091-f32c5680-bcaf-11eb-998b-131bc561fb02.png)|

