### PR TITLE
Allow page headings and titles to be set independently

### DIFF
--- a/app/components/header/hero_component.rb
+++ b/app/components/header/hero_component.rb
@@ -6,7 +6,7 @@ module Header
       return if front_matter.blank?
 
       front_matter.with_indifferent_access.tap do |fm|
-        @title           = fm["title"]
+        @title           = fm["heading"] || fm["title"]
         @subtitle        = fm["subtitle"]
         @subtitle_link   = fm["subtitle_link"]
         @subtitle_button = fm["subtitle_button"]

--- a/app/models/pages/navigation.rb
+++ b/app/models/pages/navigation.rb
@@ -34,7 +34,7 @@ module Pages
         @path = front_matter[:navigation_path] || path
 
         front_matter.tap do |fm|
-          @title = fm[:navigation_title] || fm[:title] || (Rails.logger.warn("page #{path} has no title") && nil)
+          @title = extract_title(fm) || (Rails.logger.warn("page #{path} has no title") && nil)
           @rank  = fm.fetch(:navigation, nil)
           @menu  = fm.fetch(:menu, false)
         end
@@ -50,6 +50,12 @@ module Pages
 
       def menu?
         @menu
+      end
+
+    private
+
+      def extract_title(front_matter)
+        front_matter.values_at(:navigation_title, :heading, :title).find(&:presence)
       end
     end
   end

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -1,5 +1,6 @@
 ---
-title: "Salaries and benefits"
+title: "Teacher salaries and benefits"
+heading: "Salaries and benefits"
 description: |-
   Pay scales for teachers in England and Wales. Find the pay ranges for different roles, how many days holiday teachers get each year, 
   and what to expect from the generous teacher pension scheme.

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -1,6 +1,5 @@
 ---
-title: "Teacher salaries and benefits"
-heading: "Salaries and benefits"
+title: "Salaries and benefits"
 description: |-
   Pay scales for teachers in England and Wales. Find the pay ranges for different roles, how many days holiday teachers get each year, 
   and what to expect from the generous teacher pension scheme.

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -15,7 +15,7 @@
               <%= tag.span(@front_matter["title_caption"], class: "caption") %>
             <% end %>
 
-            <%= tag.h1(@front_matter["title"]) %>
+            <%= tag.h1(@front_matter["heading"] || @front_matter["title"]) %>
           </header>
         <% end %>
 

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe Header::HeroComponent, type: "component" do
+  let(:extra_front_matter) { {} }
   let(:front_matter) do
     {
       "title" => "Teaching, it's pretty awesome",
@@ -10,15 +11,23 @@ describe Header::HeroComponent, type: "component" do
       "subtitle_link" => "/signup",
       "subtitle_button" => "Find out more",
       "image" => "media/images/content/hero-images/0012.jpg",
-    }
+    }.merge(extra_front_matter)
   end
   let(:component) { described_class.new(front_matter) }
   subject! { render_inline(component) }
 
   describe "rendering a hero section" do
     describe "title and subtitle" do
-      specify "renders the title" do
+      specify "renders the title in a h1 element" do
         expect(page).to have_css(".hero__title > h1", text: front_matter["title"])
+      end
+
+      context "when the heading overrides the title" do
+        let(:extra_front_matter) { { "heading" => "Here's my custom heading" } }
+
+        specify "renders the heading in a h1 element" do
+          expect(page).to have_css(".hero__title > h1", text: front_matter["heading"])
+        end
       end
 
       specify "renders the subtitle" do

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -151,8 +151,10 @@ RSpec.feature "content pages check", type: :feature, content: true do
     scenario "navigable pages appear in desktop navbar" do
       # skip home as we've just navigated to '/'
       navigation_pages.reject { |k, _v| k == "/home" }.each do |url, frontmatter|
+        expected_title = frontmatter[:navigation_title] || frontmatter[:heading] || frontmatter[:title]
+
         page.within "nav ol.primary" do
-          is_expected.to have_link frontmatter[:title], href: url
+          is_expected.to have_link expected_title, href: url
         end
       end
     end

--- a/spec/models/pages/navigation_spec.rb
+++ b/spec/models/pages/navigation_spec.rb
@@ -103,14 +103,27 @@ RSpec.describe Pages::Navigation do
       end
     end
 
