### PR TITLE
Set `is_online` to true for `online` type events on creation

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -106,6 +106,12 @@ module Internal
                        .new.get_teaching_event_buildings
     end
 
+    def type_id=(value)
+      super(value)
+
+      self.is_online = true if online_event?
+    end
+
     def invalid?
       invalid_building = building.present? && building.invalid?
       super || invalid_building

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -234,6 +234,15 @@ describe Internal::Event do
     end
   end
 
+  describe "#type_id=" do
+    context "when event is initialised with 'online' event_type" do
+      subject { described_class.new({ type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }) }
+      it "sets 'is_online' to true" do
+        expect(subject.is_online).to be true
+      end
+    end
+  end
+
   describe "#save" do
     subject { described_class.new }
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -377,7 +377,7 @@ describe Internal::EventsController do
                 end_at: params[:end_at].getutc.floor,
                 scribble_id: params[:scribble_id],
                 building: nil,
-                is_online: nil,
+                is_online: true,
                 is_virtual: nil,
                 video_url: nil,
                 message: nil,


### PR DESCRIPTION
### Context
Some bad events were created via the CRM recently which alerted me to the fact that all `online` type events must have the `is_online` property set to true. Currently, there is a potential for `online` type events to be posted to the API with `is_online` set to `nil`. An event object is always initialised with a `type_id`, so set `is_online` there.

The behaviour for Provider events will remain the same, where the user chooses via the form.

### Changes proposed in this pull request
Set `is_online` to true for `online` type events on creation