### PR TITLE
Update copy for when there are no TTT events

### DIFF
--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -22,7 +22,7 @@
     <% else %>
       <% if type_id == ttt_event_type_id %>
         <%= render(Events::NoResultsComponent.new) do %>
-          <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
+          <p>There are no Train to Teach events in your chosen month. Sign up to be notified about upcoming events.</p>
           <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>
         <% end %>
       <% else %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,7 +9,7 @@
 
 <% if display_no_ttt_events_message %>
   <%= render(Events::NoResultsComponent.new) do %>
-    <p>DfE's Train to Teach events will return in September. Sign up for updates to be notified about spaces.</p>
+    <p>There are no Train to Teach events in your chosen month. Sign up to be notified about upcoming events.</p>
     <%= link_to('Sign up for notifications', mailing_list_steps_url, class: "button") %>
   <% end %>
 <% end %>

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -4,7 +4,7 @@ describe "Find an event near you" do
   include_context "stub types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }
-  let(:no_ttt_events_regex) { /Train to Teach events will return in September/ }
+  let(:no_ttt_events_regex) { /There are no Train to Teach events in your chosen month/ }
   let(:category_headings_regex) { /<h3>(Train to Teach events|Online Q&amp;As|School and University events)<\/h3>/ }
   let(:types) { Events::Search.available_event_type_ids }
   let(:events) do


### PR DESCRIPTION
### Trello card

[Trello-1721](https://trello.com/c/jS5CrKyF/1721-no-ttt-event-message-copy-update)

### Context

Make it clearer that there are no Train to Teach events for your chosen month, but there may be for other months. The previous message leads the user to believe that TTT events won't be added until September, which isn't the case -
they may be available now for the September time period.

### Changes proposed in this pull request

- Update copy for when there are no TTT events

### Guidance to review

| Before      | After |
| ----------- | ----------- |
|  <img width="1024" alt="Screenshot 2021-07-22 at 11 58 41" src="https://user-images.githubusercontent.com/29867726/126628999-1f24f8ea-5329-46bf-9796-5b510bf9c955.png">   | <img width="1026" alt="Screenshot 2021-07-22 at 11 58 28" src="https://user-images.githubusercontent.com/29867726/126628982-1ccf91fe-a222-4769-8923-521e5feba077.png">    |