### PR TITLE
Force a width on external link icons

### DIFF
--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -33,6 +33,7 @@ a {
 
 .external-link-icon {
   margin-left: .2em;
+  width: .8em !important;
 }
 
 .button {


### PR DESCRIPTION
Now they're inline images rather than applied via CSS (#1548) the regular styles are being applied. Now we have external links in the blog (where we have generic image styles on mobile), the icons are picking up the styles intended for photos.

This forces them to always be .8em


![Screenshot from 2021-08-13 10-55-39](https://user-images.githubusercontent.com/128088/129339910-f7fd2bb9-9fa9-45b7-b42c-485df9930abe.png)
