### PR TITLE
Remove the experimental *google.com.sa wildcard

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
 
   tta_service_hosts = []
   tta_service_hosts << URI.parse(ENV["TTA_SERVICE_URL"]).host if ENV["TTA_SERVICE_URL"].present?
-  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk adservice.google.com *google.com.sa https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
+  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.google.co.uk adservice.google.com *.google.com.sa https://www.googleadservices.com https://www.google.com https://googleads.g.doubleclick.net]
   lid_pixels = %w[pixelg.adswizz.com tracking.audio.thisisdax.com]
 
   config.csp = {


### PR DESCRIPTION
This was added in 7b46beee34a to see whether or not it has any impact on paid-for search.

Refs #1480
