### PR TITLE
Grey out events search button

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -8,25 +8,25 @@
             <div class="search__controls" data-controller="conditional-field" data-conditional-field-mode="hide" data-conditional-field-expected="">
               <% if include_type %>
                 <%= tag.div(class: input_field_classes(:type)) do %>
-                    <%= f.label :type, "Event type" %>
-                    <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" } %>
+                  <%= f.label :type, "Event type" %>
+                  <%= f.collection_select :type, search.class.available_event_types, :id, :value, { include_blank: "All events" }, data: { action: "event-search-button#parameterChanged" } %>
                 <% end %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:distance)) do %>
-                  <%= f.label :distance, "Location" %>
-                  <%= f.select :distance, search.class.available_distances, {},
-                        data: { action: "conditional-field#toggle", "conditional-field-target": "source" } %>
+                <%= f.label :distance, "Location" %>
+                <%= f.select :distance, search.class.available_distances, {},
+                             data: { action: "conditional-field#toggle event-search-button#parameterChanged", "conditional-field-target": "source" } %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:postcode), data: { "conditional-field-target": "showhide" }) do %>
                 <%= f.label :postcode, "Postcode" %>
-                <%= f.text_field :postcode %>
+                <%= f.text_field :postcode, data: { action: "event-search-button#parameterChanged" } %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:month)) do %>
-                  <%= f.label :month, "Month" %>
-                  <%= f.select :month, search.available_months, **month_args %>
+                <%= f.label :month, "Month" %>
+                <%= f.select :month, search.available_months, month_args, data: { action: "event-search-button#parameterChanged" } %>
               <% end %>
             </div>
 
@@ -38,7 +38,8 @@
               </div>
             <% end %>
 
-            <button class="request-button">Update results <%= helpers.fas_icon "sync" %></button>
+            <button class="request-button" id="updateResultsButton" data-event-search-button-target="updateResultsButton">Update
+              results <%= helpers.fas_icon "sync" %></button>
           <% end %>
         </div>
       </div>

--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -3,7 +3,7 @@
     <article class="markdown overhang fullwidth">
       <h2 id="searchforevents" class="colored-stripe__title purple"><%= heading %></h2>
       <div class="colored-stripe__content">
-        <div class="search">
+        <div class="search" data-controller="<%= "event-search-button" if @performed_search %>">
           <%= form_for search, method: :get, url: path do |f| %>
             <div class="search__controls" data-controller="conditional-field" data-conditional-field-mode="hide" data-conditional-field-expected="">
               <% if include_type %>

--- a/app/components/events/search_component.rb
+++ b/app/components/events/search_component.rb
@@ -2,11 +2,12 @@ module Events
   class SearchComponent < ViewComponent::Base
     BLANK_MONTH_TEXT = "All months".freeze
 
-    attr_accessor :search, :path, :include_type, :heading, :allow_blank_month
+    attr_accessor :search, :path, :performed_search, :include_type, :heading, :allow_blank_month
 
-    def initialize(search, path, include_type: true, heading: "Search for events", allow_blank_month: false)
+    def initialize(search, path, performed_search, include_type: true, heading: "Search for events", allow_blank_month: false)
       @search            = search
       @path              = path
+      @performed_search  = performed_search
       @include_type      = include_type
       @heading           = heading
       @allow_blank_month = allow_blank_month

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -57,6 +57,7 @@ private
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
     group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
     @events = group_presenter.paginated_events_of_type(@type.id, params[:page]) || []
+    @performed_search = true
   end
 
   def load_type

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -57,7 +57,7 @@ private
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
     group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
     @events = group_presenter.paginated_events_of_type(@type.id, params[:page]) || []
-    @performed_search = true
+    @performed_search = @event_search.valid?
   end
 
   def load_type

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -66,7 +66,7 @@ private
     search_results = @event_search.query_events(MAXIMUM_EVENTS_PER_CATEGORY)
 
     @display_empty_types = @event_search.type.nil?
