### PR TITLE
Display confirmation in correct time zone

### DIFF
--- a/app/controllers/callbacks/steps_controller.rb
+++ b/app/controllers/callbacks/steps_controller.rb
@@ -16,7 +16,7 @@ module Callbacks
     end
 
     def completed_step_path
-      phone_call_scheduled_at = @wizard.find("callback").phone_call_scheduled_at
+      phone_call_scheduled_at = @wizard.find("callback").phone_call_scheduled_at.in_time_zone(Time.zone)
       date = phone_call_scheduled_at.to_date.to_formatted_s(:govuk)
       time = phone_call_scheduled_at.to_formatted_s(:govuk_time_with_period)
 

--- a/app/views/callbacks/steps/completed.html.erb
+++ b/app/views/callbacks/steps/completed.html.erb
@@ -5,7 +5,7 @@
 
   <h3>What happens next</h3>
 
-  <p>One of our agents will call you on <%= params[:date] %> at <%= params[:time] %>.</p>
+  <p>One of our agents will call you within 30 minutes of <%= params[:date] %> at <%= params[:time] %>.</p>
 
 </section>
 

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -63,9 +63,10 @@ RSpec.feature "Book a callback", type: :feature do
     expect(page).to have_title("Get Into Teaching: Callback confirmed")
     expect(page).to have_text "Callback confirmed"
 
-    date = quota.start_at.to_date.to_formatted_s(:govuk)
-    time = quota.start_at.to_formatted_s(:govuk_time_with_period)
-    expect(page).to have_text "call you on #{date} at #{time}"
+    start_at = quota.start_at.in_time_zone("London")
+    date = start_at.to_date.to_formatted_s(:govuk)
+    time = start_at.to_formatted_s(:govuk_time_with_period)
+    expect(page).to have_text "call you within 30 minutes of #{date} at #{time}"
   end
 
   scenario "Journey encountering errors" do
@@ -129,9 +130,10 @@ RSpec.feature "Book a callback", type: :feature do
     expect(page).to have_title("Get Into Teaching: Callback confirmed")
     expect(page).to have_text "Callback confirmed"
 
-    date = quota.start_at.to_date.to_formatted_s(:govuk)
-    time = quota.start_at.to_formatted_s(:govuk_time_with_period)
-    expect(page).to have_text "call you on #{date} at #{time}"
+    start_at = quota.start_at.in_time_zone("London")
+    date = start_at.to_date.to_formatted_s(:govuk)
+    time = start_at.to_formatted_s(:govuk_time_with_period)
+    expect(page).to have_text "call you within 30 minutes of #{date} at #{time}"
   end
 
   scenario "Journey when candidate has issues signing in" do


### PR DESCRIPTION
### Trello card

[Trello-1775](https://trello.com/c/0mJTnskW/1775-fix-booking-confirmation-page-being-an-hour-out-callback-feature)

### Context

When a user books a callback we display the slots available in London/Europe timezone, however when we display the selected time on the confirmation page we were outputting the UTC time.

Convert the chosen time from UTC to London/Europe prior to displaying on the confirmation page.

### Changes proposed in this pull request

- Display confirmation in correct time zone

### Guidance to review

