### PR TITLE
Remove Expires header

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,6 @@ Rails.application.configure do
 
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{365.days.to_i}",
-    "Expires" => 365.days.from_now.to_formatted_s(:rfc822),
   }
 
   # Compress CSS using a preprocessor.


### PR DESCRIPTION
### Trello card

[Trello-1782](https://trello.com/c/LRxqCzeI/1782-remove-expires-header-from-the-app)

### Context

We have the `Cache-Control` header already present, which makes the `Expires` header redundant. We also think its formatting the date slightly incorrectly, which may be effecting the caching behaviour of CloudFront.

### Changes proposed in this pull request

- Remove Expires header

### Guidance to review

