### PR TITLE
Lazy-load YouTube iFrame

### DIFF
--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -14,10 +14,10 @@ module StoriesHelper
       "",
       width: 560,
       height: 315,
-      src: url,
+      data: { src: url },
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
       allowfullscreen: true,
-      class: "story__video",
+      class: "story__video lazyload",
       loading: "lazy",
     )
   end

--- a/app/views/content/returning-to-teaching.md
+++ b/app/views/content/returning-to-teaching.md
@@ -52,7 +52,7 @@ Returning to teaching might be easier than you expect.
 
 If you’re considering coming back to the profession, or if you’re qualified to teach but have never taught in a state school in England, we’re here to help.  
 
-<iframe src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe class="lazyload" data-src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 ## Why now
 
@@ -78,7 +78,7 @@ secondary school in England, a [return to teaching adviser](https://adviser-geti
 * accessing courses to enhance your subject knowledge
 * finding teaching vacancies
 
-<iframe src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe class="lazyload" data-src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 Return to teaching advisers also run [events](/event-categories/online-q-as) to support returners.
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -56,7 +56,7 @@
   <% if @event.video_url %>
   <h2>Video</h2>
   <div class="responsive-video">
-    <iframe title="An event preview" class="responsive-video__iframe" src="<%= embed_event_video_url(@event.video_url) %>"></iframe>
+    <iframe title="An event preview" class="responsive-video__iframe" class="lazyload" data-src="<%= embed_event_video_url(@event.video_url) %>"></iframe>
   </div>
   <br />
   <% end %>

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -75,7 +75,7 @@ describe Stories::StoryComponent, type: "component" do
     let(:front_matter) { default_front_matter.merge(video_story) }
 
     specify "the video iframe is present in the document and the src is correct" do
-      is_expected.to have_css("iframe[src='#{video_url}']")
+      is_expected.to have_css("iframe[data-src='#{video_url}'].lazyload")
     end
   end
 

--- a/spec/helpers/stories_helper_spec.rb
+++ b/spec/helpers/stories_helper_spec.rb
@@ -29,8 +29,8 @@ describe StoriesHelper, type: "helper" do
     let(:url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
     subject { helper.youtube(url) }
 
-    specify %(should generate an iframe with the src attribute set to the video's URL) do
-      expect(subject).to have_css(%(iframe[src='#{url}']), class: "story__video")
+    specify %(should generate an iframe with the data-src attribute set to the video's URL) do
+      expect(subject).to have_css(%(iframe[data-src='#{url}']), class: "story__video lazyload")
     end
   end
 


### PR DESCRIPTION
The YouTube iFrame tanks our Google Page Speed Score; instead, we can lazy-load it using the same library we use for lazy loading images after the main content paint.

I'm not sure how much of an impact this will actually have; the Lighthouse audit in Chrome doesn't seem to report the YouTube iFrame page speed hit in the same way as their website/API.