### PR TITLE
JS linting in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,11 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - name: ESLint - JavaScript linting
+        run: |-
+          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true \
+            ${{needs.build.outputs.DOCKER_IMAGE}} "yarn && yarn js-lint"
+
       - name: Run Javascript Tests
         run: |-
           docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true \

--- a/README.md
+++ b/README.md
@@ -106,19 +106,18 @@ fi
 
 ### JavaScript
 
-[Prettier](https://prettier.io/) is used for code formatting.
-To enforce stylistic rules with Prettier (note: this overwrites the file), run:
+[Prettier](https://prettier.io/) is used for code formatting. [ESLint](https://eslint.org/) is used for static analysis of JavaScript code quality. It is configured to ignore stylistic rules that conflict with Prettier, and uses the [JavaScript Standard style](https://standardjs.com/).
+
+To list any violations in the project's JavaScript:
 
 ```bash
-yarn prettier --write <path to your file>
+yarn js-lint
 ```
 
-[ESLint](https://eslint.org/) is used for static analysis of JavaScript code quality. It is configured to ignore stylistic rules that conflict with Prettier, and uses the [JavaScript Standard style](https://standardjs.com/).
-
-To check a file:
+To automatically fix any violations. Any violations that cannot be automatically fixed will be listed in the output (note: this will overwrite any file that needs formatting):
 
 ```bash
-yarn eslint <path to your file>
+yarn js-lint-fix
 ```
 
 ### CSS

--- a/app/webpacker/controllers/twitter_controller.js
+++ b/app/webpacker/controllers/twitter_controller.js
@@ -13,9 +13,10 @@ export default class extends AnalyticsBaseController {
   initService() {
     !(function (e, t, n, s, u, a) {
       e.twq ||
-        ((s = e.twq = function () {
-          s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
-        }),
+        ((s = e.twq =
+          function () {
+            s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+          }),
         (s.version = '1.1'),
         (s.queue = []),
         (u = t.createElement(n)),

--- a/app/webpacker/controllers/welcome-guide-quiz_controller.js
+++ b/app/webpacker/controllers/welcome-guide-quiz_controller.js
@@ -6,12 +6,12 @@ export default class extends Controller {
   connect() {}
 
   selectRightAnswer(_event) {
-    this.resultsTarget.classList.remove("incorrect");
-    this.resultsTarget.classList.add("correct");
+    this.resultsTarget.classList.remove('incorrect');
+    this.resultsTarget.classList.add('correct');
   }
 
   selectWrongAnswer(_event) {
-    this.resultsTarget.classList.remove("correct");
-    this.resultsTarget.classList.add("incorrect");
+    this.resultsTarget.classList.remove('correct');
+    this.resultsTarget.classList.add('incorrect');
   }
 }

--- a/app/webpacker/javascript/redacter.js
+++ b/app/webpacker/javascript/redacter.js
@@ -1,31 +1,32 @@
 export default class Redacter {
-  static postcodeMatcher = /[A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2}/m
-  static dateMatcher = /\b\d\d?(st|nd|rd|th)?[ .\/-]([a-zA-Z]+|[012]?\d?)[ .\/-]\d\d\d{2}?\b/m
-  static emailMatcher = /[^\s]+@[^\s]+/m
+  static postcodeMatcher = /[A-Z][A-HJ-Y]?\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2}/m;
+  static emailMatcher = /[^\s]+@[^\s]+/m;
+  static dateMatcher =
+    /\b\d\d?(st|nd|rd|th)?[ ./-]([a-zA-Z]+|[012]?\d?)[ ./-]\d\d\d{2}?\b/m;
 
-  originalText = null
+  originalText = null;
 
   constructor(string) {
-    this.originalText = string
+    this.originalText = string;
   }
 
   get redacted() {
-    let redacted = this.redactEmailAddresses(this.originalText)
-    redacted = this.redactPostcodes(redacted)
-    redacted = this.redactDates(redacted)
+    let redacted = this.redactEmailAddresses(this.originalText);
+    redacted = this.redactPostcodes(redacted);
+    redacted = this.redactDates(redacted);
 
-    return redacted
+    return redacted;
   }
 
   redactEmailAddresses(text) {
-    return text.replace(Redacter.emailMatcher, '[EMAIL]')
+    return text.replace(Redacter.emailMatcher, '[EMAIL]');
   }
 
   redactPostcodes(text) {
-    return text.replace(Redacter.postcodeMatcher, '[POSTCODE]')
+    return text.replace(Redacter.postcodeMatcher, '[POSTCODE]');
   }
 
   redactDates(text) {
-    return text.replace(Redacter.dateMatcher, '[DATE]')
+    return text.replace(Redacter.dateMatcher, '[DATE]');
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "scripts": {
     "spec": "jest",
     "scss-lint": "npx stylelint app/webpacker/styles",
-    "prettier": "yarn prettier app/webpacker/controllers"
+    "js-lint": "yarn eslint app/webpacker/controllers/*js app/webpacker/javascript/*js spec/javascript/*js",
+    "js-lint-fix": "yarn prettier --write app/webpacker/controllers/*js app/webpacker/javascript/*js spec/javascript/*js && yarn eslint --fix app/webpacker/controllers/*js app/webpacker/javascript/*js spec/javascript/*js"
   }
 }


### PR DESCRIPTION
### Context
We want to enforce the JavaScript linting consistently so that we don't have to run a regular lint.

### Changes proposed in this pull request
- Add commands to run the JavaScript linters project wide
- Add JavaScript linting to the build workflow
- Fix any remaining linting issues

### Guidance to review
I couldn't figure out why I the build command fails without `yarn &&` [here](https://github.com/DFE-Digital/get-into-teaching-app/blob/72bd29563d20434bf3c465fb3421db99b72b334f/.github/workflows/build.yml#L150) (this is the same for the jest workflow). I don't think this is installing node modules again, it just says `Already up-to-date`. 