### PR TITLE
Ignore www.nett.org.uk in external link check

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -45,6 +45,7 @@ class LinkChecker
     www.ringwood.hants.sch.uk
     www.sjctsa.co.uk
     tommyflowersscitt.co.uk
+    www.nett.org.uk
   ].freeze
 
   attr_reader :page, :document


### PR DESCRIPTION
We have had connection errors on this domain multiple times; it appears to be quite flakey (usually works when I try it locally) - adding it to the ignore list to reduce noise.