### PR TITLE
Rewrite and neaten the popup CSS

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -2,19 +2,25 @@
   <div class="dialog" data-cookie-acceptance-target="overlay">
     <div class="dialog__background"></div>
     <div class="dialog__content">
-      <div>
-        <div class="logo__image">
-          <span href="/">
-            <%= image_pack_tag "media/images/getintoteachinglogo.svg", alt: "Get Into Teaching", size: "140x48" %>
-          </span>
+      <div class="logo-wrapper">
+        <div class="logo">
+          <a href="/" class="logo__image">
+            <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "180x62", data: { "lazy-disable": true } %>
+          </a>
         </div>
-        <h2>Tell us whether you accept cookies</h2>
       </div>
-      <p>
-        We use <a href="/cookies" class="dark-link">cookies</a> to collect information about how you use this website.
-        We use this information to make the website work as well as possible, and improve this website.
-        We also share some of this information with our social media, advertising and analytics partners.
-      </p>
+
+      <div class="dialog__text">
+
+        <h2>Tell us whether you accept cookies</h2>
+
+        <p>
+          We use <a href="/cookies" class="dark-link">cookies</a> to collect information about how you use this website.
+          We use this information to make the website work as well as possible, and improve this website.
+          We also share some of this information with our social media, advertising and analytics partners.
+        </p>
+
+      </div>
 
       <div class="dialog__buttons">
         <!--

--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -12,8 +12,6 @@
 
       <div class="dialog__text">
 
-        <h2>Tell us whether you accept cookies</h2>
-
         <p>
           We use <a href="/cookies" class="dark-link">cookies</a> to collect information about how you use this website.
           We use this information to make the website work as well as possible, and improve this website.

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -10,131 +10,43 @@
   align-items: center;
 
   &__background {
-    opacity: .4;
+    opacity: .8;
     background-color: $black;
     width: 100%;
     min-height: 100vh;
     box-sizing: border-box;
-    padding: $indent-amount;
     position: absolute;
-    top: 0;
-    left: 0;
   }
 
   &__content {
     width: 100%;
-    max-width: 700px;
+    max-width: 40em;
     background-color: $grey;
-    padding: 40px;
     box-sizing: border-box;
     position: relative;
-    margin: $indent-amount;
-    overflow: hidden;
+    overflow-x: clip;
+    padding-bottom: 1em;
 
-    .logo__image {
-      display: inline-block;
-      top: 0;
-      left: -45px;
-      width: 240px;
-      margin-bottom: $indent-amount;
+    .logo-wrapper {
+      padding: 0;
+      top: -30px;
 
-      a {
-        margin-left: 8px;
-
-        &:focus {
-          &:before {
-            content: "";
-            display: block;
-            background: $yellow;
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            top: 0;
-          }
-        }
-      }
-
-      div {
-        margin-left: 48px;
+      @include mq($until: desktop) {
+        top: 0;
+        padding: 0 0 1em;
       }
     }
+  }
 
-    h2,
-    h3 {
-      @include font-size("large");
-    }
-
-    h3 {
-      margin-top: 0;
-    }
-
-    .secondary-link {
-      @include chevron($color: $blue);
-
-      display: inline-block;
-      cursor: pointer;
-      font-weight: bold;
-      margin-top: $indent-amount;
-      padding: 0 $indent-amount;
-    }
+  &__text,
+  &__buttons {
+    padding: .2em 2em;
   }
 
   &__buttons {
     display: flex;
-    gap: .4em;
-
-    @include mq($until: tablet) {
-      flex-direction: column;
-    }
-  }
-}
-
-@include mq($until: tablet) {
-  .dialog {
-    &__content {
-      padding: $indent-amount;
-      max-height: calc(100vh - 40px);
-      overflow: auto;
-
-      &__header {
-        margin-bottom: 25px;
-      }
-
-      .logo__image {
-        width: 220px;
-        margin-left: $indent-amount;
-
-        div {
-          margin-left: 39px;
-          margin-top: -3px;
-        }
-      }
-
-      h2 {
-        display: block;
-        margin: .3em 0;
-        @include font-size("small");
-      }
-
-      p {
-        line-height: 1.25;
-        @include font-size("xsmall");
-      }
-
-      a {
-        &.button {
-          @include font-size("xsmall");
-        }
-
-        .git-link {
-          margin: 8px 0 0;
-          padding: 0 12px;
-        }
-
-        .visually-hidden {
-          padding: 0;
-        }
-      }
-    }
+    flex-wrap: wrap;
+    gap: .5em;
+    margin: .5em;
   }
 }

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -44,7 +44,7 @@
 
   &__image {
     @include rotated-block;
-    background-color: $green-dark-90;
+    background-color: $green-dark;
     z-index: 1000;
 
     // position the logo slightly off the left of the page


### PR DESCRIPTION
### Trello card

https://trello.com/c/rCNx9Xfg/1770-dev-prevent-horizontal-scroll-on-small-devices

### Context and changes

Also make the dimmed background darker to make the popup a bit more obvious.

| Old | New |
| ------ | ------ |
| ![Screenshot from 2021-08-02 14-33-46](https://user-images.githubusercontent.com/128088/127870570-237d8e10-fded-491a-a160-5835c4f11969.png)| ![Screenshot from 2021-08-02 14-34-30](https://user-images.githubusercontent.com/128088/127870599-c351c511-ea9e-4928-a361-16ab006e00f4.png) |
| ![Screenshot from 2021-08-02 14-35-32](https://user-images.githubusercontent.com/128088/127870626-d02fff57-1bae-4094-a600-f917d74d5957.png) | ![Screenshot from 2021-08-02 14-35-41](https://user-images.githubusercontent.com/128088/127870643-0b4a74e5-c224-4694-95e3-195ee2342506.png) |


