### PR TITLE
Make the event pagination links accessible

### DIFF
--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -112,8 +112,7 @@
       align-items: center;
 
       @mixin pagination-item {
-        font-weight: bold;
-        @include font-size("xsmall");
+        @include font-size(medium);
         padding: .8em;
         text-decoration: none;
         margin: 1em 0;
@@ -129,6 +128,11 @@
         @include pagination-item;
         border: 2px solid $pink-dark;
         color: $pink-dark;
+
+        &:hover {
+          background-color: $pink-dark;
+          color: $white;
+        }
       }
 
       .page {

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -133,6 +133,12 @@
           background-color: $pink-dark;
           color: $white;
         }
+
+        &:focus {
+          background-color: $yellow;
+          border: 2px solid $yellow-dark;
+          color: $black;
+        }
       }
 
       .page {


### PR DESCRIPTION
### Trello card

https://trello.com/c/Ezql5PKm/1737-pagination-contrast

### Context

The pagination links don't meet WCAG contrast requirements.

### Changes proposed in this pull request

- Make pagination links bigger, remove bold and add hover state
- Add a clear focus state to pagination links


### Options

The suggested fix is to make the text bigger, which works but the pagination looks rather large compared to the other items on the page. Alternatively we can make them slightly bigger but bolder.

**I've gone with 'bigger' as suggested for the time being**.

| Bigger | Bolder |
| ------ | ------- |
| ![Screenshot from 2021-08-03 16-44-13](https://user-images.githubusercontent.com/128088/128046018-5742c5ee-2a1f-4760-b5aa-66070de3a9b6.png)| ![Screenshot from 2021-08-03 16-43-42](https://user-images.githubusercontent.com/128088/128046034-b7584c23-ed92-4541-93c1-1bc8bf4d2b17.png) |

Also, there's now a hover state and a better focus state on the links:


https://user-images.githubusercontent.com/128088/128046202-4c0f46fc-9f8d-4d1b-b9bb-51ead5a0f853.mp4


