### PR TITLE
Make sure that users cannot enter a year with more than 4 digits

### DIFF
--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -38,12 +38,15 @@
 
   <%= render "form/govuk_error_message", label: "Start at", field_errors: @event.errors[:start_at] do %>
     <%= f.datetime_field :start_at,
+                         max: Date.new(9999, 01, 01),
                          class: class_names("datetime", "govuk-input", { "govuk-input--error": @event.errors[:start_at].any? }),
                          data: { "internal-events-target": "startAt" } %>
   <% end %>
   <%= render "form/govuk_error_message", label: "End at", field_errors: @event.errors[:end_at] do %>
-    <%= f.datetime_field :end_at, class: class_names("datetime", "govuk-input",
-                                                     { "govuk-input--error": @event.errors[:end_at].any? }) %>
+    <%= f.datetime_field :end_at,
+                         max: Date.new(9999, 01, 01),
+                         class: class_names("datetime", "govuk-input",
+                                            { "govuk-input--error": @event.errors[:end_at].any? }) %>
   <% end %>
 
   <%= f.govuk_text_field :readable_id,


### PR DESCRIPTION
### Context
When entering a date manually, rather than using the selector, it is possible to enter a 6 digit year. This slows the user down when filling out the form quickly. 

Add a `max` date attribute, so that the input now moves the user on to the time input after the date is completed.

### Changes proposed in this pull request
- Add `max` date attribute to `Start at` and `End at` 