### PR TITLE
Enable book a callback feature in production

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -5,9 +5,6 @@
 
   <p>
     You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.
-    <% if Rails.env.production? %>
-    Call us for free on <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a>, Monday to Friday between 8.30am and 5.30pm.
-    <% end %>
   </p>
 
   <% unless Rails.env.production? %>
@@ -18,20 +15,21 @@
 
     <%= link_to("View your personalised Welcome Guide", "/welcome", class: "button button--secondary button--inline") %>
 
-    <h3>Want to talk to someone?</h3>
-
-    <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
-
-    <div class="mailing-list__actions">
-      <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
-      <div>
-        <small>or call us now:</small>
-        <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
-      </div>
-    </div>
-
-    <p>Monday - Friday between 8:30am and 5:30pm.</p>
   <% end %>
+
+  <h3>Want to talk to someone?</h3>
+
+  <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
+
+  <div class="mailing-list__actions">
+    <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
+    <div>
+      <small>or call us now:</small>
+      <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+    </div>
+  </div>
+
+  <p>Monday - Friday between 8:30am and 5:30pm.</p>
 
   <span data-controller="pinterest"
         data-pinterest-action="track"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,13 +89,11 @@ Rails.application.routes.draw do
     end
   end
 
-  unless Rails.env.production?
-    namespace :callbacks do
-      resources :steps, path: "/book", only: %i[index show update] do
-        collection do
-          get :completed
-          get :resend_verification
-        end
+  namespace :callbacks do
+    resources :steps, path: "/book", only: %i[index show update] do
+      collection do
+        get :completed
+        get :resend_verification
       end
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-1747](https://trello.com/c/etoiMjla/1747-pending-go-ahead-enable-callback-booking-feature-in-production)

### Context

The CRM has been updated to include the required fields, so we should be good to enable this now.

### Changes proposed in this pull request

- Enable book a callback feature in production

### Guidance to review

<img width="1313" alt="Screenshot 2021-08-04 at 09 32 53" src="https://user-images.githubusercontent.com/29867726/128149321-36b3c6e8-2fa9-471c-a77f-a85e82bd6f8d.png">

