### PR TITLE
Add overseas AO providers

### DIFF
--- a/app/components/grouped_cards/listing_component.html.erb
+++ b/app/components/grouped_cards/listing_component.html.erb
@@ -14,6 +14,12 @@
     </h3>
   </div>
 
+  <% if description(group) %>
+    <div class="group__description">
+      <%= render(description(group)) %>
+    </div>
+  <% end %>
+
   <div class="group__cards">
   <% for item in items(group) %>
     <%= render GroupedCards::CardComponent.new item %>

--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -13,7 +13,11 @@ module GroupedCards
     end
 
     def items(group)
-      @data[group]
+      @data.dig(group, "providers")
+    end
+
+    def description(group)
+      @data.dig(group, "description")
     end
   end
 end

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -456,19 +456,20 @@ providers:
     name: Mikki Burns
     telephone: 0203 194 3200
     email: Institute@tesglobal.com
-  Overseas AO Providers:
+  Teacher training providers offering assessment only QTS to international teachers:
   - header: University of Sunderland
     link: https://www.sunderland.ac.uk/study/short-courses-cpd/assessment-only-route-qts/
     name: Ian Elliott
     telephone: 0191 515 2159
     email: ian.elliott@sunderland.ac.uk
   - header: Educational Success Partners (ESP)
-    link: https://www.espeducation.co.uk/assessment-only-route-to-qts
+    link: https://www.espeducation.co.uk/ao-route
     name: Mark Bignell
     telephone: 07425 555142
     email: mark@espeducation.co.uk
   - header: Buckingham International School of Education
     link: https://www.bise.org
+    name: Admissions Team
     telephone: +86 135 2015 3752
     email: admissions@bise.org
   - header: Tes Institute
@@ -486,6 +487,21 @@ keywords:
 
 If you’re an experienced teacher with a degree, you may be able to get qualified teacher status (QTS) through a 12-week assessment only (AO) programme.
 
-The following accredited teacher training providers offer the AO programme.
+The accredited teacher training providers listed on this page offer the AO programme.
 
 Contact them directly to ask them about entry criteria and to apply.
