### PR TITLE
Rework talk to us section to give phone more prominence

### DIFF
--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -1,35 +1,35 @@
-<section class="talk-to-us">
-   <section class="container">
-      <div class="talk-to-us__inner">
-         <h2 class="purple" id="talk-to-us">Talk to us</h2>
-         <div class="talk-to-us__inner__table">
-            <section class="talk-to-us__inner__table__column" data-controller="talk-to-us">
-               <h3 class="talk-to-us__inner__table__column__heading">Chat online</h3>
-               <p>
-                  Get the answers you need through online chat, Monday to Friday between 8.30am and 5.30pm.
-               </p>
-               <a href="#" class="button" data-action="click->talk-to-us#startChat">
-                 Chat online
-               </a>
-
-            </section>
-            <section class="talk-to-us__inner__table__column" data-talk-to-us-target="tta">
-               <h3 class="talk-to-us__inner__table__column__heading">Get a teacher training adviser</h3>
-               <p>
-                  An experienced teaching professional can help if you're ready to get into teaching or if you're returning to teaching and qualified to teach maths, physics or languages.
-               </p>
-               <a href="/tta-service" class="button">
-                 Get an adviser
-               </a>
-            </section>
-
-         </div>
-               <div class="talk-to-us__inner__freephone">
-                  <h3 class="talk-to-us__inner__table__column__heading">Call us</h3>
-                  <p>
-                     Call us for free about teacher training on <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a>, Monday to Friday between 8.30am and 5.30pm. You can also use this number to update or amend your details.
-                  </p>
-               </div>
+<section class="talk-to-us" data-controller="talk-to-us">
+  <section class="container">
+    <div>
+      <h2 class="purple" id="talk-to-us">Talk to us</h2>
+      <div class="content">
+        <section class="contact">
+          <p>Monday-Friday between <strong>8:30am and 5:30pm</strong></p>
+          <div class="options">
+            <div>
+              <p>Live chat</p>
+              <a href="#" class="button button--smaller" data-action="click->talk-to-us#startChat">
+                Chat online
+              </a>
+            </div>
+            <div>
+              <p>Freephone</p>
+              <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+            </div>
+          </div>
+        </section>
+        <section>
+          <h3>Teacher training adviser service</h3>
+          <p>
+            An experienced teaching professional can help if you're ready to get into
+            teaching or if you're returning to teaching and qualified to teach maths,
+            physics or languages.
+          </p>
+          <a href="/tta-service" class="button">
+            Get to an adviser
+          </a>
+        </section>
       </div>
-   </section>
+    </div>
+  </section>
 </section>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -4,7 +4,7 @@
       <h2 class="purple" id="talk-to-us">Talk to us</h2>
       <div class="content">
         <section class="contact">
-          <p>Monday-Friday between <strong>8:30am and 5:30pm</strong></p>
+          <p>Monday to Friday between <strong>8:30am and 5:30pm</strong></p>
           <div class="options">
             <div>
               <p>Live chat</p>

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -19,7 +19,7 @@
           </div>
         </section>
         <section>
-          <h3>Get an adviser</h3>
+          <h3>Get a teacher training adviser</h3>
           <p>
             An experienced teaching professional can help if you're ready to get into
             teaching or if you're returning to teaching and qualified to teach maths,

--- a/app/views/sections/_talk-to-us.html.erb
+++ b/app/views/sections/_talk-to-us.html.erb
@@ -13,20 +13,20 @@
               </a>
             </div>
             <div>
-              <p>Freephone</p>
+              <p>Call us</p>
               <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
             </div>
           </div>
         </section>
         <section>
-          <h3>Teacher training adviser service</h3>
+          <h3>Get an adviser</h3>
           <p>
             An experienced teaching professional can help if you're ready to get into
             teaching or if you're returning to teaching and qualified to teach maths,
             physics or languages.
           </p>
           <a href="/tta-service" class="button">
