### PR TITLE
Hard-code the mailing list URL in the header and footer

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -43,7 +43,7 @@
           <a href="<%= resource.path %>"><%= resource.title %></a>
         <% end %>
         <%= link_to "Find an event near you", events_path %>
-        <%= link_to "Sign up for updates", mailing_list_steps_path %>
+        <%= link_to "Sign up for updates", "/mailinglist/signup/name" %>
         <%= link_to("Three things to help you get into teaching", page_path(page: "three-things-to-help-you-get-into-teaching")) %>
         <%= link_to("COVID-19", page_path(page: "covid-19")) %>
       </div>

--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(class: classes) do %>
   <ul class="extra-navigation__list">
-    <li class="extra-navigation__link "><%= link_to("Register your interest", mailing_list_steps_path) %><%= helpers.fas_icon "envelope" %></li>
+    <li class="extra-navigation__link "><%= link_to("Register your interest", "/mailinglist/signup/name" ) %><%= helpers.fas_icon "envelope" %></li>
 
     <li class="extra-navigation__link extra-navigation__search-fallback">
       <%= link_to("Search", search_path) %></li>


### PR DESCRIPTION
### Context and changes

We're currently relying on Rails' routing for generating the mailing list paths in these two places but using the hard-coded path everywhere else in the app.

Due to the way the sign-up wizard is written the individual pages don't have their own paths; instead they rely on a redirect in WizardSteps#index to send users to the right place.

A _correct_ navigation to `/mailinglist/signup` results in a 302 and the user is routed to `/mailinglist/signup/name` (the first step in that particular wizard). We believe this redirection has had an impact on paid search results.

We have two options here:

* Supply the wizard class to the `step_path` method so we can use Rails'
  built-in functionality:

  ```ruby
    redirect_to step_path(wizard_class.first_key, query_params)
  ```

* or, hard-code it

I'm going for the latter here as it's lighter touch, we don't need to introduce any new routing rules or helpers to ease the process and we can test it out. It also makes links to the mailing list easier to find via ag/grep

The disadvantage is that we can't change the routing on a whim and have the new rules reflected throughout automatically.
