### PR TITLE
Updates to book a callback feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 85622bdfeb43e5764ac7c7a1b49f284429cf5004
+  revision: 87844c0e514093f23e951795efcb1719ddffbae4
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.38)
+    get_into_teaching_api_client_faraday (0.1.39)
       activesupport
       faraday
       faraday-encoding
@@ -357,7 +357,7 @@ GEM
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     secure_headers (6.3.2)
     selenium-webdriver (3.142.7)

--- a/app/models/callbacks/steps/matchback_failed.rb
+++ b/app/models/callbacks/steps/matchback_failed.rb
@@ -1,0 +1,27 @@
+module Callbacks
+  module Steps
+    class MatchbackFailed < ::Wizard::Step
+      def skipped?
+        @store["authenticate"]
+      end
+
+      def can_proceed?
+        false
+      end
+
+      def try_again?
+        matchback_failures <= 2
+      end
+
+      def crm_unavailable?
+        @store["last_matchback_failure_code"] != 404
+      end
+
+    private
+
+      def matchback_failures
+        @store["matchback_failures"].to_i
+      end
+    end
+  end
+end

--- a/app/models/callbacks/steps/talking_points.rb
+++ b/app/models/callbacks/steps/talking_points.rb
@@ -1,0 +1,20 @@
+module Callbacks
+  module Steps
+    class TalkingPoints < ::Wizard::Step
+      OPTIONS = [
+        "Eligibility to become a teacher",
+        "Routes into teaching",
+        "Funding your training",
+        "Gaining classroom experience",
+        "Finding training providers",
+        "Applying for teacher training",
+        "Support with international qualifications",
+        "Something else",
+      ].freeze
+
+      attribute :talking_points
+
+      validates :talking_points, inclusion: { in: OPTIONS }
+    end
+  end
+end

--- a/app/models/callbacks/wizard.rb
+++ b/app/models/callbacks/wizard.rb
@@ -6,8 +6,10 @@ module Callbacks
 
     self.steps = [
       Steps::PersonalDetails,
+      Steps::MatchbackFailed,
       ::Wizard::Steps::Authenticate,
       Steps::Callback,
+      Steps::TalkingPoints,
       Steps::PrivacyPolicy,
     ].freeze
 

--- a/app/views/callbacks/steps/_callback.html.erb
+++ b/app/views/callbacks/steps/_callback.html.erb
@@ -1,7 +1,16 @@
 <h1>Choose a time for your callback</h1>
 
 <p>
-  Enter the number you’d like us to call, then choose the 30 minute slot that suits you best.
+  Enter the number you’d like us to call,
+  then choose the 30 minute slot that suits you best.
+</p>
+
+<p>
+  All slots are in UK time.
+</p>
+
+<p>
+  Please include international dialling code where applicable.
 </p>
 
 <%= f.govuk_phone_field :address_telephone, width: 20 %>

--- a/app/views/callbacks/steps/_matchback_failed.html.erb
+++ b/app/views/callbacks/steps/_matchback_failed.html.erb
@@ -1,0 +1,13 @@
+<% if f.object.crm_unavailable? %>
+  <h1>Sorry, a technical problem means we can’t book your callback right now.</h1>
+  <p>We are working to fix the problem, please try again later.</p>
+<% elsif f.object.try_again? %>
+  <h1>We didn’t recognise the first name, last name or email address you entered</h1>
+  <p><%= link_to("Try entering your details again.", :back) %></p>
+<% else %>
+  <h1>We didn’t recognise your first name, last name or email address</h1>
+  <p>To book a callback, you need to be registered with us.</p>
+  <p>Once you’re registered, you can try again.</p>
+<% end %>
+
+

--- a/app/views/callbacks/steps/_personal_details.html.erb
+++ b/app/views/callbacks/steps/_personal_details.html.erb
@@ -1,6 +1,6 @@
 <h1>Book a callback</h1>
 
