### PR TITLE
Rename accept cookies button id to bypass ad-blockers

### DIFF
--- a/app/views/sections/_cookie-acceptance.html.erb
+++ b/app/views/sections/_cookie-acceptance.html.erb
@@ -18,7 +18,11 @@
 
 
             <div class="dialog__buttons">
-              <a href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="cookies-agree">
+              <!--
+                The id is `biscuits-agrees` instead of `cookies-agree`
+                to prevent ad blockers from removing the button.
+              -->
+              <a href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
                   <span>Accept all cookies</span>
               </a>
               <a class="button button--secondary" href="/cookie_preference" data-cookie-acceptance-target="disagree" id="cookies-disagree">

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -27,11 +27,11 @@ export default class extends Controller {
 
   showDialog() {
     this.overlayTarget.style.display = 'flex';
-    document.getElementById('cookies-agree').focus();
+    document.getElementById('biscuits-agree').focus();
 
     this.disagreeTarget.addEventListener('blur', function (e) {
       e.preventDefault();
-      document.getElementById('cookies-agree').focus();
+      document.getElementById('biscuits-agree').focus();
     });
 
     this.agreeTarget.addEventListener('blur', function (e) {

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -11,7 +11,7 @@ describe('CookieAcceptanceController', () => {
                     Header
                 </div>
                 BODY
-                <a href="#" id="cookies-agree" data-cookie-acceptance-target="agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
+                <a href="#" id="biscuits-agree" data-cookie-acceptance-target="agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
                     Yes, I agree. Continue to the new <span>website</span>
                 </a>
                 <a class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-cookie-acceptance-target="disagree" id="cookies-disagree">
@@ -59,7 +59,7 @@ describe('CookieAcceptanceController', () => {
     beforeEach(() => {
       initApp();
 
-      const acceptanceButton = document.getElementById('cookies-agree');
+      const acceptanceButton = document.getElementById('biscuits-agree');
       acceptanceButton.click();
     });
 


### PR DESCRIPTION
### Trello card

[Trello-1623](https://trello.com/c/6yvBReQt/1623-investigate-the-impacts-of-privacy-software-on-the-usability-of-the-site)

### Context

It appears that AdBlockers in general allow our cookie modal to appear, however they hide the "Accept all cookies" button (seemingly targetting the `id` because it includes `cookie`).

A workaround is to rename the `id` to something else - I've left a note in the code to prevent this from being changed back in the future.

### Changes proposed in this pull request

- Rename accept cookies button id to bypass ad-blockers

### Guidance to review

The only way I was able to replicate this bug was to install uBlock and enable all of the 'annoyances' under filters:

<img width="269" alt="Screenshot 2021-06-10 at 10 52 20" src="https://user-images.githubusercontent.com/29867726/121504463-ef9c0d80-c9d9-11eb-841d-7bbb0992dfb9.png">
