### PR TITLE
Fix the external link checker

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -35,8 +35,16 @@ class PageLister
 end
 
 class LinkChecker
-  IGNORE = %w[127.0.0.1 localhost ::1 www.linkedin.com linkedin.com].freeze
-  GET_NOT_HEAD = %w[www.instagram.com].freeze
+  IGNORE = %w[
+    127.0.0.1
+    localhost
+    ::1
+    www.linkedin.com
+    linkedin.com
+    www.exetermathematicsschool.ac.uk
+    www.ringwood.hants.sch.uk
+    www.sjctsa.co.uk
+  ].freeze
 
   attr_reader :page, :document
 
@@ -77,19 +85,20 @@ private
   end
 
   def check(link)
-    if needs_get?(link)
-      faraday(link).get.status
-    else
-      faraday(link).head.status
-    end
+    status = faraday(link).head.status
+    return status if (200..299).include?(status)
+
+    fallback_check(link)
   rescue ::Faraday::Error
-    nil
+    fallback_check(link)
   end
 
-  def needs_get?(link)
-    GET_NOT_HEAD.any? do |domain|
-      link.starts_with? %r{https?://#{domain}/}
-    end
+  def fallback_check(link)
+    # Not all websites respond to a HEAD request,
+    # so we do a GET request as a fallback check.
+    faraday(link).get.status
+  rescue ::Faraday::Error
+    nil
   end
 
   def ignored?(link)


### PR DESCRIPTION
### Trello card

[Trello-1681](https://trello.com/c/2RjKUZGx/1681-fix-external-link-checker)

### Context

The external link checker has been failing on the nightly runs for a couple of reasons.

Some websites don't respond to HEAD requests; we have a mechanism in place already to perform GET requests for specific websites, but that requires us to manually update a list; a new link that fails HEAD requests was added and the list wasn't updated. Instead, I've changed it to try a HEAD request and fallback to a GET request dynamically if it fails (by either returning a 404 or there being a connection error).

A number of other external links also appear to fail Faraday's SSL certificate checks. I don't think these are bullet-proof as I checked a few manually and they were fine, so I've had to add these domains to the ignore list for now.

### Changes proposed in this pull request

- Fix the external link checker

### Guidance to review

