### PR TITLE
Revamp the events page

### DIFF
--- a/app/components/events/type_description_component.rb
+++ b/app/components/events/type_description_component.rb
@@ -7,7 +7,7 @@ module Events
     end
 
     def description
-      t("event_types.#{type}.description")
+      t("event_types.#{type}.description.long")
     end
 
     def type_name_plural

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -67,6 +67,7 @@ private
 
     @display_empty_types = @event_search.type.nil?
     @performed_search = true
+    @events_search_type = params["events_search"]["type"]
 
     @group_presenter = Events::GroupPresenter.new(search_results, @display_empty_types)
     pages = params.permit(@group_presenter.page_param_names.values)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -116,7 +116,7 @@ module EventsHelper
   # Currently the button needs to be hidden only in
   # the TTT block and when the are no TTT events.
   def show_see_all_events_button?(type_id, events)
-    events.blank? && type_id == ttt_event_type_id ? false : true
+    events.present? || type_id != ttt_event_type_id
   end
 
   def ttt_event_type_id

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -102,10 +102,11 @@ module EventsHelper
 
   def display_no_ttt_events_message?(performed_search, events, event_search_type)
     train_to_teach_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+    searching_for_ttt = train_to_teach_id.to_s == event_search_type
+    searching_for_all = event_search_type.blank?
 
-    searching_for_ttt_or_all_events = [train_to_teach_id.to_s, ""].include? event_search_type
     no_ttt_events = events.map(&:first).exclude?(train_to_teach_id)
 
-    performed_search && searching_for_ttt_or_all_events && no_ttt_events
+    performed_search && (searching_for_ttt || searching_for_all) && no_ttt_events
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -84,7 +84,7 @@ module EventsHelper
 
   def event_type_color(type_id)
     case type_id
-    when GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+    when ttt_event_type_id
       "purple"
     else
       "blue"
@@ -101,12 +101,25 @@ module EventsHelper
   end
 
   def display_no_ttt_events_message?(performed_search, events, event_search_type)
-    train_to_teach_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+    train_to_teach_id = ttt_event_type_id
     searching_for_ttt = train_to_teach_id.to_s == event_search_type
     searching_for_all = event_search_type.blank?
 
     no_ttt_events = events.map(&:first).exclude?(train_to_teach_id)
 
     performed_search && (searching_for_ttt || searching_for_all) && no_ttt_events
+  end
+
+  # Determines if the "see all events" button should
+  # be shown in the events blocks or not.
+  #
+  # Currently the button needs to be hidden only in
+  # the TTT block and when the are no TTT events.
+  def show_see_all_events_button?(type_id, events)
+    events.blank? && type_id == ttt_event_type_id ? false : true
+  end
+
+  def ttt_event_type_id
+    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -99,4 +99,13 @@ module EventsHelper
     t "event_types.#{type_id}.name.past",
       default: "Past " + pluralised_category_name(type_id)
   end
+
+  def display_no_ttt_events_message?(performed_search, events, event_search_type)
+    train_to_teach_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+
+    searching_for_ttt_or_all_events = [train_to_teach_id.to_s, ""].include? event_search_type
+    no_ttt_events = events.map(&:first).exclude?(train_to_teach_id)
+
+    performed_search && searching_for_ttt_or_all_events && no_ttt_events
+  end
 end

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,4 +1,5 @@
 <% plural_category_name = pluralised_category_name(type_id) %>
+<% ttt_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
 <% with_logo = type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] %>
 
 <div class="types-of-event">
@@ -21,8 +22,15 @@
         <%= render partial: "event", collection: events %>
       </div>
     <% else %>
-      <%= render(Events::NoResultsComponent.new) do %>
-        Sorry your search has not found any events of this type, try a different location or month.
+      <% if type_id == ttt_type_id %>
+        <%= render(Events::NoResultsComponent.new) do %>
+          <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
+          <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>
+        <% end %>
+      <% else %>
+        <%= render(Events::NoResultsComponent.new) do %>
+          Sorry your search has not found any events of this type, try a different location or month.
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,5 +1,4 @@
 <% plural_category_name = pluralised_category_name(type_id) %>
-<% ttt_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
 <% with_logo = type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] %>
 
 <div class="types-of-event">
