### PR TITLE
Ensure `events/search` with no params does not raise error

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -67,7 +67,7 @@ private
 
     @display_empty_types = @event_search.type.nil?
     @performed_search = true
-    @events_search_type = params["events_search"]["type"]
+    @events_search_type = params.dig("events_search", "type")
 
     @group_presenter = Events::GroupPresenter.new(search_results, @display_empty_types)
     pages = params.permit(@group_presenter.page_param_names.values)

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -107,6 +107,14 @@ describe EventsController do
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes media_type: "text/html" }
     end
+
+    context "with no search params" do
+      let(:search_params) { nil }
+      let(:expected_request_attributes) { { type_id: nil } }
+
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes media_type: "text/html" }
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
### Context
Fix - The events search is attempting to access params. When they are not there, we are getting a nil exception. 

### Changes proposed in this pull request
- Safely access params with dig.