### PR TITLE
Remove Uni of Gloucestershire

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -355,11 +355,6 @@ providers:
     name: Ania Glowczynska
     telephone: 01726 891 745
     email: info@learninginstitute.co.uk
-  - header: University of Gloucestershire
-    link: https://www.glos.ac.uk/study/Pages/study-with-us.aspx
-    name: Tim Adams
-    telephone: 01242 714638
-    email: qtsassessmentonly@glos.ac.uk
   - header: Wessex Schools Training Partnership
     name: Mike Petrus
     telephone: 01202 662044


### PR DESCRIPTION
Uni of Gloucestershire are no longer offering AO route. Removing following an email this morning (23/06).
