### PR TITLE
Stop numeric keywords from breaking the search

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -21,7 +21,7 @@ private
 
   def search_frontmatter
     searchable_pages.select do |_path, frontmatter|
-      keywords_match?(frontmatter[:keywords]) || title_matches?(frontmatter[:title])
+      keywords_match?(frontmatter[:keywords]&.map(&:to_s)) || title_matches?(frontmatter[:title])
     end
   end
 

--- a/spec/fixtures/files/markdown_content/second.md
+++ b/spec/fixtures/files/markdown_content/second.md
@@ -4,6 +4,7 @@ priority: 20
 keywords:
   - teachers
   - teaching
+  - 2000
 ---
 
 Second page

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Search do
       it { is_expected.to be_nil }
     end
 
+    context "with numeric keyword" do
+      let(:search) { "2000" }
+
+      it { is_expected.to include("/second") }
+    end
+
     context "with search term matching partially page title" do
       let(:search) { "sec" }
 


### PR DESCRIPTION
It's feasible that people might want to tag content by year, and users might want to search by it too. Previously YAML parsed it into an integer which failed on #downcase, so now we'll just ensure every keyword is a string before taking it any further.
