### PR TITLE
Updated copy to reflect time of cycle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,11 +223,15 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.0.3)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
+    nokogiri (1.11.6)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.6-x86_64-linux)
       racc (~> 1.4)
     os (1.1.1)
@@ -423,6 +427,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -6,6 +6,9 @@
     training.
   date: "2021-03-11"
   image: "media/images/content/funding-hero-dt.jpg"
+  subtitle: There’s still time to apply and start your training this September. 
+  subtitle_button: "Find a course"
+  subtitle_link: "/start-teacher-training-this-september"
   mobileimage: "media/images/content/funding-hero-mob.jpg"
   backlink: "../"
   navigation: 25

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -5,12 +5,12 @@
     If you want to get into teaching, we can help. Get information on training
     courses, funding, salaries and benefits - everything you need to take
     the next step.
-  date: "2021-03-03"
+  date: "2021-06-07"
   fullwidth: true
   lid_pixel_event: "Homepage"
-  subtitle: "Get information and support to help you become a teacher."
-  subtitle_button: "Register for updates"
-  subtitle_link: "/mailinglist/signup/name"
+  subtitle: "There’s still time to apply and start your training this September."
+  subtitle_button: "Find a course"
+  subtitle_link: "/start-teacher-training-this-september"
   image: "media/images/hero-home-dt.jpg"
   backlink: "/"
   content:

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -22,7 +22,7 @@ Courses cover a range of subjects including modern languages, mathematics, scien
 
 Search for a teacher training course:
 
-<a href = "https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher <span>training</span></a>
+<a class="button button--white" href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
 
 ## Get help to complete your application in time
 
@@ -34,6 +34,6 @@ They will help you to:
 * choose the best people to be your references
 * explain any gaps in your work history
 
-<a href = "/tta-service">Get a teacher training <span>adviser</span></a>
+<a class="button button--white" href = "/tta-service">Get a teacher training adviser</a>
 
 An adviser will be in touch within 24 hours.

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -17,13 +17,13 @@ Places fill up quickly at this time of year, but there are still hundreds of cou
 
 Courses cover a range of subjects including modern languages, mathematics, science and more.
 
-### Find a course
+## Find a course
 
 Search for a teacher training course:
 
 <a href = "https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher <span>training</span></a>
 
-### Get help to complete your application in time
+## Get help to complete your application in time
 
 Our Teacher Training Advisors can help you write a strong application quickly. 
 

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -23,9 +23,8 @@ Courses cover a range of subjects including modern languages, mathematics, scien
 ## Find a course
 
 Search for a teacher training course:
-<p class ="button button--white">
-<a href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
-</p>
+
+<a class ="button button--white" href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
 
 ## Get help to complete your application in time
 
@@ -37,8 +36,6 @@ They will help you to:
 * choose the best people to be your references
 * explain any gaps in your work history
 
-<p class ="button button--white">
-<a href = "/tta-service">Get a teacher training adviser</a>
-</p>
+<a href = "/tta-service" class ="button button--white">Get a teacher training adviser</a>
 
 An adviser will be in touch within 24 hours.

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -1,6 +1,7 @@
 ---
 title: "There's still time to apply"
 subtitle: "Start teacher training this September"
+article_classes: ['longform']
 description: |-
   There's still time to apply for teacher training in 2021. You could apply now and be training by September 2021 if you follow these instructions.
 date: "2021-06-07"
@@ -20,11 +21,11 @@ Places fill up quickly at this time of year, but there are still hundreds of cou
 
 Courses cover a range of subjects including modern languages, mathematics, science and more.
 
-### Search for a teacher training course
+## Search for a teacher training course
 
 <a class ="button button--white" href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
 
-### Get help to complete your application in time
+## Get help to complete your application in time
 
 Our teacher training advisers can help you write a strong application quickly. 
 

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -1,5 +1,6 @@
 ---
-title: "Start teacher training this September"
+title: "There's still time to apply"
+subtitle: "Start teacher training this September"
 description: |-
   There's still time to apply for teacher training in 2021. You could apply now and be training by September 2021 if you follow these instructions.
 date: "2021-06-07"

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -11,6 +11,8 @@ keywords:
     - Application
     - Apply
     - 2021 
+    - support
+    - training
 ---
 Everyday, people are being accepted onto courses that start this September. 
 
@@ -21,12 +23,13 @@ Courses cover a range of subjects including modern languages, mathematics, scien
 ## Find a course
 
 Search for a teacher training course:
-
-<a class="button button--white" href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
+<p class ="button button--white">
+<a href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
+</p>
 
 ## Get help to complete your application in time
 
-Our Teacher Training Advisors can help you write a strong application quickly. 
+Our teacher training advisers can help you write a strong application quickly. 
 
 They will help you to:
 
@@ -34,6 +37,8 @@ They will help you to:
 * choose the best people to be your references
 * explain any gaps in your work history
 
-<a class="button button--white" href = "/tta-service">Get a teacher training adviser</a>
+<p class ="button button--white">
+<a href = "/tta-service">Get a teacher training adviser</a>
+</p>
 
 An adviser will be in touch within 24 hours.

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -14,7 +14,7 @@ keywords:
     - support
     - training
 ---
