### PR TITLE
Add full stop to hero text copy

### DIFF
--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -1,6 +1,6 @@
 ---
 title: "There's still time to apply"
-subtitle: "Start teacher training this September"
+subtitle: "Start teacher training this September."
 article_classes: ['longform']
 description: |-
   There's still time to apply for teacher training in 2021. You could apply now and be training by September 2021 if you follow these instructions.


### PR DESCRIPTION
The hero subtitle on our new 'urgency' page requires a full stop. Adding this in.
