### PR TITLE
Fix logo ratio

### DIFF
--- a/app/components/header/logo_component.html.erb
+++ b/app/components/header/logo_component.html.erb
@@ -4,7 +4,4 @@
       <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "140x48", data: { "lazy-disable": true } %>
     </a>
   </div>
-  <div class="dfe-logo">
-      <%= image_pack_tag 'media/images/dfelogo-black.svg', alt: "Department for education", size: "92x54", data: { "lazy-disable": true } %>
-  </div>
 </div>

--- a/app/components/header/logo_component.html.erb
+++ b/app/components/header/logo_component.html.erb
@@ -1,7 +1,7 @@
 <div class="logo-wrapper">
   <div class="logo">
     <a href="/" class="logo__image">
-      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "140x48", data: { "lazy-disable": true } %>
+      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "180x62", data: { "lazy-disable": true } %>
     </a>
   </div>
 </div>

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -39,11 +39,23 @@
     @include rotated-block;
     background-color: $green-dark-90;
     z-index: 1000;
+
+    // position the logo slightly off the left of the page
+    // and make sure there's a slight gap beneath the extra nav
+    // and that the DfE logo's suitably far away
     margin: 1em 1em 0 -.5em;
 
     img {
-      padding: 1.2em;
+      padding: 1em;
       transform: rotate(3deg);
+
+      // use the margin to set the size/aspect ratio of the logo's background
+
+      // from the styleguide the ratios around the checkbox in the logo should be (using the checkbox for scale)
+      // - border-at-edge-of-screen: 1.5 (the left side on the main header logo)
+      // - border-closest-to-centre-of-screen: 1 (the right side on the main header logo)
+      // - border-below: 1.5
+      margin: .3em 1em .2em 2em;
     }
   }
 }

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -1,13 +1,11 @@
 .logo-wrapper {
-  // background-color: thistle;
-
   z-index: 0;
   overflow: hidden;
   top: 8px;
   padding-bottom: 20px;
   display: flex;
   align-items: center;
-  
+
   @include mq($from: tablet) {
 	  	overflow: visible;
 	  	padding-bottom: 0;
@@ -18,6 +16,7 @@
 
 .logo {
   display: block;
+  overflow-x: clip;
 
   a {
     text-decoration: none;

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -59,13 +59,3 @@
     }
   }
 }
-
-.dfe-logo {
-  top: 4px;
-  flex-shrink: 0;
-
-  img {
-    margin-top: .5em;
-    width: 100%;
-  }
-}

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -12,6 +12,10 @@
 	  	position: relative;
   }
 
+  @include mq($from: tablet) {
+    top: -8px;
+  }
+
   @include mq($from: desktop) {
     top: -23px;
   }

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -9,8 +9,11 @@
   @include mq($from: tablet) {
 	  	overflow: visible;
 	  	padding-bottom: 0;
-	  	top: -23px;
 	  	position: relative;
+  }
+
+  @include mq($from: desktop) {
+    top: -23px;
   }
 }
 

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -55,7 +55,7 @@
       // - border-at-edge-of-screen: 1.5 (the left side on the main header logo)
       // - border-closest-to-centre-of-screen: 1 (the right side on the main header logo)
       // - border-below: 1.5
-      margin: .3em 1em .2em 2em;
+      margin: .3em 1.5em .2em 2em;
     }
   }
 }

--- a/spec/components/header/logo_component_spec.rb
+++ b/spec/components/header/logo_component_spec.rb
@@ -7,7 +7,6 @@ describe Header::LogoComponent, type: "component" do
   specify "renders the logo wrapper with the get into teaching and DfE logos" do
     expect(page).to have_css(".logo-wrapper") do |wrapper|
       expect(wrapper).to have_css(".logo")
-      expect(wrapper).to have_css(".dfe-logo")
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/jrc2EZKx/1711-logo-amend

### Context and changes

- Make the logo background clip on the left
- Make spacing around the border match styleguide

|Styleguide | Before | After |
|-----------| ------- | -------| 
|<img width="637" alt="logo-ratios" src="https://user-images.githubusercontent.com/128088/126303252-7cc96d65-7eeb-48bb-9102-04b62b1fadb3.png">| ![Screenshot from 2021-07-20 10-51-12](https://user-images.githubusercontent.com/128088/126302995-378ce48a-a666-4877-a5e1-b35c5865f43e.png) | ![Screenshot from 2021-07-20 10-51-18](https://user-images.githubusercontent.com/128088/126303014-fd578d98-6313-4730-a645-826b092e0c34.png) |



### Guidance to review

@gazcarr - please feel free to adjust these a bit further if needed