-<p>One of our advisers can call you back at a time that suits you.</p>
+<p>Do you have any immediate questions, or want to speak to someone? One of our experienced agents can call you back at a time that suits you.</p>
 
 <p>They know the process inside out and can answer any of your questions.</p>
 

--- a/app/views/callbacks/steps/_talking_points.html.erb
+++ b/app/views/callbacks/steps/_talking_points.html.erb
@@ -1,0 +1,3 @@
+<h1>Tell us what you’d like to talk to an adviser about</h1>
+
+<%= f.govuk_select :talking_points, f.object.class::OPTIONS, options: { prompt: "Please select" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,6 +387,10 @@ en:
             accept_privacy_policy:
               blank: Accept the privacy policy to continue
               accepted: Accept the privacy policy to continue
+        callbacks/steps/talking_points:
+          attributes:
+            talking_points:
+              inclusion: Choose an option
 
         mailing_list/steps/name:
           attributes:
@@ -519,6 +523,8 @@ en:
       callbacks_steps_callback:
         address_telephone: Phone number
         phone_call_scheduled_at: Select your preferred day and time for a callback
+      callbacks_steps_talking_points:
+        talking_points: Choose an option
 
       mailing_list_steps_name:
         first_name: First name

--- a/spec/models/callbacks/steps/matchback_failed_spec.rb
+++ b/spec/models/callbacks/steps/matchback_failed_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe Callbacks::Steps::MatchbackFailed do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  describe "#can_proceed?" do
+    it "returns false" do
+      expect(subject).not_to be_can_proceed
+    end
+  end
+
+  describe "#skipped?" do
+    it "returns false if authenticate is false or nil" do
+      wizardstore["authenticate"] = false
+      expect(subject).not_to be_skipped
+      wizardstore["authenticate"] = nil
+      expect(subject).not_to be_skipped
+    end
+
+    it "returns true if authenticate is true" do
+      wizardstore["authenticate"] = true
+      expect(subject).to be_skipped
+    end
+  end
+
+  describe "#crm_unavailable?" do
+    it "returns true if the last error code != 404" do
+      wizardstore["last_matchback_failure_code"] = 500
+      expect(subject).to be_crm_unavailable
+    end
+
+    it "returns false if the last error code == 404" do
+      wizardstore["last_matchback_failure_code"] = 404
+      expect(subject).not_to be_crm_unavailable
+    end
+  end
+
+  describe "#try_again?" do
+    it "returns true if matchback_failures are fewer than 3" do
+      wizardstore["matchback_failures"] = nil
+      expect(subject).to be_try_again
+
+      wizardstore["matchback_failures"] = 0
+      expect(subject).to be_try_again
+
+      wizardstore["matchback_failures"] = 1
+      expect(subject).to be_try_again
+
+      wizardstore["matchback_failures"] = 2
+      expect(subject).to be_try_again
+    end
+
+    it "returns false if matchback_failures are greater than 2" do
+      wizardstore["matchback_failures"] = 3
+      expect(subject).not_to be_try_again
+    end
+  end
+end

--- a/spec/models/callbacks/steps/talking_points_spec.rb
+++ b/spec/models/callbacks/steps/talking_points_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe Callbacks::Steps::TalkingPoints do
+  include_context "wizard step"
+  it_behaves_like "a wizard step"
+
+  describe "attributes" do
+    it { is_expected.to respond_to :talking_points }
+  end
+
+  describe "#talking_points" do
+    it { is_expected.to_not allow_values(nil, "", "invalid value").for :talking_points }
+    it { is_expected.to allow_values(described_class::OPTIONS).for :talking_points }
+  end
+end

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -21,8 +21,10 @@ describe Callbacks::Wizard do
     it do
       is_expected.to eql [
         Callbacks::Steps::PersonalDetails,
+        Callbacks::Steps::MatchbackFailed,
         ::Wizard::Steps::Authenticate,
         Callbacks::Steps::Callback,
+        Callbacks::Steps::TalkingPoints,
         Callbacks::Steps::PrivacyPolicy,
       ]
     end

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -8,6 +8,7 @@ describe Callbacks::Wizard do
         "email" => "email@address.com",
         "first_name" => "John",
         "last_name" => "Doe",
+        "talking_points" => "Something",
       },
     }
   end
