### PR TITLE
Navigation data structure

### DIFF
--- a/app/components/navigation/navbar_component.html.erb
+++ b/app/components/navigation/navbar_component.html.erb
@@ -5,7 +5,7 @@
             <ul>
                 <%= nav_link("Home", '/') %>
                 <% resources.each do |resource| %>
-                    <%= nav_link(resource[:front_matter][:title], resource[:path]) %>
+                    <%= nav_link(resource.title, resource.path) %>
                 <% end %>
                 <%= nav_link("Teaching events", events_path) %>
                 <%= nav_link("Register your interest", mailing_list_steps_path) %>
@@ -45,7 +45,7 @@
                 <ul>
                   <%= nav_link("Home", '/') %>
                   <% resources.each do |resource| %>
-                    <%= nav_link(resource[:front_matter][:title], resource[:path]) %>
+                    <%= nav_link(resource.title, resource.path) %>
                   <% end %>
                   <%= nav_link("Teaching events", events_path) %>
                   <%= nav_link("Register your interest", mailing_list_steps_path) %>

--- a/app/helpers/sitemap_helper.rb
+++ b/app/helpers/sitemap_helper.rb
@@ -1,9 +1,5 @@
 module SitemapHelper
   def navigation_resources
-    Pages::Frontmatter
-      .list
-      .select { |_relative_path, fm| fm.key?(:navigation) }
-      .sort_by { |_relative_path, fm| fm.fetch(:navigation) }
-      .map { |relative_path, fm| { path: relative_path, front_matter: fm } }
+    Pages::Navigation.root_pages
   end
 end

--- a/app/models/pages/navigation.rb
+++ b/app/models/pages/navigation.rb
@@ -1,0 +1,56 @@
+module Pages
+  class Navigation
+    attr_reader :nodes
+
+    class << self
+      delegate :all_pages, :root_pages, to: :instance
+
+    private
+
+      def instance
+        new
+      end
+    end
+
+    def initialize(pages = Pages::Frontmatter.list)
+      @nodes = pages
+        .select { |_p, fm| fm.key?(:navigation) }
+        .map { |p, fm| Node.new(p, fm) }
+    end
+
+    def all_pages
+      nodes.sort_by(&:rank)
+    end
+
+    def root_pages
+      nodes.select(&:root?).sort_by(&:rank)
+    end
+
+    class Node
+      attr_reader :path, :title, :rank
+
+      def initialize(path, front_matter)
+        @path = path
+
+        front_matter.tap do |fm|
+          @title = fm.fetch(:title) do
+            Rails.logger.warn("page #{path} has no title")
+
+            nil
+          end
+
+          @rank  = fm.fetch(:navigation, nil)
+          @menu  = fm.fetch(:menu, false)
+        end
+      end
+
+      def root?
+        path !~ %r{\A/.*/(\S+)\z}
+      end
+
+      def menu?
+        @menu
+      end
+    end
+  end
+end

--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -28,7 +28,7 @@
       <div class="site-footer-top__links-container">
         <%= link_to("Home", root_path) %>
         <% navigation_resources.each do |resource| %>
-          <a href="<%= resource[:path] %>"><%= resource[:front_matter][:title] %></a>
+          <a href="<%= resource.path %>"><%= resource.title %></a>
         <% end %>
         <%= link_to "Find an event near you", events_path %>
         <%= link_to "Sign up for updates", mailing_list_steps_path %>

--- a/spec/helpers/sitemap_helper_spec.rb
+++ b/spec/helpers/sitemap_helper_spec.rb
@@ -2,25 +2,12 @@ require "rails_helper"
 
 describe SitemapHelper, type: :helper do
   describe "#navigation_resources" do
-    let(:sitemap) do
-      {
-        "/content/page_1": { title: "Page 1", navigation: 10 },
-        "/content/page_2": { title: "Page 2", navigation: 30 },
-        "/content/page_3": { title: "Page 3", navigation: 20 },
-        "/content/page_4": { title: "Page 4" },
-      }
-    end
-
-    before { allow(Pages::Frontmatter).to receive(:list).and_return(sitemap) }
+    before { allow(Pages::Navigation).to receive(:root_pages) }
 
     subject! { helper.navigation_resources }
 
-    specify "obtains the resources from Pages::Frontmatter" do
-      expect(Pages::Frontmatter).to have_received(:list)
-    end
-
-    specify "selects the items with a navigation key and order them" do
-      expect(subject.map { |r| r.dig(:front_matter, :title) }).to eq(["Page 1", "Page 3", "Page 2"])
+    specify "calls Pages::Navigation.root_pages" do
+      expect(Pages::Navigation).to have_received(:root_pages).with(no_args)
     end
   end
 end