-    @performed_search = true
+    @performed_search = @event_search.valid?
 
     @group_presenter = Events::GroupPresenter.new(search_results, @display_empty_types)
     pages = params.permit(@group_presenter.page_param_names.values)

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -1,6 +1,7 @@
 <% @search_component = Events::SearchComponent.new(
         @event_search,
         @form_action.to_s,
+        @performed_search,
         include_type: false,
         heading: "Search for #{@category_name}",
         allow_blank_month: true,

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -1,12 +1,14 @@
-<% @search_component = Events::SearchComponent.new(
-        @event_search,
-        @form_action.to_s,
-        @performed_search,
-        include_type: false,
-        heading: "Search for #{@category_name}",
-        allow_blank_month: true,
-      )
-%>
+<% content_for :search_component do %>
+  <%= render Events::SearchComponent.new(
+    @event_search,
+    @form_action.to_s,
+    @performed_search,
+    include_type: false,
+    heading: "Search for #{@category_name}",
+    allow_blank_month: true,
+    )
+  %>
+<% end %>
 
 <% content_for :before_search do %>
   <p><%= safe_html_format(t("find_an_event.types.#{@type.id}")) %></p>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,7 +17,7 @@
 </section>
 <% end %>
 
-<% unless @performed_search %>
+<% unless @performed_search || @no_results %>
   <div class="content-alert content-alert--left">
     <div class="content-alert__icon">
       <%= image_pack_tag "media/images/icon-moved-online-purple.svg", alt: "", size: "40x26" %>
@@ -31,7 +31,7 @@
 
 <% unless @no_results %>
   <% unless @performed_search %>
-  <h2>Discover events</h2>
+    <h2>Discover events</h2>
   <% end %>
   <% @events_by_type.each do |type_id, events| %>
     <%= render "event_group",

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,8 +1,10 @@
-<% @search_component = Events::SearchComponent.new(
-  @event_search,
-  search_events_path(anchor: "searchforevents"),
-   @performed_search
-) %>
+<% content_for :search_component do %>
+  <%= render Events::SearchComponent.new(
+    @event_search,
+    search_events_path(anchor: "searchforevents"),
+    @performed_search
+  ) %>
+<% end %>
 
 <% @before_search_fullwidth = true %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,6 +1,7 @@
 <% @search_component = Events::SearchComponent.new(
   @event_search,
-  search_events_path(anchor: "searchforevents")
+  search_events_path(anchor: "searchforevents"),
+   @performed_search
 ) %>
 
 <% @before_search_fullwidth = true %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -14,7 +14,7 @@
         </article>
       </section>
       <div class="feature">
-        <%= render @search_component %>
+        <%= yield :search_component %>
       </div>
       <section class="container events">
         <article class="fullwidth">

--- a/app/webpacker/controllers/event_search_button_controller.js
+++ b/app/webpacker/controllers/event_search_button_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['updateResultsButton'];
+
+  connect() {
+    this.setButtonStyle('disabled');
+  }
+
+  parameterChanged() {
+    this.setButtonStyle('enabled');
+  }
+
+  setButtonStyle(style) {
+    if (style === 'disabled') {
+      this.updateResultsButtonTarget.classList.add('disabled-button');
+      this.updateResultsButtonTarget.classList.remove('request-button');
+    } else if (style === 'enabled') {
+      this.updateResultsButtonTarget.classList.remove('disabled-button');
+      this.updateResultsButtonTarget.classList.add('request-button');
+    }
+  }
+}

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -85,6 +85,12 @@ a {
   @include button($bg: $pink);
 }
 
