### PR TITLE
Use `is_at_most` matcher

### DIFF
--- a/spec/models/callbacks/steps/personal_details_spec.rb
+++ b/spec/models/callbacks/steps/personal_details_spec.rb
@@ -18,11 +18,11 @@ describe Callbacks::Steps::PersonalDetails do
   end
 
   describe "#first_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :first_name }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(256) }
   end
 
   describe "#last_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :last_name }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(256) }
   end
 
   describe "#email address" do

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -18,11 +18,11 @@ describe Events::Steps::PersonalDetails do
   end
 
   describe "#first_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :first_name }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(256) }
   end
 
   describe "#last_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :last_name }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(256) }
   end
 
   describe "#email address" do

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -27,11 +27,11 @@ describe MailingList::Steps::Name do
   end
 
   describe "validations for first_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :first_name }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(256) }
   end
 
   describe "validations for last_name" do
-    it { is_expected.not_to allow_value("a" * 257).for :last_name }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(256) }
   end
 
   describe "validations for email address" do


### PR DESCRIPTION
### Context
Tidy up - There are a couple of places where we are building strings to test attribute length validations. There is a `is_at_most` shoulda matcher that can be used instead.

### Changes proposed in this pull request
- Use `is_at_most` matcher