--- a/spec/models/pages/navigation_spec.rb
+++ b/spec/models/pages/navigation_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe Pages::Navigation do
+  let(:primary_nav) do
+    {
+      "/page-one" => { title: "Page one", navigation: 1 },
+      "/page-two" => { title: "Page two", navigation: 2 },
+      "/page-three" => { title: "Page three", navigation: 3 },
+      "/page-four" => { title: "Page four", navigation: 4 },
+      "/page-five" => { title: "Page five", navigation: 5, menu: true },
+      "/page-six" => { title: "Page six", navigation: 6, menu: true },
+      "/page-seven" => { title: "Page seven", navigation: 7 },
+    }
+  end
+
+  let(:secondary_nav) do
+    {
+      "/page-five/part-1" => { title: "Page five: part 1", navigation: 5.1 },
+      "/page-five/part-2" => { title: "Page five: part 2", navigation: 5.2 },
+      "/page-five/part-3" => { title: "Page five: part 3", navigation: 5.3 },
+      "/page-six/part-1" => { title: "Page six: part 1", navigation: 6.1 },
+      "/page-six/part-2" => { title: "Page six: part 2", navigation: 6.2 },
+      "/page-six/part-3" => { title: "Page six: part 3", navigation: 6.3 },
+    }
+  end
+
+  let(:nav) { primary_nav.merge(secondary_nav) }
+  let(:actual_pages) { subject.map(&:path) }
+
+  describe "delegation" do
+    subject { described_class }
+
+    it { is_expected.to delegate_method(:all_pages).to(:instance) }
+    it { is_expected.to delegate_method(:root_pages).to(:instance) }
+  end
+
+  describe "#all_pages" do
+    subject { described_class.new(nav).all_pages }
+
+    specify "contains all of the pages, both primary and secondary" do
+      expected_pages = nav.keys
+
+      expect(actual_pages).to match_array(expected_pages)
+    end
+
+    specify "pages are in the right order" do
+      expected_order = nav.sort_by { |_p, fm| fm[:navigation] }.map { |path, _fm| path }
+
+      expect(actual_pages).to eql(expected_order)
+    end
+  end
+
+  describe "#root_pages" do
+    subject { described_class.new(nav).root_pages }
+    let(:actual_pages) { subject.map(&:path) }
+
+    specify "contains only the root pages" do
+      expected_pages = primary_nav.keys
+
+      expect(actual_pages).to match_array(expected_pages)
+    end
+  end
+
+  describe Pages::Navigation::Node do
+    let(:path) { "/an-amazing-page" }
+    let(:title) { "Page five" }
+    let(:navigation) { 5 }
+    let(:menu) { true }
+    let(:front_matter) { { title: title, navigation: navigation, menu: menu } }
+
+    subject { described_class.new(path, front_matter) }
+
+    specify "assigns the path" do
+      expect(subject.path).to eql(path)
+    end
+
+    specify "assigns the title" do
+      expect(subject.title).to eql(title)
+    end
+
+    specify "assigns the navigation param to rank" do
+      expect(subject.rank).to eql(navigation)
+    end
+
+    specify "assigns the menu flag" do
+      expect(subject.menu?).to eql(menu)
+    end
+
+    context "when front matter is incomplete" do
+      let(:front_matter) { {} }
+
+      before do
+        allow(Rails.logger).to receive(:warn) { true }
+      end
+
+      specify "title is nil and warning logged" do
+        expect(subject.title).to be(nil)
+
+        expect(Rails.logger).to have_received(:warn).with(/has no title/)
+      end
+
+      specify "rank is nil" do
+        expect(subject.rank).to be_nil
+      end
+
+      specify "menu is false" do
+        expect(subject.menu?).to be(false)
+      end
+    end
+
+    describe "#root?" do
+      examples = {
+        "/" => true,
+        "/path" => true,
+        "/path-with-trailing-slash/" => true,
+        "/path/with-subpage" => false,
+        "/path/with-multiple/subpages" => false,
+      }
+
+      examples.each do |path, expected|
+        specify "path '#{path}' should #{expected ? '' : 'not '}be root" do
+          node = described_class.new(path, {})
+
+          expect(node.root?).to eql(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/S0eMP5DN/1589-develop-top-level-navigation-on-back-of-workshop

### Context

The work on the navigation has been split up into smaller chunks.

This change introduces the `Pages::Navigation` model.  It's now responsible for building up a collection of nodes (`Pages::Navigation::Node`) that each represent a page on the site in the navigation tree, and is already used to build the existing navigation (both desktop, mobile and footer).

Currently we're only interested in root pages, but this structure will make it easier to find child pages for a particular node.

Unlike the previous iteration, we're now leaning towards using the path for hierarchy and determining whether or not a page is root based on it.  This is going to be easier to understand than setting `parent` metadata in the front matter.
