### PR TITLE
Update CODEOWNERS to reflect new image location

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-app/views/content/* @MylesJarvis 
-public/assets/* @MylesJarvis 
+app/views/content/* @MylesJarvis
+app/webpacker/images/* @MylesJarvis


### PR DESCRIPTION
There's nothing of importance in `public/assets` any more
