### PR TITLE
Stop current page being included in breadcrumbs

### DIFF
--- a/config/initializers/loaf.rb
+++ b/config/initializers/loaf.rb
@@ -1,3 +1,3 @@
 Loaf.configure do |config|
-  config.match = :exact
+  config.match = :exclusive
 end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -35,6 +35,24 @@ RSpec.feature "Breadcrumbs", type: :feature do
     end
   end
 
+  context "when query params are present" do
+    let(:path) { page_path("ways-to-train", amazing: "yes") }
+
+    it { is_expected.to have_css(".breadcrumb") }
+
+    it "includes the parent page" do
+      page.within ".breadcrumb" do
+        is_expected.to have_link "Home", href: "/"
+      end
+    end
+
+    it "doesn't include the current page" do
+      page.within ".breadcrumb" do
+        is_expected.not_to have_link "Ways to train"
+      end
+    end
+  end
+
   context "when visiting a content page without a title" do
     let(:path) { page_path("no-title") }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/jCFsTfba/1609-extra-breadcrumbs-are-shown-when-query-params-are-present

### Context and changes

This happens when a query param is present, according to [Loaf's config](https://github.com/piotrmurach/loaf#213-match), `:exact` only matches the path, but crumb.current? takes the query param into account too so the final breadcrumb (the current page) isn't skipped.

Changing the match type to `:exclusive` fixes this by taking the query param into account too.
