### PR TITLE
Ignore domain failing SSL check

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -46,6 +46,7 @@ class LinkChecker
     www.sjctsa.co.uk
     tommyflowersscitt.co.uk
     www.nett.org.uk
+    www.2schools.org
   ].freeze
 
   attr_reader :page, :document


### PR DESCRIPTION
The domain fails the SSL check and so Faraday prevents the request. If we get many more of these it may be worth trying to configure Faraday to ignore SSL errors, but thats not ideal. It may also be caused by a configuration issue on the docker container running the tests:

https://github.com/lostisland/faraday/wiki/Setting-up-SSL-certificates#error-messages