### PR TITLE
Adding events to the hero image

### DIFF
--- a/app/models/pages/frontmatter.rb
+++ b/app/models/pages/frontmatter.rb
@@ -1,4 +1,6 @@
 module Pages
+  class BadFrontmatterError < RuntimeError; end
+
   class Frontmatter
     attr_reader :content_dirs
 
@@ -145,6 +147,8 @@ module Pages
 
     def extract_frontmatter(file)
       FrontMatterParser::Parser.parse_file(file).front_matter.symbolize_keys
+    rescue Psych::SyntaxError => e
+      fail(BadFrontmatterError, "error in #{file}: #{e}")
     end
 
     def file_from_template(template)

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -11,6 +11,10 @@
   subtitle_link: "/event-categories/train-to-teach-events"
   backlink: "../"
   navigation: 25
+  title: New events added.
+      text: Decide how you will fund your training at our next training event.  
+      link_text: "Events near you"
+      link_target: "/event-categories/train-to-teach"
   lid_pixel_event: "Funding"
   jump_links:
     Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -12,9 +12,6 @@
   backlink: "../"
   navigation: 25
   title: New events added.
-      text: Find out how to fund your training at our next training event.  
-      link_text: "Events near you"
-      link_target: "/event-categories/train-to-teach"
   lid_pixel_event: "Funding"
   jump_links:
     Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -11,7 +11,6 @@
   subtitle_link: "/event-categories/train-to-teach-events"
   backlink: "../"
   navigation: 25
-  title: New events added.
   lid_pixel_event: "Funding"
   jump_links:
     Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -6,9 +6,9 @@
     training.
   date: "2021-03-11"
   image: "media/images/content/hero-images/0013.jpg"
-  subtitle: There’s still time to apply and start your training this September. 
-  subtitle_button: "Find a course"
-  subtitle_link: "/start-teacher-training-this-september"
+  subtitle: New events added - join an event near you and get all the info you need to become a teacher. 
+  subtitle_button: "Book your place"
+  subtitle_link: "/event-categories/train-to-teach-events"
   backlink: "../"
   navigation: 25
   lid_pixel_event: "Funding"

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -11,6 +11,15 @@
   subtitle_link: "/event-categories/train-to-teach-events"
   backlink: "../"
   navigation: 25
+  right_column:
+  ctas:
+    - title: New events added.
+      text: Turn your questions into confidence. Decide how to fund your training at our next event.  
+      link_text: "Events near you"
+      link_target: "/event-categories/train-to-teach"
+      icon: "icon-calendar"
+      hide_on_mobile: Yes
+      hide_on_tablet: Yes
   lid_pixel_event: "Funding"
   jump_links:
     Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -12,7 +12,7 @@
   backlink: "../"
   navigation: 25
   title: New events added.
-      text: Decide how you will fund your training at our next training event.  
+      text: Find out how to fund your training at our next training event.  
       link_text: "Events near you"
       link_target: "/event-categories/train-to-teach"
   lid_pixel_event: "Funding"

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -8,9 +8,9 @@
   date: "2021-06-16"
   fullwidth: true
   lid_pixel_event: "Homepage"
-  subtitle: "Get one step closer to the classroom with personalised guidance to your inbox."
-  subtitle_button: "Sign up"
-  subtitle_link: "/mailinglist/signup/name"
+  subtitle: "New events added - join an event near you and get all the info you need to become a teacher."
+  subtitle_button: "Book your place"
+  subtitle_link: "/event-categories/train-to-teach-events"
   image: "media/images/content/hero-images/0012.jpg"
   navigation: 5
   navigation_title: "Home"

--- a/app/views/content/my-story-into-teaching.md
+++ b/app/views/content/my-story-into-teaching.md
@@ -6,9 +6,9 @@ description: |-
   that comes with making a difference to young people's lives.
 date: "2021-02-02"
 image: "media/images/content/hero-images/0010.jpg"
-  subtitle: New events added - join an event near you and get all the info you need to become a teacher. 
-  subtitle_button: "Book your place"
-  subtitle_link: "/event-categories/train-to-teach-events"
+subtitle: New events added - join an event near you and get all the info you need to become a teacher. 
+subtitle_button: "Book your place"
+subtitle_link: "/event-categories/train-to-teach-events"
 hide_page_helpful_question: true
 navigation: 35
 fullwidth: true

--- a/app/views/content/my-story-into-teaching.md
+++ b/app/views/content/my-story-into-teaching.md
@@ -6,6 +6,9 @@ description: |-
   that comes with making a difference to young people's lives.
 date: "2021-02-02"
 image: "media/images/content/hero-images/0010.jpg"
+  subtitle: New events added - join an event near you and get all the info you need to become a teacher. 
+  subtitle_button: "Book your place"
+  subtitle_link: "/event-categories/train-to-teach-events"
 hide_page_helpful_question: true
 navigation: 35
 fullwidth: true

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -14,7 +14,7 @@ article_classes: ['ways-to-train']
 right_column:
   ctas:
     - title: New events added.
-      text: Join our next event to decide which training suits you best.  
+      text: Turn your questions into confidence. Join our next event to decide which training suits you best.  
       link_text: "Events near you"
       link_target: "/event-categories/train-to-teach"
       icon: "icon-calendar"

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -13,11 +13,10 @@ navigation: 20
 article_classes: ['ways-to-train']
 right_column:
   ctas:
-    - title: Start your teacher training this September
-      text: |
-       Places fill up quickly, but many courses are still available.  
-      link_text: "Find a course"
-      link_target: "/start-teacher-training-this-september"
+    - title: New events added.
+      text: Join our next event to decide which training suits you best.  
+      link_text: "Events near you"
+      link_target: "/event-categories/train-to-teach"
       icon: "icon-calendar"
       hide_on_mobile: Yes
       hide_on_tablet: Yes

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -4,9 +4,9 @@ image: "media/images/content/hero-images/0003.jpg"
 description: |-
   To teach in England you must have a degree and Qualified Teacher Status. You can
   get QTS by doing a PGCE, Postgraduate Teaching Apprenticeship, School Direct (which can be fee-funded or salaried) or one of the other routes listed here. 
-subtitle: There’s still time to apply and start your training this September. 
-subtitle_button: "Find a course"
-subtitle_link: "/start-teacher-training-this-september"
+subtitle: New events added - join an event near you and get all the info you need to become a teacher. 
+subtitle_button: "Book your place"
+subtitle_link: "event-categories/train-to-teach-events"
 date: "2021-06-07"
 backlink: "../"
 navigation: 20


### PR DESCRIPTION
Promoting teacher training events alongside the hero image, and pointing to Train to teach page.

### https://trello.com/c/ajUIVPWs/1722-content-update-homepage-hero-copy-to-reflect-events
