### PR TITLE
Exclude URL from external link checker

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -44,6 +44,7 @@ class LinkChecker
     www.exetermathematicsschool.ac.uk
     www.ringwood.hants.sch.uk
     www.sjctsa.co.uk
+    tommyflowersscitt.co.uk
   ].freeze
 
   attr_reader :page, :document


### PR DESCRIPTION
The domain tommyflowersscitt.co.uk appears to return a 403 when we make the request from GitHub
actions (though it works locally). 

Ignoring it to get the link checker passing again.
