### PR TITLE
Add Basic Auth Switch as Environment Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ terraform.tfstate.backup
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+fetch_config.rb

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,5 +1,7 @@
 locals {
-  environment_map = { HTTPAUTH_PASSWORD = data.azurerm_key_vault_secret.http_password.value, HTTPAUTH_USERNAME = data.azurerm_key_vault_secret.http_username.value }
+  environment_map = { HTTPAUTH_PASSWORD = data.azurerm_key_vault_secret.http_password.value,
+                      HTTPAUTH_USERNAME = data.azurerm_key_vault_secret.http_username.value,
+                      BASIC_AUTH        = var.basic_auth}
 }
 
 resource "cloudfoundry_app" "app_application" {

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -4,6 +4,7 @@ paas_app_application_name = "get-into-teaching-app-prod"
 paas_redis_1_name         = "get-into-teaching-prod-redis-svc"
 paas_internet_hostnames   = ["beta-getintoteaching", "getintoteaching"]
 instances                 = 2
+basic_auth                = 0
 azure_key_vault           = "s146p01-kv"
 azure_resource_group      = "s146p01-rg"
 alerts = {

--- a/terraform/paas/ur.env.tfvars
+++ b/terraform/paas/ur.env.tfvars
@@ -4,6 +4,7 @@ paas_app_application_name = "get-into-teaching-app-ur"
 paas_app_route_name       = "get-into-teaching-app-ur"
 logging                   = 0
 instances                 = 1
+basic_auth                = 0
 alerts                    = {}
 azure_key_vault           = "s146t01-kv"
 azure_resource_group      = "s146t01-rg"

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -37,6 +37,10 @@ variable "logging" {
   default = 1
 }
 
+variable "basic_auth" {
+   default = 1
+}
+
 variable "paas_internet_hostnames" {
   default = []
 }


### PR DESCRIPTION
# Purpose
Sometimes the UR team, and other teams may want to switch off the Basic Authentication. This needs to be set at environment level so it can be simply manipulated.

# Solution
Add an environment variable BASIC_AUTH which has :
- 0 BASIC-AUTH off
- 1 BASIC-AUTH on 

Terraform will set the variable to 1 as default. and the Production environment will be overriden to 0 ( as will UR inititially )