-Everyday, people are being accepted onto courses that start this September. 
+Every day, people are being accepted onto courses that start this September.
 
 Places fill up quickly at this time of year, but there are still hundreds of courses available across the country.
 

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -1,0 +1,38 @@
+---
+title: "Start teacher training this September"
+description: |-
+  There's still time to apply for teacher training in 2021. You could apply now and be training by September 2021 if you follow these instructions.
+date: "2021-06-07"
+image: "media/images/content/teaching-as-a-career-hero-dt.jpg"
+mobileimage: "media/images/content/teaching-as-a-career-hero-mob.jpg"
+backlink: "../"
+keywords:
+    - Application
+    - Apply
+    - 2021 
+---
+Everyday, people are being accepted onto courses that start this September. 
+
+Places fill up quickly at this time of year, but there are still hundreds of courses available across the country.
+
+Courses cover a range of subjects including modern languages, mathematics, science and more.
+
+### Find a course
+
+Search for a teacher training course:
+
+<a href = "https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher <span>training</span></a>
+
+### Get help to complete your application in time
+
+Our Teacher Training Advisors can help you write a strong application quickly. 
+
+They will help you to:
+
+* create a personal statement that shows off your strengths
+* choose the best people to be your references
+* explain any gaps in your work history
+
+<a href = "/tta-service">Get a teacher training <span>adviser</span></a>
+
+An adviser will be in touch within 24 hours.

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -20,13 +20,11 @@ Places fill up quickly at this time of year, but there are still hundreds of cou
 
 Courses cover a range of subjects including modern languages, mathematics, science and more.
 
-## Find a course
-
-Search for a teacher training course:
+### Search for a teacher training course
 
 <a class ="button button--white" href ="https://www.find-postgraduate-teacher-training.service.gov.uk">Find postgraduate teacher training</a>
 
-## Get help to complete your application in time
+### Get help to complete your application in time
 
 Our teacher training advisers can help you write a strong application quickly. 
 

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -6,14 +6,17 @@ description: |-
   To teach in England you must have a degree and Qualified Teacher Status. You can
   get QTS by doing a PGCE, Postgraduate Teaching Apprenticeship or via one of the
   other routes listed here.
-date: "2021-02-26"
+subtitle: There’s still time to apply and start training this September. 
+subtitle_button: "Find a course"
+subtitle_link: "/start-teacher-training-this-september"
+date: "2021-06-07"
 backlink: "../"
 navigation: 20
 right_column:
   ctas:
-    - title: Get support from a teacher training adviser
+    - title: There's still time to apply and start training this September
       text: |
-       Unsure about the best route for you? A teacher training adviser can help.
+       Places fill up quickly, but many courses are still available.  
       link_text: "Get a teaching training adviser"
       link_target: "/tta-service"
       icon: "icon-person"

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -6,7 +6,7 @@ description: |-
   To teach in England you must have a degree and Qualified Teacher Status. You can
   get QTS by doing a PGCE, Postgraduate Teaching Apprenticeship or via one of the
   other routes listed here.
-subtitle: There’s still time to apply and start training this September. 
+subtitle: There’s still time to apply and start your training this September. 
 subtitle_button: "Find a course"
 subtitle_link: "/start-teacher-training-this-september"
 date: "2021-06-07"

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -17,8 +17,8 @@ right_column:
     - title: There's still time to apply and start training this September
       text: |
        Places fill up quickly, but many courses are still available.  
-      link_text: "Get a teaching training adviser"
-      link_target: "/tta-service"
+      link_text: "Find a course"
+      link_target: "/start-teacher-training-this-september"
       icon: "icon-person"
       hide_on_mobile: Yes
       hide_on_tablet: Yes

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -14,7 +14,7 @@ backlink: "../"
 navigation: 20
 right_column:
   ctas:
-    - title: There's still time to apply and start training this September
+    - title: Start your training this September
       text: |
        Places fill up quickly, but many courses are still available.  
       link_text: "Find a course"

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -19,7 +19,7 @@ right_column:
        Places fill up quickly, but many courses are still available.  
       link_text: "Find a course"
       link_target: "/start-teacher-training-this-september"
-      icon: "icon-person"
+      icon: "icon-calendar"
       hide_on_mobile: Yes
       hide_on_tablet: Yes
 keywords:

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -86,6 +86,8 @@
     }
   }
 
+  a.button { @include suppress-external-link-icon; }
+
   ul,
   ol {
     @include mq($until: tablet) {


### PR DESCRIPTION
### Trello card
https://trello.com/c/LPvdX6Jw/1621-late-applicants-promotion

### Context
We are updating our promo links to reflect the time in the cycle, this means that our focus is gong to be the adviser service and the fact there's time left to apply.

### Changes proposed in this pull request

* Updated hero banner on Home and Ways to Train
* Added page for 'there's still time to apply'

### Guidance to review

* Does copy look accurate, is it typo free? 
* Do links work to the right places?