+.disabled-button {
+  @include button($bg: $pink);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .survey-button {
   @include button($bg: $blue-dark);
   margin-bottom: 0.5rem;

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 describe Events::SearchComponent, type: "component" do
   let(:search) { build(:events_search, :invalid) }
   let(:path) { "/some/path" }
+  let(:performed_search) { nil }
 
-  let(:component) { described_class.new(search, path) }
+  let(:component) { described_class.new(search, path, performed_search) }
   subject! { render_inline(component) }
 
   specify "builds a search form" do
@@ -20,7 +21,7 @@ describe Events::SearchComponent, type: "component" do
 
     context "when overridden" do
       let(:new_heading) { "Search for Awesome events" }
-      subject! { render_inline(described_class.new(search, path, heading: new_heading)) }
+      subject! { render_inline(described_class.new(search, path, performed_search, heading: new_heading)) }
 
       specify %(the title is overridden) do
         expect(page).to have_css("h2", text: new_heading)
@@ -56,10 +57,26 @@ describe Events::SearchComponent, type: "component" do
     end
 
     describe "optionally-blank month field" do
-      subject! { render_inline(described_class.new(search, path, allow_blank_month: true)) }
+      subject! { render_inline(described_class.new(search, path, performed_search, allow_blank_month: true)) }
 
       specify "there should be a blank option with the text '#{described_class::BLANK_MONTH_TEXT}'" do
         expect(page).to have_css("option[value='']", text: described_class::BLANK_MONTH_TEXT)
+      end
+    end
+
+    describe "data attributes" do
+      context "when `performed_search` is nil" do
+        let(:performed_search) { nil }
+        it "does not have `event-search-button` attribute" do
+          expect(page.find(".search")["data-controller"]).not_to include("event-search-button")
+        end
+      end
+
+      context "when `performed_search` is true" do
+        let(:performed_search) { true }
+        it "has the `event-search-button` attribute" do
+          expect(page.find(".search")["data-controller"]).to include("event-search-button")
+        end
       end
     end
   end

--- a/spec/javascript/controllers/event_search_button_controller_spec.js
+++ b/spec/javascript/controllers/event_search_button_controller_spec.js
@@ -1,0 +1,105 @@
+import EventSearchButtonController from 'event_search_button_controller.js';
+import { Application } from 'stimulus';
+
+describe('EventSearchButtonController', () => {
+  document.body.innerHTML = `
+    <div class="search" data-controller="event-search-button">
+      <form class="new_events_search" id="new_events_search" action="/events/search#searchforevents" accept-charset="UTF-8" method="get">
+        <input name="utf8" type="hidden" value="✓">
+        <div class="search__controls" data-controller="conditional-field" data-conditional-field-mode="hide" data-conditional-field-expected="">
+          <div>
+            <label for="events_search_type">Event type</label>
+            <select data-action="event-search-button#parameterChanged" name="events_search[type]" id="events_search_type"><option value="">All events</option></select>
+          </div>
+          <div>
+            <label for="events_search_distance">Location</label>
+            <select data-action="conditional-field#toggle event-search-button#parameterChanged" data-conditional-field-target="source" name="events_search[distance]" id="events_search_distance"><option selected="" value="">Nationwide</option></select>
+          </div>
+          <div data-conditional-field-target="showhide" class="hidden">
+            <label for="events_search_postcode">Postcode</label>
+            <input data-action="event-search-button#parameterChanged" type="text" name="events_search[postcode]" id="events_search_postcode" disabled="">
+          </div>
+          <div>
+            <label for="events_search_month">Month</label>
+            <select data-action="event-search-button#parameterChanged" name="events_search[month]" id="events_search_month"><option selected="" value="2021-06">June 2021</option></select>
+          </div>
+        </div>
+       <button class="disabled-button" id="updateResultsButton" data-event-search-button-target="updateResultsButton">Update
+        results <span class="fas fa-sync"></span></button>
+      </form>
+    </div>
+`;
+
+  let updateResultsButton;
+
+  beforeEach(() => {
+    const application = Application.start();
+    application.register('event-search-button', EventSearchButtonController);
+    updateResultsButton = document.getElementById('updateResultsButton');
+  });
+
+  describe('on connect', () => {
+    it('updates the "Update results" button style to disabled', () => {
+      expectButtonToBeDisabled();
+    });
+  });
+
+  describe('when "Event type" select value changed', () => {
+    it('updates the "Update results" button style to enabled', () => {
+      expectButtonToBeDisabled();
+      simulateEventOnElement(
+        document.getElementById('events_search_type'),
+        'change'
+      );
+      expectButtonToBeEnabled();
+    });
+  });
+
+  describe('when "Location" select value changed', () => {
+    it('updates the "Update results" button style to enabled', () => {
+      expectButtonToBeDisabled();
+      simulateEventOnElement(
+        document.getElementById('events_search_distance'),
+        'change'
+      );
+      expectButtonToBeEnabled();
+    });
+  });
+
+  describe('when "Month" select value changed', () => {
+    it('updates the "Update results" button style to enabled', () => {
+      expectButtonToBeDisabled();
+      simulateEventOnElement(
+        document.getElementById('events_search_month'),
+        'change'
+      );
+      expectButtonToBeEnabled();
+    });
+  });
+
+  describe('when "Postcode" input value changed', () => {
+    it('updates the "Update results" button style to enabled', () => {
+      expectButtonToBeDisabled();
+      simulateEventOnElement(
+        document.getElementById('events_search_postcode'),
+        'input'
+      );
+      expectButtonToBeEnabled();
+    });
+  });
+
+  function expectButtonToBeEnabled() {
+    expect(updateResultsButton.classList).not.toContain('disabled-button');
+    expect(updateResultsButton.classList).toContain('request-button');
+  }
+
+  function expectButtonToBeDisabled() {
+    expect(updateResultsButton.classList).toContain('disabled-button');
+    expect(updateResultsButton.classList).not.toContain('request-button');
+  }
+
+  function simulateEventOnElement(element, event) {
+    const eventToDispatch = new Event(event);
+    element.dispatchEvent(eventToDispatch);
+  }
+});

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -18,6 +18,12 @@ describe "View events by category" do
       receive(:search_teaching_events_grouped_by_type) { events_by_type }
   end
 
+  it "has the `event-search-button` data-controller attribute" do
+    get event_category_path("train-to-teach-events")
+
+    expect(response.body).to include "event-search-button"
+  end
+
   context "when viewing a category archive" do
     let(:category) { "online-q-as" }
     before do


### PR DESCRIPTION
### Trello card
https://trello.com/c/q28oZTps

### Context
Some users were confused by the events search - after searching events again, they were unclear if the UI had updated to show their new search results.

After a chat with @gazcarr, we decided see what a reduced opacity button with a `not-allowed` cursor would look like.

Behaviour is now:
- Landing on `/events` = Button normal
- Make a valid search = Button disabled (in appearance)
- Make an invalid search - Button normal
- Make a valid search, then change any of the `select` elements, or type in the `input` = Button normal
- Land on a categories page, such as `/event-categories/online-q-as` = Button disabled (event search has already taken place)

Because the button only appears disabled when the JavaScript is attached, the behaviour for people with JavaScript turned off will just be the current behaviour.

### Changes proposed in this pull request
- Connect Stimulus `event-search-button` controller when search performed
  - The `event-search-button` Stimulus controller will be used to update the appearance of the `Update results` button. This should only happen when a search has been performed, so conditionally connect the controller using the existing `search_performed` variable. 
- Reduce opacity of `Update results` button when parameters unchanged
  - When the search parameters have not changed since the last search, then reduce to opacity of the `Update results` button to suggest to users that it won't do anything. When any of the parameters are updated, turn opacity back up to 100%.
- Don't set `performed_search` when postcode is invalid
  - Currently, the events search sets a `performed_search` variable when postcode is invalid. Don't set this when search is invalid so that I can control the behaviour of the `Update results` button.
- Update use of search component. 
  - Pass `search component` to view with `content_for` - We want to avoid setting instance variables in the view and passing them to the layout. When we look at the layout we assume any instance variable is set in the controller, which makes the logic harder to follow if it is set in the view instead.