### PR TITLE
Native support for Question Time events

### DIFF
--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -55,7 +55,11 @@ private
   def load_events(period)
     @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: period))
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
-    group_presenter = Events::GroupPresenter.new(events_by_type, false, @event_search.future?)
+    group_presenter = Events::GroupPresenter.new(
+      events_by_type,
+      display_empty: false,
+      ascending: @event_search.future?,
+    )
     @events = group_presenter.paginated_events_of_type(@type.id, params[:page]) || []
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -67,7 +67,12 @@ private
       quantity_per_type: UPCOMING_EVENTS_PER_TYPE,
       start_after: DateTime.now.utc.beginning_of_day,
     )
-    @group_presenter = Events::GroupPresenter.new(search_results)
+    @group_presenter = Events::GroupPresenter.new(
+      search_results,
+      display_empty: false,
+      ascending: true,
+      limit_per_type: UPCOMING_EVENTS_PER_TYPE,
+    )
     @events_by_type = @group_presenter.sorted_events_by_type
     @no_results = @events_by_type.all? { |_, events| events.empty? }
   end
@@ -79,7 +84,7 @@ private
     @performed_search = true
     @events_search_type = params.dig("events_search", "type")
 
-    @group_presenter = Events::GroupPresenter.new(search_results, @display_empty_types)
+    @group_presenter = Events::GroupPresenter.new(search_results, display_empty: @display_empty_types)
     pages = params.permit(@group_presenter.page_param_names.values)
     @events_by_type = @group_presenter.paginated_events_by_type(pages)
     @no_results = @events_by_type.all? { |_, events| events.empty? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,29 +34,29 @@ en:
     types:
       222750001: |-
         <p>Our Train to Teach events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom.</p>
-        <p>At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. 
+        <p>At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts.
         Some events are in person and others replicate the experience online.</p>
         <p>Whichever event you choose to attend, you will have the chance to:</p>
         <ul>
           <li>put your questions to expert advisers, teachers and training providers</li>
           <li>chat with current teachers and find out what a career in teaching is really like</li>
-          <li>watch presentations which provide a step-by-step guide on how to get into teaching, the application 
+          <li>watch presentations which provide a step-by-step guide on how to get into teaching, the application
           process and funding your training</li>
         </ul>
-        <p>You need to register for Train to Teach events in advance, as spaces are 
+        <p>You need to register for Train to Teach events in advance, as spaces are
         limited and fill up on a first come, first served basis.</p>
         <p>
         The presentations used at these events can be found <a href="/presentations">here</a>.
         </p>
       222750008: |-
         <p>
-          Ask a panel of specialists the questions that matter to you in one of our real-time Q&A online events. 
-          These Q&A sessions cover a range of different topics and give you the opportunity to ask specific questions 
+          Ask a panel of specialists the questions that matter to you in one of our real-time Q&A online events.
+          These Q&A sessions cover a range of different topics and give you the opportunity to ask specific questions
           and receive advice tailored to your circumstances.
         </p>
       222750009: |-
         <p>
-          Schools and universities that run teacher training courses often hold their own events giving you a valuable opportunity to 
+          Schools and universities that run teacher training courses often hold their own events giving you a valuable opportunity to
           get a feel for what their teacher training course might be like.
         </p>
 
@@ -69,7 +69,7 @@ en:
           <li><span>a chance to talk to current trainees or staff</span></li>
         </ul>
 
-        <p>Use the search tool below to find events being held by 
+        <p>Use the search tool below to find events being held by
         training providers in the area you would like to train.</p>
   funding_widget:
     subjects:
@@ -284,6 +284,10 @@ en:
         long: |-
           Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
           will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
+    222750007: # Question Time (displayed as Train to Teach)
+      name:
+        singular: "Train to Teach event"
+        plural: "Train to Teach events"
     222750008:
       name:
         singular: "Online Q&A"

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -3,6 +3,7 @@ module GetIntoTeachingApiClient
     EVENT_TYPES =
       {
         "Train to Teach event" => 222_750_001,
+        "Question Time" => 222_750_007,
         "Online event" => 222_750_008,
         "School or University event" => 222_750_009,
       }.freeze

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
     end
 
+    trait :question_time_event do
+      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"] }
+    end
+
     trait :virtual do
       is_online { true }
       is_virtual { true }

--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :events_search, class: "Events::Search" do
-    type { Events::Search.available_event_types.first.id }
+    type { Events::Search.available_event_types.last.id }
     distance { Events::Search.available_distances.first[0] }
     postcode { "TE57 1NG" }
     month { "2020-07" }

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -23,7 +23,7 @@ describe Events::Search do
 
   describe ".available_event_type_ids" do
     subject { described_class.new.available_event_type_ids }
-    it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.values }
+    it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.except("Question Time").values }
   end
 
   describe "#future?" do
