### PR TITLE
Attempt to Online event tag

### DIFF
--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -54,7 +54,7 @@ module Events
     end
 
     def online_text
-      return "Event has moved online" if virtual?
+      return "Online event" if virtual?
 
       "Online event"
     end

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -25,7 +25,7 @@ describe Events::EventBoxComponent, type: "component" do
 
   describe "online/offline" do
     let(:online_heading) { "Online event" }
-    let(:moved_online_heading) { "Event has moved online" }
+    let(:moved_online_heading) { "Online event" }
 
     context "when the event is an online event type" do
       let(:event) { build(:event_api, :online_event) }
@@ -101,7 +101,7 @@ describe Events::EventBoxComponent, type: "component" do
     end
 
     specify %(the event should also be described as a 'Event has moved online') do
-      expect(page).to have_content("Event has moved online")
+      expect(page).to have_content("Online event")
     end
 
     specify %(the online icon should be purple) do


### PR DESCRIPTION
Renaming the 'event has moved online' tag to Online Event now we're moving into a new phase of restriction lifting where Online Event is now the exception.