### PR TITLE
Move Anchore scan to new file with cron schedule

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -1,0 +1,44 @@
+name: Nightly Anchore Security Scan
+on:
+  schedule:
+    - cron: '30 5 * * *'  # 5:30am daily
+
+jobs:
+  security_tests:
+    name: Anchore Security Scan
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1.2
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'SLACK-WEBHOOK'
+
+      - name: Scan image
+        uses: anchore/scan-action@v2.0.4
+        with:
+          image: ${{needs.build.outputs.DOCKER_IMAGE}}
+          fail-build: false
+          severity-cutoff: high
+          acs-report-enable: true
+
+      - name: upload Anchore scan SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif
+
+      - name: Run Brakeman static security scanner
+        run: |-
+          docker run -t --rm -e RAILS_ENV=test ${{needs.build.outputs.DOCKER_IMAGE}}  brakeman --no-pager


### PR DESCRIPTION
### Trello card

N/A

### Context

The Anchore security scan is currently run for every PR. This doesn't really make sense because in most cases it's not going to be the PR that will have caused failures, but general security flaws being uncovered in our images, libraries and gems. These are unlikely to be fixed within the same PR.

As a result, it _probably_ makes more sense to run the scan nightly against `master` instead. This is the first step, it's simply duplicating the relevant part of `build.yml` in `anchore.yml`. When we're happy this is running correctly the step from `build.yml` can be dropped.