@@ -145,7 +145,7 @@ describe Events::Search do
 
     let(:expected_attributes) do
       {
-        type_id: subject.type,
+        type_ids: [subject.type],
         radius: subject.distance,
         postcode: subject.postcode,
         start_after: DateTime.now.utc.beginning_of_day,
@@ -169,6 +169,18 @@ describe Events::Search do
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
             receive(:search_teaching_events_grouped_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
+        end
+      end
+
+      context "when searching Train to Teach events" do
+        before do
+          subject.type = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+          expected_attributes[:type_ids] << GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+        end
+
+        it "queries Question Time and Train to Teach events" do
+          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+            receive(:search_teaching_events_grouped_by_type).with(**expected_attributes)
         end
       end
 

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -2,28 +2,29 @@ require "rails_helper"
 
 describe Events::GroupPresenter do
   let(:train_to_teach_events) { build_list(:event_api, 5, :train_to_teach_event) }
+  let(:question_time_events) { build_list(:event_api, 5, :question_time_event) }
   let(:online_events) { build_list(:event_api, 2, :online_event) }
   let(:school_and_university_events) { build_list(:event_api, 15, :school_or_university_event) }
-  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
+  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events, question_time_events].flatten }
   let(:events_by_type) { group_events_by_type(all_events) }
   let(:display_empty_types) { false }
 
-  subject { described_class.new(events_by_type, display_empty_types) }
+  subject { described_class.new(events_by_type, display_empty: display_empty_types) }
 
   describe "#sorted_events_by_type" do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
     let(:online_event_type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
 
-    it "returns events_by_type as an array of [type_id, events] tuples" do
+    it "returns events_by_type as an array of [type_id, events] tuples (with TTT and QT events combined)" do
       expect(subject.sorted_events_by_type).to eq([
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events],
+        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events + question_time_events],
         [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"], online_events],
         [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events],
       ])
     end
 
     it "sorts event types according to GetIntoTeachingApiClient::Constants::EVENT_TYPES" do
-      expect(type_ids).to eq(GetIntoTeachingApiClient::Constants::EVENT_TYPES.values)
+      expect(type_ids).to eq(GetIntoTeachingApiClient::Constants::EVENT_TYPES.except("Question Time").values)
     end
 
     context "when there are no events for a type" do
@@ -41,6 +42,21 @@ describe Events::GroupPresenter do
       it "contains a key for types that have no events" do
         expect(type_ids).to include(online_event_type_id)
       end
+
+      context "when there are Question Time or Train to Teach events" do
+        let(:train_to_teach_events) { [] }
+        let(:question_time_events) { [] }
+
+        it "still contains a key for Train to Teach events" do
+          train_to_teach_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+          expect(type_ids).to include(train_to_teach_type_id)
+        end
+
+        it "does not contain a key for Question Time events" do
+          question_time_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+          expect(type_ids).not_to include(question_time_type_id)
+        end
+      end
     end
 
     describe "sorting within an event type" do
@@ -51,7 +67,7 @@ describe Events::GroupPresenter do
       let(:unsorted_events) { [middle, late, early] }
       let(:ascending) { true }
 
-      subject { described_class.new(group_events_by_type(unsorted_events), false, ascending) }
+      subject { described_class.new(group_events_by_type(unsorted_events), display_empty: false, ascending: ascending) }
 
       it "sorts events of the same type by date, ascending" do
         expect(subject.sorted_events_by_type.to_h[type_id]).to eql([early, middle, late])
