### PR TITLE
Set `start_at` and `end_at` to nil on duplicate

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -5,6 +5,7 @@ module Internal
     helper_method :event_type_name
 
     DEFAULT_EVENT_TYPE = "provider".freeze
+    NILIFY_ON_DUPLICATE = %i[id readable_id start_at end_at].freeze
 
     def index
       @event_type = determine_event_type(params[:event_type])
@@ -26,8 +27,7 @@ module Internal
     def new
       if params[:duplicate]
         @event = get_event_by_id(params[:duplicate])
-        @event.id = nil
-        @event.readable_id = nil
+        @event.assign_attributes(NILIFY_ON_DUPLICATE.to_h { |attribute| [attribute, nil] })
       else
         @event_type = determine_event_type(params[:event_type])
         @event = Event.new(venue_type: Event::VENUE_TYPES[:existing], type_id: @event_type)

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -189,12 +189,14 @@ describe Internal::EventsController do
           expect(response.body).to include("value=\"Pending online event\"")
         end
 
-        it "removes 'id' and 'partial url' values" do
+        it "removes 'id', 'partial url', 'start at' and 'end at' values" do
           get new_internal_event_path(duplicate: event_to_duplicate_readable_id), headers: generate_auth_headers(:author)
 
           assert_response :success
           expect(css_select("#internal_event_id").first[:value]).to be_nil
           expect(css_select("#internal-event-readable-id-field").first[:value]).to be_nil
+          expect(css_select("#internal_event_start_at").first[:value]).to be_nil
+          expect(css_select("#internal_event_end_at").first[:value]).to be_nil
         end
       end
 


### PR DESCRIPTION
### Context
CRM team requested for `start_at` and `end_at` attributes to be emptied when duplicating an event

### Changes proposed in this pull request
- Set `start_at` and `end_at` to nil on duplicate