### PR TITLE
Fix typos in the SCITT acronym

### DIFF
--- a/config/frontmatter.yml
+++ b/config/frontmatter.yml
@@ -7,7 +7,7 @@ acronyms:
   EEA: European Economic Area
   DfE: Department for Education
   TLR: Teaching and learning responsibility
-  SCITT: School-Centred Initial Ieacher Iraining
+  SCITT: School-Centred Initial Teacher Training
   CAS: Confirmation of Acceptance for Studies
   ICT: Information and Communication Technologies
   NPQ: National Professional Qualification


### PR DESCRIPTION
### Context and changes

These were copied over from the old get-into-teaching-content repo
