### PR TITLE
Hide footer distractions from registation layout

### DIFF
--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -15,6 +15,6 @@
       </section>
     </main>
 
-    <%= render FooterComponent.new %>
+    <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
   <% end %>
 </html>


### PR DESCRIPTION
This brings the mailing list steps two onwards in line with the first and will make the event signup screens a little more minimal.
