### PR TITLE
Set to London timezone on callback booking

### DIFF
--- a/app/controllers/callbacks/steps_controller.rb
+++ b/app/controllers/callbacks/steps_controller.rb
@@ -7,6 +7,7 @@ module Callbacks
 
     before_action :set_step_page_title, only: %i[show update]
     before_action :set_completed_page_title, only: [:completed]
+    around_action :set_time_zone, only: %i[show update]
 
     layout "registration"
 
@@ -29,6 +30,14 @@ module Callbacks
     end
 
   private
+
+    def set_time_zone
+      old_time_zone = Time.zone
+      Time.zone = "London"
+      yield
+    ensure
+      Time.zone = old_time_zone
+    end
 
     def step_path(step = params[:id], urlparams = {})
       callbacks_step_path step, urlparams

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Book a callback", type: :feature do
 
   let(:quota) do
     GetIntoTeachingApiClient::CallbackBookingQuota.new(
-      startAt: DateTime.now.utc + 2.hours,
-      endAt: DateTime.now.utc + 3.hours,
+      startAt: DateTime.new(2099, 6, 1, 10),
+      endAt: DateTime.new(2099, 6, 1, 11),
     )
   end
 
@@ -41,7 +41,8 @@ RSpec.feature "Book a callback", type: :feature do
 
     expect(page).to have_text "Choose a time for your callback"
     fill_in "Phone number", with: "123456789"
-    select_first_option "Select your preferred day and time for a callback"
+    # Select time in local time zone (London)
+    select "11:00 am - 12:00 pm", from: "Select your preferred day and time for a callback"
     click_on "Next Step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -86,7 +87,8 @@ RSpec.feature "Book a callback", type: :feature do
 
     expect(page).to have_text "Choose a time for your callback"
     expect(find_field("Phone number").value).to eq(response.address_telephone)
-    select_first_option "Select your preferred day and time for a callback"
+    # Select time in local time zone (London)
+    select "11:00 am - 12:00 pm", from: "Select your preferred day and time for a callback"
     click_on "Next Step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -124,7 +126,8 @@ RSpec.feature "Book a callback", type: :feature do
     click_on "Next Step"
     expect(page).to have_text "Enter a valid phone number"
     fill_in "Phone number", with: "123456789"
-    select_first_option "Select your preferred day and time for a callback"
+    # Select time in local time zone (London)
+    select "11:00 am - 12:00 pm", from: "Select your preferred day and time for a callback"
     click_on "Next Step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -149,9 +152,5 @@ RSpec.feature "Book a callback", type: :feature do
     fill_in "First name", with: first_name if first_name
     fill_in "Last name", with: last_name if last_name
     fill_in "Email address", with: email if email
-  end
-
-  def select_first_option(field_label)
-    find_field(field_label).first("option").select_option
   end
 end


### PR DESCRIPTION
The book a callback form displays time slots from the API, which are in UTC time. We need to set the time zone explicitly
to `London` for this wizard flow in order to get the times outputting with the correct offset (they started at 8am previously when the time should show as 9am).