### PR TITLE
Only show teaching logo for first category

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,6 +1,10 @@
 module EventsHelper
   include TextFormattingHelper
 
+  def show_events_teaching_logo(index, type_id)
+    index.zero? && type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+  end
+
   def format_event_date(event, stacked: true)
     return if event.start_at.blank?
 

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -1,15 +1,14 @@
 <% plural_category_name = pluralised_category_name(type_id) %>
-<% with_logo = type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] %>
 
 <div class="types-of-event">
-  <div class="events-featured <%= "events-featured--with-logo" if with_logo %>">
+  <div class="events-featured <%= "events-featured--with-logo" if show_logo %>">
     <div class="events-featured__heading">
       <header>
         <h3><%= plural_category_name %></h3>
         <div role="doc-subtitle"><%= t("event_types.#{type_id}.description.short") %></div>
       </header>
-      
-      <% if with_logo %>
+
+      <% if show_logo %>
       <div class="events-featured__logo">
         <%= image_pack_tag "media/images/getintoteachinglogo-with-bg-purple.svg", alt: "", size: "250x125" %>
       </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -15,12 +15,13 @@
 <% end %>
 
 <% unless @no_results %>
-  <% @events_by_type.each do |type_id, events| %>
+  <% @events_by_type.each_with_index do |(type_id, events), index| %>
     <%= render "event_group",
       type_id: type_id,
       events: events,
       page_param_name: @performed_search ? @group_presenter.page_param_name(type_id) : nil,
-      show_see_all_events: show_see_all_events_button?(type_id, events)
+      show_see_all_events: show_see_all_events_button?(type_id, events),
+      show_logo: show_events_teaching_logo(index, type_id)
     %>
   <% end %>
 <% else %>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -8,6 +8,26 @@ describe EventsHelper, type: "helper" do
   let(:event) { build(:event_api, start_at: startdate, end_at: enddate) }
   let(:building_fully_populated) { build(:event_building_api, address_line3: "Line 3") }
 
+  describe "#show_events_teaching_logo" do
+    it "returns false if the index != 0" do
+      show_logo = show_events_teaching_logo(1, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"])
+      expect(show_logo).to be_falsy
+    end
+
+    it "returns false if the type_id is School or University event" do
+      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
+      expect(show_logo).to be_falsy
+    end
+
+    it "returns true if the index is 0 and the type_id is not chool or University event" do
+      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"])
+      expect(show_logo).to be_truthy
+
+      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
+      expect(show_logo).to be_truthy
+    end
+  end
+
   describe "#format_event_date" do
     let(:stacked) { true }
     subject { format_event_date event, stacked: stacked }


### PR DESCRIPTION
### Trello card

[Trello-1717](https://trello.com/c/DV5h6KCO/1717-only-show-teaching-logo-on-first-category)

### Context

We show the teaching logo for any category that is not School and university events. This has been fine whilst we haven't had any Train to Teach events, but now we are getting some back on the website it means both categories end up with the teaching logo.

Instead, we want to show the teaching logo for only the first category that is _not_ School and University events.

### Changes proposed in this pull request

- Only show teaching logo for first category

### Guidance to review

| Before      | After |
| ----------- | ----------- |
| <img width="1151" alt="Screenshot 2021-07-21 at 13 40 21" src="https://user-images.githubusercontent.com/29867726/126489860-aaff2822-3986-4537-843e-14c57b4035d6.png">      | <img width="1151" alt="Screenshot 2021-07-21 at 13 39 55" src="https://user-images.githubusercontent.com/29867726/126489804-7235f451-56cb-47fb-9124-1d4dd54f8d39.png">       |