@@ -22,7 +21,7 @@
         <%= render partial: "event", collection: events %>
       </div>
     <% else %>
-      <% if type_id == ttt_type_id %>
+      <% if type_id == ttt_event_type_id %>
         <%= render(Events::NoResultsComponent.new) do %>
           <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
           <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,11 +1,14 @@
 <% plural_category_name = pluralised_category_name(type_id) %>
-<% with_logo = type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] %>
+<% with_logo = type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] %>
 
 <div class="types-of-event">
   <div class="events-featured <%= "events-featured--with-logo" if with_logo %>">
     <div class="events-featured__heading">
-      <h3><%= plural_category_name %></h3>
-
+      <header>
+        <h3><%= plural_category_name %></h3>
+        <div role="doc-subtitle"><%= t("event_types.#{type_id}.description.short") %></div>
+      </header>
+      
       <% if with_logo %>
       <div class="events-featured__logo">
         <%= image_pack_tag "media/images/getintoteachinglogo-with-bg-purple.svg", alt: "", size: "250x125" %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -20,7 +20,7 @@
       type_id: type_id,
       events: events,
       page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
-      show_see_all_events: display_no_ttt_events_message
+      show_see_all_events: events.blank? && type_id == 222750001 ? false : true
     %>
   <% end %>
 <% else %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -20,11 +20,11 @@
       type_id: type_id,
       events: events,
       page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
-      show_see_all_events: events.blank? && type_id == 222750001 ? false : true
+      show_see_all_events: show_see_all_events_button?(type_id, events)
     %>
   <% end %>
 <% else %>
-  <% if @performed_search && @events_search_type != "222750001" %>
+  <% if @performed_search && @events_search_type != ttt_event_type_id.to_s %>
     <%= render(Events::NoResultsComponent.new) do %>
       Sorry your search has not found any events, try a different type, location or month.
     <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -5,33 +5,14 @@
 
 <% @before_search_fullwidth = true %>
 
-<% content_for :before_search do %>
-<h2>Types of events</h2>
-<section class="event-type-descriptions">
-  <section class="event-type-descriptions__content">
-    <% GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.each do |type_id| %>
-      <%= render Events::TypeDescriptionComponent.new(type_id) %>
-    <% end %>
-  </section>
-</section>
-<% end %>
-
-<% unless @performed_search %>
-  <div class="content-alert content-alert--left">
-    <div class="content-alert__icon">
-      <%= image_pack_tag "media/images/icon-moved-online-purple.svg", alt: "", size: "40x26" %>
-    </div>
-    <div>
-      <h4>Some events have moved online</h4>
-      <p>Until it is safe to see you in person, the Train to Teach and most of School and University events are online.</p>
-    </div>
-  </div>
+<% if display_no_ttt_events_message?(@performed_search, @events_by_type, @events_search_type) %>
+  <%= render(Events::NoResultsComponent.new) do %>
+    <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
+    <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>
+  <% end %>
 <% end %>
 
 <% unless @no_results %>
-  <% unless @performed_search %>
-  <h2>Discover events</h2>
-  <% end %>
   <% @events_by_type.each do |type_id, events| %>
     <%= render "event_group",
       type_id: type_id,
@@ -41,8 +22,10 @@
     %>
   <% end %>
 <% else %>
-  <%= render(Events::NoResultsComponent.new) do %>
-    Sorry your search has not found any events, try a different type, location or month.
+  <% if @performed_search && @events_search_type != "222750001" %>
+    <%= render(Events::NoResultsComponent.new) do %>
+      Sorry your search has not found any events, try a different type, location or month.
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -20,7 +20,7 @@
       type_id: type_id,
       events: events,
       page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
-      show_see_all_events: display_no_ttt_events_message ? true : false
+      show_see_all_events: display_no_ttt_events_message
     %>
   <% end %>
 <% else %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,3 +1,5 @@
