### PR TITLE
Enable smooth scrolling

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -3,6 +3,10 @@
   margin: auto;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: $git-font-family;
 


### PR DESCRIPTION
This only kicks in when users follow an anchor link on a page and the browser scrolls them to the right position. Unsupported in Safari but should work fine elsewhere and degrade gracefully.

It has a key usability benefit of _showing_ users what's happened when they click an anchor. When they're taken straight there it's potentially unclear and confusing.


https://user-images.githubusercontent.com/128088/125651147-d8378a28-caee-4dec-a499-c11182fa4d5e.mp4

