### PR TITLE
Apply abbr style inside table cells

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -103,7 +103,8 @@
 
   p,
   ol,
-  ul {
+  ul,
+  td {
     abbr {
       @include abbr-styles;
       cursor: help;


### PR DESCRIPTION
### Trello card
https://trello.com/c/MJfhNKpe

### Context
The abbr styling isn't currently applied in table cells

### Changes proposed in this pull request
- Add table cells to the list of abbr styles.

