### PR TITLE
Use default Prometheus client data store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,25 +16,9 @@ require "action_view/railtie"
 require "rails/test_unit/railtie"
 require "view_component/engine"
 
-require "prometheus/client/data_stores/direct_file_store"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-
-PROMETHEUS_DIR = "/tmp/prometheus".freeze
-
-# Needs to clear before initializing - we don't do this in test
-# env as its not needed and also not thread-safe (specs run in parallel).
-unless Rails.env.test?
-  Dir["#{PROMETHEUS_DIR}/*.bin"].each do |file_path|
-    File.unlink(file_path)
-  end
-end
-
-# The DirectFileStore is the only way to aggregate metrics across processes.
-file_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_DIR)
-Prometheus::Client.config.data_store = file_store
 
 module GetIntoTeachingWebsite
   class Application < Rails::Application


### PR DESCRIPTION
### Trello card

[Trello-1713](https://trello.com/c/24EwocwF/1713-switch-prometheus-client-to-use-redis-as-the-data-store)

### Context

We are seeing high CPU usage over time with the `DataFileStore`; it turns out that we don't run Puma in
a multi-process environment and so we can use the default store, which is in-memory.

### Changes proposed in this pull request

- Use default Prometheus data store

### Guidance to review


