### PR TITLE
Further AO provider update for Billericay

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -12,7 +12,7 @@ content:
   - content/assessment-only-providers/update-details
 providers:
   East of England:
-  - header: Billericay Educational Consortium
+  - header: BEC Teacher Training
     link: http://secondary.billericayscitt.com/assessment-only-route-2/
     name: Fiona Manby
     telephone: 01268 477611 (extn 471)


### PR DESCRIPTION
We've received a further request from Billericay Education Consortium. They're now called BEC Teacher Training. Changing page to reflect that.

