### PR TITLE
Add check for static asset availability

### DIFF
--- a/.github/workflows/static_asset_checker.yml
+++ b/.github/workflows/static_asset_checker.yml
@@ -1,0 +1,25 @@
+name: Run Static Asset Checker
+on:
+  schedule:
+    - cron:  '* * * * *' # every minute
+  workflow_dispatch:
+
+jobs:
+  pagespeed:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - uses: Azure/get-keyvault-secrets@v1.2
+      id: azSecret
+      with:
+          keyvault: ${{ secrets.KEY_VAULT }}
+          secrets: 'HTTP-USERNAME, HTTP-PASSWORD'
+    - name: Run Static Asset Checker
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: 'https://get-into-teaching-app-pagespeed.london.cloudapps.digital/assets/check'
+        method: 'GET'
+        username: ${{ secrets.HTTP-USERNAME }}
+        password: ${{ secrets.HTTP-PASSWORD }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,16 @@ Rails.application.routes.draw do
     [204, {}, []]
   }
 
+  get "/assets/check", constraints: -> { Rails.env.pagespeed? }, to: proc { |_env|
+    require "asset_checker"
+
+    root_url = "https://getintoteaching.education.gov.uk"
+    checker = AssetChecker.new(root_url)
+    result = checker.run
+
+    [result.empty? ? 204 : 404, {}, [result.join($INPUT_RECORD_SEPARATOR)]]
+  }
+
   namespace :internal do
     resources :events, only: %i[index show new create edit]
     put "/approve", to: "events#approve"

--- a/lib/asset_checker.rb
+++ b/lib/asset_checker.rb
@@ -1,0 +1,23 @@
+class AssetChecker
+  attr_reader :root_url
+
+  ASSET_PATTERN = /(\/packs\/(js|css)\/.+\.(js|css))/.freeze
+
+  def initialize(root_url)
+    @root_url = root_url
+  end
+
+  def run
+    html = Faraday.get(root_url).body
+    html.scan(ASSET_PATTERN)
+      .map(&:first)
+      .map { |path| root_url + path }
+      .reject { |url| reachable?(url) }
+  end
+
+  def reachable?(url)
+    Faraday.get(url).status != 404
+  rescue Faraday::ConnectionFailed
+    false
+  end
+end

--- a/spec/lib/asset_checker_spec.rb
+++ b/spec/lib/asset_checker_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+require "asset_checker"
+
+describe AssetChecker do
+  let(:root_url) { "https://example.com" }
+  let(:js_asset) { "/packs/js/application-digest.js" }
+  let(:css_asset) { "/packs/css/application-digest.css" }
+  let(:html) do
+    <<~HTML
+      <html>
+        <head>
+          <script src="#{js_asset}"></script>
+          <link href="#{css_asset}" />
+        </head>
+      </html>
+    HTML
+  end
+  let(:instance) { described_class.new(root_url) }
+
+  describe "#run" do
+    before do
+      stub_request(:get, root_url).to_return(status: 200, body: html)
+    end
+
+    subject(:run) { instance.run }
+
+    context "when the assets are available" do
+      before do
+        stub_request(:get, root_url + js_asset).to_return(status: 200)
+        stub_request(:get, root_url + css_asset).to_return(status: 200)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the assets are not found" do
+      before do
+        stub_request(:get, root_url + js_asset).to_return(status: 404)
+        stub_request(:get, root_url + css_asset).to_return(status: 404)
+      end
+
+      it { is_expected.to contain_exactly(root_url + js_asset, root_url + css_asset) }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1622](https://trello.com/c/leu6mmtZ/1622-investigate-packcs-js-applicationjs-404ing)

### Context

We are seeing sporadic 404s being returned for assets that contain a digest from an old deployment. We suspect CloudFront is not caching these assets according to the 1 year cache-control TTL we have set, but we want to determine if users are running into this error during deployments when the asset digests are changing, or if its just bots poking about.

This introduces an `AssetChecker` that loads the home page, pulls out the CSS/JS pack URLS and then attempts to download them; if the requests fail it will be returned as a 404 to the client with a list of the failed URLs, if it passes then we return an empty 204.

We are using the page speed environment for ease; this doesn't really warrant its own environment and it can be torn out once we get to the root cause of the 404ing.

### Changes proposed in this pull request

- Add check for static asset availability

### Guidance to review

