### PR TITLE
Attach external link icons in Ruby

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,12 +57,17 @@ private
     doc = Nokogiri::HTML(body)
     markdown_links = doc.css(".markdown a")
     classes_to_suppress = %w[button]
+
     markdown_links.each do |anchor|
       classes = anchor.attr("class")&.split
-      if anchor[:href].include?("//") && classes_to_suppress.none? { |klass| classes&.include?(klass) }
+
+      next if classes && (classes & classes_to_suppress).any?
+
+      if anchor[:href].include?("//")
         anchor.add_child(helpers.image_pack_tag("media/images/icon-external.svg", class: "external-link-icon", alt: ""))
       end
     end
+
     doc.to_html(encoding: "UTF-8", indent: 2)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :toggle_vwo
 
   after_action :process_images
+  after_action :process_links
 
 private
 
@@ -44,6 +45,25 @@ private
     response.body = NextGenImages.new(response.body).html
     response.body = ResponsiveImages.new(response.body).html
     response.body = LazyLoadImages.new(response.body).html
+  end
+
+  def process_links
+    return unless response_is_html?
+
+    response.body = add_external_link_icons(response.body)
+  end
+
+  def add_external_link_icons(body)
+    doc = Nokogiri::HTML(body)
+    markdown_links = doc.css(".markdown a")
+    classes_to_suppress = %w[button]
+    markdown_links.each do |anchor|
+      classes = anchor.attr("class")&.split
+      if anchor[:href].include?("//") && classes_to_suppress.none? { |klass| classes&.include?(klass) }
+        anchor.add_child(helpers.image_pack_tag("media/images/icon-external.svg", class: "external-link-icon", alt: ""))
+      end
+    end
+    doc.to_html(encoding: "UTF-8", indent: 2)
   end
 
   def response_is_html?

--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -56,7 +56,6 @@ $space-between-sections: 3.7em;
       padding: 0;
 
       li > a {
-        @include suppress-external-link-icon;
         @include font-size('xsmall');
         color: $black;
         line-height: 1.8em;

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -1,5 +1,4 @@
 @mixin button($bg: $green, $fg: $white) {
-  @include suppress-external-link-icon;
   display: block;
   font-weight: bold;
   background-color: $bg;
@@ -30,6 +29,10 @@ a {
     color: darken($blue-dark, 15%);
     text-decoration: none;
   }
+}
+
+.external-link-icon {
+  margin-left: .2em;
 }
 
 .button {

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -1,7 +1,6 @@
 .markdown,
 .text-content {
   @mixin overhang { margin-left: auto; margin-right: auto; }
-  @include external-link-icon;
 
   word-break: break-word;
 
@@ -74,19 +73,13 @@
     margin-left: 0;
   }
 
-  // stop the external icon from appearing inside CTA 'button' style links
-  // and the home page featured content video thumbnail links
   .call-to-action__action,
   .featured-content__item {
-    a { @include suppress-external-link-icon; }
-
     // this is added by Kramdown when using the ToC (table of contents) plugin
     #markdown-toc {
       margin-bottom: 3em;
     }
   }
-
-  a.button { @include suppress-external-link-icon; }
 
   ul,
   ol {

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -3,33 +3,6 @@
   padding: 0;
 }
 
-@mixin suppress-external-link-icon {
-  &[href*="//"] {
-    &:after {
-      content: none;
-      margin-left: unset;
-    }
-  }
-}
-
-@mixin _external-link-icon-style {
-  &[href*="//"] {
-    &:after {
-      content: url('../images/icon-external.svg');
-      content: url('../images/icon-external.svg') / "External link icon";
-      margin-left: .2em;
-      display: inline-block;
-      background-repeat: no-repeat;
-    }
-  }
-}
-
-@mixin external-link-icon {
-  a:not(.button) {
-    @include _external-link-icon-style;
-  }
-}
-
 // these are typically headers or section headings, often
 // placed over images or other sections
 @mixin rotated-block($degrees: -3deg, $blur: 4px) {

--- a/spec/requests/external_links_image_spec.rb
+++ b/spec/requests/external_links_image_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "External link images" do
+  excluded_classes = %w[button]
+  before { get "/ways-to-train" }
+  subject { response.body }
+
+  context "when external link and not #{excluded_classes.join(' ')}" do
+    it "adds an external link icon" do
+      doc = Nokogiri::HTML.parse(response.body)
+      markdown_links = doc.css(".markdown a")
+      markdown_links.each do |anchor|
+        classes = anchor.attr("class")&.split
+        if anchor[:href].include?("//") && !classes&.difference(excluded_classes)
+          expect(anchor.children.at("img").to_html).to include('class="external-link-icon')
+          expect(anchor.children.at("img").to_html).to include('alt=""')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/QSHLpZlP

### Context
External link icons are currently set in CSS. However, they need an alt attribute, and while this can be done in CSS, it is not supported by all browsers.

### Changes proposed in this pull request
- Apply external link icons in Ruby instead of CSS

### Guidance to review
In CSS, the external link icon was being suppressed in several places. I have only included these in the `markdown` class, supressing the `button` class. Flicking through I can't see any difference.