### PR TITLE
Add custom event 404 page

### DIFF
--- a/app/views/events/not_found.html.erb
+++ b/app/views/events/not_found.html.erb
@@ -1,0 +1,7 @@
+<h1>Unfortunately, that event has already happened.</h1>
+
+<p>Would you like to see what's coming up?</p>
+
+<%= link_to(events_path, class: "button") do %>
+  <span>All events</span>
+<% end %>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -211,7 +211,8 @@ describe EventsController do
         context "when the event is a 'Pending event'" do
           let(:event) { build(:event_api, web_feed_id: nil, status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]) }
 
-          it { expect(response).to have_http_status :not_found }
+          it { expect(response).to have_http_status :success }
+          it { expect(response.body).to include("Unfortunately, that event has already happened.") }
         end
 
         it "has a meta description" do
@@ -236,7 +237,8 @@ describe EventsController do
         get(event_path(id: event_readable_id))
       end
 
-      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_http_status :success }
+      it { expect(response.body).to include("Unfortunately, that event has already happened.") }
     end
   end
 


### PR DESCRIPTION
### Trello card

[Trello-1695](https://trello.com/c/9AhFzOK3/1695-redirect-404ing-events-requests-to-the-index-page-with-a-message)

### Context

When an event is not found, instead of showing the default 404 page we want to show a custom one specific to events that lets the user know the event has already happened and directs them to the event search page.

### Changes proposed in this pull request

- Add custom event 404 page

### Guidance to review

| Desktop      | Mobile |
| ----------- | ----------- |
| <img width="1213" alt="Screenshot 2021-07-16 at 11 14 53" src="https://user-images.githubusercontent.com/29867726/125932595-49ef1055-c78e-4465-81fa-7c89c3412ba0.png">      | <img width="710" alt="Screenshot 2021-07-16 at 11 15 04" src="https://user-images.githubusercontent.com/29867726/125932613-5989bff6-424d-4f86-bd48-02014a641d7b.png">       |


