### PR TITLE
Load all future events in category view

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -26,7 +26,7 @@
 
               <%= tag.div(class: input_field_classes(:month)) do %>
                   <%= f.label :month, "Month" %>
-                  <%= f.select :month, search.available_months, **month_args %>
+                  <%= f.select :month, filterable_months, **month_args %>
               <% end %>
             </div>
 

--- a/app/components/events/search_component.rb
+++ b/app/components/events/search_component.rb
@@ -1,6 +1,7 @@
 module Events
   class SearchComponent < ViewComponent::Base
     BLANK_MONTH_TEXT = "All months".freeze
+    FILTERABLE_MONTHS_COUNT = 6
 
     attr_accessor :search, :path, :include_type, :heading, :allow_blank_month
 
@@ -22,6 +23,10 @@ module Events
       else
         {}
       end
+    end
+
+    def filterable_months
+      search.available_months.take(FILTERABLE_MONTHS_COUNT)
     end
 
     def error_messages

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -5,7 +5,7 @@ module Events
     include ActiveModel::Validations::Callbacks
 
     RESULTS_PER_TYPE = 9
-    FUTURE_MONTHS = 5
+    FUTURE_MONTHS = 24
     PAST_MONTHS = 4
     DISTANCES = [10, 25].freeze
     MONTH_FORMAT = %r{\A20[234]\d-(0[1-9]|1[012])\z}.freeze

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -6,6 +6,7 @@ describe Events::SearchComponent, type: "component" do
 
   let(:component) { described_class.new(search, path) }
   subject! { render_inline(component) }
+  before { freeze_time }
 
   specify "builds a search form" do
     expect(page).to have_css("form[action='#{path}'][method='get']")
@@ -53,6 +54,15 @@ describe Events::SearchComponent, type: "component" do
           expect(page).to have_css("#{field[:element]}[id='events_search_#{field[:attribute]}']")
         end
       end
+    end
+
+    it "only shows the next 6 months in the month field" do
+      months = page.find_field("Month").find_all("option").map(&:text)
+      expected_months = (0..5).map do |i|
+        i.months.from_now.to_date.to_formatted_s(:humanmonthyear)
+      end
+
+      expect(months).to eq(expected_months)
     end
 
     describe "optionally-blank month field" do

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Events::Search do
+  before { freeze_time }
+
   describe "attributes" do
     it { is_expected.to respond_to :type }
     it { is_expected.to respond_to :distance }
@@ -37,14 +39,14 @@ describe Events::Search do
       let(:period) { :future }
 
       it {
-        is_expected.to eq([
-          ["November 2020", "2020-11"],
-          ["December 2020", "2020-12"],
-          ["January 2021", "2021-01"],
-          ["February 2021", "2021-02"],
-          ["March 2021", "2021-03"],
-          ["April 2021", "2021-04"],
-        ])
+        expected_months = (0..24).map do |i|
+          [
+            i.months.from_now.to_date.to_formatted_s(:humanmonthyear),
+            i.months.from_now.to_date.to_formatted_s(:yearmonth),
+          ]
+        end
+
+        is_expected.to eq(expected_months)
       }
     end
 
@@ -177,10 +179,10 @@ describe Events::Search do
         context "when the month is nil" do
           subject { build(:events_search, month: nil).tap(&:validate) }
 
-          it "searches from the beginning of today to the end of the next 5 months" do
+          it "searches from the beginning of today to the end of the next 24 months" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
               receive(:search_teaching_events_grouped_by_type)
-                .with(**expected_attributes.merge(start_after: travel_date.beginning_of_day, start_before: DateTime.new(2020, 6, 30).end_of_day))
+                .with(**expected_attributes.merge(start_after: travel_date.beginning_of_day, start_before: DateTime.new(2022, 1, 31).end_of_day))
           end
         end
 

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -88,7 +88,7 @@ describe "View events by category" do
 
   context "when viewing the schools and university events category" do
     let(:start_after) { DateTime.now.utc.beginning_of_day }
-    let(:start_before) { start_after.advance(months: 5).end_of_month }
+    let(:start_before) { start_after.advance(months: 24).end_of_month }
     let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_after, start_before: start_before, type_id: nil } }
 
     it "queries events for the correct category" do
@@ -103,7 +103,7 @@ describe "View events by category" do
     let(:postcode) { "TE57 1NG" }
     let(:radius) { 25 }
     let(:start_after) { DateTime.now.utc.beginning_of_day }
-    let(:start_before) { start_after.advance(months: 5).end_of_month }
+    let(:start_before) { start_after.advance(months: 24).end_of_month }
     let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_id: nil } }
 
     it "queries events for the correct category" do


### PR DESCRIPTION
### Trello card

[Trello-1703](https://trello.com/c/bePOUa37/1703-update-event-category-page-to-show-all-future-events-when-all-months-is-selected)

### Context

When we are viewing an event category we only want to allow the user to filter over the next 6 months, but give them the option to page through the entire list of events (we need to be able to surface all live, future events in the website somewhere).

### Changes proposed in this pull request

- Load all future events in a category view

As the to/from date logic is reasonably complex already, the simplest solution is to extend the future date from 6 months to 24 (which should cover all future events) and filter down the `available_months` in the `SearchComponent`.

### Guidance to review

You can test by visiting the [last page on the review instance](https://review-get-into-teaching-app-1514.london.cloudapps.digital/event-categories/school-and-university-events?page=2) and compare it to the [last page in live](https://getintoteaching.education.gov.uk/event-categories/school-and-university-events?page=2) (which is missing the events beyond 6 months from now).