### PR TITLE
Update steps to become a teacher graphic

### DIFF
--- a/app/webpacker/images/steps-graphic-mob.svg
+++ b/app/webpacker/images/steps-graphic-mob.svg
@@ -1,29 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="330.689" height="338.344" viewBox="0 0 330.689 338.344">
-  <g id="Group_1442" data-name="Group 1442" transform="translate(-21.655 -1058.001)">
-    <path id="Path_1614" data-name="Path 1614" d="M-282.99,11558.619c8.948,79.262,87.188,61.18,142.62,41.137,120.8-40.068,139.391,11.941,121.427,84.267,1.54,1,3.17,2.024,4.859,3.04-51.172,103.15-84.12,111.881-177.328,48.037s-120.323,80.086-52.589,115.676,183.227-34.26,246-23.229" transform="translate(328 -10477)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="327.345" height="269.966" viewBox="0 0 327.345 269.966">
+  <g id="Group_1" data-name="Group 1" transform="translate(-21.655 -1058.001)">
+    <path id="Path_1614" data-name="Path 1614" d="M-282.99,11558.619c8.948,63.8,87.188,49.246,142.62,33.113,120.8-32.254,144.25,9.514,126.286,67.732,1.54.809-1.689,1.727,0,2.545-.051.083-2.046,4.309-2.2,4.555-50.983,82.631-82.015,85.452-175.13,34.111-93.208-51.391-120.323,64.467-52.589,93.113s183.227-27.576,246-18.7" transform="translate(328 -10477)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
     <g id="Group_1385" data-name="Group 1385" transform="translate(-107.905 282)">
       <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
     </g>
-    <g id="Group_1387" data-name="Group 1387" transform="translate(-224.905 403)">
+    <g id="Group_1387" data-name="Group 1387" transform="translate(-327.56 442.963)">
       <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
     </g>
-    <g id="Group_1388" data-name="Group 1388" transform="translate(-579.905 451)">
+    <g id="Group_1388" data-name="Group 1388" transform="translate(-662.905 491.31)">
       <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
     </g>
-    <g id="Group_1389" data-name="Group 1389" transform="translate(-819.904 572)">
+    <g id="Group_1389" data-name="Group 1389" transform="translate(-583.904 495)">
       <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
     </g>
-    <g id="Group_1390" data-name="Group 1390" transform="translate(-580.561 548)">
-      <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
-    </g>
-    <g id="Group_1386" data-name="Group 1386" transform="translate(-157.561 321)">
+    <g id="Group_1386" data-name="Group 1386" transform="translate(-75.248 309)">
       <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
     </g>
   </g>
 </svg>

--- a/app/webpacker/images/steps-graphic.svg
+++ b/app/webpacker/images/steps-graphic.svg
@@ -1,29 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="490.689" height="279.344" viewBox="0 0 490.689 279.344">
-  <g id="Group_1441" data-name="Group 1441" transform="translate(-619.656 -845.001)">
-    <path id="Path_1614" data-name="Path 1614" d="M-282.547,11569.416c73.975,18.928,36.042-157.584,43.609-151.932,130.453-106.531,36.416,110.557,144.938,95.666,77.391,9.563-6.852-143.824,87-87.41s-49.412,142.451,54.563,170.207,67.609-66.766,49.773-121.946-3.109-119.876,59.664-108.845" transform="translate(935 -10495)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="488.345" height="279.773" viewBox="0 0 488.345 279.773">
+  <g id="Group_1441" data-name="Group 1441" transform="translate(-619.656 -844.744)">
+    <path id="Path_1614" data-name="Path 1614" d="M-282.547,11569.416c73.975,18.928,36.042-157.584,43.609-151.932,130.453-106.531,36.416,110.557,144.938,95.666,66.169,8.176,59.486-99.555,60.025-101.381,9.541-32.323,30.7-29.115,44.3-20.936,93.852,56.414-66.742,177.357,37.232,205.113s67.609-66.766,49.773-121.946-3.109-119.876,59.664-108.845" transform="translate(935 -10495)" fill="none" stroke="#fff" stroke-width="6" stroke-dasharray="7"/>
     <g id="Group_1385" data-name="Group 1385" transform="translate(490.095 276)">
       <rect id="Rectangle_216" data-name="Rectangle 216" width="46" height="46" transform="translate(129.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
+      <text id="_1" data-name="1" transform="translate(153.561 807)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">1</tspan></text>
     </g>
-    <g id="Group_1386" data-name="Group 1386" transform="translate(359.439 124)">
+    <g id="Group_1386" data-name="Group 1386" transform="translate(360.439 117.088)">
       <rect id="Rectangle_217" data-name="Rectangle 217" width="46" height="46" transform="translate(318.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
+      <text id="_2" data-name="2" transform="translate(342.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">2</tspan></text>
     </g>
-    <g id="Group_1387" data-name="Group 1387" transform="translate(304.095 217)">
+    <g id="Group_1387" data-name="Group 1387" transform="translate(341.493 201.346)">
       <rect id="Rectangle_218" data-name="Rectangle 218" width="46" height="46" transform="translate(506.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
+      <text id="_3" data-name="3" transform="translate(530.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">3</tspan></text>
     </g>
-    <g id="Group_1388" data-name="Group 1388" transform="translate(199.095 125)">
+    <g id="Group_1388" data-name="Group 1388" transform="translate(289.095 300.172)">
       <rect id="Rectangle_219" data-name="Rectangle 219" width="46" height="46" transform="translate(692.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
+      <text id="_4" data-name="4" transform="translate(716.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">4</tspan></text>
     </g>
-    <g id="Group_1389" data-name="Group 1389" transform="translate(77.096 300)">
+    <g id="Group_1389" data-name="Group 1389" transform="translate(175.096 68.743)">
       <rect id="Rectangle_1309" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
-    </g>
-    <g id="Group_1390" data-name="Group 1390" transform="translate(177.439 69)">
-      <rect id="Rectangle_1309-2" data-name="Rectangle 1309" width="46" height="46" transform="translate(884.561 778.408) rotate(-3)" fill="#f9b400" opacity="0.9"/>
-      <text id="_6" data-name="6" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="sans-serif" font-weight="700"><tspan x="-6.744" y="0">6</tspan></text>
+      <text id="_5" data-name="5" transform="translate(908.561 808)" fill="#fff" font-size="24" font-family="AkzidenzGroteskBQ-Bold, Akzidenz-Grotesk BQ" font-weight="700"><tspan x="-6.744" y="0">5</tspan></text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
### Trello card

[Trello-1583](https://trello.com/c/xStxjgbo/1583-update-steps-svg-to-5-steps-instead-of-6)

### Context

Update the steps to become a teacher graphic, removing the sixth step.

### Changes proposed in this pull request

- Update steps to become a teacher graphic

### Guidance to review

| Mobile      | Tablet | Desktop |
| ----------- | ----------- |----------- |
| <img width="359" alt="Screenshot 2021-06-10 at 11 45 12" src="https://user-images.githubusercontent.com/29867726/121512140-5244d780-c9e1-11eb-83c0-945ad55ec3ff.png"> | <img width="608" alt="Screenshot 2021-06-10 at 11 45 41" src="https://user-images.githubusercontent.com/29867726/121512207-638de400-c9e1-11eb-8596-5b5cd42f22c3.png">       |  <img width="1052" alt="Screenshot 2021-06-10 at 11 45 50" src="https://user-images.githubusercontent.com/29867726/121512231-6983c500-c9e1-11eb-824a-3c32b89418ff.png">       |







