### PR TITLE
Add Skylight badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 - NodeJS 12.22.x
 - Yarn 1.22.x
 
+## Status
+
+[![View performance data on Skylight](https://badges.skylight.io/status/cCXe4O12iXtO.svg?token=dmQT0j0nuvDKRWL0RSr5ZMr-ARd25yfRzTePxnMsLYU)](https://www.skylight.io/app/applications/cCXe4O12iXtO)
+[![View traffic data on Skylight](https://badges.skylight.io/rpm/cCXe4O12iXtO.svg?token=dmQT0j0nuvDKRWL0RSr5ZMr-ARd25yfRzTePxnMsLYU)](https://www.skylight.io/app/applications/cCXe4O12iXtO)
+[![View typical response times on Skylight](https://badges.skylight.io/typical/cCXe4O12iXtO.svg?token=dmQT0j0nuvDKRWL0RSr5ZMr-ARd25yfRzTePxnMsLYU)](https://www.skylight.io/app/applications/cCXe4O12iXtO)
+[![View problem response times on Skylight](https://badges.skylight.io/problem/cCXe4O12iXtO.svg?token=dmQT0j0nuvDKRWL0RSr5ZMr-ARd25yfRzTePxnMsLYU)](https://www.skylight.io/app/applications/cCXe4O12iXtO)
+
 ## Mac Setup (as of Catalina 11-07-20)
 
 1. install homebrew, this will ask to install the xcode command line tools if you dont have it already


### PR DESCRIPTION
In order to sign up for [Skylight for Open Source](https://www.skylight.io/support/skylight-for-open-source#setup) we need to [link to Skylight from our README](https://www.skylight.io/support/skylight-for-open-source#requirements) and these badges do that and are also generally useful.
