### PR TITLE
Fix console error by importing JavaScript into head with `content_for`

### DIFF
--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,5 +1,9 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
+<% content_for :head do %>  
+  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
+<% end %>
+
 <%= render "sections/head" %>
 <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video internal-events", "link-target": "content" }, id: "body" do %>
   <div id="skiplink-container">
@@ -19,6 +23,5 @@
   </main>
 
   <%= render "components/videoplayer" %>
-  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
 <% end %>
 </html>


### PR DESCRIPTION
### Context
Bug fix - Ensure that the internal JavaScript is imported correctly in the head.

Fixes the following console error:
![image](https://user-images.githubusercontent.com/47089130/120307653-2469df80-c2cb-11eb-9251-80508c8082a8.png)

### Changes proposed in this pull request
- import JS with `content_for :head`