### PR TITLE
Display images of event venues

### DIFF
--- a/app/models/internal/event_building.rb
+++ b/app/models/internal/event_building.rb
@@ -11,6 +11,7 @@ module Internal
     attribute :address_line3, :string
     attribute :address_city, :string
     attribute :address_postcode, :string
+    attribute :image_url, :string
 
     validates :venue, presence: true, allow_blank: false, length: { maximum: 100 }
     validates :address_line1, length: { maximum: 255 }

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -31,10 +31,14 @@
   <% if @event.building && !@event.is_online %>
   <h2>Venue information</h2>
   <p><%= @event.building.venue %>, <%= event_address(@event) %>.</p>
+  <p><%= link_to("Open in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %></p>
   <% if @event.provider_website_url %>
     <p><%= link_to("Visit venue website", @event.provider_website_url, { target: "blank" }) %><i class="icon"></i></p>
   <%end %>
   <p><%= event_location_map(@event) %></p>
+  <% if @event.building.image_url %>
+    <%= image_tag(@event.building.image_url, alt: "A photograph of the venue", class: "event-info__venue_img") %>
+  <% end %>
   <% end %>
 
   <% if event_has_provider_info?(@event) %>

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -1,7 +1,7 @@
 .embedded-map {
   box-sizing: border-box;
   position: relative;
-  width: 80%;
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
   margin-top: 0;

--- a/app/webpacker/styles/event.scss
+++ b/app/webpacker/styles/event.scss
@@ -10,26 +10,9 @@
     @include font-size("medium");
   }
 
-  &__venue {
-    float: left;
-    text-align: left;
-    width: calc(100% - 360px);
-    padding-top: $indent-amount;
-
-    h1 {
-      margin: 0;
-    }
-
-    &__map {
-      width: 100%;
-      height: 362px;
-      background-color: $grey;
-      margin-bottom: 40px;
-      background-image: url('../images/map-screen.jpg');
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: cover;
-    }
+  &__venue_img {
+    width: 100%;
+    margin-top: $indent-amount;
   }
 }
 
@@ -39,16 +22,6 @@
       display: block;
       width: 100%;
       text-align: center;
-    }
-
-    &__detail {
-      display: block;
-      width: 100%;
-    }
-
-    &__venue {
-      display: block;
-      width: 100%;
     }
   }
 }

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     address_line3 { nil }
     address_city { "Manchester" }
     address_postcode { "MA1 1AM" }
+    image_url { "http:://example.com/image.png" }
   end
 end

--- a/spec/factories/api/event_building_api_factory.rb
+++ b/spec/factories/api/event_building_api_factory.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     address_line3 { nil }
     address_city { "Manchester" }
     address_postcode { "MA1 1AM" }
-    image_url { "http:://example.com/image.png" }
+    image_url { "http://example.com/image.png" }
   end
 end

--- a/spec/factories/internal/event_building_factory.rb
+++ b/spec/factories/internal/event_building_factory.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     address_line3 { "test" }
     address_city { "test" }
     address_postcode { "M1 7AX" }
+    image_url { "http:://example.com/image.png" }
   end
 end

--- a/spec/factories/internal/event_building_factory.rb
+++ b/spec/factories/internal/event_building_factory.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     address_line3 { "test" }
     address_city { "test" }
     address_postcode { "M1 7AX" }
-    image_url { "http:://example.com/image.png" }
+    image_url { "http://example.com/image.png" }
   end
 end

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -56,6 +56,7 @@ describe Internal::EventBuilding do
         address_line3: api_building.address_line3,
         address_city: api_building.address_city,
         address_postcode: api_building.address_postcode,
+        image_url: api_building.image_url,
       )
     end
     it "should have correct attributes" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -152,6 +152,7 @@ describe EventsController do
         it { is_expected.to include(event.provider_target_audience) }
         it { is_expected.to include(event.provider_organiser) }
         it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }
+        it { is_expected.to include(event.building.image_url) }
 
         context "when the event can be registered for online" do
           let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id) }

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -342,6 +342,7 @@ describe Internal::EventsController do
                   address_line3: nil,
                   address_city: nil,
                   address_postcode: expected_postcode,
+                  image_url: nil,
                 })
 
               expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)


### PR DESCRIPTION
### Trello card

### Context

Some event buildings will have an `image_url` set; if they do we want to surface this image below the Google Map of the venue location.

### Changes proposed in this pull request

- Display images of event venues
- Clean out some unused event CSS rules
- Add a link to open the map in Google Maps

### Guidance to review

The `show` template could use an overhaul in general; I'm going to create a ticket to tidy it up.

I think there is an issue with our local Google Maps API key not allowing localhost (or review apps, for that matter). You can preview the change [here](https://review-get-into-teaching-app-1526.london.cloudapps.digital/events/train-to-teach-birmingham-event-110921)

| Mobile      | Desktop |
| ----------- | ----------- |
| <img width="434" alt="Screenshot 2021-07-21 at 14 41 31" src="https://user-images.githubusercontent.com/29867726/126498493-236e36f9-19e1-426e-b27a-4f1f44527804.png">      | <img width="944" alt="Screenshot 2021-07-21 at 14 42 16" src="https://user-images.githubusercontent.com/29867726/126498592-7b6a1678-9bfb-427e-b31d-6ea03b3ca0f4.png">       |

