### PR TITLE
Add draft status to posts

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -22,7 +22,7 @@ private
   def build
     Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
-        Pages::Frontmatter.list.each do |path, metadata|
+        published_pages.each do |path, metadata|
           xml.url do
             xml.loc(request.base_url + page_location(path))
             xml.lastmod(metadata.fetch(:date) { DEFAULT_LASTMOD })
@@ -38,6 +38,10 @@ private
         end
       end
     end
+  end
+
+  def published_pages
+    Pages::Frontmatter.list.reject { |_path, fm| fm[:draft] }
   end
 
   def page_location(path)

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,4 +1,4 @@
-module SitemapHelper
+module NavigationHelper
   def navigation_resources
     Pages::Navigation.root_pages
   end

--- a/app/views/content/guidance/financial-support-for-international-applicants.md
+++ b/app/views/content/guidance/financial-support-for-international-applicants.md
@@ -1,5 +1,6 @@
 ---
 title: Financial support for international applicants
+draft: true
 ---
 
 This page has moved.

--- a/app/views/content/welcome.md
+++ b/app/views/content/welcome.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome to teaching
+draft: true
 layout: "layouts/welcome"
 content:
   - "content/welcome/landing/welcome-to-teaching"

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SitemapHelper, type: :helper do
+describe NavigationHelperSpec, type: :helper do
   describe "#navigation_resources" do
     before { allow(Pages::Navigation).to receive(:root_pages) }
 

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe NavigationHelperSpec, type: :helper do
+describe NavigationHelper, type: :helper do
   describe "#navigation_resources" do
     before { allow(Pages::Navigation).to receive(:root_pages) }
 

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -72,5 +72,28 @@ RSpec.describe SitemapController do
         end
       end
     end
+
+    context "when a page is set to draft" do
+      let(:content_pages) do
+        {
+          "/draft" => {
+            name: "Draft page",
+            draft: true,
+          },
+          "/published" => {
+            name: "Published page",
+            draft: false,
+          },
+        }
+      end
+
+      specify "draft pages aren't included in the sitemap" do
+        expect(subject).not_to match(/draft/)
+      end
+
+      specify "published pages are included in the sitemap" do
+        expect(subject).to match(/published/)
+      end
+    end
   end
 end


### PR DESCRIPTION
There are a few pages that are either in development or old and ready to be dropped that we don't want to appear in Google searches or generally be accessed by visitors.

Hiding them from the sitemap should help on that front.

We may at some point want to also withhold draft pages from the navigation, that can be done in a similar manner.

### Context and changes

- Rename sitemap helper to navigation helper
- Stop draft pages from appearing in the sitemap
- Set the welcome guide and guidance page as draft
