### PR TITLE
Remove breadcrumbs from main content pages

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -4,4 +4,8 @@ module ContentHelper
       classes << "fullwidth" if front_matter["fullwidth"]
     end
   end
+
+  def root_page?(path)
+    path.count("/") == 1
+  end
 end

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(breadcrumbs: !root_page?(request.path)) %>
 
     <main role="main" id="main-content">
       <section class="container blog">

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-    <%= render HeaderComponent.new do |c| %>
+    <%= render HeaderComponent.new(breadcrumbs: !root_page?(request.path)) do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>
 

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-    <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
+    <%= render HeaderComponent.new do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>
 

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-    <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
+    <%= render HeaderComponent.new(breadcrumbs: !root_page?(request.path)) do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>
 

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-    <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
+    <%= render HeaderComponent.new do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>
 

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link scroll", "link-target": "content" }, id: "body" do %>
 
-      <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
+      <%= render HeaderComponent.new do |c| %>
         <%= c.hero(@front_matter) %>
       <% end %>
 

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -35,46 +35,10 @@ RSpec.feature "Breadcrumbs", type: :feature do
     end
   end
 
-  context "when query params are present" do
-    let(:path) { page_path("ways-to-train", amazing: "yes") }
-
-    it { is_expected.to have_css(".breadcrumb") }
-
-    it "includes the parent page" do
-      page.within ".breadcrumb" do
-        is_expected.to have_link "Home", href: "/"
-      end
-    end
-
-    it "doesn't include the current page" do
-      page.within ".breadcrumb" do
-        is_expected.not_to have_link "Ways to train"
-      end
-    end
-  end
-
   context "when visiting a content page without a title" do
     let(:path) { page_path("no-title") }
 
     it { is_expected.to have_http_status(:success) }
-  end
-
-  context "when visiting a disclaimer page" do
-    let(:path) { page_path("disclaimer") }
-
-    it { is_expected.to have_css(".breadcrumb") }
-  end
-
-  context "when visiting the stories landing page" do
-    let(:path) { page_path("stories/landing-page") }
-
-    it { is_expected.to have_css(".breadcrumb") }
-  end
-
-  context "when visiting the story listing page" do
-    let(:path) { page_path("stories/list-page") }
-
-    it { is_expected.to have_css(".breadcrumb") }
   end
 
   context "when visiting the story page" do

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -29,4 +29,19 @@ describe ContentHelper, type: :helper do
       end
     end
   end
+
+  describe "#root_page?" do
+    {
+      "/" => true,
+      "/one" => true,
+      "/one/two" => false,
+      "/one/two/three" => false,
+    }.each do |path, expected_result|
+      context "path: #{path}" do
+        specify "returns #{expected_result}" do
+          expect(root_page?(path)).to be expected_result
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

It doesn't really make sense to include a breadcrumbs list with one entry ('Home') on pages that are siblings to the home page. Home is also represented in the main nav and is accessible by clicking the logo.

We should only show breadcrumbs on pages that are more than one level deep.

This PR removes them from:

* the content layout (used by 'ways to train', 'salaries and benefits', 'funding your training')
* the stories landing page layout (but not the story categories or individual story pages)
* the steps layout

It's probably worth discussing before merging this 😅

### Preview

| Before | After |
| ----- | ----- |
| ![Screenshot from 2021-08-11 16-27-22](https://user-images.githubusercontent.com/128088/129058194-4f161004-a92a-4bba-9172-5565b132cb71.png) | ![Screenshot from 2021-08-11 16-27-10](https://user-images.githubusercontent.com/128088/129058202-2e645d71-b29d-400b-8ec7-7eed853428e6.png) |
 | ![Screenshot from 2021-08-11 16-27-35](https://user-images.githubusercontent.com/128088/129058263-5aeb4216-2f8e-4df8-af77-dd727ea9adc4.png) |![Screenshot from 2021-08-11 16-27-45](https://user-images.githubusercontent.com/128088/129058260-b259f7eb-9980-45b3-a198-2d28b50fdd24.png) |
| ![Screenshot from 2021-08-11 16-28-03](https://user-images.githubusercontent.com/128088/129058368-cc2feb04-f0cf-47cf-9565-51cc46f183d9.png) | ![Screenshot from 2021-08-11 16-27-55](https://user-images.githubusercontent.com/128088/129058385-4c470c04-2315-4237-b824-aefedd81d3ca.png) |


