### PR TITLE
Darken blue links where background is grey

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -11,7 +11,7 @@
         <h2>Tell us whether you accept cookies</h2>
       </div>
       <p>
-        We use <a href="/cookies">cookies</a> to collect information about how you use this website.
+        We use <a href="/cookies" class="dark-link">cookies</a> to collect information about how you use this website.
         We use this information to make the website work as well as possible, and improve this website.
         We also share some of this information with our social media, advertising and analytics partners.
       </p>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -36,7 +36,7 @@
 <section class="content-cta">
   <h3>Do you have a teaching event?</h3>
   <p>
-    If you'd like to advertise your teaching event in this listing, <a href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
+    If you'd like to advertise your teaching event in this listing, <a class="dark-link" href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
       title="Submit your event details on GOV.UK"
       target="_blank"
       rel="noopener norefferer">

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -22,5 +22,6 @@ $yellow-dark: #f9b400;
 $yellow-dark-90: rgba($yellow-dark, .9);
 $red: #d4351c;
 
-// not part of the official colourscheme but used for tags
-$dark-cyan: #008b8b;
+// NOT PART OF THE OFFICIAL COLOUR SCHEME
+$dark-cyan: #008b8b; // used for tags
+$blue-very-dark: #0062A3; // passes accessibility contrast check on $grey

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -68,14 +68,6 @@
       margin-top: 0;
     }
 
-    a {
-      text-decoration: none;
-    }
-
-    a:hover {
-      text-decoration: underline;
-    }
-
     .secondary-link {
       @include chevron($color: $blue);
 

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -99,3 +99,8 @@ a {
     display: inline-block;
   }
 }
+
+// passes accessibility contrast check on grey background
+.dark-link {
+  color: #005487;
+}


### PR DESCRIPTION
### Trello card
https://trello.com/c/r6dpxSG6/1726-link-contrast-in-cookies-popup

### Context
Some of the links that are on grey backgrounds are not passing accessibility contrast checks. The cookies popup link is also missing an underline.

### Changes proposed in this pull request
- Darken blue links where background is grey
- Add underline back to cookies link

### Guidance to review
We decided to change the colour of these links only, changing the colour of all links didn't look great

![image](https://user-images.githubusercontent.com/47089130/127518049-9454067c-2546-4c4d-b53d-755806056273.png)

