### PR TITLE
Compile assets once per test run

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -76,7 +76,7 @@ development:
 
 test:
   <<: *default
-  compile: true
+  compile: false
 
   # Compile test packs to a separate directory
   public_output_path: packs-test

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,10 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include SpecHelpers::Events
   config.include SpecHelpers::BasicAuth
+
+  config.before(:suite) do
+    Webpacker.compile
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
### Trello card

[Trello-1766](https://trello.com/c/8TKcAPwU/1766-investigate-slowness-in-specs)

### Context

According to Stackprof the test run is constantly computing digests for the assets (~50% is file IO and digest creation). The PR to move all our assets into webpacker caused the runtime of the tests to double. Instead of checking constantly for asset recompilation we can disable this in the test environment and run a single `Webpacker.compile` for the suite. This brings the test run time from 5m back down to around 2m.

### Changes proposed in this pull request

- Compile assets once per test run

### Guidance to review

Stackprof before optimising Webpacker:

```
==================================
  Mode: wall(1000)
  Samples: 373459 (0.86% miss rate)
  GC: 16217 (4.34%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    228459  (61.2%)      228459  (61.2%)     Digest::Instance#file
    259236  (69.4%)       29139   (7.8%)     Webpacker::Compiler#watched_files_digest
     11897   (3.2%)       11896   (3.2%)     ActiveSupport::FileUpdateChecker#watched
      9312   (2.5%)        9312   (2.5%)     (sweeping)
      6891   (1.8%)        6891   (1.8%)     (marking)
```