### PR TITLE
Remove online from Events CTA

### DIFF
--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,7 +1,7 @@
 <section class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Have all your questions answered at an online event.",
+    title: "Have all your questions answered at an event.",
     link_text: "Find events",
     link_target: "/events",
     image: "media/images/content/featured-3.jpg")


### PR DESCRIPTION
Updating home page events box to remove reference to 'Online' as we now have F2F.