### PR TITLE
Support walk in event sign up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 87844c0e514093f23e951795efcb1719ddffbae4
+  revision: 394921fa4d11b7a6e48f8490182d74d22eea6313
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.39)
+    get_into_teaching_api_client_faraday (0.1.41)
       activesupport
       faraday
       faraday-encoding
@@ -503,4 +503,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.17
+   2.2.25

--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -6,10 +6,15 @@ module Events
       attribute :email
       attribute :first_name
       attribute :last_name
+      attribute :is_walk_in, :boolean
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true, length: { maximum: 256 }
       validates :last_name, presence: true, length: { maximum: 256 }
+
+      def is_walk_in?
+        is_walk_in.present?
+      end
 
       before_validation if: :email do
         self.email = email.to_s.strip

--- a/app/models/wizard/issue_verification_code.rb
+++ b/app/models/wizard/issue_verification_code.rb
@@ -3,9 +3,9 @@ module Wizard
     extend ActiveSupport::Concern
 
     def save
-      purge_store_retaining_matchback_failures
-
       if valid?
+        purge_store_retaining_matchback_failures
+
         Rails.logger.info("#{self.class} requesting access code")
 
         begin

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -1,3 +1,4 @@
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
 <%= f.govuk_email_field :email %>
+<%= f.hidden_field :is_walk_in, value: f.object.is_walk_in? %>

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -8,6 +8,7 @@ describe Events::Steps::PersonalDetails do
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }
   it { is_expected.to respond_to :email }
+  it { is_expected.to respond_to :is_walk_in }
 
   describe "validations" do
     before { instance.valid? }
@@ -29,5 +30,28 @@ describe Events::Steps::PersonalDetails do
     it { is_expected.to allow_value("me@you.com").for :email }
     it { is_expected.to allow_value(" me@you.com ").for :email }
     it { is_expected.not_to allow_value("me@you").for :email }
+  end
+
+  describe "#is_walk_in" do
+    it { expect(instance).not_to be_is_walk_in }
+  end
+
+  describe "#is_walk_in?" do
+    subject { instance.is_walk_in? }
+
+    context "when is_walk_in is nil" do
+      before { instance.is_walk_in = nil }
+      it { is_expected.to be(false) }
+    end
+
+    context "when is_walk_in is false" do
+      before { instance.is_walk_in = false }
+      it { is_expected.to be(false) }
+    end
+
+    context "when is_walk_in is true" do
+      before { instance.is_walk_in = true }
+      it { is_expected.to be(true) }
+    end
   end
 end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -38,6 +38,12 @@ describe EventStepsController do
       let(:event) { build :event_api, :closed, readable_id: readable_event_id }
 
       it { is_expected.to redirect_to(event_path(id: event.readable_id)) }
+
+      context "when the candidate is a 'walk-in'" do
+        let(:step_path) { event_step_path readable_event_id, model.key, walk_in: true }
+
+        it { is_expected.to have_http_status :success }
+      end
     end
 
     context "with an invalid step" do

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -96,7 +96,7 @@ shared_examples "an issue verification code wizard step" do
         subject.save
         expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).not_to receive(:create_candidate_access_token)
         expect(wizardstore["authenticate"]).to be_falsy
-        expect(wizardstore["matchback_failures"]).to eq(0)
+        expect(wizardstore["matchback_failures"]).to be_nil
         expect(wizardstore["last_matchback_failure_code"]).to be_nil
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-1767](https://trello.com/c/0pE9y92j/1767-create-a-ml-sign-up-form-for-events-walk-ins)

### Context

When an event is in a 'closed' state we no longer accept new sign ups via the website. On the day of an event there may be several 'walk-in' candidates that turn up to the event but have not registered online. We need to be able to provide a link that enables these candidates to sign up once at the venue.

For now we are following the process of the old website; the CRM team will generate the 'walk in URLs' (which are the event sign up URLs but with a `?walk_in` query param on the end) and pass them to the events team ahead of an event. The events team will generate QR codes of the URL to display at the event; a walk-in candidate can scan the QR code and access the registration form.

### Changes proposed in this pull request

- Update API client

Include new `is_walk_in` flag to indicate if a sign up is by a walk-in candidate.

- Add is_walk_in attribute to PersonalDetails step

Add a hidden field that tracks the `is_walk_in` value of the candidate.

- Allow walk-in candidates to sign up to closed events

If an event is closed we usually prevent the candidate for signing up. If the candidate visits the 'walk-in' URL of the event, we want to let them sign up.

Check for a `?walk_in` query parameter and pre-populate the store if present. 

Allow candidate to go through the sign up journey if the event is closed and they are a walk-in (otherwise keep the current behaviour of redirecting back to the event page).

- Add test coverage for walk-in candidate journey

Covers the new walk-in sign up flow.

Adds a better expectation around the data posted to the API for each journey.

### Guidance to review

https://review-get-into-teaching-app-1592.london.cloudapps.digital/events/train-to-teach-birmingham-event-110921/apply/personal_details?walk_in