### PR TITLE
Add an extra assertion to redirects spec

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -38,7 +38,6 @@ redirects:
   "/life-as-a-teacher/my-story-into-teaching/career-changers/financiers-future-in-maths": "/my-story-into-teaching/career-changers/financiers-future-in-maths"
   "/life-as-a-teacher/my-story-into-teaching/career-changers/from-construction-site-to-classroom": "/my-story-into-teaching/career-changers/from-construction-site-to-classroom"
   "/life-as-a-teacher/my-story-into-teaching/career-changers/from-developing-software-to-developing-students": "/my-story-into-teaching/career-changers/from-developing-software-to-developing-students"
-  "/life-as-a-teacher/my-story-into-teaching/career-changers/leaping-to-head-of-department": "/my-story-into-teaching/career-changers/leaping-to-head-of-department"
   "/life-as-a-teacher/my-story-into-teaching/career-changers/make-a-difference-to-young-people": "/my-story-into-teaching/career-changers/make-a-difference-to-young-people"
   "/life-as-a-teacher/my-story-into-teaching/career-changers/natural-transition-from-engineering-to-teaching-physics": "/my-story-into-teaching/career-changers/natural-transition-from-engineering-to-teaching-physics"
   "/life-as-a-teacher/my-story-into-teaching/career-changers/passing-on-my-knowledge": "/my-story-into-teaching/career-changers/passing-on-my-knowledge"

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Redirects" do
+describe "Redirects", content: true do
   let(:query_string) { "abc=def&ghi=jkl" }
 
   redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -17,6 +17,13 @@ describe "Redirects" do
         specify "redirects successfully" do
           expect(subject).to be 301
           expect(response).to redirect_to(to)
+
+          target = Nokogiri.parse(response.body).at_css("a")["href"].gsub(root_url, "/")
+
+          # skip events stuff and the privacy policy because they're pulled from the CRM
+          next if target =~ /event|privacy/
+
+          expect(get(target)).to be_in([200, 301, 302])
         end
       end
 


### PR DESCRIPTION
### Trello card

N/A

### Context and changes

The new assertion does a `GET` to ensure the target pages is definitely there. Skip any pages where we contact the CRM (dates and privacy policy).

This highlighted an incorrect rule that's a result of an old duplicate story that was removed several months ago - it has been removed.
