### PR TITLE
Make Scribble ID optional when creating online events

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -43,7 +43,7 @@ module Internal
     validates :provider_organiser, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { provider_event? }
     validates :provider_target_audience, presence: true, allow_blank: false, length: { maximum: 500 }, if: -> { provider_event? }
     validates :provider_website_url, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { provider_event? }
-    validates :scribble_id, presence: true, allow_blank: false, length: { maximum: 300 }, if: -> { online_event? }
+    validates :scribble_id, length: { maximum: 300 }, if: -> { online_event? }
     validates :venue_type, inclusion: { in: VENUE_TYPES.values }
     validate :dates_in_future
     validate :end_after_start

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -177,8 +177,6 @@ private
 
   def expect_online_validation_errors
     expect_common_validation_errors
-
-    expect(page).to have_text "Enter a Scribble ID"
   end
 
   def expect_provider_validation_errors

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -73,8 +73,7 @@ describe Internal::Event do
       before { allow(subject).to receive(:online_event?).and_return(true) }
 
       describe "#scribble_id" do
-        it { is_expected.to allow_value("test").for :scribble_id }
-        it { is_expected.to_not allow_values("", nil).for :scribble_id }
+        it { is_expected.to allow_values("test", "", nil).for :scribble_id }
         it { is_expected.to validate_length_of(:scribble_id).is_at_most(300) }
       end
     end


### PR DESCRIPTION
### Context
Not all Online events are Scribble events. Non-Scribble events are rare, but this change will enable these to be created via the form instead of having to use the CRM. 
The only difference between Scribble and non-Scribble events is that non-Scribble don't have a Scribble ID.

### Changes proposed in this pull request
Make Scribble ID optional when creating online events