### PR TITLE
Add https://googleads.g.doubleclick.net to CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
 
   tta_service_hosts = []
   tta_service_hosts << URI.parse(ENV["TTA_SERVICE_URL"]).host if ENV["TTA_SERVICE_URL"].present?
-  google_analytics = %w[*.google-analytics.com *.googletagmanager.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.googleadservices.com *.googleads.g.doubleclick.net]
+  google_analytics = %w[*.google-analytics.com *.googletagmanager.com *.googleusercontent.com *.gstatic.com s.ytimg.com *.googleadservices.com *.googleads.g.doubleclick.net https://googleads.g.doubleclick.net]
 
   # curl https://www.google.com/supported_domains | sed 's!\(.*\)!"*\1",!g'
   google_analytics += [


### PR DESCRIPTION
We are seeing this violation in the reports and as there is no subdomain the current wildcard directive may not be matching.