### PR TITLE
Remove double link to `Home` in footer

### DIFF
--- a/app/views/sections/_footer.html.erb
+++ b/app/views/sections/_footer.html.erb
@@ -26,7 +26,6 @@
         </a>
       </div>
       <div class="site-footer-top__links-container">
-        <%= link_to("Home", root_path) %>
         <% navigation_resources.each do |resource| %>
           <a href="<%= resource.path %>"><%= resource.title %></a>
         <% end %>


### PR DESCRIPTION
### Context
A `Pages::Navigation` model was introduced as part of the top nav work. Because it includes the Home page, we don't need the extra link to `Home` in the footer anymore.

### Changes proposed in this pull request
- Remove double link to `Home` in footer

### Guidance to review
![image](https://user-images.githubusercontent.com/47089130/124776259-34628800-df37-11eb-95dc-1ddd6cdd49da.png)

