### PR TITLE
Allow users to paste a date and time into `start at` and `end at` inputs

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -45,11 +45,7 @@ module Internal
     validates :provider_website_url, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { provider_event? }
     validates :scribble_id, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { online_event? }
     validates :venue_type, inclusion: { in: VENUE_TYPES.values }
-    validates_each :start_at, :end_at do |record, attr, value|
-      unless value.nil?
-        record.errors.add attr, "Must be in the future" if value <= Time.zone.now
-      end
-    end
+    validate :dates_in_future
     validate :end_after_start
     validate :existing_building_present
 
@@ -138,6 +134,17 @@ module Internal
 
       if end_at <= start_at
         errors.add(:end_at, "Must be after the start date")
+      end
+    end
+
+    def dates_in_future
+      date_attributes = %i[start_at end_at]
+
+      date_attributes.each do |attribute_name|
+        attribute_value = send(attribute_name)
+        if attribute_value.present? && attribute_value <= Time.zone.now
+          errors.add(attribute_name, "Must be in the future")
+        end
       end
     end
 

--- a/app/views/internal/events/new.html.erb
+++ b/app/views/internal/events/new.html.erb
@@ -36,18 +36,20 @@
     <% end %>
   <% end %>
 
-  <%= render "form/govuk_error_message", label: "Start at", field_errors: @event.errors[:start_at] do %>
-    <%= f.datetime_field :start_at,
-                         max: Date.new(9999, 01, 01),
-                         class: class_names("datetime", "govuk-input", { "govuk-input--error": @event.errors[:start_at].any? }),
-                         data: { "internal-events-target": "startAt" } %>
-  <% end %>
-  <%= render "form/govuk_error_message", label: "End at", field_errors: @event.errors[:end_at] do %>
-    <%= f.datetime_field :end_at,
-                         max: Date.new(9999, 01, 01),
-                         class: class_names("datetime", "govuk-input",
-                                            { "govuk-input--error": @event.errors[:end_at].any? }) %>
-  <% end %>
+  <label class="govuk-label">Event dates</label>
+  <span class="govuk-hint">
+    Input in the format: DD/MM/YYYY HH:MM (e.g., 01/07/2021 17:00), or click to use the selector</span>
+
+  <%= f.govuk_text_field :start_at,
+                         label: { text: "Start at" },
+                         width: 'one-third',
+                         class: "flatpickr-enhanced-field",
+                         data: { "internal-events-target": "startAt" }%>
+
+  <%= f.govuk_text_field :end_at,
+                         label: { text: "End at" },
+                         width: 'one-third',
+                         class: "flatpickr-enhanced-field" %>
 
   <%= f.govuk_text_field :readable_id,
                          label: { text: 'Event partial URL' },

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   formatDate(dateTimeString) {
-    return DateTime.fromISO(dateTimeString).toFormat('yyMMdd');
+    return DateTime.fromJSDate(new Date(dateTimeString)).toFormat('yyMMdd');
   }
 
   formatName(name) {

--- a/app/webpacker/packs/internal.js
+++ b/app/webpacker/packs/internal.js
@@ -1,20 +1,43 @@
 import { initAll } from 'govuk-frontend';
 import { enhanceSelectElement } from 'accessible-autocomplete';
+import flatpickr from 'flatpickr';
 import 'trix';
 import '../styles/internal.scss';
 
-initAll();
+initialiseGovUk();
+initialiseSelectElement();
+initialiseFlatpickr();
 
-// Needed for GovUK JavaScript
-document.body.className = document.body.className
-  ? document.body.className + ' js-enabled'
-  : 'js-enabled';
+function initialiseGovUk() {
+  initAll();
 
-const selectId = document.querySelector('#internal-event-building-id-field');
+  // Needed for GovUK JavaScript
+  document.body.className = document.body.className
+    ? document.body.className + ' js-enabled'
+    : 'js-enabled';
+}
 
-if (selectId) {
-  enhanceSelectElement({
-    selectElement: selectId,
-    placeholder: 'E.g., M1 7JA',
+function initialiseSelectElement() {
+  const selectId = document.querySelector('#internal-event-building-id-field');
+
+  if (selectId) {
+    enhanceSelectElement({
+      selectElement: selectId,
+      placeholder: 'E.g., M1 7JA',
+    });
+  }
+}
+
+function initialiseFlatpickr() {
+  const dateFormats = {
+    // https://flatpickr.js.org/formatting/
+    UK_FORMAT: 'd/m/Y H:i',
+  };
+
+  flatpickr('.flatpickr-enhanced-field', {
+    enableTime: true,
+    allowInput: true,
+    altInput: true,
+    altFormat: dateFormats.UK_FORMAT,
   });
 }

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -2,6 +2,7 @@ $govuk-include-default-font-face: false;
 
 @import "~govuk-frontend/govuk/all";
 @import "~trix";
+@import "~flatpickr";
 @import "colours";
 $grey-very-light: #f3f2f1;
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@rails/webpacker": "5.4.0",
     "@stimulus/polyfills": "^2.0.0",
     "accessible-autocomplete": "^2.0.3",
+    "flatpickr": "^4.6.9",
     "govuk-frontend": "^3.11.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^2.2.1",

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -27,7 +27,7 @@ describe('InternalEventsController', () => {
       beforeEach(
         () =>
           (document.getElementById('internal_event_start_at').value =
-            '2021-05-15T10:51')
+            '2021-05-15 10:51')
       );
 
       describe('name', () => {

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -208,8 +208,8 @@ describe Internal::EventsController do
           assert_response :success
           expect(css_select("#internal_event_id").first[:value]).to be_nil
           expect(css_select("#internal-event-readable-id-field").first[:value]).to be_nil
-          expect(css_select("#internal_event_start_at").first[:value]).to be_nil
-          expect(css_select("#internal_event_end_at").first[:value]).to be_nil
+          expect(css_select("#internal-event-end-at-field").first[:value]).to be_nil
+          expect(css_select("#internal-event-end-at-field").first[:value]).to be_nil
         end
       end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4087,6 +4087,11 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flatpickr@^4.6.9:
+  version "4.6.9"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.9.tgz#9a13383e8a6814bda5d232eae3fcdccb97dc1499"
+  integrity sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw==
+
 flatted@^3.1.0, flatted@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz"


### PR DESCRIPTION
### Context
The users of the `internal/events` forms receive events via email from the Advertise a Teaching Event form on the main website. They would like the ability to paste a date and time into the `start at` and `end at` fields in the format of the email (e.g., `01/07/2021 17:00`), as it is tedious to type the full date out or to use the selector. This updates the `internal/events` form to use `flatpickr` for its datetime fields, which lets us paste into the input and specify custom formatting.

The API accepts a full ISO format datetime such as `2021-07-01T09:00:00.000Z`, or a localised format such as `2021-07-02T09:00:00`. However, the CRM seems to store the localised version without any additional time zone information (it also stores a separate time zone code), which in turn will update the API cache after a sync. This means (without changing how the API works) it is easier to work with a localised datetime in the APP. Otherwise, the format of the returned date will unexpectedly 
change when a sync runs, and both formats will need to be handled.

We were previously using `<input type="datetime-local">` which also stores a localised datetime with no timezone information and was working nicely.

### Changes proposed in this pull request
- Swap inputs to `flatpickr` inputs
- Move `must be in the future` validation into private method to match the other validation.
- Add a hint above the date fields.
- Small tidy up of `internal.js`