### PR TITLE
Remove uneeded `.vscode` shared settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-debug.log*
 /config/credentials/*.key
 /coverage
 .idea
+.vscode/
 .terraform/
 tokens
 terraform.tfstate

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#0C332E",
-    "titleBar.activeBackground": "#114840",
-    "titleBar.activeForeground": "#F2FCFB"
-  }
-}


### PR DESCRIPTION
Remove unneeded `.vscode` shared settings. These have been accidently committed at some time in the past.