### PR TITLE
Add some CSS to better-style the blog quotes

### DIFF
--- a/app/views/content/blog/how-to-find-school-experience.md
+++ b/app/views/content/blog/how-to-find-school-experience.md
@@ -37,7 +37,7 @@ Once you have selected a school, you can view more information about their place
 
 You can request a booking by inputting your details for your chosen school to review. They may contact you for further information.
 
-> “I volunteered at a local primary school for two days a week and from the moment I walked into my first class, it felt very natural to be interacting with children.”
+> I volunteered at a local primary school for two days a week and from the moment I walked into my first class, it felt very natural to be interacting with children.
 >
 > Zainab Kasmani, trainee primary school teacher.
 

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -128,9 +128,57 @@
   }
 
   blockquote {
-    padding: 1.5em;
+    $color: $pink-dark;
+
+    padding: 2em;
     background: $grey;
     margin: 2em auto;
+    $blog-content-width: 50ch;
+
+    p {
+      position: relative;
+      @include font-size(medium);
+
+      // some extra rules to make the quotes a bit nicer. this 'smart' css
+      // unfortunately has the side affect of requiring attribution for
+      // multi-paragraph quotes; to get around it we'll need to implement
+      // something more powerful like the regular quote module that wraps
+      // the <blockquote> in a <figure> with a <figcaption>
+
+      &:before,
+      &:after {
+        @include font-size(xlarge);
+        color: $pink-dark;
+      }
+
+      // always open the quote on the first paragraph
+      &:first-child {
+        &:before {
+          content: open-quote;
+          position: absolute;
+          left: -.6em;
+          top: -.3em;
+        }
+      }
+
+      // close the quote on the only paragraph (if there's no attribution)
+      // or the second last if there is
+      &:nth-last-child(2),
+      &:only-of-type {
+        &:after {
+          position: absolute;
+          content: close-quote;
+          margin-left: .02em;
+          margin-top: -.1em;
+        }
+      }
+
+      // if we have more than one paragraph make the last one smaller,
+      // it should be an attribution
+      &:last-child:not(:only-of-type) {
+        font-size: medium;
+      }
+    }
   }
 
   @include mq($until: tablet) {


### PR DESCRIPTION
The styles are more-or-less lifted from the Welcome Guide, but here we have less control over the markup (as it's plain markdown) so the CSS is a bit "smarter" with regards to not quoting (and making smaller) the final lines of multi-paragraph quotes.

As in the comment below, we can revisit and improve this if it becomes a hindrance, but for the time being living by the rule of "always cite multiline quotes" should be enough!

| Single-line quote | Single-line quote with attribution | Multi-line quote with attribution |
| ---------- | ---------- | -----------------| 
| ![Screenshot from 2021-08-04 16-40-09](https://user-images.githubusercontent.com/128088/128213508-2c57c9dd-d0b0-4a7f-b1b6-11780ad735c3.png) | ![Screenshot from 2021-08-04 16-39-34](https://user-images.githubusercontent.com/128088/128213639-fbd20c6a-e308-402b-a147-8da0d6bb9682.png) | ![Screenshot from 2021-08-04 16-53-50](https://user-images.githubusercontent.com/128088/128213550-c74ecfa9-6471-4d5a-b348-01c44df94eda.png) |


## Notes

When there's more than one line the last one will become the attribution, it'll be smaller and unquoted. The compromise of this approach is that multi-line quotes _need to have an attribution line_.
