### PR TITLE
Fix non-JS search

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,9 @@
+module SearchHelper
+  def display_search_path(path)
+    humanized_path = humanize_path(path)
+
+    return unless humanized_path
+
+    tag.span(humanized_path, class: "search-result__path")
+  end
+end

--- a/app/views/searches/_result.html.erb
+++ b/app/views/searches/_result.html.erb
@@ -1,4 +1,7 @@
-<%= link_to result[0], class: "search-result" do %>
-  <p><%= humanize_path result[0] %></p>
-  <h3><%= result[1][:title] %></h3>
+<%= link_to result[:path], class: "search-result" do %>
+  <%= display_search_path(result[:path]) %>
+
+  <h3 class="search-result__header"><%= result.dig(:frontmatter, :title) %></h3>
+
+  <p class="search-result__description"><%= result.dig(:frontmatter, :description) %></p>
 <% end %>

--- a/app/webpacker/styles/search-page.scss
+++ b/app/webpacker/styles/search-page.scss
@@ -9,17 +9,17 @@
   display: block;
   text-decoration: none;
   color: initial;
-  padding: 1em 0;
+  padding: 1em .5em;
 
-  h3 {
-    margin-top: .2rem;
-    margin-bottom: 0;
+  &__header {
+    margin-top: .4em;
   }
 
-  p {
-    margin-top: 0;
-    margin-bottom: .2rem;
-    font-size: .9em;
+  &__path {
+    @include font-size("xsmall");
+    color: $grey-dark;
+    padding: 0;
+    margin: 0;
   }
 
   span {

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Internal search without JavaScript", type: :feature do
+  let(:search_term) do
+    Pages::Frontmatter
+      .list
+      .values
+      .detect { |v| v.key?(:keywords) }
+      .fetch(:keywords)
+      .first
+  end
+
+  specify "searching yields results" do
+    visit "/search"
+    fill_in "Enter your search term", with: search_term
+    within("form") { click_on "Search" }
+
+    expect(page).to have_css(".search-result", minimum: 1)
+  end
+end

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -28,10 +28,10 @@ describe "searches/show.html.erb" do
 
     context "with some results" do
       let(:results) do
-        {
-          "/page1" => { title: "Page 1" },
-          "/page2" => { title: "Page 2" },
-        }
+        [
+          { path: "/page1", front_matter: { title: "Page 1" } },
+          { path: "/page1", front_matter: { title: "Page 1" } },
+        ]
       end
 
       it { is_expected.to have_css "p" }


### PR DESCRIPTION
The non-JavaScript search had broken, due to the format of results changing slightly, and we hadn't noticed. This change makes them work again and also adds a feature that runs them and ensures results are rendered.

Also, now the pages have `description` in the frontmatter, display it with the results and improve the CSS a little.
