### PR TITLE
Support Open Graph images

### DIFF
--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -1,8 +1,21 @@
 module MetadataHelper
+  include Webpacker::Helper
+
   def meta_tag(key:, value:, opengraph: false)
     return if value.blank?
 
     tag.meta(name: prepend_opengraph(key, opengraph), content: value)
+  end
+
+  def image_meta_tags(base_url:, image_path:, alt:, opengraph: true)
+    return if image_path.blank?
+
+    image_url = "#{base_url}#{asset_pack_path(image_path)}"
+
+    safe_join([
+      meta_tag(key: "image", value: image_url, opengraph: opengraph),
+      meta_tag(key: "image:alt", value: alt, opengraph: opengraph),
+    ])
   end
 
 private

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -25,4 +25,9 @@
   <%= meta_tag(key: 'site_name', value: "Get Into Teaching", opengraph: true) %>
   <%= meta_tag(key: 'locale', value: "en_GB", opengraph: true) %>
   <%= meta_tag(key: "facebook-domain-verification", value: "h1r6sd9bvqql7fyzy5jmdoniuw1rtf") %>
+  <%= image_meta_tags(
+    base_url: request.base_url,
+    image_path: @front_matter&.dig("image"),
+    alt: "Photograph of teaching taking place in a classroom"
+  ) %>
 </head>

--- a/spec/helpers/metadata_helper_spec.rb
+++ b/spec/helpers/metadata_helper_spec.rb
@@ -21,4 +21,26 @@ describe MetadataHelper, type: "helper" do
       end
     end
   end
+
+  describe "#image_meta_tags" do
+    it "returns nil when not given an image_path" do
+      expect(image_meta_tags(base_url: "https://example.com", image_path: "", alt: "")).to be_nil
+    end
+
+    it "returns image/alt meta tags when given an image_path" do
+      tags = image_meta_tags(base_url: "https://example.com", image_path: "media/images/content/hero-images/0012.jpg", alt: "An image")
+
+      expect(tags).to include(
+        <<~HTML.chomp,
+          <meta name="og:image" content="https://example.com/packs-test/media/images/content/hero-images/0012-c5b6a5e08291f24da05ca6b336ebe604.jpg">
+        HTML
+      )
+
+      expect(tags).to include(
+        <<~HTML.chomp,
+          <meta name="og:image:alt" content="An image">
+        HTML
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1700](https://trello.com/c/yDPUgqJo/1700-ensure-that-twitter-posts-have-a-thumbnail-that-is-pulled-through-to-complement-the-accompanying-snippet)

### Context

When a web page is shared on social media the platform will render the Open Graph image contained within the `og:image` meta tag in the post.

Currently we do not specify an `og:image` meta tag and get the default no image/grey box icon for most platforms.

We can also provide `alt` text; as we have opted to use the hero images I've copied the same `alt` text used there.

### Changes proposed in this pull request

- Support Open Graph images

### Guidance to review

