### PR TITLE
Change asset checker to be POST instead of GET

### DIFF
--- a/.github/workflows/static_asset_checker.yml
+++ b/.github/workflows/static_asset_checker.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pagespeed:
+  asset_checker:
     runs-on: ubuntu-latest
     steps:
     - uses: Azure/login@v1
@@ -20,6 +20,6 @@ jobs:
       uses: fjogeleit/http-request-action@master
       with:
         url: 'https://get-into-teaching-app-pagespeed.london.cloudapps.digital/assets/check'
-        method: 'GET'
+        method: 'POST'
         username: ${{ secrets.HTTP-USERNAME }}
         password: ${{ secrets.HTTP-PASSWORD }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
     [204, {}, []]
   }
 
-  get "/assets/check", constraints: -> { Rails.env.pagespeed? }, to: proc { |_env|
+  post "/assets/check", constraints: -> { Rails.env.pagespeed? }, to: proc { |_env|
     require "asset_checker"
 
     root_url = "https://getintoteaching.education.gov.uk"


### PR DESCRIPTION
Its showing as an unauthorised request in the GitHub Actions, I'm not sure why as we send the username/password in the same way as the page speed task. The only difference I can see is one is this is a GET request; changing to a POST to see if that makes a difference.
