### PR TITLE
Type search attribute as a string

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -2,7 +2,7 @@ class Search
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :search
+  attribute :search, :string
 
   def results
     return nil if search.blank?

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe Search do
       it { is_expected.to be_empty }
     end
 
+    context "when the search term is not a string" do
+      let(:search) { 2021 }
+
+      it { is_expected.to be_empty }
+    end
+
     describe "non-content pages" do
       describe "events" do
         Search::NON_CONTENT_PAGES.dig("/events", :keywords).each do |kw|


### PR DESCRIPTION
### Trello card

[Trello-1628](https://trello.com/c/HJdxDUqF/1628-fix-sentry-error-in-app)

### Context

When Javascript is disabled if you perform a search with a non-string value, such as `2021`, ActiveModel will cast it to an integer - we were then calling `downcase` on the integer and getting an exception. Instead, we need to explicitly tell ActiveModel that the search term is a string.

### Changes proposed in this pull request

- Type search attribute as a string

### Guidance to review

