### PR TITLE
Prevent double clicking form buttons

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -7,6 +7,6 @@ module TextFormattingHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b br div], attributes: %w[href target]
+    sanitize html, tags: %w[strong a ul li p b br div span], attributes: %w[href target]
   end
 end

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -12,10 +12,8 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <%= f.button class: "call-to-action-button button" do %>
-        <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
-        <span></span>
-      <% end %>
+      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next Step <span></span>") %>
+      <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
   <% end %>
 </section>

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% if f.object.can_subscribe_to_mailing_list? %>
-  <div data-controller="last-step" data-last-step-complete="Complete sign up" data-last-step-continue="Next Step">
+  <div data-controller="last-step" data-last-step-complete="Complete sign up<span></span>" data-last-step-continue="Next Step<span></span>">
     <div data-action="click->last-step#updateSubmit">
       <%= f.govuk_radio_buttons_fieldset :subscribe_to_mailing_list, inline: true do %>
         <%= f.govuk_radio_button :subscribe_to_mailing_list, true, label: { text: "Yes" } %>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -7,10 +7,8 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <%= f.button class: "call-to-action-button button" do %>
-        <%= wizard.last_step? ? "Complete sign up" : "Next Step" %>
-        <span></span>
-      <% end %>
+      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next Step <span></span>") %>
+      <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
   <% end %>
 </section>

--- a/app/webpacker/controllers/last_step_controller.js
+++ b/app/webpacker/controllers/last_step_controller.js
@@ -28,6 +28,7 @@ export default class extends Controller {
   }
 
   setSubmitText(submitMsg) {
-    this.submitButton.innerText = submitMsg;
+    this.submitButton.innerHTML = submitMsg;
+    this.submitButton.dataset.disableWith = submitMsg;
   }
 }

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -37,6 +37,10 @@ a {
   @include chevron;
   display: inline-block;
 
+  &:disabled {
+    opacity: 0.7;
+  }
+
   span {
     white-space: nowrap;
   }

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -19,7 +19,7 @@ describe TextFormattingHelper, type: :helper do
     subject { safe_html_format html }
 
     context "with allowed HTML" do
-      let(:html) { "<div>test</div><p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul>" }
+      let(:html) { "<div>test</div><p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul><span>test</span>" }
       it { is_expected.to eql html }
     end
 

--- a/spec/javascript/controllers/last_step_controller_spec.js
+++ b/spec/javascript/controllers/last_step_controller_spec.js
@@ -35,12 +35,17 @@ describe('LastStepController', () => {
   });
 
   function buttonLabel() {
-    return document.getElementById('button').innerText;
+    return document.getElementById('button').innerHTML;
+  }
+
+  function buttonDisableText() {
+    return document.getElementById('button').dataset.disableWith;
   }
 
   describe('When no button clicked', () => {
     it('should have default message', () => {
       expect(buttonLabel()).toEqual('continue');
+      expect(buttonDisableText()).toEqual('continue');
     });
   });
 
@@ -51,6 +56,7 @@ describe('LastStepController', () => {
 
     it('should set message to continue', () => {
       expect(buttonLabel()).toEqual('continue');
+      expect(buttonDisableText()).toEqual('continue');
     });
   });
 
@@ -61,6 +67,7 @@ describe('LastStepController', () => {
 
     it('should set message to complete', () => {
       expect(buttonLabel()).toEqual('complete');
+      expect(buttonDisableText()).toEqual('complete');
     });
   });
 });


### PR DESCRIPTION
### Trello

[Trello-1659](https://trello.com/c/Cl0hYG6a/1659-duplicate-crm-record)

### Context

As we are not using the `govuk_submit` helper (due to our own submit button styling) the default prevent double click behaviour was not being applied.

Update to include the `data-prevent-double-click` and `data-disable-with` for correct double click prevention behaviour.

Update disabled button styling to fade it out slightly so it looks disabled.

### Changes proposed in this pull request

- Prevent double clicking form buttons

### Guidance to review

I could have swapped it out to use the `govuk_submit` and re-style it but I think that may have ended up messier than applying the double click attributes manually.

It would be worth DRYing up the `_form` partials but I'd prefer to do that in a separate PR.
