### PR TITLE
Remove the right margin from extra nav on mobile

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -110,7 +110,7 @@ html.js-enabled {
       flex-direction: column;
       text-align: left;
       background-color: $grey;
-      padding: 1.5em 4em;
+      padding: 1.5em 0 1.5em 4em;
 
       input {
         margin: 0;


### PR DESCRIPTION
This was pushing the width of the page wider than necessary on mobile.  Now there's no horizontal scroll down to iPhone 5 sizes.


![Screenshot-2021-08-20-17:59:17](https://user-images.githubusercontent.com/128088/130268293-8fc6714b-5e78-4fc4-8dd0-e9b94b869989.png)
