### PR TITLE
Re-add the *google.com.sa CSP rule

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
 
   tta_service_hosts = []
   tta_service_hosts << URI.parse(ENV["TTA_SERVICE_URL"]).host if ENV["TTA_SERVICE_URL"].present?
-  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk adservice.google.com *.google.com.sa https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
+  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk adservice.google.com *google.com.sa *.google.com.sa https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
   lid_pixels = %w[pixelg.adswizz.com tracking.audio.thisisdax.com]
 
   config.csp = {


### PR DESCRIPTION
This was disabled last week and looks invalid. Oddly, perhaps coincidentally our paid search rank took a bit of a hit at roughly the same time. I don't _think_ these two events are related but re-enabling it for a bit just to see if it has any impract.
