### PR TITLE
Split the inline search out to its own partial

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -33,10 +33,10 @@ private
     end
   end
 
-  def render_result(*result)
+  def render_result(*inline_result)
     render_to_string \
-      partial: "result",
-      object: result,
+      partial: "inline_result",
+      object: inline_result,
       formats: [:html]
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,9 @@
+module SearchHelper
+  def display_search_path(path)
+    humanized_path = humanize_path(path)
+
+    return unless humanized_path
+
+    tag.span(humanized_path, class: "search-result__path")
+  end
+end

--- a/app/views/searches/_inline_result.html.erb
+++ b/app/views/searches/_inline_result.html.erb
@@ -1,0 +1,6 @@
+<%= link_to inline_result[0], class: "search-result" do %>
+  <% if humanize_path(inline_result[0]).present? %>
+    <p><%= humanize_path inline_result[0] %></p>
+  <% end %>
+  <h3><%= inline_result[1][:title] %></h3>
+<% end %>

--- a/app/views/searches/_result.html.erb
+++ b/app/views/searches/_result.html.erb
@@ -1,4 +1,7 @@
-<%= link_to result[0], class: "search-result" do %>
-  <p><%= humanize_path result[0] %></p>
-  <h3><%= result[1][:title] %></h3>
+<%= link_to result[:path], class: "search-result" do %>
+  <%= display_search_path(result[:path]) %>
+
+  <h3 class="search-result__header"><%= result.dig(:frontmatter, :title) %></h3>
+
+  <p class="search-result__description"><%= result.dig(:frontmatter, :description) %></p>
 <% end %>

--- a/app/webpacker/styles/search-page.scss
+++ b/app/webpacker/styles/search-page.scss
@@ -29,13 +29,25 @@
 
 .searchpage__results .search-result {
   border-top: 1px solid $grey-mid;
+  padding: 1em .5em;
+
+  &__header {
+    margin-bottom: .4em;
+  }
+
+  &__path {
+    @include font-size("xsmall");
+    color: $grey-dark;
+    padding: 0;
+    margin: 0;
+  }
 
   &:hover {
     color: $blue-dark;
     background: $grey;
 
     h3 {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 }

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Internal search without JavaScript", type: :feature do
+  let(:search_term) do
+    Pages::Frontmatter
+      .list
+      .values
+      .detect { |v| v.key?(:keywords) }
+      .fetch(:keywords)
+      .first
+  end
+
+  specify "searching yields results" do
+    visit "/search"
+    fill_in "Enter your search term", with: search_term
+    within("form") { click_on "Search" }
+
+    expect(page).to have_css(".search-result", minimum: 1)
+  end
+end

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -28,10 +28,10 @@ describe "searches/show.html.erb" do
 
     context "with some results" do
       let(:results) do
-        {
-          "/page1" => { title: "Page 1" },
-          "/page2" => { title: "Page 2" },
-        }
+        [
+          { path: "/page1", front_matter: { title: "Page 1" } },
+          { path: "/page1", front_matter: { title: "Page 1" } },
+        ]
       end
 
       it { is_expected.to have_css "p" }


### PR DESCRIPTION
This is the second stab at fixing search. It could do with some proper tests and they will follow, but this just gets both JS and non-JS searches working.

The problem arose because the format for search results is different (and has been for some time) between the JS and non-JS searches, yet they share the same partial. This wasn't caught by our tests because they mock the results rather than actually running searches against the site.

The previous attempt #1406 fixed the non-JS search and broke the JS one.

## Reviewing suggestions

Ensure both search types work in the review app.
