### PR TITLE
Edit published events

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -62,6 +62,20 @@ module Internal
       )
     end
 
+    def live_events
+      events = GetIntoTeachingApiClient::TeachingEventsApi
+                 .new
+                 .search_teaching_events_grouped_by_type(quantity_per_type: 1_000,
+                                                         start_after: DateTime.now.utc.beginning_of_day,
+                                                         status_ids: [open_event_status_id])
+      events = events.select do |key|
+        key.type_id == event_types[:provider] || key.type_id == event_types[:online]
+      end
+      if events[0] && events[1]
+        @live_events = events[0].teaching_events.concat(events[1].teaching_events)
+      end
+    end
+
     def create
       @event = Event.new(event_params)
       @event.assign_building(building_params) unless @event.online_event?
@@ -131,6 +145,10 @@ module Internal
 
     def pending_event_status_id
       GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+    end
+
+    def open_event_status_id
+      GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
     end
 
     def event_types

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -13,10 +13,7 @@ module Internal
       load_pending_events(@event_type)
       @no_results = @events.blank?
 
-      @successful = params[:status]
-      @withdrawn = params[:status] == "withdrawn"
-      @published = params[:status] == "published"
-      @pending = params[:status] == "pending"
+      @status = params[:status]
       @readable_id = params[:readable_id]
     end
 

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -62,18 +62,17 @@ module Internal
       )
     end
 
-    def live_events
+    def open_events
       events = GetIntoTeachingApiClient::TeachingEventsApi
                  .new
                  .search_teaching_events_grouped_by_type(quantity_per_type: 1_000,
                                                          start_after: DateTime.now.utc.beginning_of_day,
                                                          status_ids: [open_event_status_id])
+
       events = events.select do |key|
         key.type_id == event_types[:provider] || key.type_id == event_types[:online]
       end
-      if events[0] && events[1]
-        @live_events = events[0].teaching_events.concat(events[1].teaching_events)
-      end
+      @open_events = events.map(&:teaching_events).flatten
     end
 
     def create

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -13,10 +13,10 @@ module Internal
       load_pending_events(@event_type)
       @no_results = @events.blank?
 
-      @success = params[:success]
-      @withdrawn = params[:success] == "withdrawn"
-      @published = params[:success] == "published"
-      @pending = params[:success] == "pending"
+      @successful = params[:status]
+      @withdrawn = params[:status] == "withdrawn"
+      @published = params[:status] == "published"
+      @pending = params[:status] == "pending"
       @readable_id = params[:readable_id]
     end
 
@@ -44,7 +44,7 @@ module Internal
       GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event(api_event)
       Rails.logger.info("#{@user.username} - publish - #{api_event.to_json}")
       redirect_to internal_events_path(
-        success: :published,
+        status: :published,
         event_type: determine_event_type_from_id(api_event.type_id),
         readable_id: api_event.readable_id,
       )
@@ -56,7 +56,7 @@ module Internal
       GetIntoTeachingApiClient::TeachingEventsApi.new.upsert_teaching_event(api_event)
       Rails.logger.info("#{@user.username} - withdrawn - #{api_event.to_json}")
       redirect_to internal_events_path(
-        success: :withdrawn,
+        status: :withdrawn,
         event_type: determine_event_type_from_id(api_event.type_id),
         readable_id: api_event.readable_id,
       )