+
+### Teachers from outside the UK
+
+If you trained as a teacher outside the UK, you can apply to certain training providers for an assessment only QTS without visiting or training in England. 
+
+[View teaching training providers offering assessment only QTS to international teachers.](#Teacher training providers offering assessment only QTS to international teachers)
+
+### Teacher training providers offering assessment only QTS to international teachers
+
+The following providers offer assessment only QTS to international teachers. You will not have to visit or train in England, but you may be assessed at your place of work by an examiner from your teaching training provider. Contact the training provider directly to ask them about entry criteria and how to apply.
+
+[Learn more about working in England if you’re a teacher from outside the UK.](https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk#consider-getting-qualified-teacher-status)
+
+If you're a provider and need to update the details on your record, please contact us at: getintoteaching.helpdesk@education.gov.uk.
+

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -10,473 +10,485 @@ fullwidth: true
 content:
   - content/assessment-only-providers/listing
   - content/assessment-only-providers/update-details
-providers:
+provider_groups:
   East of England:
-  - header: BEC Teacher Training
-    link: http://secondary.billericayscitt.com/assessment-only-route-2/
-    name: Fiona Manby
-    telephone: 01268 477611 (extn 471)
-    email: fiona@billericayscitt.com
-  - header: Chiltern Training Group SCITT
-    link: https://www.challneyboys.co.uk/
-    name: Karen Bateman
-    telephone: '01582 599921'
-    email: kbateman@challneyboys.luton.sch.uk
-  - header: Essex and Thames Primary SCITT
-    link: https://etpscitt.co.uk/
-    name: Fan Attwood
-    telephone: '01268 570215'
-    email: Fran@etpscitt.co.uk
-  - header: Essex Teacher Training
-    # link: https://www.essexteachertraining.co.uk/assessment-only/
-    name: Kay Satchell
-    email: kay.satchell@essexteachertraining.co.uk
-  - header: Mid Essex Initial Teacher Training
-    link: https://midessexteachertraining.com/
-    name: Keith Ferguson
-    telephone: 01376 556398
-    email: ao@midessexteachertraining.com
-  - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
-    link: https://www.essexprimaryscitt.co.uk/
-    name: Fiona Willett
-    telephone: '0738885808'
-    email: fiona@essexprimaryscitt.co.uk
-  - header: Norfolk Teacher Training Centre
-    link: https://www.norfolkttc.org.uk/
-    name: Jacqui Waring
-    telephone: 01603 773708
-    email: jacqui.waring@ccn.ac.uk
-  - header: North Essex Teacher Training (NETT)
-    link: http://www.nett.org.uk/
-    telephone: '01255431949'
-    email: teach@nett.org.uk
-  - header: SAF ITT
-    name: Su Bernard
-    telephone: 01234 827145
-    email: SBernard@saf.org.uk
-  - header: Suffolk and Norfolk ITT
-    link: https://www.suffolkandnorfolkscitt.co.uk
-    name: Lucinda James
-    telephone: 01473 265077
-    email: enquiries@suffolkandnorfolkscitt.co.uk
-  - header: The Bedfordshire Schools Training Partnership
-    link: https://www.bedsscitt.org.uk/
-    name: David Goode
-    telephone: 01462 817445
-    email: office@bedsscitt.org.uk
-  - header: The Cambridge Partnership
-    link: http://www.thecambridgepartnership.co.uk/
-    name: Claire Mott
-    telephone: '01487 833707'
-    email: cmott@campartnership.org
-  - header: The Shire Foundation
-    name: Julie Darmody
-    telephone: '01582 522121'
-    email: jdarmody@shirefoundation.co.uk
-  - header: University of Bedfordshire
-    link: https://www.beds.ac.uk/
-    name: Bedford Admissions
-    telephone: 01234 793279
-    email: admission@beds.ac.uk
-  - header: University of Hertfordshire
-    link: https://www.herts.ac.uk/apply/schools-of-study/education/initial-teacher-training/assessment-only-route
-    name: AO Administration Team
-    telephone: 01707 286300
-    email: AOenquiries@herts.ac.uk
+    providers:
+    - header: BEC Teacher Training
+      link: http://secondary.billericayscitt.com/assessment-only-route-2/
+      name: Fiona Manby
+      telephone: 01268 477611 (extn 471)
+      email: fiona@billericayscitt.com
+    - header: Chiltern Training Group SCITT
+      link: https://www.challneyboys.co.uk/
+      name: Karen Bateman
+      telephone: '01582 599921'
+      email: kbateman@challneyboys.luton.sch.uk
+    - header: Essex and Thames Primary SCITT
+      link: https://etpscitt.co.uk/
+      name: Fan Attwood
+      telephone: '01268 570215'
+      email: Fran@etpscitt.co.uk
+    - header: Essex Teacher Training
+      # link: https://www.essexteachertraining.co.uk/assessment-only/
+      name: Kay Satchell
+      email: kay.satchell@essexteachertraining.co.uk
+    - header: Mid Essex Initial Teacher Training
+      link: https://midessexteachertraining.com/
+      name: Keith Ferguson
+      telephone: 01376 556398
+      email: ao@midessexteachertraining.com
+    - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
+      link: https://www.essexprimaryscitt.co.uk/
+      name: Fiona Willett
+      telephone: '0738885808'
+      email: fiona@essexprimaryscitt.co.uk
+    - header: Norfolk Teacher Training Centre
+      link: https://www.norfolkttc.org.uk/
+      name: Jacqui Waring
+      telephone: 01603 773708
+      email: jacqui.waring@ccn.ac.uk
+    - header: North Essex Teacher Training (NETT)
+      link: http://www.nett.org.uk/
+      telephone: '01255431949'
+      email: teach@nett.org.uk
+    - header: SAF ITT
+      name: Su Bernard
+      telephone: 01234 827145
+      email: SBernard@saf.org.uk
+    - header: Suffolk and Norfolk ITT
+      link: https://www.suffolkandnorfolkscitt.co.uk
+      name: Lucinda James
+      telephone: 01473 265077
+      email: enquiries@suffolkandnorfolkscitt.co.uk
+    - header: The Bedfordshire Schools Training Partnership
+      link: https://www.bedsscitt.org.uk/
+      name: David Goode
+      telephone: 01462 817445
+      email: office@bedsscitt.org.uk
+    - header: The Cambridge Partnership
+      link: http://www.thecambridgepartnership.co.uk/
+      name: Claire Mott
+      telephone: '01487 833707'
+      email: cmott@campartnership.org
+    - header: The Shire Foundation
+      name: Julie Darmody
+      telephone: '01582 522121'
+      email: jdarmody@shirefoundation.co.uk
+    - header: University of Bedfordshire
+      link: https://www.beds.ac.uk/
+      name: Bedford Admissions
+      telephone: 01234 793279
+      email: admission@beds.ac.uk
+    - header: University of Hertfordshire
+      link: https://www.herts.ac.uk/apply/schools-of-study/education/initial-teacher-training/assessment-only-route
+      name: AO Administration Team
+      telephone: 01707 286300
+      email: AOenquiries@herts.ac.uk
   East Midlands:
-  - header: Bishop Grosseteste University
-    link: https://www.bishopg.ac.uk
-    name: Enquiries Team
-    telephone: 01522 583658
-    email: enquiries@bishopg.ac.uk
-  - header: CfBT Education Trust SCITT
-    name: Julie Woolley
-    telephone: '07919 568841'
-    email: jwoolley@cfbt.com
-  - header: Educate Teacher Training
-    link: https://educate-group.co.uk/itt/
-    name: Claire King
-    telephone: 01476 512793
-    email: aor@educate-group.co.uk
-  - header: Nottingham Trent University
-    link: https://www.ntu.ac.uk/
-    name: Admissions team
-    telephone: 0115 848 4200
-    email: applications@ntu.ac.uk
-  - header: The Grand Union Training Partnership
-    link: https://www.gutp.co.uk/
-    name: Tracey Oakley
-    telephone: 01327 350284 ext. 251
-    email: gutp@sponne.org.uk
-  - header: University of Derby
-    link: https://www.derby.ac.uk/
-    name: Aneesa Akhtar
-    email: AO@derby.ac.uk
+    providers:
+    - header: Bishop Grosseteste University
+      link: https://www.bishopg.ac.uk
+      name: Enquiries Team
+      telephone: 01522 583658
+      email: enquiries@bishopg.ac.uk
+    - header: CfBT Education Trust SCITT
+      name: Julie Woolley
+      telephone: '07919 568841'
+      email: jwoolley@cfbt.com
+    - header: Educate Teacher Training
+      link: https://educate-group.co.uk/itt/
+      name: Claire King
+      telephone: 01476 512793
+      email: aor@educate-group.co.uk
+    - header: Nottingham Trent University
+      link: https://www.ntu.ac.uk/
+      name: Admissions team
+      telephone: 0115 848 4200
+      email: applications@ntu.ac.uk
+    - header: The Grand Union Training Partnership
+      link: https://www.gutp.co.uk/
+      name: Tracey Oakley
+      telephone: 01327 350284 ext. 251
+      email: gutp@sponne.org.uk
+    - header: University of Derby
+      link: https://www.derby.ac.uk/
+      name: Aneesa Akhtar
+      email: AO@derby.ac.uk
   Greater London:
-  - header: 2Schools Consortium
-    link: https://www.2schools.org/assessment-only-route/
-    name: Isabella Mora
-    telephone: '0208 807 6906'
-    email: training@oakthorpe.enfield.sch.uk
-  - header: Bromley Schools’ Collegiate
-    link: https://www.bscteach.co.uk/
-    name: Derek Boyle
-    telephone: 020 8300 6566
-    email: Administrator@gradteach.co.uk
-  - header: Goldsmiths, University of London
-    link: https://www.gold.ac.uk/
-    name: Lynsey Salt
-    telephone: 020 7717 2245
-    email: ao@gold.ac.uk
-  - header: Henry Maynard Training E17
-    link: http://www.henrymaynardtraining.co.uk
-    name: Clare Hunton
-    telephone: '0208 5203142'
-    email: training@henrymaynard.waltham.sch.uk
-  - header: Jewish Teacher Training Partnership
-    link: https://www.lsjs.ac.uk/
-    name: Galia Segal
-    telephone: 020 8203 6427
-    email: galia.segal@lsjs.ac.uk
-  - header: Kingston University
-    link: https://www.kingston.ac.uk/postgraduate-course/assessment-only-route-leading-to-qualified-teacher-status/
-    name: Marcus Bhargava
-    telephone: 020 8417 4766
-    email: aoenquiries@kingston.ac.uk
-  - header: London Metropolitan University
-    link: https://www.londonmet.ac.uk/courses/postgraduate/assessment-only-ao-route-to-qualified-teacher-status---qts---qts/
-    name: Maria Dominguez
-    telephone: 0207 133 2983
-    email: m.dominguez@londonmet.ac.uk
-  - header: London South Bank University
-    link: https://www.lsbu.ac.uk
-    name: Andrew Read
-    telephone: 0207 815 5444
-    email: qtsao@lsbu.ac.uk
-  - header: Middlesex University
-    telephone: 020 8411 5555
-    email: enquiries@mdx.ac.uk
-  - header: St Mary’s University
-    link: https://www.stmarys.ac.uk/education-theology-and-leadership/assessment-only-qts.htm
-    name: Elizabeth Jackson
-    telephone: '0208 2404326'
-    email: ao@stmarys.ac.uk
-  - header: 'Teaching London: LDBS SCITT'
-    link: https://teachinglondon.org
-    name: Saskia Rossi
-    telephone: 0207 932 1126
-    email: admin@teachinglondon.org
-  - header: The Havering Teacher Training Partnership
-    link: https://www.haveringteachertraining.co.uk/
-    name: Liz Connell
-    telephone: '01708 255006'
-    email: http@hallmeadschool.com
-  - header: The Pimlico-London SCITT
-    link: https://www.futuretraining.org/page/?title=Assessment+Only+Route&pid=20
-    email: info@futuretraining.org
-  - header: University of East London
-    link: https://www.uel.ac.uk/
-    name: Bryce Wilby
-    telephone: 020 8223 6372
-    email: b.wilby@uel.ac.uk
-  - header: University of Greenwich
-    name: Enquiry Unit
-    telephone: 020 8331 9000
-    email: courseinfo@gre.ac.uk
-  - header: Wandsworth Primary Schools’ Consortium
-    link: https://www.beatrixpotterschool.com/our-school/wandsworth-scitt-teacher-training/
-    name: Sam Steward
-    telephone: 020 8772 9528
-    email: ssteward@scitt.wandsworth.sch.uk
+    providers:
+    - header: 2Schools Consortium
+      link: https://www.2schools.org/assessment-only-route/
+      name: Isabella Mora
+      telephone: '0208 807 6906'
+      email: training@oakthorpe.enfield.sch.uk
+    - header: Bromley Schools’ Collegiate
+      link: https://www.bscteach.co.uk/
+      name: Derek Boyle
+      telephone: 020 8300 6566
+      email: Administrator@gradteach.co.uk
+    - header: Goldsmiths, University of London
+      link: https://www.gold.ac.uk/
+      name: Lynsey Salt
+      telephone: 020 7717 2245
+      email: ao@gold.ac.uk
+    - header: Henry Maynard Training E17
+      link: http://www.henrymaynardtraining.co.uk
+      name: Clare Hunton
+      telephone: '0208 5203142'
+      email: training@henrymaynard.waltham.sch.uk
+    - header: Jewish Teacher Training Partnership
+      link: https://www.lsjs.ac.uk/
+      name: Galia Segal
+      telephone: 020 8203 6427
+      email: galia.segal@lsjs.ac.uk
+    - header: Kingston University
+      link: https://www.kingston.ac.uk/postgraduate-course/assessment-only-route-leading-to-qualified-teacher-status/
+      name: Marcus Bhargava
+      telephone: 020 8417 4766
+      email: aoenquiries@kingston.ac.uk
+    - header: London Metropolitan University
+      link: https://www.londonmet.ac.uk/courses/postgraduate/assessment-only-ao-route-to-qualified-teacher-status---qts---qts/
+      name: Maria Dominguez
+      telephone: 0207 133 2983
+      email: m.dominguez@londonmet.ac.uk
+    - header: London South Bank University
+      link: https://www.lsbu.ac.uk
+      name: Andrew Read
+      telephone: 0207 815 5444
+      email: qtsao@lsbu.ac.uk
+    - header: Middlesex University
+      telephone: 020 8411 5555
+      email: enquiries@mdx.ac.uk
+    - header: St Mary’s University
+      link: https://www.stmarys.ac.uk/education-theology-and-leadership/assessment-only-qts.htm
+      name: Elizabeth Jackson
+      telephone: '0208 2404326'
+      email: ao@stmarys.ac.uk
+    - header: 'Teaching London: LDBS SCITT'
+      link: https://teachinglondon.org
+      name: Saskia Rossi
+      telephone: 0207 932 1126
+      email: admin@teachinglondon.org
+    - header: The Havering Teacher Training Partnership
+      link: https://www.haveringteachertraining.co.uk/
+      name: Liz Connell
+      telephone: '01708 255006'
+      email: http@hallmeadschool.com
+    - header: The Pimlico-London SCITT
+      link: https://www.futuretraining.org/page/?title=Assessment+Only+Route&pid=20
+      email: info@futuretraining.org
+    - header: University of East London
+      link: https://www.uel.ac.uk/
+      name: Bryce Wilby
+      telephone: 020 8223 6372
+      email: b.wilby@uel.ac.uk
+    - header: University of Greenwich
+      name: Enquiry Unit
+      telephone: 020 8331 9000
+      email: courseinfo@gre.ac.uk
+    - header: Wandsworth Primary Schools’ Consortium
+      link: https://www.beatrixpotterschool.com/our-school/wandsworth-scitt-teacher-training/
+      name: Sam Steward
+      telephone: 020 8772 9528
+      email: ssteward@scitt.wandsworth.sch.uk
   North East:
-  - header: Carmel Teacher Training Partnership (CTTP)
-    link: https://carmelteachertraining.com/
-    name: Marielle Thonnart
-    telephone: 01325 254525
-    email: thonnartm@carmel.bhcet.org.uk
-  - header: Durham University
-    email: ed.ite@durham.ac.uk
-  - header: Stockton-on-Tees Teacher Training Partnership
-    link: https://www.stocktonscitt.uk
-    name: Kirsten Webber
-    telephone: 01642 527675
-    email: scitt@stockton.gov.uk
-  - header: University of Sunderland
-    link: https://www.sunderland.ac.uk/
-    name: Jill Wilkinson
-    telephone: '0191 5153099'
-    email: jill.wilkinson@sunderland.ac.uk
+    providers:
+    - header: Carmel Teacher Training Partnership (CTTP)
+      link: https://carmelteachertraining.com/
+      name: Marielle Thonnart
+      telephone: 01325 254525
+      email: thonnartm@carmel.bhcet.org.uk
+    - header: Durham University
+      email: ed.ite@durham.ac.uk
+    - header: Stockton-on-Tees Teacher Training Partnership
+      link: https://www.stocktonscitt.uk
+      name: Kirsten Webber
+      telephone: 01642 527675
+      email: scitt@stockton.gov.uk
+    - header: University of Sunderland
+      link: https://www.sunderland.ac.uk/
+      name: Jill Wilkinson
+      telephone: '0191 5153099'
+      email: jill.wilkinson@sunderland.ac.uk
   North West:
-  - header: Ashton on Mersey SCITT
-    link: http://aomscitt.co.uk/assessment-only/
-    name: Samantha Buckley
-    telephone: 0161 973 1179 (ext 2229)
-    email: SamanthaBuckley@thedeantrust.co.uk
-  - header: Cumbria Teacher Training
-    link: http://www.ctt.ac.uk
-    email: scittlead@ctt.ac.uk
-  - header: Kingsbridge EIP SCITT
-    name: Gail Thomson
-    telephone: '01942 510712 ext 500'
-    email: g.thomson@kingsbridgeeip.co.uk
-  - header: Mersey Boroughs ITT Partnership
-    link: https://merseyitt.org.uk/
-    name: Gill Makin
-    telephone: 0151 443 2663
-    email: merseyboroughsitt@knowsley.gov.uk
-  - header: North Manchester ITT Partnership
-    link: https://www.teachnorthmanchester.com/assessment-only
-    name: Carrie Carvell
-    telephone: 0161 202 0161
-    email: teachertraining@mca.manchester.sch.uk
-  - header: Star Teachers SCITT
-    name: Felicity Ackroyd
-    telephone: 0330 313 9876
-    email: felicity.ackroyd@staracademies.org
-  - header: University of Chester
-    link: https://www.chester.ac.uk/
-    name: Jenn Simmonds
-    email: j.simmonds@chester.ac.uk
-  - header: University of Cumbria
-    link: https://www.cumbria.ac.uk/study/academic-departments/institute-of-education/qts-direct-assessment-only-route/
-    name: Carolyn Reade
-    email: arolyn.reade@cumbria.ac.uk
+    providers:
+    - header: Ashton on Mersey SCITT
+      link: http://aomscitt.co.uk/assessment-only/
+      name: Samantha Buckley
+      telephone: 0161 973 1179 (ext 2229)
+      email: SamanthaBuckley@thedeantrust.co.uk
+    - header: Cumbria Teacher Training
+      link: http://www.ctt.ac.uk
+      email: scittlead@ctt.ac.uk
+    - header: Kingsbridge EIP SCITT
+      name: Gail Thomson
+      telephone: '01942 510712 ext 500'
+      email: g.thomson@kingsbridgeeip.co.uk
+    - header: Mersey Boroughs ITT Partnership
+      link: https://merseyitt.org.uk/
+      name: Gill Makin
+      telephone: 0151 443 2663
+      email: merseyboroughsitt@knowsley.gov.uk
+    - header: North Manchester ITT Partnership
+      link: https://www.teachnorthmanchester.com/assessment-only
+      name: Carrie Carvell
+      telephone: 0161 202 0161
+      email: teachertraining@mca.manchester.sch.uk
+    - header: Star Teachers SCITT
+      name: Felicity Ackroyd
+      telephone: 0330 313 9876
+      email: felicity.ackroyd@staracademies.org
+    - header: University of Chester
+      link: https://www.chester.ac.uk/
+      name: Jenn Simmonds
+      email: j.simmonds@chester.ac.uk
+    - header: University of Cumbria
+      link: https://www.cumbria.ac.uk/study/academic-departments/institute-of-education/qts-direct-assessment-only-route/
+      name: Carolyn Reade
+      email: arolyn.reade@cumbria.ac.uk
   South East:
-  - header: Astra School Centred Initial Teacher Training / Dr Challoner's Grammar
-      School
-    link: https://www.astra-alliance.com/285/the-assessment-only-route
-    name: Stephanie Rodgers
-    telephone: '01494 787573'
-    email: sro@challoners.org
-  - header: Boleyn Trust
-    link: https://www.elascitt.com
-    email: elascitt@tollgate.boleyntrust.org
-  - header: Bourton Meadow Initial Teacher Training Centre
-    # link: https://www.bourtonmeadowittc.co.uk
-    name: Helen Byrom
-    telephone: '01280 823374'
-    email: hbyrom@bucksgfl.org.uk
-  - header: Canterbury Christ Church University
-    name: Keith Saunders
-    telephone: 01227 925555
-    email: pgadmissions@canterbury.ac.uk
-  - header: e-Qualitas
-    link: https://www.e-qualitas.co.uk/for-schools/training-routes/assessment-only/
-    name: Vivien Johnston
-    email: vivien@e-qualitas.co.uk
-  - header: George Abbot SCITT
-    link: https://georgeabbottraining.co.uk/courses/
-    name: Joanna Jones
-    telephone: '01483 888070'
-    email: contactscitt@georgeabbot.surrey.sch.uk
-  - header: GLF Schools’ Teacher Training
-    link: http://www.glynsurreyscitt.co.uk/846/assessment-only-route
-    name: Helen Shaw
-    telephone: '0208 716 4934'
-    email: info@glftt.org
-  - header: Kent and Medway Training
-    link: https://www.kmtraining.org.uk/
-    email: polly.butterfield-tracey@kmtraining.org.uk
-  - header: Oxford Brookes University
-    name: Lorna Shires
-    email: assessment-only-qts@brookes.ac.uk
-  - header: Surrey South Farnham SCITT
-    name: Eukaria Finch
-    telephone: 01252 717408
-    email: scitt@sfet.org.uk
-  - header: Thamesmead SCITT
-    name: Claire Lane
-    telephone: '01932 219412'
-    email: c.lane@thamesmead.surrey.sch.uk
-  - header: The Buckingham Partnership
-    link: https://www.bpscitt.uk/
-    name: Laura Whitty
-    telephone: '01280 827 377'
-    email: lwhitty@royallatin.org
-  - header: The Tommy Flowers SCITT
-    link: https://tommyflowersscitt.co.uk/assessment-only/
-    name: Catherine Brown (senior administrator)
-    telephone: '01908 505030'
-    email: brownc@denbigh.net
-  - header: The University of Buckingham
-    link: https://www.buckingham.ac.uk/
-    name: Nikki Mugford
-    telephone: '01280 820219'
-    email: education@buckingham.ac.uk
-  - header: Two Mile Ash ITT Partnership
-    link: https://www.mkitt.co.uk/
-    name: Sarah Hand
-    telephone: '01908 533284'
-    email: info@mkitt.co.uk
-  - header: University of Chichester
-    link: https://www.chi.ac.uk/institute-education/degrees-qts/assessment-only-route
-    email: ao@chi.ac.uk
-  - header: University of Reading
-    link: https://www.reading.ac.uk/
-    name: Marc Jacobs
-    telephone: '0118 378 2672'
-    email: m.l.jacobs@reading.ac.uk
-  - header: University of Sussex
-    link: https://www.sussex.ac.uk/
-    name: Janet Steadman
-    email: l.harknett@sussex.ac.uk
-  - header: University of Winchester
-    link: https://www.winchester.ac.uk/pages/home.aspx
-    name: Keith Smith
-    email: ao@winchester.ac.uk
-  - header: West Berkshire Training Partnership
-    name: Emmeline Bird
-    telephone: 01635 42155
-    email: admin@itt-westberks.org
-  - header: Xavier Catholic Education Trust
-    link: https://www.teachsoutheast.co.uk/
-    email: a.harper@sjb.surrey.sch.uk
+    providers:
+    - header: Astra School Centred Initial Teacher Training / Dr Challoner's Grammar
+        School
+      link: https://www.astra-alliance.com/285/the-assessment-only-route
+      name: Stephanie Rodgers
+      telephone: '01494 787573'
+      email: sro@challoners.org
+    - header: Boleyn Trust
+      link: https://www.elascitt.com
+      email: elascitt@tollgate.boleyntrust.org
+    - header: Bourton Meadow Initial Teacher Training Centre
+      # link: https://www.bourtonmeadowittc.co.uk
+      name: Helen Byrom
+      telephone: '01280 823374'
+      email: hbyrom@bucksgfl.org.uk
+    - header: Canterbury Christ Church University
+      name: Keith Saunders
+      telephone: 01227 925555
+      email: pgadmissions@canterbury.ac.uk
+    - header: e-Qualitas
+      link: https://www.e-qualitas.co.uk/for-schools/training-routes/assessment-only/
+      name: Vivien Johnston
+      email: vivien@e-qualitas.co.uk
+    - header: George Abbot SCITT
+      link: https://georgeabbottraining.co.uk/courses/
+      name: Joanna Jones
+      telephone: '01483 888070'
+      email: contactscitt@georgeabbot.surrey.sch.uk
+    - header: GLF Schools’ Teacher Training
+      link: http://www.glynsurreyscitt.co.uk/846/assessment-only-route
+      name: Helen Shaw
+      telephone: '0208 716 4934'
+      email: info@glftt.org
+    - header: Kent and Medway Training
+      link: https://www.kmtraining.org.uk/
+      email: polly.butterfield-tracey@kmtraining.org.uk
+    - header: Oxford Brookes University
+      name: Lorna Shires
+      email: assessment-only-qts@brookes.ac.uk
+    - header: Surrey South Farnham SCITT
+      name: Eukaria Finch
+      telephone: 01252 717408
+      email: scitt@sfet.org.uk
+    - header: Thamesmead SCITT
+      name: Claire Lane
+      telephone: '01932 219412'
+      email: c.lane@thamesmead.surrey.sch.uk
+    - header: The Buckingham Partnership
+      link: https://www.bpscitt.uk/
+      name: Laura Whitty
+      telephone: '01280 827 377'
+      email: lwhitty@royallatin.org
+    - header: The Tommy Flowers SCITT
+      link: https://tommyflowersscitt.co.uk/assessment-only/
+      name: Catherine Brown (senior administrator)
+      telephone: '01908 505030'
+      email: brownc@denbigh.net
+    - header: The University of Buckingham
+      link: https://www.buckingham.ac.uk/
+      name: Nikki Mugford
+      telephone: '01280 820219'
+      email: education@buckingham.ac.uk
+    - header: Two Mile Ash ITT Partnership
+      link: https://www.mkitt.co.uk/
+      name: Sarah Hand
+      telephone: '01908 533284'
+      email: info@mkitt.co.uk
+    - header: University of Chichester
+      link: https://www.chi.ac.uk/institute-education/degrees-qts/assessment-only-route
+      email: ao@chi.ac.uk
+    - header: University of Reading
+      link: https://www.reading.ac.uk/
+      name: Marc Jacobs
+      telephone: '0118 378 2672'
+      email: m.l.jacobs@reading.ac.uk
+    - header: University of Sussex
+      link: https://www.sussex.ac.uk/
+      name: Janet Steadman
+      email: l.harknett@sussex.ac.uk
+    - header: University of Winchester
+      link: https://www.winchester.ac.uk/pages/home.aspx
+      name: Keith Smith
+      email: ao@winchester.ac.uk
+    - header: West Berkshire Training Partnership
+      name: Emmeline Bird
+      telephone: 01635 42155
+      email: admin@itt-westberks.org
+    - header: Xavier Catholic Education Trust
+      link: https://www.teachsoutheast.co.uk/
+      email: a.harper@sjb.surrey.sch.uk
   South West:
-  - header: Bath Spa University
-    link: https://www.bathspa.ac.uk/
-    name: Clare Furlonger
-    telephone: 01225 875650
-    email: assessmentonly@bathspa.ac.uk
-  - header: Cornwall School Centred Initial Teacher Training (Cornwall SCITT)
-    link: https://www.cornwallscitt.org/
-    name: Julie Bennett
-    telephone: '01872 267092'
-    email: juliebennett@truro-penwith.ac.uk
-  - header: Mid Somerset Consortium for Teacher Training
-    link: https://www.mscitt.org.uk/Routes/Assessment-only/
-    name: Sarah Lewis
-    telephone: '01458 449418'
-    email: office@mscitt.org.uk
-  - header: Somerset SCITT Consortium
-    link: https://www.sciltraining.co.uk
-    email: CLeoni@somerset.gov.uk
-  - header: The Learning Institute South West SCITT
-    link: https://www.learninginstitute.co.uk
-    name: Ania Glowczynska
-    telephone: 01726 891 745
-    email: info@learninginstitute.co.uk
-  - header: Wessex Schools Training Partnership
-    name: Mike Petrus
-    telephone: 01202 662044
-    email: WSTP@poolehigh.poole.sch.uk
+    providers:
+    - header: Bath Spa University
+      link: https://www.bathspa.ac.uk/
+      name: Clare Furlonger
+      telephone: 01225 875650
+      email: assessmentonly@bathspa.ac.uk
+    - header: Cornwall School Centred Initial Teacher Training (Cornwall SCITT)
+      link: https://www.cornwallscitt.org/
+      name: Julie Bennett
+      telephone: '01872 267092'
+      email: juliebennett@truro-penwith.ac.uk
+    - header: Mid Somerset Consortium for Teacher Training
+      link: https://www.mscitt.org.uk/Routes/Assessment-only/
+      name: Sarah Lewis
+      telephone: '01458 449418'
+      email: office@mscitt.org.uk
+    - header: Somerset SCITT Consortium
+      link: https://www.sciltraining.co.uk
+      email: CLeoni@somerset.gov.uk
+    - header: The Learning Institute South West SCITT
+      link: https://www.learninginstitute.co.uk
+      name: Ania Glowczynska
+      telephone: 01726 891 745
+      email: info@learninginstitute.co.uk
+    - header: Wessex Schools Training Partnership
+      name: Mike Petrus
+      telephone: 01202 662044
+      email: WSTP@poolehigh.poole.sch.uk
   West Midlands:
-  - header: Birmingham City University
-    link: https://www.bcu.ac.uk/
-    name: Programme Leader
-    telephone: 0121 331 4627
-    email: assessmentonlyqts@bcu.ac.uk
-  - header: Haybridge Alliance SCITT
-    link: https://www.teachwithhaybridge.co.uk
-    email: tforward@haybridge.worcs.sch.uk
-  - header: Keele and North Staffordshire Teacher Education
-    link: https://knste-shaw.org.uk/assessment-route
-    name: Tricia Locker
-    telephone: '01782 432538'
-    email: ao@knste-shaw.org.uk
-  - header: St. Joseph's College Stoke Secondary Partnership
-    link: http://www.stjosephstrentvale.com/teaching-school/partnership/
-    email: schater@stjosephsmail.com
-  - header: Staffordshire University
-    link: https://www.staffs.ac.uk/
-    name: Cath Hickling
-    email: c.hickling@staffs.ac.uk
-  - header: The Coventry SCITT
-    link: https://www.coventryscitt.org.uk
-    email: info@coventryscitt.org.uk
-  - header: The National School of Education and Teaching, Coventry University
-    name: Carol Rowntree
-    telephone: 01327 850320
-    email: NSET@coventry.ac.uk
-  - header: The OAKS (Ormiston and Keele SCITT)
-    name: Rob Tweats
-    telephone: '01782 734332'
-    email: r.tweats@keele.ac.uk
-  - header: Titan Partnership Ltd
-    link: https://www.titanteachertraining.co.uk/itt-courses/assessment-only/
-    name: Sean Bates
-    telephone: 0121 607 1930
-    email: sean.bates@titan.org.uk
-  - header: University College Birmingham
-    link: https://www.ucb.ac.uk/home.aspx
-    name: Dr. Marj Jeavons
-    email: m.jeavons@ucb.ac.uk
-  - header: University of Warwick
-    link: https://warwick.ac.uk/fac/soc/cte/professionaldevelopment/assessmentonly/
-    name: CTE Admissions and Enrolment Team
-    email: cte.admissions@warwick.ac.uk
-  - header: University of Wolverhampton – primary
-    link: https://www.wlv.ac.uk/
-    email: AOPrimary@wlv.ac.uk
-  - header: University of Wolverhampton – secondary
-    link: https://www.wlv.ac.uk/
-    email: AOSecondary@wlv.ac.uk
-  - header: West Midlands Consortium
-    link: https://wmc.ttsonline.net/
-    name: Su Plant
-    telephone: '01952 200000'
-    email: ssplant@ttsonline.net
+    providers:
+    - header: Birmingham City University
+      link: https://www.bcu.ac.uk/
+      name: Programme Leader
+      telephone: 0121 331 4627
+      email: assessmentonlyqts@bcu.ac.uk
+    - header: Haybridge Alliance SCITT
+      link: https://www.teachwithhaybridge.co.uk
+      email: tforward@haybridge.worcs.sch.uk
+    - header: Keele and North Staffordshire Teacher Education
+      link: https://knste-shaw.org.uk/assessment-route
+      name: Tricia Locker
+      telephone: '01782 432538'
+      email: ao@knste-shaw.org.uk
+    - header: St. Joseph's College Stoke Secondary Partnership
+      link: http://www.stjosephstrentvale.com/teaching-school/partnership/
+      email: schater@stjosephsmail.com
+    - header: Staffordshire University
+      link: https://www.staffs.ac.uk/
+      name: Cath Hickling
+      email: c.hickling@staffs.ac.uk
+    - header: The Coventry SCITT
+      link: https://www.coventryscitt.org.uk
+      email: info@coventryscitt.org.uk
+    - header: The National School of Education and Teaching, Coventry University
+      name: Carol Rowntree
+      telephone: 01327 850320
+      email: NSET@coventry.ac.uk
+    - header: The OAKS (Ormiston and Keele SCITT)
+      name: Rob Tweats
+      telephone: '01782 734332'
+      email: r.tweats@keele.ac.uk
+    - header: Titan Partnership Ltd
+      link: https://www.titanteachertraining.co.uk/itt-courses/assessment-only/
+      name: Sean Bates
+      telephone: 0121 607 1930
+      email: sean.bates@titan.org.uk
+    - header: University College Birmingham
+      link: https://www.ucb.ac.uk/home.aspx
+      name: Dr. Marj Jeavons
+      email: m.jeavons@ucb.ac.uk
+    - header: University of Warwick
+      link: https://warwick.ac.uk/fac/soc/cte/professionaldevelopment/assessmentonly/
+      name: CTE Admissions and Enrolment Team
+      email: cte.admissions@warwick.ac.uk
+    - header: University of Wolverhampton – primary
+      link: https://www.wlv.ac.uk/
+      email: AOPrimary@wlv.ac.uk
+    - header: University of Wolverhampton – secondary
+      link: https://www.wlv.ac.uk/
+      email: AOSecondary@wlv.ac.uk
+    - header: West Midlands Consortium
+      link: https://wmc.ttsonline.net/
+      name: Su Plant
+      telephone: '01952 200000'
+      email: ssplant@ttsonline.net
   Yorkshire and the Humber:
-  - header: The Sheffield SCITT
-    link: https://www.sheffieldscitt.org.uk/
-    email: admin@sheffieldscitt.org.uk
-  - header: Bradford College
-    link: https://www.bradfordcollege.ac.uk/courses/course/qualified-teacher-status-qts-assessment-only-programme/
-    name: Lee Parsell
-    telephone: 01274 088 368
-    email: l.parsell@bradfordcollege.ac.uk
-  - header: GORSE SCITT
-    name: Stephen McKenzie
-    telephone: '01134871777'
-    email: info@gorsescitt.org.uk
-  - header: Leeds Trinity University
-    name: Admissions
-    telephone: 0113 283 7123
-    email: admissions@leedstrinity.ac.uk
-  - header: North Lincolnshire SCITT Partnership
-    name: Jo Leedham
-    telephone: 01724 297950
-    email: jo.leedham@northlincs.gov.uk
-  - header: Three Counties Alliance SCITT
-    link: https://ytcascitt.co.uk/
-    name: Rebecca Turner-Loisel
-    telephone: '01977 657604'
-    email: ytca@minsthorpe.cc
-  - header: University of Hull
-    name: Initial Teacher Education Partners
-    link: https://www.hull.ac.uk
-    email: FACE-ITEPartners@hull.ac.uk
-  - header: Yorkshire and Humber Teacher Training
-    link: https://www.yhtt.co.uk
-    name: Chris Fletcher
-    telephone: '01482 349611'
-    email: cfletcher@yhtt.co.uk
+    providers:
+    - header: The Sheffield SCITT
+      link: https://www.sheffieldscitt.org.uk/
+      email: admin@sheffieldscitt.org.uk
+    - header: Bradford College
+      link: https://www.bradfordcollege.ac.uk/courses/course/qualified-teacher-status-qts-assessment-only-programme/
+      name: Lee Parsell
+      telephone: 01274 088 368
+      email: l.parsell@bradfordcollege.ac.uk
+    - header: GORSE SCITT
+      name: Stephen McKenzie
+      telephone: '01134871777'
+      email: info@gorsescitt.org.uk
+    - header: Leeds Trinity University
+      name: Admissions
+      telephone: 0113 283 7123
+      email: admissions@leedstrinity.ac.uk
+    - header: North Lincolnshire SCITT Partnership
+      name: Jo Leedham
+      telephone: 01724 297950
+      email: jo.leedham@northlincs.gov.uk
+    - header: Three Counties Alliance SCITT
+      link: https://ytcascitt.co.uk/
+      name: Rebecca Turner-Loisel
+      telephone: '01977 657604'
+      email: ytca@minsthorpe.cc
+    - header: University of Hull
+      name: Initial Teacher Education Partners
+      link: https://www.hull.ac.uk
+      email: FACE-ITEPartners@hull.ac.uk
+    - header: Yorkshire and Humber Teacher Training
+      link: https://www.yhtt.co.uk
+      name: Chris Fletcher
+      telephone: '01482 349611'
+      email: cfletcher@yhtt.co.uk
   National:
-  - header: TES Institute
-    link: https://www.tes.com/institute/assessment-only-route
-    name: Mikki Burns
-    telephone: 0203 194 3200
-    email: Institute@tesglobal.com
+    providers:
+    - header: TES Institute
+      link: https://www.tes.com/institute/assessment-only-route
+      name: Mikki Burns
+      telephone: 0203 194 3200
+      email: Institute@tesglobal.com
   Teacher training providers offering assessment only QTS to international teachers:
-  - header: University of Sunderland
-    link: https://www.sunderland.ac.uk/study/short-courses-cpd/assessment-only-route-qts/
-    name: Ian Elliott
-    telephone: 0191 515 2159
-    email: ian.elliott@sunderland.ac.uk
-  - header: Educational Success Partners (ESP)
-    link: https://www.espeducation.co.uk/ao-route
-    name: Mark Bignell
-    telephone: 07425 555142
-    email: mark@espeducation.co.uk
-  - header: Buckingham International School of Education
-    link: https://www.bise.org
-    name: Admissions Team
-    telephone: +86 135 2015 3752
-    email: admissions@bise.org
-  - header: Tes Institute
-    link: https://www.tes.com/institute/courses/international-assessment-only-route
-    name: Mikki Burns
-    telephone: +44 (0)203 194 3000
-    email: mikki.burns@tes.com
+    description: content/assessment-only-providers/descriptions/teacher-training-providers-offering-assessment-only-qts-to-international-teachers
+    providers:
+    - header: University of Sunderland
+      link: https://www.sunderland.ac.uk/study/short-courses-cpd/assessment-only-route-qts/
+      name: Ian Elliott
+      telephone: 0191 515 2159
+      email: ian.elliott@sunderland.ac.uk
+    - header: Educational Success Partners (ESP)
+      link: https://www.espeducation.co.uk/ao-route
+      name: Mark Bignell
+      telephone: 07425 555142
+      email: mark@espeducation.co.uk
+    - header: Buckingham International School of Education
+      link: https://www.bise.org
+      name: Admissions Team
+      telephone: +86 135 2015 3752
+      email: admissions@bise.org
+    - header: Tes Institute
+      link: https://www.tes.com/institute/courses/international-assessment-only-route
+      name: Mikki Burns
+      telephone: +44 (0)203 194 3000
+      email: mikki.burns@tes.com
 keywords:
   - Assessment Only
   - Assessment
@@ -495,13 +507,4 @@ Contact them directly to ask them about entry criteria and to apply.
 
 If you trained as a teacher outside the UK, you can apply to certain training providers for an assessment only QTS without visiting or training in England. 
 
-[View teaching training providers offering assessment only QTS to international teachers.](#group--overseas-ao-providers)
-
-### Teacher training providers offering assessment only QTS to international teachers
-
-The following providers offer assessment only QTS to international teachers. You will not have to visit or train in England, but you may be assessed at your place of work by an examiner from your teaching training provider. Contact the training provider directly to ask them about entry criteria and how to apply.
-
-[Learn more about working in England if you’re a teacher from outside the UK.](/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk#consider-getting-qualified-teacher-status)
-
-
-
+[View teaching training providers offering assessment only QTS to international teachers.](#group--teacher-training-providers-offering-assessment-only-qts-to-international-teachers)

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -495,13 +495,13 @@ Contact them directly to ask them about entry criteria and to apply.
 
 If you trained as a teacher outside the UK, you can apply to certain training providers for an assessment only QTS without visiting or training in England. 
 
-[View teaching training providers offering assessment only QTS to international teachers.](#Teacher training providers offering assessment only QTS to international teachers)
+[View teaching training providers offering assessment only QTS to international teachers.](#group--overseas-ao-providers)
 
 ### Teacher training providers offering assessment only QTS to international teachers
 
 The following providers offer assessment only QTS to international teachers. You will not have to visit or train in England, but you may be assessed at your place of work by an examiner from your teaching training provider. Contact the training provider directly to ask them about entry criteria and how to apply.
 
-[Learn more about working in England if you’re a teacher from outside the UK.](https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk#consider-getting-qualified-teacher-status)
+[Learn more about working in England if you’re a teacher from outside the UK.](/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk#consider-getting-qualified-teacher-status)
 
-If you're a provider and need to update the details on your record, please contact us at: getintoteaching.helpdesk@education.gov.uk.
+
 

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -456,6 +456,26 @@ providers:
     name: Mikki Burns
     telephone: 0203 194 3200
     email: Institute@tesglobal.com
+  Overseas AO Providers:
+  - header: University of Sunderland
+    link: https://www.sunderland.ac.uk/study/short-courses-cpd/assessment-only-route-qts/
+    name: Ian Elliott
+    telephone: 0191 515 2159
+    email: ian.elliott@sunderland.ac.uk
+  - header: Educational Success Partners (ESP)
+    link: https://www.espeducation.co.uk/assessment-only-route-to-qts
+    name: Mark Bignell
+    telephone: 07425 555142
+    email: mark@espeducation.co.uk
+  - header: Buckingham International School of Education
+    link: https://www.bise.org
+    telephone: +86 135 2015 3752
+    email: admissions@bise.org
+  - header: Tes Institute
+    link: https://www.tes.com/institute/courses/international-assessment-only-route
+    name: Mikki Burns
+    telephone: +44 (0)203 194 3000
+    email: mikki.burns@tes.com
 keywords:
   - Assessment Only
   - Assessment

--- a/app/views/content/assessment-only-providers/_listing.html.erb
+++ b/app/views/content/assessment-only-providers/_listing.html.erb
@@ -1,5 +1,5 @@
 <h2>Select the region of the provider</h2>
 
 <section class="assessment-only-providers">
-  <%= render GroupedCards::ListingComponent.new @front_matter["providers"] %>
+  <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
 </section>

--- a/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
+++ b/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
@@ -1,0 +1,5 @@
+The following providers offer assessment only QTS to international teachers. You will not have to visit or train in England, but you may be assessed at your place of work by an examiner from your teaching training provider. Contact the training provider directly to ask them about entry criteria and how to apply.
+
+[Learn more about working in England if you’re a teacher from outside the UK.](https://getintoteaching.education.gov.uk/come-to-england-to-teach-if-you-are-a-teacher-from-outside-the-uk#consider-getting-qualified-teacher-status)
+
+If you're a provider and need to update the details on your record, please contact us at: getintoteaching.helpdesk@education.gov.uk.

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -7,7 +7,8 @@
   padding: 1em;
   margin: 1em auto;
 
-  h3 {
+  h3,
+  &__description {
     margin: .2em auto 1em;
   }
 

--- a/spec/components/grouped_cards/listing_component_spec.rb
+++ b/spec/components/grouped_cards/listing_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe GroupedCards::ListingComponent, type: "component" do
   subject { render_inline(instance) && page }
+  let(:custom_description) { "a very nice card indeed" }
 
   let(:instance) { described_class.new data }
   let(:organisation) do
@@ -14,8 +15,11 @@ describe GroupedCards::ListingComponent, type: "component" do
   end
   let :data do
     {
-      "Region 1" => [organisation, organisation],
-      "Region 2" => [organisation],
+      "Region 1" => { "providers" => [organisation, organisation] },
+      "Region 2" => {
+        "providers" => [organisation],
+        "description" => { plain: custom_description }
+      },
     }
   end
 
@@ -27,4 +31,6 @@ describe GroupedCards::ListingComponent, type: "component" do
   it { is_expected.to have_css "h3", text: "Region 2" }
 
   it { is_expected.to have_css ".group__card", count: 3 }
+
+  it { is_expected.to have_css(".group__description", text: custom_description) }
 end


### PR DESCRIPTION
### Trello card

N/A

Replaces #1427

### Context

We've had a request from international colleagues to include a new set of AO providers that are overseas providers of Assessment Only. Adding these in.
Reviewing tips

### Guidance to review

Disable whitespace sweat_smile

