### PR TITLE
Make the event section layout columnar on mobile

### DIFF
--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -216,6 +216,10 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+
+        @include mq($until: tablet) {
+          flex-direction: column-reverse;
+        }
       }
 
       &__logo {
@@ -224,6 +228,10 @@
         left: auto;
         transform: scale(.7);
         margin-right: -58px;
+
+        @include mq($until: tablet) {
+          align-self: end;
+        }
       }
     }
   }

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -230,7 +230,7 @@
         margin-right: -58px;
 
         @include mq($until: tablet) {
-          align-self: end;
+          align-self: flex-end;
         }
       }
     }


### PR DESCRIPTION
### Trello card

https://trello.com/c/3QNsSmwD/1877-events-section-heading-doesnt-resize-gracefully

### Context

This prevents the logo from squishing the text into an awkward shape.  We're using column-reverse here to make the logo appear above the heading text.

| Before | After |
| ------ | ------ |
| ![Screenshot-2021-08-20-15:54:22](https://user-images.githubusercontent.com/128088/130252884-03e6c884-0435-44c8-ab39-f6f4337c20b0.png) | ![Screenshot-2021-08-20-15:54:07](https://user-images.githubusercontent.com/128088/130252899-daf47146-f8c0-4f77-9edd-2b820bb28206.png) |

### Review guidance

My mouse must've gone over the Birmingham event when screenshotting on live, the black outline is from the hover state!