### PR TITLE
Add timeout to static asset checker

### DIFF
--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -24,3 +24,4 @@ jobs:
         username: ${{ secrets.HTTP-USERNAME }}
         password: ${{ secrets.HTTP-PASSWORD }}
         timeout: 3600000 # 1hr in ms
+        preventFailureOnNoResponse: true

--- a/.github/workflows/static_asset_checker.yml
+++ b/.github/workflows/static_asset_checker.yml
@@ -23,3 +23,5 @@ jobs:
         method: 'POST'
         username: ${{ secrets.HTTP-USERNAME }}
         password: ${{ secrets.HTTP-PASSWORD }}
+        timeout: 20000 # 20s
+        preventFailureOnNoResponse: true


### PR DESCRIPTION
Add timeout to the static asset checker as it still seems to be failing for 'no response'. Also turn on `preventFailureOnNoResponse` for the page speed and asset checker actions so they stop spamming me.