@@ -82,7 +82,7 @@ module Internal
       if @event.save
         Rails.logger.info("#{@user.username} - create/update - #{@event.to_api_event.to_json}")
         redirect_to internal_events_path(
-          success: :pending,
+          status: :pending,
           readable_id: @event.readable_id,
           event_type: determine_event_type_from_id(@event.type_id),
         )

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -1,23 +1,23 @@
-<div class="markdown events-index">
-  <% if @success %>
-    <div class="confirmation-panel-container">
-      <div class="govuk-panel govuk-panel--confirmation">
-        <h1 class="govuk-panel__title">
-          <%= @pending ? "Event submitted for review" : "Event published" %>
-        </h1>
-        <% if @readable_id %>
-          <div class="govuk-panel__body">
-            <%= @pending ? "Pending event" : "Published event" %><br>
-            <strong>
-              <%= link_to @readable_id,
-                          @pending ? internal_event_path(@readable_id) : event_path(@readable_id) %>
-            </strong>
-          </div>
-        <% end %>
-      </div>
+<% if @success %>
+  <div class="confirmation-panel-container">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        <%= @pending ? "Event submitted for review" : "Event published" %>
+      </h1>
+      <% if @readable_id %>
+        <div class="govuk-panel__body">
+          <%= @pending ? "Pending event" : "Published event" %><br>
+          <strong>
+            <%= link_to @readable_id,
+                        @pending ? internal_event_path(@readable_id) : event_path(@readable_id) %>
+          </strong>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
+<% end %>
 
+<div class="markdown events-listing">
   <div class="tab-bar">
     <%= link_to "Provider events",
                 internal_events_path(event_type: "provider"),
@@ -57,3 +57,13 @@
     </div>
   <% end %>
 </div>
+
+<% if @user.publisher? %>
+  <div class="withdraw-box-container">
+    <div class="withdraw-box markdown">
+      <h3>Edit a published event?</h3>
+      <p>Withdraw the event <%= link_to "here", internal_live_events_path %>. The event will be removed from from the
+        live site while it is edited and will need to be re-approved.</p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -65,7 +65,7 @@
   <div class="withdraw-box-container">
     <div class="withdraw-box markdown">
       <h3>Edit a published event?</h3>
-      <p>Withdraw the event <%= link_to "here", internal_live_events_path %>. The event will be removed from from the
+      <p>Withdraw the event <%= link_to "here", internal_open_events_path %>. The event will be removed from from the
         live site while it is edited and will need to be re-approved.</p>
     </div>
   </div>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -1,4 +1,4 @@
-<% if @success %>
+<% if @successful %>
   <div class="confirmation-panel-container">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -1,18 +1,15 @@
-<% if @successful %>
+<% if @status %>
   <div class="confirmation-panel-container">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        <%= "Event submitted for review" if @pending %>
-        <%= "Event published" if @published %>
-        <%= "Event withdrawn" if @withdrawn %>
+        <%= t("internal.status.#{@status}.title") %>
       </h1>
       <% if @readable_id %>
         <div class="govuk-panel__body">
-          <%= "Pending event" if @pending || @withdrawn %>
-          <%= "Published event" if @published %>
+          <%= t("internal.status.#{@status}.body") %>
           <strong>
             <%= link_to @readable_id,
-                        @pending || @withdrawn ? internal_event_path(@readable_id) : event_path(@readable_id) %>
+                        @status == "published" ? event_path(@readable_id) : internal_event_path(@readable_id) %>
           </strong>
         </div>
       <% end %>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -2,14 +2,17 @@
   <div class="confirmation-panel-container">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        <%= @pending ? "Event submitted for review" : "Event published" %>
+        <%= "Event submitted for review" if @pending %>
+        <%= "Event published" if @published %>
+        <%= "Event withdrawn" if @withdrawn %>
       </h1>
       <% if @readable_id %>
         <div class="govuk-panel__body">
-          <%= @pending ? "Pending event" : "Published event" %><br>
+          <%= "Pending event" if @pending || @withdrawn %>
+          <%= "Published event" if @published %>
           <strong>
             <%= link_to @readable_id,
-                        @pending ? internal_event_path(@readable_id) : event_path(@readable_id) %>
+                        @pending || @withdrawn ? internal_event_path(@readable_id) : event_path(@readable_id) %>
           </strong>
         </div>
       <% end %>

