### PR TITLE
Improve the nav link display

### DIFF
--- a/app/webpacker/styles/header/navigation.scss
+++ b/app/webpacker/styles/header/navigation.scss
@@ -6,6 +6,7 @@
   a {
     color: $black;
     text-decoration: none;
+    display: inline-block;
 
     &:hover {
       text-decoration: none;
@@ -92,11 +93,9 @@ body > header nav {
       background: $grey;
 
       > li {
-        padding-left: 1em;
         border-left: 6px solid $grey;
         border-bottom: 1px solid $white;
         max-width: 80%;
-        //margin-bottom: .8em;
 
         .menu__text {
           flex-grow: 1;
@@ -109,7 +108,7 @@ body > header nav {
         > a,
         div {
           display: block;
-          padding: 1em 0;
+          padding: 1em;
         }
       }
     }
@@ -120,7 +119,6 @@ body > header nav {
       > li {
         margin: 1em;
 
-        padding-left: 1em;
         border-left: 6px solid $white;
 
         &:hover {
@@ -161,14 +159,14 @@ body > header nav {
         }
 
         a {
-          padding: 1em 0 0 0;
-          border-bottom: 1px solid $white;
+          padding: 1em .2em 0;
+          border-bottom: 2px solid $white;
 
           &:hover {
             border-bottom: 2px solid $black;
           }
         }
-        
+
         div {
 	        line-height: 1.5;
         }


### PR DESCRIPTION
The nav link focus styles were a little bit broken, mainly due to them being `inline` instead of `block`, so when they wrapped the background colour from one line overlapped the other.

| Before | After |
| ----- | ------ |
| ![Screenshot from 2021-07-30 13-30-36](https://user-images.githubusercontent.com/128088/127653404-a00f9d96-926d-4ec2-9f4b-0f48c6796794.png) | ![Screenshot from 2021-07-30 13-30-08](https://user-images.githubusercontent.com/128088/127653414-6be37aae-0988-4f5d-bd69-e5047a13553c.png) |
| ![Screenshot from 2021-07-30 11-09-48](https://user-images.githubusercontent.com/128088/127653449-e2802da2-b150-4073-a3a4-fb84fc4b2669.png) | ![Screenshot from 2021-07-30 11-12-17](https://user-images.githubusercontent.com/128088/127653469-55626d15-9596-4445-a61e-96b458bac88c.png) |


