### PR TITLE
Combine dependabot updates into a single PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem "redis"
 
 gem "kaminari", "~> 1.2", ">= 1.2.1"
-gem "view_component", "~> 2.35.0"
+gem "view_component", "~> 2.36.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "addressable", "~> 2.8.0"
 
 gem "rack-attack"
 
-gem "faraday", "~> 1.5.0"
+gem "faraday", "~> 1.6.0"
 gem "faraday-encoding"
 gem "faraday-http-cache"
 gem "faraday_middleware"

--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem "listen", ">= 3.0.5", "< 3.6"
+  gem "listen", "~> 3.6.0"
   gem "web-console", ">= 4.1.0"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development, :test do
   gem "rubocop-govuk", "~> 3.14.0" # FIXME: stop gap fix but we should relint the codebase
 
   # Static security scanner
-  gem "brakeman", "~> 5.0.4", require: false
+  gem "brakeman", "~> 5.1.1", require: false
 
   # Debugging
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 87844c0e514093f23e951795efcb1719ddffbae4
+  revision: 394921fa4d11b7a6e48f8490182d74d22eea6313
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.39)
+    get_into_teaching_api_client_faraday (0.1.41)
       activesupport
       faraday
       faraday-encoding

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.7.7)
       msgpack (~> 1.0)
-    brakeman (5.0.4)
+    brakeman (5.1.1)
     builder (3.2.4)
     byebug (11.1.3)
     canonical-rails (0.2.11)
@@ -448,7 +448,7 @@ DEPENDENCIES
   addressable (~> 2.8.0)
   amazing_print
   bootsnap (>= 1.1.0)
-  brakeman (~> 5.0.4)
+  brakeman (~> 5.1.1)
   byebug
   canonical-rails (>= 0.2.11)
   capybara (~> 3.35, >= 3.35.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     kaminari-core (1.2.1)
     kramdown (2.3.1)
       rexml
-    listen (3.5.1)
+    listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loaf (0.10.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (>= 2.7.2)
   kaminari (~> 1.2, >= 1.2.1)
   kramdown (>= 2.3.1)
-  listen (>= 3.0.5, < 3.6)
+  listen (~> 3.6.0)
   loaf (>= 0.10.0)
   logger (>= 1.4.3)
   matrix (>= 0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.5.1)
+    faraday (1.6.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -137,6 +137,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -150,6 +151,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     faraday_middleware (1.1.0)
       faraday (~> 1.0)
     faraday_middleware-circuit_breaker (0.4.1)
@@ -453,7 +455,7 @@ DEPENDENCIES
   delegate (>= 0.2.0)
   dotenv-rails (>= 2.7.6)
   factory_bot_rails (>= 6.1.0)
-  faraday (~> 1.5.0)
+  faraday (~> 1.6.0)
   faraday-encoding
   faraday-http-cache
   faraday_middleware

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,7 +414,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (1.7.0)
-    view_component (2.35.0)
+    view_component (2.36.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.1.0)
@@ -496,7 +496,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   text
   tzinfo-data
-  view_component (~> 2.35.0)
+  view_component (~> 2.36.0)
   web-console (>= 4.1.0)
   webmock (>= 3.12.2)
   webpacker (>= 5.4.0)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "flatpickr": "^4.6.9",
     "govuk-frontend": "^3.13.0",
     "is-touch-device": "^1.0.1",
-    "js-cookie": "^2.2.1",
+    "js-cookie": "^3.0.0",
     "lazysizes": "^5.3.2",
     "luxon": "^2.0.1",
     "rails-ujs": "^5.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5613,10 +5613,10 @@ jest@^27.0.6:
     import-local "^3.0.2"
     jest-cli "^27.0.6"
 
-js-cookie@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.0.tgz#db1661d5459920ec95aaf186ccf74ceb4a495164"
+  integrity sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Upgrade listen to 3.6.0
- Update Faraday to 1.6.0
- Upgrade brakeman to 5.1.1
- Upgrade view_component to 2.36.0
- Update get_into_teaching_api_client_faraday
- Update js-cookie from 2.2.1 to 3.0.0