--- a/app/views/internal/events/live_events.html.erb
+++ b/app/views/internal/events/live_events.html.erb
@@ -1,0 +1,43 @@
+<%= link_to "Return to pending events",
+            internal_events_path, method: :get,
+            class: "govuk-back-link" %>
+
+<% if @live_events.nil? %>
+  <div class="pending-no-results">
+    <%= render(Events::NoResultsComponent.new) do %>
+      No live events
+    <% end %>
+  </div>
+<% else %>
+  <div class="live-events-container">
+    <table class="govuk-table">
+      <caption class="table-header">Live events</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Event</th>
+        <th scope="col" class="govuk-table__header">Partial URL</th>
+        <% if @user.publisher? %>
+          <th scope="col" class="govuk-table__header">Withdraw</th>
+        <% end %>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @live_events.each do |event| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= link_to event.name, event_path(event.readable_id) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= event.readable_id %>
+          </td>
+          <% if @user.publisher? %>
+            <td class="govuk-table__cell">
+              <%= link_to "select", internal_withdraw_path(id: event.readable_id), method: :put %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/internal/events/open_events.html.erb
+++ b/app/views/internal/events/open_events.html.erb
@@ -2,16 +2,16 @@
             internal_events_path, method: :get,
             class: "govuk-back-link" %>
 
-<% if @live_events.nil? %>
+<% if @open_events.empty? %>
   <div class="pending-no-results">
     <%= render(Events::NoResultsComponent.new) do %>
-      No live events
+      No open events
     <% end %>
   </div>
 <% else %>
-  <div class="live-events-container">
+  <div class="open-events-container">
     <table class="govuk-table">
-      <caption class="table-header">Live events</caption>
+      <caption class="table-header">Open events</caption>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Event</th>
@@ -22,7 +22,7 @@
       </tr>
       </thead>
       <tbody class="govuk-table__body">
-      <% @live_events.each do |event| %>
+      <% @open_events.each do |event| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <%= link_to event.name, event_path(event.readable_id) %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -14,7 +14,7 @@
   </div>
 
 
-  <main role="main" id="main-content" class="<%= class_names("internal", { "index": current_page?(action: 'index') }) %>">
+  <main role="main" id="main-content" class="<%= class_names("internal", action_name ) %>">
     <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -37,18 +37,6 @@ $grey-very-light: #f3f2f1;
     display: none;
   }
 
-  .confirmation-panel-container {
-    background-color: $grey-very-light;
-    padding-bottom: 30px;
-    margin: 0;
-
-    a {
-      color: $white;
-    }
-  }
-
-  // Tab navigation
-
   $grey-very-dark: #202124;
   $light-greyish-blue: #e8eaed;
   $very-dark-greyish-blue: #5f6368;
@@ -57,7 +45,16 @@ $grey-very-light: #f3f2f1;
     background-color: $grey-very-light;
     max-width: none;
 
