### PR TITLE
Update 'how to attend' for in-person events

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -68,10 +68,16 @@
   <% if event_status_open?(@event) || event_status_pending?(@event) %>
     <% if can_sign_up_online?(@event) %>
       <h2>How to attend</h2>
-      <p>
-        To attend this event, you must register for a place. Once registered, you will receive log-in information and joining instructions via email.
-        Please note: to access this event you will require a laptop/desktop pc and be using chrome as your browser.
-      </p>
+      <% if @event.is_online %>
+        <p>
+          To attend this event, you must register for a place. Once registered, you will receive log-in information and joining instructions via email.
+          Please note: to access this event you will require a laptop/desktop pc and be using chrome as your browser.
+        </p>
+      <% else %>
+        <p>
+          Registration for this event is free, and by registering you will receive information about what to expect and how to make the most of your experience at the event.
+        </p>
+      <% end %>
       <p>
         <%= link_to event_steps_path(@event.readable_id), class: "call-to-action-button button" do %>
             Sign up for this event

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -71,7 +71,7 @@
       <% if @event.is_online %>
         <p>
           To attend this event, you must register for a place. Once registered, you will receive log-in information and joining instructions via email.
-          Please note: to access this event you will require a laptop/desktop pc and be using chrome as your browser.
+          Please note: to access this event you will require a laptop/desktop PC and be using Google Chrome as your browser.
         </p>
       <% else %>
         <p>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -157,7 +157,14 @@ describe EventsController do
         context "when the event can be registered for online" do
           let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id) }
 
+          it { is_expected.to match(/by registering you will receive information about what to expect/) }
           it { is_expected.to match(/Sign up for this event/) }
+
+          context "when the event is online" do
+            let(:event) { build(:event_api, :online, web_feed_id: "123", readable_id: event_readable_id) }
+
+            it { is_expected.to match(/to access this event you will require a laptop\/desktop pc/) }
+          end
         end
 
         context "when the event can be registered for by email" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -163,7 +163,7 @@ describe EventsController do
           context "when the event is online" do
             let(:event) { build(:event_api, :online, web_feed_id: "123", readable_id: event_readable_id) }
 
-            it { is_expected.to match(/to access this event you will require a laptop\/desktop pc/) }
+            it { is_expected.to match(/to access this event you will require a laptop\/desktop PC/) }
           end
         end
 


### PR DESCRIPTION
### Trello card

[Trello-1720](https://trello.com/c/OoKnAbta/1720-update-copy-for-in-person-ttt-events-how-to-attend)

### Context

For in-person events we want to show different copy under the 'How to attend' section of the event page (the process is different from the online event types).

### Changes proposed in this pull request

- Update 'how to attend' for in-person events

### Guidance to review

<img width="634" alt="Screenshot 2021-07-21 at 16 40 47" src="https://user-images.githubusercontent.com/29867726/126518322-aa5b866a-9464-4183-b343-8a9ff9225199.png">


