### PR TITLE
Introduce delay before executing search

### DIFF
--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -69,6 +69,7 @@ export default class extends Controller {
       minLength: 2,
       source: this.performXhrSearch.bind(this),
       confirmOnBlur: false,
+      tNoResults: () => this.searching ? "Searching..." : "No results found",
       onConfirm: this.onConfirm.bind(this),
       templates: {
         inputValue: this.inputValueTemplate.bind(this),
@@ -82,6 +83,8 @@ export default class extends Controller {
   }
 
   performXhrSearch(query, callback) {
+    this.searching = true
+
     if (this.delaySearchTimeout) {
       clearTimeout(this.delaySearchTimeout);
     }
@@ -93,9 +96,10 @@ export default class extends Controller {
       let request = new XMLHttpRequest()
       request.open('GET', '/search.json?' + this.searchParams(query), true)
       request.timeout = 10 * 1000
-      request.onreadystatechange = function () {
+      request.onreadystatechange = () => {
         if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
           const results = JSON.parse(request.responseText)
+          this.searching = false
           callback(results)
         }
       }

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -82,20 +82,26 @@ export default class extends Controller {
   }
 
   performXhrSearch(query, callback) {
-    this.searchQuery = query
-    this.scheduleSubmissionToAnalytics()
-
-    let request = new XMLHttpRequest()
-    request.open('GET', '/search.json?' + this.searchParams(query), true)
-    request.timeout = 10 * 1000
-    request.onreadystatechange = function () {
-      if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
-        const results = JSON.parse(request.responseText)
-        callback(results)
-      }
+    if (this.delaySearchTimeout) {
+      clearTimeout(this.delaySearchTimeout);
     }
 
-    request.send()
+    this.delaySearchTimeout = setTimeout(() => {
+      this.searchQuery = query
+      this.scheduleSubmissionToAnalytics()
+
+      let request = new XMLHttpRequest()
+      request.open('GET', '/search.json?' + this.searchParams(query), true)
+      request.timeout = 10 * 1000
+      request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+          const results = JSON.parse(request.responseText)
+          callback(results)
+        }
+      }
+
+      request.send()
+    }, 500)
   }
 
   onConfirm(chosen) {

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -89,6 +89,18 @@ describe('SearchboxController', () => {
         done();
       }, 1500);
     })
+
+    it("shows 'Searching...' while searching", (done) => {
+      const input = document.getElementById('searchbox__input')
+
+      input.value = 'search term'
+
+      setTimeout(() => {
+        const noResultsItem = document.querySelector('.autocomplete__option--no-results')
+        expect(noResultsItem.innerHTML).toEqual("Searching...")
+        done()
+      }, 250)
+    })
   })
 
   describe("toggling search open and close", () => {


### PR DESCRIPTION
### Trello card

[Trello-345](https://trello.com/c/eDPlKMPS/345-development-add-js-superset-to-search)

### Context

Currently the search is executed after every key press, which both results in a lot of search API calls and also means our analytics include search terms for each character.

Instead, we want to introduce a 500ms delay after the user finishes typing before executing the search.

### Changes proposed in this pull request

- Introduce delay before executing search

### Guidance to review

It would have been nicer to use Jest's fake timers for the tests, however the `accessible-autocomplete` lib uses timers to poll the input field internally and this makes using the fake timers not possible (it just hangs, even when you ask it to only run on the pending timers).

Now that there's a delay do we need a 'loading...' entry instead of 'no results' while the user types?