### PR TITLE
Ensure footer is at bottom of viewport on short pages

### DIFF
--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -1,35 +1,37 @@
-<section class="talk-to-us" data-controller="talk-to-us">
-  <section class="container">
-    <div>
-      <h2 class="purple" id="talk-to-us">Talk to us</h2>
-      <div class="content">
-        <section class="contact">
-          <p>Monday to Friday between <strong>8:30am and 5:30pm</strong></p>
-          <div class="options">
-            <div>
-              <p>Live chat</p>
-              <a href="#" class="button" data-action="click->talk-to-us#startChat">
-                Chat online
-              </a>
+<div>
+  <section class="talk-to-us" data-controller="talk-to-us">
+    <section class="container">
+      <div>
+        <h2 class="purple" id="talk-to-us">Talk to us</h2>
+        <div class="content">
+          <section class="contact">
+            <p>Monday to Friday between <strong>8:30am and 5:30pm</strong></p>
+            <div class="options">
+              <div>
+                <p>Live chat</p>
+                <a href="#" class="button" data-action="click->talk-to-us#startChat">
+                  Chat online
+                </a>
+              </div>
+              <div>
+                <p>Call us</p>
+                <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+              </div>
             </div>
-            <div>
-              <p>Call us</p>
-              <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
-            </div>
-          </div>
-        </section>
-        <section>
-          <h3>Get a teacher training adviser</h3>
-          <p>
-            An experienced teaching professional can help if you're ready to get into
-            teaching or if you're returning to teaching and qualified to teach maths,
-            physics or languages.
-          </p>
-          <a href="/tta-service" class="button">
-            Get an adviser
-          </a>
-        </section>
+          </section>
+          <section>
+            <h3>Get a teacher training adviser</h3>
+            <p>
+              An experienced teaching professional can help if you're ready to get into
+              teaching or if you're returning to teaching and qualified to teach maths,
+              physics or languages.
+            </p>
+            <a href="/tta-service" class="button">
+              Get an adviser
+            </a>
+          </section>
+        </div>
       </div>
-    </div>
+    </section>
   </section>
-</section>
+</div>

--- a/app/components/header/breadcrumb_component.html.erb
+++ b/app/components/header/breadcrumb_component.html.erb
@@ -1,4 +1,4 @@
-<section class="container container--narrow">
+<section class="breadcrumbs container container--narrow">
   <nav class="breadcrumb" aria-label="breadcrumb">
     <ol>
       <% helpers.breadcrumb_trail do |crumb| %>

--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -1,46 +1,50 @@
-.breadcrumb {
-  ol {
-    display: flex;
-    flex-wrap: wrap;
-    box-sizing: border-box;
-    padding: .5rem $indent-amount;
-    margin: 2em 0 0;
-    list-style: none;
+.breadcrumbs {
+  min-width: $content-max-width;
 
-    * {
+  .breadcrumb {
+    ol {
+      display: flex;
+      flex-wrap: wrap;
       box-sizing: border-box;
-    }
+      padding: .5rem $indent-amount;
+      margin: 2em 0 0;
+      list-style: none;
 
-    li {
-      a {
-        position: relative;
-        display: block;
-        margin-right: .8em;
-        color: $black;
-        font-size: .842em;
-        @include mq($until: tablet) {
-          font-size: .737em;
-        }
-
-        &:after {
-          content: "";
-          display: inline-block;
-          width: .5em;
-          height: .5em;
-          border: 2px solid $black;
-          border-width: 2px 2px 0 0;
-          margin-left: 6px;
-          transform: rotate(45deg);
-        }
+      * {
+        box-sizing: border-box;
       }
 
-      &:last-child {
+      li {
         a {
-          margin-right: 0;
-          padding-right: 0;
+          position: relative;
+          display: block;
+          margin-right: .8em;
+          color: $black;
+          font-size: .842em;
+          @include mq($until: tablet) {
+            font-size: .737em;
+          }
 
           &:after {
-            display: none;
+            content: "";
+            display: inline-block;
+            width: .5em;
+            height: .5em;
+            border: 2px solid $black;
+            border-width: 2px 2px 0 0;
+            margin-left: 6px;
+            transform: rotate(45deg);
+          }
+        }
+
+        &:last-child {
+          a {
+            margin-right: 0;
+            padding-right: 0;
+
+            &:after {
+              display: none;
+            }
           }
         }
       }

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -1,9 +1,15 @@
 %content-width-limiter-shared {
+  width: 100%;
   max-width: $page-max-width;
   margin: auto;
 }
 
 body {
+  display: flex;
+  flex-direction: column;
+  justify-items: flex-start;
+  min-height: 100vh;
+
   font-family: $git-font-family;
 
   &.govuk-body {
@@ -41,6 +47,8 @@ $content-max-width: 1000px;
 
 main {
   margin-bottom: 3em;
+
+  flex-grow: 1;
 
   @include mq($from: tablet) {
     margin-bottom: 4em;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -43,7 +43,7 @@ main,
 
 // new layouts, intended to remove the reliance on float and instead use semantic markup and flexbox:
 
-$content-max-width: 1000px;
+$content-max-width: 1200px;
 
 main {
   margin-bottom: 3em;


### PR DESCRIPTION
### Trello card

https://trello.com/c/FVynHujX/1768-footer-is-too-high-on-mailing-list-signup

### Context

We currently have a bug where the `<main>` element being short means that the footer isn't at the bottom of the screen. This looks bad but is admittedly a minor problem.

The simple fix is to make `<body>` [flex](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow) and allow `<main>` to grow. This will push the footer to the bottom of the viewport. I've also made the content area a tiny bit wider on bigger screens.

### Changes proposed in this pull request

- Make body element display as a flex column
- Make content container a bit wider

### Guidance to review

Probably worth giving this a closer look in Safari to make sure nothing's horribly broken - it shouldn't be!

### Preview

| Before | After |
| ------ | ------- |
| ![Screenshot from 2021-08-11 16-02-48](https://user-images.githubusercontent.com/128088/129056389-fdfe2257-cf86-4730-930e-2032daaac215.png) | ![Screenshot from 2021-08-11 16-02-50](https://user-images.githubusercontent.com/128088/129056406-d5354ad0-2d29-462f-bc55-abf369d398e6.png)|