+<% display_no_ttt_events_message = display_no_ttt_events_message?(@performed_search, @events_by_type, @events_search_type) %>
+
 <% @search_component = Events::SearchComponent.new(
   @event_search,
   search_events_path(anchor: "searchforevents")
@@ -5,7 +7,7 @@
 
 <% @before_search_fullwidth = true %>
 
-<% if display_no_ttt_events_message?(@performed_search, @events_by_type, @events_search_type) %>
+<% if display_no_ttt_events_message %>
   <%= render(Events::NoResultsComponent.new) do %>
     <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
     <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>
@@ -18,7 +20,7 @@
       type_id: type_id,
       events: events,
       page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
-      show_see_all_events: true
+      show_see_all_events: display_no_ttt_events_message ? true : false
     %>
   <% end %>
 <% else %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -13,9 +13,11 @@
           <%= yield :before_search %>
         </article>
       </section>
-      <div class="feature">
-        <%= render @search_component %>
-      </div>
+      <% if @search_component %>
+        <div class="feature">
+          <%= render @search_component %>
+        </div>
+      <% end %>
       <section class="container events">
         <article class="fullwidth">
           <%= yield %>

--- a/app/webpacker/styles/components/events/no-results.scss
+++ b/app/webpacker/styles/components/events/no-results.scss
@@ -10,7 +10,11 @@
     color: $white;
   }
 