-    .container {
+    .confirmation-panel-container {
+      padding-bottom: 30px;
+      margin: 0;
+
+      a {
+        color: $white;
+      }
+    }
+
+    .events-listing {
       background-color: $white;
 
       .tab-bar {
@@ -99,6 +96,15 @@ $grey-very-light: #f3f2f1;
 
       .event-pagination {
         min-height: 50px;
+      }
+    }
+
+    .withdraw-box-container {
+      padding-top: 45px;
+
+      .withdraw-box {
+        background-color: $white;
+        display: inline-block;
       }
     }
   }

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -4,6 +4,7 @@ $govuk-include-default-font-face: false;
 @import "~trix";
 @import "~flatpickr";
 @import "colours";
+@import "font-sizes";
 $grey-very-light: #f3f2f1;
 
 .internal {
@@ -35,6 +36,23 @@ $grey-very-light: #f3f2f1;
 
   .hidden {
     display: none;
+  }
+
+  &.live_events {
+    background-color: $grey-very-light;
+    max-width: none;
+
+    .live-events-container {
+      background-color: $white;
+      padding: 1.5rem;
+
+      .table-header {
+        margin-bottom: 30px;
+        text-align: left;
+        font-weight: bold;
+        @include font-size('xlarge');
+      }
+    }
   }
 
   $grey-very-dark: #202124;

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -38,11 +38,11 @@ $grey-very-light: #f3f2f1;
     display: none;
   }
 
-  &.live_events {
+  &.open_events {
     background-color: $grey-very-light;
     max-width: none;
 
-    .live-events-container {
+    .open-events-container {
       background-color: $white;
       padding: 1.5rem;
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -587,3 +587,15 @@ en:
         accept_privacy_policy:
           text: Are you over 16 and do you agree to our %{link}?
           link: privacy policy
+
+  internal:
+    status:
+      pending:
+        title: Event submitted for review
+        body: Pending event
+      published:
+        title: Event published
+        body: Published event
+      withdrawn:
+        title: Event withdrawn
+        body: Pending event

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     resources :events, only: %i[index show new create edit]
     put "/approve", to: "events#approve"
     put "/withdraw", to: "events#withdraw"
-    get "/live_events", to: "events#live_events"
+    get "/open_events", to: "events#open_events"
   end
 
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   namespace :internal do
     resources :events, only: %i[index show new create edit]
     put "/approve", to: "events#approve"
+    put "/withdraw", to: "events#withdraw"
   end
 
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     resources :events, only: %i[index show new create edit]
     put "/approve", to: "events#approve"
     put "/withdraw", to: "events#withdraw"
+    get "/live_events", to: "events#live_events"
   end
 
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -58,5 +58,16 @@ FactoryBot.define do
     trait :no_location do
       building { nil }
     end
+
+    trait :pending do
+      status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"] }
+    end
+
+    trait :without_train_to_teach_fields do
+      is_virtual { nil }
+      video_url { nil }
+      message { nil }
+      web_feed_id { nil }
+    end
   end
 end

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -163,8 +163,8 @@ RSpec.feature "Internal section", type: :feature do
     end
   end
 
-  context "when there are live events" do
-    start_at = Time.zone.today.at_beginning_of_month + 1.day
+  context "when there are open events" do
+    let(:start_at) { Time.zone.today.at_beginning_of_month + 1.day }
     let(:live_online_event) { build(:event_api, :online_event, name: "Open online event") }
     let(:live_provider_event) { build(:event_api, :school_or_university_event, name: "Open provider event", start_at: start_at) }
     let(:events) { [live_online_event, live_provider_event] }

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -165,8 +165,8 @@ RSpec.feature "Internal section", type: :feature do
 
   context "when there are live events" do
     start_at = Time.zone.today.at_beginning_of_month + 1.day
-    let(:live_online_event) { build(:event_api, name: "Live online event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]) }
-    let(:live_provider_event) { build(:event_api, name: "Live provider event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]) }
+    let(:live_online_event) { build(:event_api, :online_event, name: "Open online event") }
+    let(:live_provider_event) { build(:event_api, :school_or_university_event, name: "Open provider event", start_at: start_at) }
     let(:events) { [live_online_event, live_provider_event] }
     let(:events_by_type) { group_events_by_type(events) }
 
@@ -184,11 +184,11 @@ RSpec.feature "Internal section", type: :feature do
 
       click_link "here"
 
-      expect(page).to have_text("Live events")
-      expect(page).to have_link("Live online event")
-      expect(page).to have_link("Live provider event")
+      expect(page).to have_text("Open events")
+      expect(page).to have_link("Open online event")
+      expect(page).to have_link("Open provider event")
 
-      within find("td", text: "Live provider event").find(:xpath, "..") do
+      within find("td", text: "Open provider event").find(:xpath, "..") do
         click_link "select"
       end
 

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -3,7 +3,7 @@ require "action_text/system_test_helper"
 
 RSpec.feature "Internal section", type: :feature do
   let(:types) { Events::Search.available_event_type_ids }
-  let(:provider_event) do
+  let(:pending_provider_event) do
     build(:event_api,
           :with_provider_info,
           name: "Pending provider event",
@@ -11,7 +11,7 @@ RSpec.feature "Internal section", type: :feature do
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
           type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
   end
-  let(:online_event) do
+  let(:pending_online_event) do
     build(:event_api,
           :with_provider_info,
           name: "Pending online event",
@@ -19,8 +19,8 @@ RSpec.feature "Internal section", type: :feature do
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
           type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
   end
-  let(:provider_events_by_type) { group_events_by_type([provider_event]) }
-  let(:online_events_by_type) { group_events_by_type([online_event]) }
+  let(:provider_events_by_type) { group_events_by_type([pending_provider_event]) }
+  let(:online_events_by_type) { group_events_by_type([pending_online_event]) }
   let(:publisher_username) { "publisher_username" }
   let(:publisher_password) { "publisher_password" }
 
@@ -42,7 +42,7 @@ RSpec.feature "Internal section", type: :feature do
       receive(:upsert_teaching_event) { [] }
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:get_teaching_event) { provider_event }
+      receive(:get_teaching_event) { pending_provider_event }
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
@@ -84,7 +84,7 @@ RSpec.feature "Internal section", type: :feature do
     end
 
     scenario "edit a pending event with no building" do
-      provider_event.building = nil
+      pending_provider_event.building = nil
 
       navigate_to_edit_form
 
@@ -160,6 +160,40 @@ RSpec.feature "Internal section", type: :feature do
 
         expect_online_validation_errors
       end
+    end
+  end
+
+  context "when there are live events" do
+    start_at = Time.zone.today.at_beginning_of_month + 1.day
+    let(:live_online_event) { build(:event_api, name: "Live online event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]) }
+    let(:live_provider_event) { build(:event_api, name: "Live provider event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]) }
+    let(:events) { [live_online_event, live_provider_event] }
+    let(:events_by_type) { group_events_by_type(events) }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+        .to receive(:search_teaching_events_grouped_by_type) { events_by_type }
+
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+        .to receive(:get_teaching_event) { live_provider_event }
+    end
+
+    scenario "withdraw" do
+      visit internal_events_path
+      expect(page).to have_text "Pending provider events"
+
+      click_link "here"
+
+      expect(page).to have_text("Live events")
+      expect(page).to have_link("Live online event")
+      expect(page).to have_link("Live provider event")
+
+      within find("td", text: "Live provider event").find(:xpath, "..") do
+        click_link "select"
+      end
+
+      expect(page).to have_text "Event withdrawn"
+      expect(page).to have_text "Pending event"
     end
   end
 

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -217,7 +217,7 @@ describe EventsController do
         end
 
         context "when the event is a 'Pending event'" do
-          let(:event) { build(:event_api, web_feed_id: nil, status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]) }
+          let(:event) { build(:event_api, :pending, web_feed_id: nil) }
 
           it { expect(response).to have_http_status :success }
           it { expect(response.body).to include("Unfortunately, that event has already happened.") }

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -668,7 +668,7 @@ describe Internal::EventsController do
     end
   end
 
-  describe "#live_events" do
+  describe "#open_events" do
     let(:events_by_type) { group_events_by_type(pen) }
 
     context "when there a no events" do
@@ -677,11 +677,11 @@ describe Internal::EventsController do
           .to receive(:search_teaching_events_grouped_by_type) { [] }
       end
 
-      it "shows 'no live events'" do
-        get internal_live_events_path, headers: generate_auth_headers(:author)
+      it "shows 'no open events'" do
+        get internal_open_events_path, headers: generate_auth_headers(:author)
 
         assert_response :success
-        expect(response.body).to include("No live events")
+        expect(response.body).to include("No open events")
       end
     end
 
@@ -689,9 +689,9 @@ describe Internal::EventsController do
       let(:events) do
         start_at = Time.zone.today.at_beginning_of_month + 1.day
         [
-          build(:event_api, name: "Live online event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]),
-          build(:event_api, name: "Live provider event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]),
-          build(:event_api, name: "Live train to teach event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]),
+          build(:event_api, name: "Open online event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]),
+          build(:event_api, name: "Open provider event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]),
+          build(:event_api, name: "Open train to teach event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]),
         ]
       end
       let(:events_by_type) { group_events_by_type(events) }
@@ -702,14 +702,14 @@ describe Internal::EventsController do
       end
 
       it "shows a table of events" do
-        get internal_live_events_path, headers: generate_auth_headers(:author)
+        get internal_open_events_path, headers: generate_auth_headers(:author)
 
         assert_response :success
 
-        expect(response.body).to include("Live events")
-        expect(response.body).to include("Live online event")
-        expect(response.body).to include("Live provider event")
-        expect(response.body).to_not include("Live train to teach event")
+        expect(response.body).to include("Open events")
+        expect(response.body).to include("Open online event")
+        expect(response.body).to include("Open provider event")
+        expect(response.body).to_not include("Open train to teach event")
       end
     end
   end

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -4,25 +4,18 @@ describe Internal::EventsController do
   let(:pending_provider_event) do
     build(:event_api,
           :with_provider_info,
-          name: "Pending provider event",
-          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-          is_virtual: nil,
-          video_url: nil,
-          message: nil,
-          web_feed_id: nil)
+          :pending,
+          :school_or_university_event,
+          :without_train_to_teach_fields,
+          name: "Pending provider event")
   end
   let(:pending_online_event) do
     build(:event_api,
+          :pending,
+          :online_event,
+          :without_train_to_teach_fields,
           name: "Pending online event",
-          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
           scribble_id: "/scribble/id/12345",
-          is_virtual: nil,
-          is_online: nil,
-          video_url: nil,
-          message: nil,
-          web_feed_id: nil,
           building: nil)
   end
   let(:events) { [pending_provider_event, build(:event_api, name: "Open event"), pending_online_event] }
@@ -286,11 +279,11 @@ describe Internal::EventsController do
         let(:building_id) { pending_provider_event.building.id }
         let(:expected_request_body) do
           build(:event_api,
+                :pending,
+                :school_or_university_event,
                 id: params[:id],
                 name: params[:name],
                 readable_id: params[:readable_id],
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
                 summary: params[:summary],
                 description: params[:description],
                 is_online: params[:is_online],
@@ -395,18 +388,17 @@ describe Internal::EventsController do
         end
         let(:expected_request_body) do
           build(:event_api,
+                :pending,
+                :online_event,
                 id: params[:id],
                 name: params[:name],
                 readable_id: params[:readable_id],
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
                 summary: params[:summary],
                 description: params[:description],
                 start_at: params[:start_at].getutc.floor,
                 end_at: params[:end_at].getutc.floor,
                 scribble_id: params[:scribble_id],
                 building: nil,
-                is_online: true,
                 is_virtual: nil,
                 video_url: nil,
                 message: nil,
@@ -443,25 +435,9 @@ describe Internal::EventsController do
         end
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
-          build(:event_api,
-                id: event.id,
-                name: event.name,
-                readable_id: event.readable_id,
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
-                summary: event.summary,
-                description: event.description,
-                is_online: event.is_online,
-                start_at: event.start_at,
-                end_at: event.end_at,
-                provider_contact_email: event.provider_contact_email,
-                provider_organiser: event.provider_organiser,
-                provider_target_audience: event.provider_target_audience,
-                provider_website_url: event.provider_website_url,
-                is_virtual: nil,
-                video_url: nil,
-                message: nil,
-                web_feed_id: nil)
+          event.tap do |event|
+            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
+          end
         end
 
         context "when event has no building" do
@@ -514,28 +490,16 @@ describe Internal::EventsController do
         let(:event) { pending_online_event }
         let(:params) { { "id": event.id } }
         let(:expected_request_body) do
-          build(:event_api,
-                id: event.id,
-                name: event.name,
-                readable_id: event.readable_id,
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
-                summary: event.summary,
-                description: event.description,
-                start_at: event.start_at,
-                end_at: event.end_at,
-                scribble_id: event.scribble_id,
-                building: nil,
-                is_online: nil,
-                is_virtual: nil,
-                video_url: nil,
-                message: nil,
-                web_feed_id: nil)
+          event.tap do |event|
+            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
+          end
         end
 
         it "posts event with event status open" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event).with(expected_request_body)
+
+
 
           put internal_approve_path,
               headers: generate_auth_headers(:publisher),
@@ -575,32 +539,16 @@ describe Internal::EventsController do
         end
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
-          build(:event_api,
-                id: event.id,
-                name: event.name,
-                readable_id: event.readable_id,
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-                summary: event.summary,
-                description: event.description,
-                is_online: event.is_online,
-                start_at: event.start_at,
-                end_at: event.end_at,
-                provider_contact_email: event.provider_contact_email,
-                provider_organiser: event.provider_organiser,
-                provider_target_audience: event.provider_target_audience,
-                provider_website_url: event.provider_website_url,
-                is_virtual: nil,
-                video_url: nil,
-                message: nil,
-                web_feed_id: nil)
+          event.tap do |event|
+            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+            event.building = nil
+          end
         end
 
         let(:params) { { "id": event.id } }
 
         it "posts the event with event status pending" do
           event.building = nil
-          expected_request_body.building = nil
 
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event).with(expected_request_body)
@@ -622,23 +570,9 @@ describe Internal::EventsController do
         let(:event) { pending_online_event }
         let(:params) { { "id": event.id } }
         let(:expected_request_body) do
-          build(:event_api,
-                id: event.id,
-                name: event.name,
-                readable_id: event.readable_id,
-                type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
-                status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-                summary: event.summary,
-                description: event.description,
-                start_at: event.start_at,
-                end_at: event.end_at,
-                scribble_id: event.scribble_id,
-                building: nil,
-                is_online: nil,
-                is_virtual: nil,
-                video_url: nil,
-                message: nil,
-                web_feed_id: nil)
+          event.tap do |event|
+            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+          end
         end
 
         it "posts event with event status pending" do
@@ -686,12 +620,12 @@ describe Internal::EventsController do
     end
 
     context "when there are events" do
+      let(:start_at) { Time.zone.today.at_beginning_of_month + 1.day }
       let(:events) do
-        start_at = Time.zone.today.at_beginning_of_month + 1.day
         [
-          build(:event_api, name: "Open online event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]),
-          build(:event_api, name: "Open provider event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]),
-          build(:event_api, name: "Open train to teach event", start_at: start_at, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]),
+          build(:event_api, :online_event, name: "Open online event", start_at: start_at),
+          build(:event_api, :school_or_university_event, name: "Open provider event", start_at: start_at),
+          build(:event_api, :train_to_teach_event, name: "Open train to teach event", start_at: start_at),
         ]
       end
       let(:events_by_type) { group_events_by_type(events) }

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -106,6 +106,34 @@ describe Internal::EventsController do
         include_examples "no pending events", default_event_type
       end
     end
+
+    context "when publisher user type" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+          .to receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
+      end
+
+      it "shows a 'withdraw event' box" do
+        get internal_events_path, headers: generate_auth_headers(:publisher)
+
+        assert_response :success
+        expect(response.body).to include("Edit a published event?")
+      end
+    end
+
+    context "when author user type" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
+          .to receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
+      end
+
+      it "shows a 'withdraw event' box" do
+        get internal_events_path, headers: generate_auth_headers(:author)
+
+        assert_response :success
+        expect(response.body).to_not include("Edit a published event?")
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -316,7 +316,7 @@ describe Internal::EventsController do
                  headers: generate_auth_headers(:author),
                  params: { internal_event: params }
 
-            expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test", event_type: "provider"))
+            expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "provider"))
             expect(Rails.logger).to have_received(:info).with("#{author_username} - create/update - #{expected_request_body.to_json}")
           end
 
@@ -336,7 +336,7 @@ describe Internal::EventsController do
                    headers: generate_auth_headers(:author),
                    params: { internal_event: params }
 
-              expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test", event_type: "provider"))
+              expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "provider"))
               expect(Rails.logger).to have_received(:info).with("#{author_username} - create/update - #{expected_request_body.to_json}")
             end
           end
@@ -373,7 +373,7 @@ describe Internal::EventsController do
                    headers: generate_auth_headers(:author),
                    params: { internal_event: params }
 
-              expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test", event_type: "provider"))
+              expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "provider"))
               expect(Rails.logger).to have_received(:info).with("#{author_username} - create/update - #{expected_request_body.to_json}")
             end
           end
@@ -413,7 +413,7 @@ describe Internal::EventsController do
                headers: generate_auth_headers(:author),
                params: { internal_event: params }
 
-          expect(response).to redirect_to(internal_events_path(success: :pending, readable_id: "Test", event_type: "online"))
+          expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "online"))
           expect(Rails.logger).to have_received(:info).with("#{author_username} - create/update - #{expected_request_body.to_json}")
         end
       end
@@ -455,7 +455,7 @@ describe Internal::EventsController do
                 params: params
 
             expect(response).to redirect_to(internal_events_path(
-                                              success: :published,
+                                              status: :published,
                                               event_type: :provider,
                                               readable_id: event.readable_id,
                                             ))
@@ -477,7 +477,7 @@ describe Internal::EventsController do
                 params: params
 
             expect(response).to redirect_to(internal_events_path(
-                                              success: :published,
+                                              status: :published,
                                               event_type: :provider,
                                               readable_id: event.readable_id,
                                             ))
@@ -499,14 +499,12 @@ describe Internal::EventsController do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event).with(expected_request_body)
 
-
-
           put internal_approve_path,
               headers: generate_auth_headers(:publisher),
               params: params
 
           expect(response).to redirect_to(internal_events_path(
-                                            success: :published,
+                                            status: :published,
                                             event_type: :online,
                                             readable_id: event.readable_id,
                                           ))
@@ -558,7 +556,7 @@ describe Internal::EventsController do
               params: params
 
           expect(response).to redirect_to(internal_events_path(
-                                            success: :withdrawn,
+                                            status: :withdrawn,
                                             event_type: :provider,
                                             readable_id: event.readable_id,
                                           ))
@@ -584,7 +582,7 @@ describe Internal::EventsController do
               params: params
 
           expect(response).to redirect_to(internal_events_path(
-                                            success: :withdrawn,
+                                            status: :withdrawn,
                                             event_type: :online,
                                             readable_id: event.readable_id,
                                           ))


### PR DESCRIPTION
### Trello card
https://trello.com/c/on2SgkXj/1774-further-events-form-updates

### Context
Sometimes the details of `open` events can change. Editing them via the website is currently not possible and must be done in the CRM.

### Changes proposed in this pull request
- Add guidance box to tell elevated users (publisher role) how to edit a published event
- Add a `withdraw` action - We have agreed that it will be fine for events to go offline while they are being edited (this also adds a level of safety because events can be checked again before being made live). Add a withdraw action so that the event can be returned to pending status, and will appear back in the internal events section where it can be edited.
- Add a page of `open` events - Each event has a link the event on the main website, plus a link to withdraw. When an event is withdrawn, we show a banner linking the user to the now `pending` event.

Some refactoring: 
  - Tidy up most of the factories
    - Move some common attributes into traits
    - Stop using FactoryBot to create expected request bodies. Remove these and use modify other existing values instead
  - The `success` param is now being used to inform the `index` banner of what event has been created (so that the user can be directed there). Rename to `status` which makes more sense now.
  - Move event status banner text to locales - Previously, we have been passing instance variables to inform the user of the status of the event. Now that the number of statuses has grown, shift it into locales instead.

### Guidance to review
I am filtering the events by type in the `open_events` action. Its probably best to open a new ticket to update the `search_teaching_events_grouped_by_type` API method to accept an array of types like it does for the `status_id`s