### PR TITLE
Ensure a title set when mailing list step failed

### DIFF
--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -5,7 +5,7 @@ module MailingList
     include WizardSteps
     self.wizard_class = MailingList::Wizard
 
-    before_action :set_step_page_title, only: [:show]
+    before_action :set_step_page_title, only: %i[show update]
     before_action :set_completed_page_title, only: [:completed]
 
     layout "registration"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -310,6 +310,25 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "Do you have a degree?"
   end
 
+  scenario "Partial journey with candidate encountering an error" do
+    expected_title = "Get Into Teaching: Get personalised guidance to your inbox, name step"
+
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
+
+    visit mailing_list_steps_path
+
+    expect(page).to have_title(expected_title)
+
+    # try incorrectly first so we can check error state
+    click_on "Next Step"
+    expect(page).to have_text "There is a problem"
+    expect(page).to have_text "Enter your first name"
+    expect(page).to have_text "Enter your last name"
+    expect(page).to have_text "Enter your full email address"
+    expect(page).to have_title(expected_title)
+  end
+
   def fill_in_name_step(
     first_name: "Test",
     last_name: "User",


### PR DESCRIPTION
### Trello card

https://trello.com/c/NJxR4c4R/1615-mailing-list-title-disappears-on-validation-error

### Context

When a mailing list step was completed incorrectly and the form is re-rendered, the title was omitted - it should always be present.

Also add a spec that ensures it works properly on the first step - the subsequent ones work in the same way so it's _probably_ sufficient.
