### PR TITLE
Improve blog tag accessibility

### DIFF
--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -24,7 +24,7 @@
       background-color: $blue;
       color: $white;
 
-      @include font-size(xsmall);
+      @include font-size(xsmall, $adjust: .5rem);
 
       a {
         display: block;

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -12,6 +12,10 @@
     width: 100%;
   }
 
+  h2 {
+    @include font-size(medium);
+  }
+
   ol {
     display: flex;
     flex-wrap: wrap;
@@ -23,8 +27,9 @@
     li {
       background-color: $blue;
       color: $white;
+      font-weight: bold;
 
-      @include font-size(xsmall, $adjust: .5rem);
+      @include font-size(xsmall, $adjust: .2rem);
 
       a {
         display: block;

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -30,6 +30,10 @@
         display: block;
         color: $white;
         padding: .4em .6em;
+
+        &:focus {
+          color: $black;
+        }
       }
 
       &:hover {

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -23,12 +23,13 @@
     li {
       background-color: $blue;
       color: $white;
-      padding: .6em;
 
       @include font-size(xsmall);
 
       a {
+        display: block;
         color: $white;
+        padding: .4em .6em;
       }
 
       &:hover {

--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -28,17 +28,15 @@ $mobile-sizes:  ("xsmall": $fs-14, "small": $fs-15, "medium": $fs-16, "large": $
 $tablet-sizes:  ("xsmall": $fs-15, "small": $fs-16, "medium": $fs-19, "large": $fs-28, "xlarge" : $fs-36, "xxlarge": $fs-42, "xxxlarge": $fs-54);
 $desktop-sizes: ("xsmall": $fs-16, "small": $fs-19, "medium": $fs-28, "large": $fs-36, "xlarge" : $fs-42, "xxlarge": $fs-54, "xxxlarge": $fs-64);
 
-@mixin font-size($size) {
-  @include mq($until: mobile) {
-    font-size: size($mobile-sizes, $size);
+@mixin font-size($size, $adjust: 0rem) {
+  font-size: size($mobile-sizes, $size) + $adjust;
+
+  @include mq($from: tablet, $until: desktop) {
+    font-size: size($tablet-sizes, $size) + $adjust;
   }
 
-  @include mq($from: mobile, $until: tablet) {
-    font-size: size($tablet-sizes, $size);
-  }
-
-  @include mq($from: tablet) {
-    font-size: size($desktop-sizes, $size);
+  @include mq($from: desktop) {
+    font-size: size($desktop-sizes, $size) + $adjust;
   }
 
   // debug util


### PR DESCRIPTION
### Trello card

https://trello.com/c/PFTjDIps/1731-contrast-in-blog-tags

### Context and changes

- Make the whole tag 'button' clickable
- Make the tag's focus text colour black
- Increase the tag font size a little

Note this also includes a minor improvement on the boundaries on the dynamic font sizes.

![Screenshot from 2021-07-29 14-22-21](https://user-images.githubusercontent.com/128088/127499593-3938b3f8-2392-40e3-a71b-945b0a411c6e.png)

