### PR TITLE
Remove `button--smaller` class and references

### DIFF
--- a/app/components/content/quote_component.html.erb
+++ b/app/components/content/quote_component.html.erb
@@ -16,7 +16,7 @@
         </div>
       </div>
       <% if cta.present? %>
-        <%= link_to(cta[:link], class: "button button--smaller") do %>
+        <%= link_to(cta[:link], class: "button") do %>
           <%= cta_title_sans_last_word %> <span><%= cta_title_last_word %></span>
         <% end %>
       <% end %>

--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -8,7 +8,7 @@
           <div class="options">
             <div>
               <p>Live chat</p>
-              <a href="#" class="button button--smaller" data-action="click->talk-to-us#startChat">
+              <a href="#" class="button" data-action="click->talk-to-us#startChat">
                 Chat online
               </a>
             </div>
@@ -25,7 +25,7 @@
             teaching or if you're returning to teaching and qualified to teach maths,
             physics or languages.
           </p>
-          <a href="/tta-service" class="button button--smaller">
+          <a href="/tta-service" class="button">
             Get an adviser
           </a>
         </section>

--- a/app/components/single_question_survey_component.html.erb
+++ b/app/components/single_question_survey_component.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-hint" data-feedback-target="text"><%= hint %></div>
   <p>
     <% answers.each do |answer| %>
-      <a href="javascript:void(0)" data-feedback-target="link" data-action="feedback#answer" role="button" class="survey-button survey-button--smaller"><%= answer %></a>
+      <a href="javascript:void(0)" data-feedback-target="link" data-action="feedback#answer" role="button" class="survey-button"><%= answer %></a>
     <% end %>
   </p>
 </div>

--- a/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_check_your_qualifications.html.erb
@@ -10,7 +10,7 @@
 
 <p>You may be able to show you meet the standard in another way if you do not have these GCSEs.</p>
 
-<%= chat_link("Chat online for qualifications advice", classes: "button button--smaller") %>
+<%= chat_link("Chat online for qualifications advice", classes: "button") %>
 
 <p>Find out what to do <a href="/train-to-teach-in-england-as-an-international-student">if you’re an international candidate with qualifications from overseas</a>.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_3_learn_about_funding.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_3_learn_about_funding.html.erb
@@ -3,7 +3,7 @@
 <p>You can also apply for a student loan to cover course fees and living costs.</p>
 
 <p>
-  <a href="/funding-your-training" class="button button--smaller">
+  <a href="/funding-your-training" class="button">
     Find out what funding you can get
   </a>
 </p>

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_the_right_training.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_the_right_training.html.erb
@@ -5,7 +5,7 @@ teach primary or secondary</a> (for example a PGCE or directly in a school).</p>
 get support training to teach if you're disabled</a>.</p>
 
 <p>
-  <a href="/tta-service" class="button button--smaller">
+  <a href="/tta-service" class="button">
     Get a teacher training adviser for help finding training
   </a>
 </p>

--- a/app/views/content/steps-to-become-a-teacher/_step_5_apply_for_your_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_5_apply_for_your_course.html.erb
@@ -3,7 +3,7 @@
 <p>Your <a href="/tta-service">teacher training adviser</a> can also help you get your application ready and explore your options.</p>
 
 <p>
-  <a href="/tips-on-applying-for-teacher-training" class="button button--smaller">
+  <a href="/tips-on-applying-for-teacher-training" class="button">
     Get tips on applying
   </a>
 </p>

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -66,11 +66,6 @@ a {
     padding: 0;
   }
 
-  &--smaller {
-    @include font-size("xsmall");
-    padding: 8px $indent-amount;
-  }
-
   &--inline {
     display: inline;
   }
@@ -93,11 +88,6 @@ a {
 .survey-button {
   @include button($bg: $blue-dark);
   margin-bottom: 0.5rem;
-
-  &--smaller {
-    @include font-size("xsmall");
-    padding: 8px $indent-amount;
-  }
 
   @include mq($from: tablet) {
     display: inline-block;


### PR DESCRIPTION
### Trello card

https://trello.com/c/wDJYES9k/1727-text-contrast-on-small-buttons

### Context

Small buttons don't have the required visibility for WCAG AA, text needs to be bigger.

| Before | After |
| ----- | ------ |
| ![Screenshot from 2021-08-03 14-23-22](https://user-images.githubusercontent.com/128088/128023036-3b3a7fec-998e-4872-b22b-af0c8b264941.png) | ![Screenshot from 2021-08-03 14-23-11](https://user-images.githubusercontent.com/128088/128023062-f74141a2-db03-420b-b2e5-13787a5c09cb.png) |

