### PR TITLE
Fix bug where mailing list bar behind hero title

### DIFF
--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -4,6 +4,7 @@
   margin: 1em 0 3em;
   position: sticky;
   bottom: 0;
+  z-index: 40;
 
   // will be enabled via JS
   display: none;


### PR DESCRIPTION
This happens because the hero title has a z-index of 20 and the green bar has none, so it appears between the hero photo and title. We want it to appear above them both, so now it has a z-index of 40.
