### PR TITLE
Make the blog title display correctly

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -5,7 +5,7 @@ class BlogController < ApplicationController
   layout "layouts/blog/index"
 
   def index
-    @front_matter = { title: "Get Into Teaching Blog" }
+    @front_matter = { "title" => "Blog" }
 
     @posts = Pages::Blog.posts
   end


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

Previously it wasn't displaying at all because front matter expects a string key rather than a symbol. Secondly, 'Get Into Teaching' would be repeated ("Get Into Teaching: Get Into Teaching Blog"), so just call it blog.
