### PR TITLE
CSP violation fixes

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
 
   tta_service_hosts = []
   tta_service_hosts << URI.parse(ENV["TTA_SERVICE_URL"]).host if ENV["TTA_SERVICE_URL"].present?
-  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
+  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk adservice.google.com *google.com.sa https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
   lid_pixels = %w[pixelg.adswizz.com tracking.audio.thisisdax.com]
 
   config.csp = {

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -22,7 +22,7 @@ SecureHeaders::Configuration.default do |config|
     form_action: %w['self' tr.snapchat.com www.facebook.com www.gov.uk dev.visualwebsiteoptimizer.com],
     frame_ancestors: %w['self'],
     frame_src: %w['self' embed.scribblelive.com tr.snapchat.com www.facebook.com www.youtube.com www.youtube-nocookie.com *.hotjar.com *.doubleclick.net dev.visualwebsiteoptimizer.com],
-    img_src: %w['self' linkbam.uk *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com *.visualwebsiteoptimizer.com ad.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels,
+    img_src: %w['self' linkbam.uk *.gov.uk data: *.googleapis.com www.facebook.com ct.pinterest.com t.co www.facebook.com cx.atdmt.com *.visualwebsiteoptimizer.com *.doubleclick.net i.ytimg.com adservice.google.com adservice.google.co.uk] + google_analytics + lid_pixels,
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %w['self' 'unsafe-inline' 'unsafe-eval' embed.scribblelive.com *.googleapis.com *.gov.uk code.jquery.com *.facebook.net *.hotjar.com *.pinimg.com sc-static.net static.ads-twitter.com analytics.twitter.com *.youtube.com *.visualwebsiteoptimizer.com] + google_analytics,


### PR DESCRIPTION
### Trello card

[Trello-1664](https://trello.com/c/gQ9VCx6p/1664-csp-violations-on-git-website)

### Context

We're seeing a few CSP violations being reported in the GiT website.

### Changes proposed in this pull request

- Allow any doubleclick subdomain for img pixel

We are seeing a CSP violation relating to DoubleClick img pixels being loaded from a subdomain not in our whitelist.

Update to allow all doubleclick subdomains for `img_src` directive.

- Allow Google Ad service in CSP 

We are seeing a CSP violation for the Google Ad service domain - this change whitelists it.

### Guidance to review