-            Get to an adviser
+            Get an adviser
           </a>
         </section>
       </div>

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -1,95 +1,93 @@
 .talk-to-us {
-  text-align: left;
   background-color: $grey;
-  padding-bottom: 1px;
 
-  &__inner {
+  h2 {
+    @include content-heading;
+    top: -15px;
+    left: $indent-amount;
     position: relative;
-    top: -27px;
+  }
 
-    h2 {
-      @include content-heading;
-    }
+  h3 {
+    margin-top: 0;
+  }
 
-    &__label {
-      margin-left: $indent-amount;
-      margin-top: $indent-amount;
-    }
+  .content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
 
-    &__table {
-      width: 100%;
-      display: flex;
+    section {
+      flex: 1 0;
+      margin: $indent-amount;
 
-      &__column {
-        display: inline-block;
-        box-sizing: border-box;
-        padding-left: $indent-amount;
-        padding-right: $indent-amount;
-        flex: 1;
-        min-width: 245px;
-        vertical-align: top;
+      &.contact {
+        padding: $indent-amount;
+        background-color: $white;
 
-        h2 {
-          margin-top: $indent-amount;
-          margin-bottom: 40px;
-        }
+        .options {
+          display: flex;
+          flex-direction: column;
 
-        a {
-          text-decoration: none;
-        }
+          > div {
+            flex: 1 0;
 
-        &__heading {
-          @include font-size("medium");
-          margin: .5em 0;
+            &:first-child {
+              border-bottom: 1px solid $purple;
+              padding-bottom: $indent-amount;
+              margin-bottom: $indent-amount;
+            }
+
+            p {
+              margin-top: 0;
+            }
+
+            .telephone {
+              font-weight: bold;
+              text-decoration: none;
+              color: $black;
+              font-size: 1.3em;
+            }
+          }
         }
       }
-
-      &__column:first-child {
-        display: none;
-
-        &.visible {
-          display: inline-block;
-        }
-      }
-
-      &__column:last-child {
-        flex: 1;
-      }
-    }
-
-    &__freephone {
-      padding-left: $indent-amount;
-      padding-top: 10px;
-      padding-right: 10px;
     }
   }
 }
 
-@include mq($until: tablet) {
+@include mq($from: tablet) {
   .talk-to-us {
-    &__inner {
-      top: -20px;
-      padding: 0 $indent-amount;
+    h2 {
+      top: -30px;
+      left: 0;
+    }
 
-      &__label {
-        margin: $indent-amount 0;
-      }
+    .content {
+      flex-direction: row;
 
-      &__table {
-        flex-direction: column;
-
-        &__column {
-          display: block;
-          width: 100%;
-          padding-bottom: 10px;
-          padding-left: 0;
-          padding-right: 0;
+      section {
+        &:first-child {
+          margin: 0 $indent-amount $indent-amount 0;
         }
-      }
 
-      &__freephone {
-        padding-left: 0;
-        padding-right: 0;
+        &:last-child {
+          margin: 0 0 $indent-amount $indent-amount;
+        }
+
+        &.contact .options {
+          flex-direction: row;
+
+          > div {
+            flex: initial;
+
+            &:first-child {
+              border: 0;
+              border-right: 1px solid $purple;
+              padding: 0 $indent-amount 0 0;
+              margin: 0 $indent-amount 0 0;
+            }
+          }
+        }
       }
     }
   }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -4,7 +4,7 @@ describe "Find an event near you" do
   include_context "stub types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }
-  let(:category_headings_regex) { /<h3>([Train|Online|School].*)<\/h3>/ }
+  let(:category_headings_regex) { /<h3>(Train to Teach events|Online Q&amp;As|School and University events)<\/h3>/ }
   let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
     5.times.collect do |index|


### PR DESCRIPTION
### Trello card

[Trello-1586](https://trello.com/c/2wQDG9tJ/1586-promote-phone-number-so-it-has-equal-parity-as-webchat-for-a-period-of-time-to-see-if-it-results-in-more-calls)

### Context

We want to promote the phone number so it has the same prominance as the web chat.

### Changes proposed in this pull request

- Rework talk to us section to give phone more prominence

### Guidance to review

| Mobile      | Desktop |
| ----------- | ----------- |
|  <img width="531" alt="Screenshot 2021-06-15 at 09 31 44" src="https://user-images.githubusercontent.com/29867726/122020235-8131c380-cdbc-11eb-929e-f377bb0cc7da.png">      | <img width="1029" alt="Screenshot 2021-06-15 at 09 31 20" src="https://user-images.githubusercontent.com/29867726/122020202-79721f00-cdbc-11eb-815d-208d6a261916.png">       |

