### PR TITLE
Make breadcrumbs bar 100% width up to max page

### DIFF
--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -1,5 +1,7 @@
 .breadcrumbs {
-  min-width: $content-max-width;
+  width: 100%;
+  max-width: $page-max-width;
+  margin: auto;
 
   .breadcrumb {
     ol {


### PR DESCRIPTION
Using max instead of min will prevent the screen from stretching on mobile.
