### PR TITLE
Make focussed footer links have black text

### DIFF
--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -30,6 +30,10 @@ footer.site-footer {
 
         color: $grey-mid;
         margin-bottom: .5em;
+
+        &:focus {
+          color: $black;
+        }
       }
 
       // column-gap: 1.5em;
@@ -69,6 +73,10 @@ footer.site-footer {
       a,
       a:hover {
         text-decoration: none;
+      }
+
+      a:focus {
+        color: $black;
       }
     }
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/vP0MCNwz/1810-fix-focus-state-contrast-in-the-footer

### Context

This provides a much higher contrast when focusses (black on yellow vs grey on yellow)


| Before | After |
| ------ | -------|
| ![Screenshot from 2021-08-09 11-49-32](https://user-images.githubusercontent.com/128088/128892688-9f5cded4-de9f-4c34-9c96-f1531ee91597.png) | ![Screenshot from 2021-08-10 15-41-04](https://user-images.githubusercontent.com/128088/128892709-fcb72006-5c9d-4547-990c-18ab2cf99fa8.png) |