### PR TITLE
Allow searching by all months

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -90,7 +90,7 @@ private
   end
 
   def event_search_params
-    defaults = ActionController::Parameters.new(month: Time.zone.today.to_formatted_s(:yearmonth))
+    defaults = ActionController::Parameters.new
 
     (params[Events::Search.model_name.param_key] || defaults)
       .permit(:type, :distance, :postcode, :month)

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,8 @@
 
 <% @search_component = Events::SearchComponent.new(
   @event_search,
-  search_events_path(anchor: "searchforevents")
+  search_events_path(anchor: "searchforevents"),
+  allow_blank_month: true,
 ) %>
 
 <% @before_search_fullwidth = true %>

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -20,6 +20,23 @@ RSpec.feature "Finding an event", type: :feature do
       receive(:get_teaching_event) { event }
   end
 
+  scenario "Landing on the find an event page and searching" do
+    visit events_path
+
+    expect(find_field("Event type").value).to be_empty # All events
+    expect(find_field("Location").value).to be_empty # Nationwide
+    expect(find_field("Month").value).to be_empty # All months
+
+    click_on "Update results"
+
+    expect(page.current_url).to include("/events/search")
+
+    expect(page.current_url).to include("events_search[type]=")
+    expect(page.current_url).to include("events_search[distance]=")
+    expect(page.current_url).to include("events_search[postcode]=")
+    expect(page.current_url).to include("events_search[month]=")
+  end
+
   scenario "Finding an event by the list of featured events" do
     visit events_path
 


### PR DESCRIPTION
We default to the current month in the search; this has been fine but now we have TTT events that start in a few months time and we find users click the search with the default month values most often. So that TTT events are in the results we are changing the month selector to default to 'all months'.

Its a tricky one to test as the review apps point to dev and there are no TTT events on dev yet. I've tested it locally against the test API instance though and it seems to work fine.