### PR TITLE
Add welcome guide link from mailing list finish

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -16,7 +16,7 @@
       In the meantime you can explore your personalised welcome guide to give you a flavour of what the world of teaching is like.
     </p>
 
-    <%= link_to("Welcome Guide", "/welcome", class: "button button--secondary button--inline") %>
+    <%= link_to("View your personalised Welcome Guide", "/welcome", class: "button button--secondary button--inline") %>
 
 
     <h3>Get in touch with an agent</h3>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -11,6 +11,14 @@
   </p>
 
   <% unless Rails.env.production? %>
+
+    <p>
+      In the meantime you can explore your personalised welcome guide to give you a flavour of what the world of teaching is like.
+    </p>
+
+    <%= link_to("Welcome Guide", "/welcome", class: "button button--secondary button--inline") %>
+
+
     <h3>Get in touch with an agent</h3>
 
     <p>They're experts who can answer questions about qualifications, funding or your application.</p>

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -70,6 +70,10 @@ a {
     @include font-size("xsmall");
     padding: 8px $indent-amount;
   }
+
+  &--inline {
+    display: inline;
+  }
 }
 
 .call-to-action-icon-button {


### PR DESCRIPTION
### Context

To aid testing the welcome guide, this change adds a link to it from the mailing list completion page. It's inside an `unless` statement that prevents it from rendering on production but it should be present (like the welcome guide), everywhere else.

![Screenshot from 2021-07-30 14-34-13](https://user-images.githubusercontent.com/128088/127660835-9c9fec7d-0a47-4baa-87aa-a05112563d05.png)
