### PR TITLE
Wrap list items in li tags in the sidebar

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -26,7 +26,7 @@
               <h2 class="link-block__header">On this page:</h2>
               <ul class="link-block__list">
                 <% @front_matter["jump_links"].each do |item, anchor| %>
-                  <%= link_to(item, anchor) %>
+                  <li><%= link_to(item, anchor) %></li>
                 <% end %>
               </ul>
             </div>
@@ -40,7 +40,7 @@
               <ul class="link-block__list">
                 <ul class="link-block__list">
                   <% @front_matter["related_content"].each do |item, anchor| %>
-                    <%= link_to(item, anchor) %>
+                    <li><%= link_to(item, anchor) %></li>
                   <% end %>
                 </ul>
               </ul>


### PR DESCRIPTION
This was an issue highlighted by the [government website accessibility report](https://index.silktide.com/uk-central-government/get-into-teaching/recommendations/list-not-following-semantics).
