### PR TITLE
Use env variable to control basic auth on/off

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,6 @@ Rails.application.configure do
     Rails.application.credentials.basic_auth_credentials.presence
 
   config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
+
+  config.x.basic_auth = ENV["BASIC_AUTH"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,6 +112,8 @@ Rails.application.configure do
 
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-HTTP")
 
+  config.x.basic_auth = ENV["BASIC_AUTH"]
+
   # Configure Semantic Logging for production environments
   # This cannot be conditionally loaded so we use it all the time in production
   # like environments.

--- a/lib/basic_auth.rb
+++ b/lib/basic_auth.rb
@@ -21,9 +21,11 @@ class BasicAuth
     end
 
     def env_requires_auth?
-      # Site-wide authentication present in all production-like
-      # environments, but not in production itself.
-      !Rails.env.production? && !Rails.env.test? && !Rails.env.development?
+      basic_auth = Rails.application.config.x.basic_auth
+
+      return false if basic_auth.blank?
+
+      ActiveModel::Type::Boolean.new.cast(basic_auth)
     end
   end
 end

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -11,21 +11,22 @@ RSpec.describe BasicAuth do
   end
 
   describe ".env_requires_auth?" do
-    before { allow(Rails).to receive(:env) { env.inquiry } }
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { basic_auth } }
     subject { instance.env_requires_auth? }
 
-    env_auth = {
-      "production" => false,
-      "rolling" => true,
-      "preprod" => true,
-      "userresearch" => true,
-      "test" => false,
-      "development" => false,
+    basic_auth_values = {
+      nil => false,
+      0 => false,
+      "" => false,
+      "1" => true,
+      "true" => true,
+      true => true,
+      "enabled" => true,
     }.freeze
 
-    env_auth.each do |k, auth|
-      context "when #{k}" do
-        let(:env) { k }
+    basic_auth_values.each do |k, auth|
+      context "when basic_auth is #{k}" do
+        let(:basic_auth) { k }
 
         it { is_expected.to eq(auth) }
       end

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -8,13 +8,8 @@ RSpec.describe "Basic auth", type: :request do
     allow_basic_auth_users([{ username: username, password: password }])
   end
 
-  it "is not enforced on non-production environments" do
-    get root_path
-    expect(response).to be_successful
-  end
-
-  context "when production" do
-    before { allow(Rails).to receive(:env) { "production".inquiry } }
+  context "when basic auth is disabled" do
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { "0" } }
 
     it "is not enforced" do
       get root_path
@@ -22,8 +17,8 @@ RSpec.describe "Basic auth", type: :request do
     end
   end
 
-  context "when production-like (but not production)" do
-    before { allow(Rails).to receive(:env) { "rolling".inquiry } }
+  context "when basic auth is enabled" do
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { "1" } }
 
     it "returns unauthorized if credentials do not match" do
       get root_path, params: {}, headers: basic_auth_headers(username, "wrong-password")


### PR DESCRIPTION
Instead of controlling explicitly by the named environment we want to be able to toggle basic auth on/off with an env variable more easily.