### PR TITLE
Update pagination to work with other event types

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -88,7 +88,7 @@ module Internal
 
       @group_presenter = Events::GroupPresenter.new(search_results)
       @events = @group_presenter.paginated_events_of_type(
-        GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+        event_type,
         params[:page],
       )
     end


### PR DESCRIPTION
### Context
The events form was originally only for Provider Events. Now that it also works for Online events, the pagination needs updating to match.

### Changes proposed in this pull request
- Pass current event type to group presenter