### PR TITLE
Update telephone validation to match API

### DIFF
--- a/app/validators/telephone_validator.rb
+++ b/app/validators/telephone_validator.rb
@@ -1,6 +1,6 @@
 class TelephoneValidator < ActiveModel::EachValidator
   TELEPHONE_FORMAT = %r{\A[^a-zA-Z]+\z}.freeze
-  MINIMUM_LENGTH = 6
+  MINIMUM_LENGTH = 5
   MAXIMUM_LENGTH = 20
 
   def validate_each(record, attribute, value)

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -13,7 +13,7 @@ describe Events::Steps::ContactDetails do
     it { is_expected.to allow_value("01234567890").for :address_telephone }
     it { is_expected.to allow_value("01234 567890").for :address_telephone }
     it { is_expected.not_to allow_value("invalid").for :address_telephone }
-    it { is_expected.not_to allow_value("01234").for :address_telephone }
+    it { is_expected.not_to allow_value("1234").for :address_telephone }
   end
 
   describe "data cleaning" do

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -24,7 +24,7 @@ describe TelephoneValidator do
     end
   end
 
-  %w[01234567890 07123456789 +448574837584 555.3442.3516 (5835)533-6326-3525].each do |number|
+  %w[12345 01234567890 07123456789 +448574837584 555.3442.3516 (5835)533-6326-3525].each do |number|
     context "checking '#{number}'" do
       let(:instance) { test_model.new(telephone: number) }
       it { is_expected.not_to include :telephone }


### PR DESCRIPTION
The API checks 5-20 characters, inclusive; if they mismatch the user may encounter an error that they can't recover from.