-  @include mq($from: tablet) {
-    width: 70%;
+  p {
+    margin: 0px 0px 10px 0px;
+  }
+
+  .button {
+    padding: 10px 1.5rem;
   }
 }

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -62,9 +62,11 @@
     }
 
     &__heading {
-      > h3 {
+      margin-bottom: $indent-amount;
+
+      > header h3 {
         @include font-size(large);
-        margin: 0 0 $indent-amount 0;
+        margin: 0px;
         line-height: 1.25;
       }
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,7 +273,7 @@ en:
         singular: "Train to Teach event"
         plural: "Train to Teach events"
       description: 
-        short: Hear from real teachers and advisers
+        short: Hear from current teachers and teacher training advisers
         long: |-
           Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
           will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
@@ -283,7 +283,7 @@ en:
         plural: "Online Q&As"
         past: "Past online Q&As"
       description: 
-          short: Have your teacher training questions answered by our experts
+          short: Have all your teacher training questions answered by our experts
           long: |-
             In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
             Get fast answers to your questions so you can take the next step to becoming a teacher.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,7 +273,7 @@ en:
         singular: "Train to Teach event"
         plural: "Train to Teach events"
       description: 
-        short: Hear from current teachers and teacher training advisers
+        short: Find out from schools and universities what training will be like and get one-to-one advice from our teaching experts on applying.
         long: |-
           Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
           will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
@@ -283,7 +283,7 @@ en:
         plural: "Online Q&As"
         past: "Past online Q&As"
       description: 
-          short: Have all your teacher training questions answered by our experts
+          short: Get fast answers to your questions on topics such as funding or ways to train, so you can take the next step to becoming a teacher.
           long: |-
             In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
             Get fast answers to your questions so you can take the next step to becoming a teacher.
@@ -292,7 +292,7 @@ en:
         singular: "School or University event"
         plural: "School and University events"
       description: 
-        short: Find out about teacher training with these providers
+        short: Find out more about a particular training provider, what they offer and help you decide on where to apply.
         long: |-
           These events, run by schools and universities, are a great way to and find out more about a particular training provider.
           Find out what they have to offer and help make your decision on where to apply.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,24 +272,30 @@ en:
       name:
         singular: "Train to Teach event"
         plural: "Train to Teach events"
-      description: |-
-        Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
-        will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
+      description: 
+        short: Hear from real teachers and advisers
+        long: |-
+          Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
+          will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
     222750008:
       name:
         singular: "Online Q&A"
         plural: "Online Q&As"
         past: "Past online Q&As"
-      description: |-
-        In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
-        Get fast answers to your questions so you can take the next step to becoming a teacher.
+      description: 
+          short: Have your teacher training questions answered by our experts
+          long: |-
+            In these online sessions, our teacher training advisers answer questions on specific topics, such as funding or ways to train.
+            Get fast answers to your questions so you can take the next step to becoming a teacher.
     222750009:
       name:
         singular: "School or University event"
         plural: "School and University events"
-      description: |-
-        These events, run by schools and universities, are a great way to and find out more about a particular training provider.
-        Find out what they have to offer and help make your decision on where to apply.
+      description: 
+        short: Find out about teacher training with these providers
+        long: |-
+          These events, run by schools and universities, are a great way to and find out more about a particular training provider.
+          Find out what they have to offer and help make your decision on where to apply.
   activemodel:
     errors:
       magic_link_token:

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -18,7 +18,7 @@ describe Events::TypeDescriptionComponent, type: "component" do
   end
 
   it "has a description" do
-    expect(page).to have_css("p", text: I18n.t("event_types.#{type}.description"))
+    expect(page).to have_css("p", text: I18n.t("event_types.#{type}.description.long"))
   end
 
   it "has a read more link" do

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -198,4 +198,27 @@ describe EventsHelper, type: "helper" do
       expect(past_category_name(222_750_001)).to eql("Past Train to Teach events")
     end
   end
+
+  describe "#display_no_ttt_events_message?" do
+    let(:performed_search) { true }
+    let(:events) { [] }
+    let(:event_search_type) { "222750001" }
+    let(:dummy_events) { [[222_750_001, []]] }
+
+    it "returns true when searching for TTT events and there are none" do
+      expect(display_no_ttt_events_message?(performed_search, events, event_search_type)).to be true
+    end
+
+    it "returns false when search was not performed" do
+      expect(display_no_ttt_events_message?(false, events, event_search_type)).to be false
+    end
+
+    it "returns false when there are TTT events" do
+      expect(display_no_ttt_events_message?(true, dummy_events, event_search_type)).to be false
+    end
+
+    it "returns false when the search is not for TTT events" do
+      expect(display_no_ttt_events_message?(true, dummy_events, "")).to be false
+    end
+  end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -221,4 +221,44 @@ describe EventsHelper, type: "helper" do
       expect(display_no_ttt_events_message?(true, dummy_events, "")).to be false
     end
   end
+
+  describe "#show_see_all_events_button?" do
+    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+
+    context "when checking for TTT event type id" do
+      it "returns false when events is empty" do
+        events = []
+
+        expect(show_see_all_events_button?(type_id, events)).to be false
+      end
+
+      it "returns true when events is not empty" do
+        events = build_list(:event_api, 2, :train_to_teach_event)
+
+        expect(show_see_all_events_button?(type_id, events)).to be true
+      end
+    end
+
+    context "when checking for any other event type ids" do
+      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+
+      it "returns true when events is empty" do
+        events = build_list(:event_api, 2, :online_event)
+
+        expect(show_see_all_events_button?(type_id, events)).to be true
+      end
+
+      it "returns true when events is not empty" do
+        events = []
+
+        expect(show_see_all_events_button?(type_id, events)).to be true
+      end
+    end
+  end
+
+  describe "#ttt_event_type_id?" do
+    it "returns the TTT event id" do
+      expect(ttt_event_type_id).to eq GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+    end
+  end
 end

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -33,23 +33,6 @@ describe "Find an event near you" do
       expect(response.body).to include("Do you have a teaching event?")
     end
 
-    it "displays the events moved online notice" do
-      expect(response.body).to include("Some events have moved online")
-    end
-
-    it "displays the discover events heading" do
-      expect(response.body).to include("Discover events")
-    end
-
-    it "displays event types" do
-      expect(response.body).to include("Types of events")
-      event_types = GetIntoTeachingApiClient::Constants::EVENT_TYPES.values
-
-      event_types.each do |type|
-        expect(response.body).to include(I18n.t("event_types.#{type}.description"))
-      end
-    end
-
     it "displays all events" do
       expect(response.body.scan(/Event [1-5]/).count).to eq(5)
     end
@@ -57,15 +40,6 @@ describe "Find an event near you" do
     it "presents the events in date order, per category" do
       headings = response.body.scan(/<h4>Event (.*)<\/h4>/).flatten.take(events.count)
       expect(headings).to eq(%w[4 1 5 2 3])
-    end
-
-    context "when there are no results" do
-      let(:events) { [] }
-
-      it "displays a single no results message" do
-        no_results_messages = response.body.scan(no_events_regex).flatten
-        expect(no_results_messages.count).to eq(1)
-      end
     end
 
     context "when there are events of different types" do
@@ -89,7 +63,7 @@ describe "Find an event near you" do
   end
 
   context "when searching for an event by type" do
-    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
     let(:events) { [build(:event_api, type_id: type_id)] }
 
     before do
@@ -101,7 +75,7 @@ describe "Find an event near you" do
 
     it "displays only the category filtered to" do
       headings = response.body.scan(category_headings_regex).flatten
-      expected_headings = ["Train to Teach events"]
+      expected_headings = ["Online Q&amp;As"]
 
       expect(headings).to eq(expected_headings)
     end
@@ -113,14 +87,36 @@ describe "Find an event near you" do
     context "when there are no results" do
       let(:events) { [] }
 
-      it "displays a single no results message" do
-        no_results_messages = response.body.scan(no_events_regex).flatten
-        expect(no_results_messages.count).to eq(1)
+      context "when event type is Train to Teach" do
+        let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+        let(:no_events_regex) { /Train to Teach events will return in September/ }
+
+        it "displays a single no results message" do
+          no_results_messages = response.body.scan(no_events_regex).flatten
+          expect(no_results_messages.count).to eq(1)
+        end
+
+        it "displays the link to sign up for notifications" do
+          sign_up_button = response.body.scan(/Sign up for notifications/)
+          expect(sign_up_button).to include("Sign up for notifications")
+        end
+
+        it "does not display any categories" do
+          headings = response.body.scan(category_headings_regex).flatten
+          expect(headings).to be_empty
+        end
       end
 
-      it "does not display any categories" do
-        headings = response.body.scan(category_headings_regex).flatten
-        expect(headings).to be_empty
+      context "when event type is not Train to Teach" do
+        it "displays a single no results message" do
+          no_results_messages = response.body.scan(no_events_regex).flatten
+          expect(no_results_messages.count).to eq(1)
+        end
+
+        it "does not display any categories" do
+          headings = response.body.scan(category_headings_regex).flatten
+          expect(headings).to be_empty
+        end
       end
     end
   end

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -4,6 +4,7 @@ describe "Find an event near you" do
   include_context "stub types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }
+  let(:no_ttt_events_regex) { /Train to Teach events will return in September/ }
   let(:category_headings_regex) { /<h3>(Train to Teach events|Online Q&amp;As|School and University events)<\/h3>/ }
   let(:types) { Events::Search.available_event_type_ids }
   let(:events) do
@@ -89,10 +90,9 @@ describe "Find an event near you" do
 
       context "when event type is Train to Teach" do
         let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
-        let(:no_events_regex) { /Train to Teach events will return in September/ }
 
         it "displays a single no results message" do
-          no_results_messages = response.body.scan(no_events_regex).flatten
+          no_results_messages = response.body.scan(no_ttt_events_regex).flatten
           expect(no_results_messages.count).to eq(1)
         end
 
@@ -167,7 +167,12 @@ describe "Find an event near you" do
         headings = response.body.scan(category_headings_regex).flatten
         no_results_messages = response.body.scan(no_events_regex).flatten
         expect(headings.count).to eq(Events::Search.available_event_types.count)
-        expect(headings.count - 1).to eq(no_results_messages.count)
+        expect(headings.count - 2).to eq(no_results_messages.count)
+      end
+
+      it "displays the no TTT results message in the TTT category" do
+        no_results_messages = response.body.scan(no_ttt_events_regex).flatten
+        expect(no_results_messages.count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
### Trello card
https://trello.com/c/n80P96ba

### Context
Users need to scroll a lot to see the events list in the current Events page, especially when on mobile devices. We want to remove the "Types of events" and the "Some events have moved online" blocks to declutter the page and make it easier for the users to see the available events.

Also, the TTT (Train to Teach) events are ending today and we want to display a message when users are searching for events, that more TTT events will be added in September and remind them that they can sign up for events notifications. It's a temp message we want to display until September and then it will be removed.

### Changes proposed in this pull request
Remove the 
- "Types of events" block
- "Some events have moved online" block
- "Discover event" title

Add a "no Trains to Teach events" message with a call-to-action for the users to sign up for notifications. The message is displayed only when there are no TTT events available and the users are searching either for `all events` or `TTT events` .

Add subheadings in event category displayed in the grey blocks. This will offers some quick description to the users, since we removed the "Types of Events" block.

Resize the NoResultsComponent from 70% to full-size in order to make it thinner.

### Guidance to review

