### PR TITLE
Link to event in confirmation panel

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -15,6 +15,7 @@ module Internal
 
       @success = params[:success]
       @pending = params[:success] == "pending"
+      @readable_id = params[:readable_id]
     end
 
     def show
@@ -47,7 +48,7 @@ module Internal
       @event.assign_building(building_params) unless @event.online_event?
 
       if @event.save
-        redirect_to internal_events_path(success: :pending)
+        redirect_to internal_events_path(success: :pending, readable_id: @event.readable_id)
       else
         render action: :new
       end

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -7,6 +7,15 @@
           for review
         <% end %>
       </h1>
+      <% if @readable_id %>
+        <div class="govuk-panel__body">
+          Pending event<br>
+          <strong>
+            <%= link_to @readable_id,
+                internal_event_path(@readable_id) %>
+          </strong>
+        </div>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -37,6 +37,10 @@ $govuk-include-default-font-face: false;
 
   .confirmation-panel {
     margin: 0;
+
+    a {
+      color: $white;
+    }
   }
 
   // Tab navigation

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature "Internal section", type: :feature do
 
       click_button "Submit for review"
       expect(page).to have_text "Event submitted for review"
+      expect(page).to have_link("test", href: internal_event_path("test"))
     end
 
     scenario "final submit" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -277,7 +277,7 @@ describe Internal::EventsController do
                headers: generate_auth_headers(:author),
                params: { internal_event: params }
 
-          expect(response).to redirect_to(internal_events_path(success: :pending))
+          expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test"))
         end
       end
 
@@ -298,7 +298,7 @@ describe Internal::EventsController do
                headers: generate_auth_headers(:author),
                params: { internal_event: params }
 
-          expect(response).to redirect_to(internal_events_path(success: :pending))
+          expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test"))
         end
       end
 
@@ -335,7 +335,7 @@ describe Internal::EventsController do
                headers: generate_auth_headers(:author),
                params: { internal_event: params }
 
-          expect(response).to redirect_to(internal_events_path(success: :pending))
+          expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test"))
         end
       end
     end


### PR DESCRIPTION
### Context
When an event is created it would be useful if users had a quick way of navigating to it, rather than searching through the list of events. This might also provide a solution to duplicating events quicker, rather than duplicating incomplete events from the form.

### Changes proposed in this pull request
- Add link to confirmation panel when event is created

![image](https://user-images.githubusercontent.com/47089130/120471741-fd7bde00-c39c-11eb-91a1-7467193515de.png)
