### PR TITLE
Hide the cookie popup for Silktide tests

### DIFF
--- a/app/components/footer/cookie_acceptance_component.rb
+++ b/app/components/footer/cookie_acceptance_component.rb
@@ -1,3 +1,16 @@
 module Footer
-  class CookieAcceptanceComponent < ViewComponent::Base; end
+  class CookieAcceptanceComponent < ViewComponent::Base
+    def render?
+      return true if request.user_agent.blank?
+
+      # we're being penalised by Silktide's accessibility checker because
+      # our cookie banner is blocking the screen. Silktide's user agents
+      # all have the suffix Silktide, so for them simply don't show the
+      # cookie acceptance popup.
+      #
+      # https://support.silktide.com/guides/ip-address-user-agent-silktide-use/
+
+      !request.user_agent.end_with?("Silktide")
+    end
+  end
 end

--- a/spec/components/footer/cookie_acceptance_component_spec.rb
+++ b/spec/components/footer/cookie_acceptance_component_spec.rb
@@ -1,14 +1,31 @@
 require "rails_helper"
 
 describe Footer::CookieAcceptanceComponent, type: "component" do
-  subject! { render_inline(described_class.new) }
+  subject { render_inline(described_class.new) }
+
   let(:cookie_acceptance_selector) { ".cookie-acceptance" }
 
   specify "renders the cookie acceptance component" do
+    subject
     expect(page).to have_css(cookie_acceptance_selector)
   end
 
   specify "the content is present" do
+    subject
     expect(page).to have_content(/We use cookies to collect/)
+  end
+
+  context "when the user agent is Silktide" do
+    before do
+      allow_any_instance_of(ActionDispatch::TestRequest).to(
+        receive(:user_agent).and_return("a-user-agent-string-that-ends-in-Silktide"),
+      )
+    end
+
+    before { subject }
+
+    specify "nothing is rendered" do
+      expect(rendered_component).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Our score is artificially low because the overlay rendered with our cookie popup affects the bot's ability to focus and click on certain elements.
