### PR TITLE
Add the urgency notice in the funding widget

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -62,8 +62,7 @@
         <div class="call-to-action__text">
           <h3>Start your teacher training this September</h3>
           <div>
-            There's still time to find funding and complete an application. We can help you get ready.<br /><br />
-            <a href='/start-teacher-training-this-september'>Find a course</a>
+            There's still time to find funding and complete an application. We can help you get ready. <a href='/start-teacher-training-this-september'>Find a course</a>
           </div>
         </div>
       <% end %>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -62,7 +62,7 @@
         <div class="call-to-action__text">
           <h3>Start your teacher training this September</h3>
           <div>
-            There's still time to find funding and complete an application. We can help you get ready. <a href='/start-teacher-training-this-september'>Find a course</a>
+            There's still time to find funding and complete an application. We can help you get ready. <a href='/start-teacher-training-this-september'>Find a course</a>.
           </div>
         </div>
       <% end %>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -59,6 +59,13 @@
         <% end %>
         <p>You may be able to get extra support <a href="#extra-financial-support-for-students-with-disabilities">if you're disabled</a>, <a href="#extra-financial-support-for-parents-and-carers">if you're a parent or carer</a>. You may still be eligible for funding <a href="#applying-for-funding-if-you-come-from-outside-england">if you're an international candidate</a>.</p>
 
+        <div class="call-to-action__text">
+          <h3>Start your teacher training this September</h3>
+          <div>
+            There's still time to find funding and complete an application. We can help you get ready.<br /><br />
+            <a href='/start-teacher-training-this-september'>Find a course</a>
+          </div>
+        </div>
       <% end %>
     </div>
   </div>

--- a/spec/components/funding_widget_component_spec.rb
+++ b/spec/components/funding_widget_component_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe FundingWidgetComponent, type: :component do
       it "has additional info for extra support" do
         expect(page).to have_css("p", text: "You may be able to get extra support")
       end
+
+      it "has the urgency notice" do
+        expect(page).to have_css("h3", text: "Start your teacher training this September")
+        expect(page).to have_css("div", text: "There's still time to find funding and complete an application. We can help you get ready.")
+        expect(page).to have_link(href: "/start-teacher-training-this-september")
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/zkp39vx7

### Context
As part of our recent push on the end of cycle and trying to increase applications before the new cycle in Sept/Oct 2021, we want to add some new copy to the funding widget.

This copy will reflect other initiatives we have in place, namely about how there's 'still time to apply before September'.

### Changes proposed in this pull request
Add a section at the bottom of the widget and display it in all subjects.

### Guidance to review
| before | after |
|-|-|
| ![before](https://user-images.githubusercontent.com/951947/121372272-0f79f580-c936-11eb-826c-f63e6269c5f5.png) | ![after](https://user-images.githubusercontent.com/951947/121372290-13a61300-c936-11eb-8503-8c0ae5db7309.png) |