-    context "when the navigation title is overridden" do
-      let(:custom_navigation_title) { "January sales!" }
-      let(:front_matter) { { title: title, navigation: navigation, menu: menu, navigation_title: custom_navigation_title } }
+    context "when the title is overridden" do
+      context "when a 'navigation_title' is set" do
+        let(:custom_navigation_title) { "January sales!" }
+        let(:front_matter) { { title: title, navigation: navigation, menu: menu, navigation_title: custom_navigation_title } }
 
-      subject { described_class.new(outer_navigation, path, front_matter) }
+        subject { described_class.new(outer_navigation, path, front_matter) }
 
-      specify "assigns the custom path to :path attr" do
-        expect(subject.title).to eql(custom_navigation_title)
+        specify "assigns the custom path to :path attr" do
+          expect(subject.title).to eql(custom_navigation_title)
+        end
+      end
+
+      context "when the page 'heading' has been set" do
+        let(:custom_heading) { "Sale on nowheading" }
+        let(:front_matter) { { title: title, navigation: navigation, menu: menu, heading: custom_heading } }
+
+        subject { described_class.new(outer_navigation, path, front_matter) }
+
+        specify "assigns the custom path to :path attr" do
+          expect(subject.title).to eql(custom_heading)
+        end
       end
     end
 
@@ -165,6 +178,32 @@ RSpec.describe Pages::Navigation do
       specify "contains only the nodes that start with the same path" do
         expect(subject.children.map(&:path)).to all(start_with("/page-five"))
         expect(subject.children.map(&:rank)).to all(be_in(5..6))
+      end
+    end
+
+    describe "#extract_title" do
+      [
+        OpenStruct.new(
+          description: "only a title is provided",
+          front_matter: { title: "Just a title" },
+          expected_key: :title,
+        ),
+        OpenStruct.new(
+          description: "a heading and title are provided",
+          front_matter: { heading: "Heading", title: "Unused title" },
+          expected_key: :heading,
+        ),
+        OpenStruct.new(
+          description: "a navigation title, heading and title are provided",
+          front_matter: { navigation_title: "Navigation title", heading: "Heading", title: "Unused title" },
+          expected_key: :navigation_title,
+        ),
+      ].each do |options|
+        context "when #{options.description}" do
+          specify "the title matches the frontmatter's #{options.expected_key}" do
+            expect(subject.send(:extract_title, options.front_matter)).to eql(options.front_matter[options.expected_key])
+          end
+        end
       end
     end
   end

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -20,4 +20,17 @@ describe "ensuring frontmatter from content pages is rendered" do
       it { is_expected.to include(expected) }
     end
   end
+
+  context "with a different heading and title" do
+    before { get "/custom-heading" }
+    subject { response.body }
+    let(:document) { Nokogiri.parse(response.body) }
+
+    it { expect(response).to have_http_status(200) }
+
+    specify "sets both the title and heading correctly" do
+      expect(document.css('title').text).to end_with("Title goes here")
+      expect(document.css('h1').text).to eql("Heading goes here")
+    end
+  end
 end

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -29,8 +29,8 @@ describe "ensuring frontmatter from content pages is rendered" do
     it { expect(response).to have_http_status(200) }
 
     specify "sets both the title and heading correctly" do
-      expect(document.css('title').text).to end_with("Title goes here")
-      expect(document.css('h1').text).to eql("Heading goes here")
+      expect(document.css("title").text).to end_with("Title goes here")
+      expect(document.css("h1").text).to eql("Heading goes here")
     end
   end
 end

--- a/spec/support/views/content/custom-heading.md
+++ b/spec/support/views/content/custom-heading.md
@@ -1,0 +1,7 @@
+---
+layout: "layouts/content"
+title: "Title goes here"
+heading: "Heading goes here"
+---
+
+Some content


### PR DESCRIPTION
### Trello card

https://trello.com/c/rgeIda1X/1861-separate-title-and-h1-to-give-greater-flexibility-for-seo

### Context

Sometimes it might be beneficial to be able to set the page title and heading separately.

#### How it fits together

cc @gemmadallmandfe 

Now there are three heading/title related settings available in the front matter:

* `title` - the minimum that's required, when only it is set this value will form the page title, the main heading (`<h1>`) on the page and the text inside the navigation menu
* `navigation_title` - when set, it'll override the `title` in the navigation menu. Used on the homepage where `title: Inspire the next generation` and `navigation_title: Home`
* `heading` - when set it'll override the `title` in the main page header (usually in the hero)

### Changes proposed in this pull request

- Allow front matter heading to override title
- Update the salaries and benefits heading