@@ -62,6 +78,14 @@ describe Events::GroupPresenter do
         it "sorts events of the same type by date, descending" do
           expect(subject.sorted_events_by_type.to_h[type_id]).to eql([late, middle, early])
         end
+      end
+    end
+
+    describe "limiting the events by type" do
+      subject { described_class.new(events_by_type, limit_per_type: 1) }
+
+      it "limits the number of events returned per type" do
+        expect(subject.sorted_events_by_type.map(&:last).map(&:count)).to all(be(1))
       end
     end
   end
@@ -119,10 +143,18 @@ describe Events::GroupPresenter do
   end
 
   describe "#sorted_events_of_type" do
-    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
 
     it "returns the events of the given type" do
-      expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events)
+      expect(subject.sorted_events_of_type(type)).to eq(online_events)
+    end
+
+    context "when type is Train to Teach event" do
+      let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+
+      it "returns the Train to Teach and Question Time events" do
+        expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events + question_time_events)
+      end
     end
   end
 end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -89,12 +89,12 @@ describe "View events by category" do
   context "when viewing the schools and university events category" do
     let(:start_after) { DateTime.now.utc.beginning_of_day }
     let(:start_before) { start_after.advance(months: 24).end_of_month }
-    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_after, start_before: start_before, type_id: nil } }
+    let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_after, start_before: start_before, type_ids: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_id: type_id, quantity_per_type: expected_limit))
+        receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_ids: [type_id], quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events")
     end
   end
@@ -104,12 +104,12 @@ describe "View events by category" do
     let(:radius) { 25 }
     let(:start_after) { DateTime.now.utc.beginning_of_day }
     let(:start_before) { start_after.advance(months: 24).end_of_month }
-    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_id: nil } }
+    let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_ids: nil } }
 
     it "queries events for the correct category" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_id: type_id, quantity_per_type: expected_limit))
+        receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_ids: [type_id], quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })
     end
   end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -58,7 +58,7 @@ describe EventsController do
     end
 
     context "with valid search params" do
-      let(:event_type_name) { "Train to Teach event" }
+      let(:event_type_name) { "School or University event" }
       let(:event_type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES[event_type_name] }
       let(:search_params) do
         attributes_for(
@@ -75,7 +75,7 @@ describe EventsController do
           radius: nil,
           start_after: date.beginning_of_day,
           start_before: date.end_of_month,
-          type_id: event_type,
+          type_ids: [event_type],
         }
       end
       let(:expected_description) { "Get your questions answered at an event." }
@@ -110,7 +110,7 @@ describe EventsController do
 
     context "with no search params" do
       let(:search_params) { nil }
-      let(:expected_request_attributes) { { type_id: nil } }
+      let(:expected_request_attributes) { { type_ids: nil } }
 
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes media_type: "text/html" }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "LID tracking pixels" do
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_grouped_by_type) { {} }
+      receive(:search_teaching_events_grouped_by_type) { [] }
   end
 
   before { get path }


### PR DESCRIPTION
[Trello-1718](https://trello.com/c/pHVDpbZ2/1718-implement-front-end-changes-for-question-time-events)

Currently the GiT API remaps Question Time events with a Train to Teach event type. This is because the events team want the QT and TTT events both displayed as if they are TTT events on the GiT website.

This, however, is a bit of confusing and potentially hazardous code in the GiT API and we would prefer to remove this and support QT events natively in the GiT website.

This commit achieves that by:

- Updating the `Events::GroupPresenter` to group TTT and QT events for   displaying in the event search results.

- As a byproduct of this ^ we need the presenter to now know about how many   events there should be per-type (as we're combining so could end up with more than expected).

- Updating the `Events::Search` model to remove QT events as a searchable   option and query both TTT and QT events if searching for TTT events.

- Mis-representing QT events as TTT event types in the event box by   providing translations.

The API was previously updated to support querying by multiple `type_ids` so that when searching we can perform a single search for both QT and TTT events.

As the QT events are being mapped to TTT events in the API, once this PR has shipped we will need to undo that bit of logic and give it a thorough test in dev to ensure its working as expected.