### PR TITLE
Link to callback booking from ML completion page

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -3,9 +3,28 @@
 <section class="text-content">
   <h2 class="green">You've signed up</h2>
 
-  <p>You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time. Call us for free on <a href="tel:08003892500" class="telephone-number"
-    aria-label="Telephone">0800 389 2500</a>, Monday to Friday between 8.30am and 5.30pm.
+  <p>
+    You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.
+    <% if Rails.env.production? %>
+    Call us for free on <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a>, Monday to Friday between 8.30am and 5.30pm.
+    <% end %>
   </p>
+
+  <% unless Rails.env.production? %>
+    <h3>Get in touch with an agent</h3>
+
+    <p>They're experts who can answer questions about qualifications, funding or your application.</p>
+
+    <div class="mailing-list__actions">
+      <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
+      <div>
+        <small>or call us now:</small>
+        <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+      </div>
+    </div>
+
+    <p>Monday - Friday between 8:30am and 5:00pm.</p>
+  <% end %>
 
   <span data-controller="pinterest"
         data-pinterest-action="track"

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -31,4 +31,17 @@
       margin: .2em 0 1em;
     }
   }
+
+  .mailing-list__actions {
+    display: flex;
+    flex-direction: row;
+    gap: $indent-amount;
+
+    .telephone {
+      display: block;
+      font-weight: bold;
+      text-decoration: none;
+      color: $black;
+    }
+  }
 }


### PR DESCRIPTION
### Trello card

[Trello-1745](https://trello.com/c/ZpQ59hIM/1745-link-mailing-list-completion-page-to-book-a-callback-form)

### Context

When a candidate has finished signing up for the mailing list we want to highlight the callback booking form in case they wish to speak to an adviser.

Only enabled in dev/test - disabled in production for now.

### Changes proposed in this pull request

- Link to callback booking from ML completion page

### Guidance to review


| Desktop      | Mobile |
| ----------- | ----------- |
| <img width="1224" alt="Screenshot 2021-07-27 at 15 19 23" src="https://user-images.githubusercontent.com/29867726/127170390-cf574f1d-86a2-4f0d-ab0d-cd08b412b0dc.png">     | <img width="762" alt="Screenshot 2021-07-27 at 15 19 53" src="https://user-images.githubusercontent.com/29867726/127170485-09c27b98-d82d-44c4-b07c-0530a991f18a.png">       |


