### PR TITLE
Improve redirect and confirmation panel on success

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -41,7 +41,11 @@ module Internal
       api_event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
       GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event(api_event)
       Rails.logger.info("#{@user.username} - publish - #{api_event.to_json}")
-      redirect_to internal_events_path(success: true)
+      redirect_to internal_events_path(
+        success: :open,
+        event_type: determine_event_type_from_id(api_event.type_id),
+        readable_id: api_event.readable_id,
+      )
     end
 
     def create

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -3,17 +3,14 @@
     <div class="confirmation-panel-container">
       <div class="govuk-panel govuk-panel--confirmation">
         <h1 class="govuk-panel__title">
-          Event submitted
-          <% if @pending %>
-            for review
-          <% end %>
+          <%= @pending ? "Event submitted for review" : "Event published" %>
         </h1>
         <% if @readable_id %>
           <div class="govuk-panel__body">
-            Pending event<br>
+            <%= @pending ? "Pending event" : "Published event" %><br>
             <strong>
               <%= link_to @readable_id,
-                  internal_event_path(@readable_id) %>
+                          @pending ? internal_event_path(@readable_id) : event_path(@readable_id) %>
             </strong>
           </div>
         <% end %>

--- a/spec/factories/internal/event_factory.rb
+++ b/spec/factories/internal/event_factory.rb
@@ -5,9 +5,16 @@ FactoryBot.define do
     name { "Test" }
     summary { "Test" }
     description { "Test" }
-    is_online { true }
     start_at { DateTime.now + 1.day }
     end_at { DateTime.now + 2.days }
+  end
+
+  trait :online_event do
+    scribble_id { "/scribble/id/1234" }
+  end
+
+  trait :provider_event do
+    is_online { true }
     provider_contact_email { "test@test.com" }
     provider_organiser { "Test" }
     provider_target_audience { "Test" }

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Internal section", type: :feature do
     build(:event_api,
           :with_provider_info,
           name: "Pending provider event",
+          readable_id: "Readable_id",
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
           type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
   end
@@ -14,6 +15,7 @@ RSpec.feature "Internal section", type: :feature do
     build(:event_api,
           :with_provider_info,
           name: "Pending online event",
+          readable_id: "Readable_id",
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
           type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
   end
@@ -55,6 +57,7 @@ RSpec.feature "Internal section", type: :feature do
 
       click_button "Submit for review"
       expect(page).to have_text "Event submitted for review"
+      expect(page).to have_text "Pending event"
       expect(page).to have_link("test", href: internal_event_path("test"))
     end
 
@@ -66,7 +69,9 @@ RSpec.feature "Internal section", type: :feature do
       expect(page).to have_text("This is a pending event")
 
       click_button "Set event status to Open"
-      expect(page).to have_text("Event submitted")
+      expect(page).to have_text("Event published")
+      expect(page).to have_text("Published event")
+      expect(page).to have_link("Readable_id", href: event_path("Readable_id"))
     end
   end
 

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -177,7 +177,7 @@ describe Internal::Event do
   end
 
   describe "#to_api_event" do
-    let(:internal_event) { build(:internal_event) }
+    let(:internal_event) { build(:internal_event, :provider_event) }
     let(:expected_attributes) do
       attributes_for(
         :event_api,
@@ -352,7 +352,7 @@ describe Internal::Event do
   end
 
   describe "#invalid" do
-    let(:event) { build(:internal_event, venue_type: described_class::VENUE_TYPES[:none]) }
+    let(:event) { build(:internal_event, :provider_event, venue_type: described_class::VENUE_TYPES[:none]) }
 
     context "when event is valid" do
       it "returns false when building is invalid" do


### PR DESCRIPTION
### Context
Currently, when creating an event, the user is redirected to the Provider events page. Update this to redirect to the page that matches the event that has just been created.

Creating pending events already links to the event in the confirmation panel, make sure approving events links to the event on the main events path.

### Changes proposed in this pull request
- Add link to open events in confirmation panel when approving events
- Redirect to the page that matches the posted event's type on create

### Guidance to review

| | | 
| ----- | -----|
| **Pending** |![image](https://user-images.githubusercontent.com/47089130/121384057-d47cbf80-c93f-11eb-9298-bfc86190a457.png) |
| **Approval** | ![image](https://user-images.githubusercontent.com/47089130/121383490-6801c080-c93f-11eb-879d-94e834f7a831.png)|
