### PR TITLE
Adding a box on the right hand side to promo event

### DIFF
--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -12,7 +12,7 @@ right_column:
     - title: Sign up for our event
       text: |
        Get tips from our experts on making a strong application.  
-      link_text: "sign up"
+      link_text: "Sign up"
       link_target: "/start-teacher-training-this-september"
       icon: "icon-calendar"
       hide_on_mobile: No

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -13,7 +13,7 @@ right_column:
       text: |
        Get tips from our experts on making a strong application.  
       link_text: "Sign up"
-      link_target: "/start-teacher-training-this-september"
+      link_target: "https://us02web.zoom.us/webinar/register/8016246210418/WN_HaeN54dwSlOVQParj9XWQg"
       icon: "icon-calendar"
       hide_on_mobile: No
       hide_on_tablet: No

--- a/app/views/content/start-teacher-training-this-september.md
+++ b/app/views/content/start-teacher-training-this-september.md
@@ -7,6 +7,16 @@ description: |-
 date: "2021-06-17"
 image: "media/images/content/hero-images/0008.jpg"
 backlink: "../"
+right_column:
+  ctas:
+    - title: Sign up for our event
+      text: |
+       Get tips from our experts on making a strong application.  
+      link_text: "sign up"
+      link_target: "/start-teacher-training-this-september"
+      icon: "icon-calendar"
+      hide_on_mobile: No
+      hide_on_tablet: No
 keywords:
     - Application
     - Apply


### PR DESCRIPTION
Promoting the 13th July 'Spotlight on teaching' event on the late entrants page.

### https://trello.com/c/dz7d7Xl5/1666-add-content-for-spotlight-on-teaching-event

### The On-Campus team are hosting an event for students that will talk about filling in the application form. It has cross over with our new (and short-lived) "late entrants" page. This ticket sees a bit of additional content being added to the page to promote the event and encourage sign ups. 