@@ -30,7 +31,7 @@ describe Callbacks::Wizard do
   describe "#complete!" do
     let(:request) do
       GetIntoTeachingApiClient::GetIntoTeachingCallback.new(
-        { email: "email@address.com", firstName: "John", lastName: "Doe" },
+        email: "email@address.com", firstName: "John", lastName: "Doe", talkingPoints: "Something",
       )
     end
 
@@ -46,7 +47,7 @@ describe Callbacks::Wizard do
     it { expect(store[uuid]).to eql({}) }
 
     it "logs the request model (filtering sensitive attributes)" do
-      filtered_json = { "email" => "[FILTERED]", "firstName" => "[FILTERED]", "lastName" => "[FILTERED]" }.to_json
+      filtered_json = { "email" => "[FILTERED]", "firstName" => "[FILTERED]", "lastName" => "[FILTERED]", "talkingPoints" => "Something" }.to_json
       expect(Rails.logger).to have_received(:info).with("Callbacks::Wizard#book_get_into_teaching_callback: #{filtered_json}")
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-1714](https://trello.com/c/duIFg3TN/1714-updates-to-the-book-a-callback-feature)

### Context

The book a callback feature is mostly done already and only enabled in the test environment. This PR adds two additional steps to the wizard:

- We want to gather 'talking points' for the call so that the adviser is aware of what the candidate wants to discuss ahead of calling them back.
- We only accept existing candidates signing up to the callback service; we need an additional step after they attempt to 'login' that handles if we were unable to match their candidate details.
  - On the first 2 failed attempts we will encourage them to check their details and try again
  - On subsequent attempts we will inform them that we are unable to process their request

### Changes proposed in this pull request

- Add talking points step to callback wizard

When signing up for a callback we want to let the user select the reason for their callback request.

Show a pre-defined list of talking points for the call to select from.

- Track number of failed matchback attempts

We want to track the number of times a user fails to matchback as part of the `IssueVerificationCode` concern, so that we can have custom copy on the book a callback feature for candidates that are failing matchback.

We are also tracking the last failure code from the CRM so that we can tailor the copy depending on if the user wasn't found vs the CRM is unavailable.

- Add matchback failed step to callback wizard

We can only support existing candidates booking a callback (not new candidates). As we only run a CTA for the book a callback form on the mailing list completion page it should always be the case that the candidate exists in the system. That being said, the sign in may fail for a couple of reasons:

```
- The candidate has entered a different first/last/email to what the signed up
  with.
- The candidate got to the form without going through the mailing list sign up
  (someone sent them a direct link, perhaps)
- The CRM is offline
```

To deal with this, if the user has attempted to log in (unsuccessfully) < 3 times we will show a message encouraging them to try again. On their third attempt we will display a message informing them that we can't accept their sign up at the moment.

If the CRM is unavailable (responded with a non-404 HTTP status code) then we inform the user we are having technical difficulties and they should try at a later time.

- Include new steps in wizard and update specs

Add the `MatchbackFailed` and `TalkingPoints` steps to the wizard flow and update the feature specs accordingly.

- Update copy on personal details/callback steps

### Guidance to review

https://review-get-into-teaching-app-1531.london.cloudapps.digital/callbacks/book/personal_details

After I finished putting in the change to determine if the CRM is unavailable I realised that users probably won't hit this screen as the API will fail silently (return 404 to signify the candidate couldn't be folund). It will work if the API is broken for any reason though, so I'm going to leave it in for that edge case.