### PR TITLE
Favour 'Next steps' over 'Next Steps'

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -35,7 +35,7 @@
             </div>
           </div>
           <div>
-            <h3>Next Steps</h3>
+            <h3>Next steps</h3>
             <div>
               Use the <a href="https://www.gov.uk/student-finance-calculator">student finance calculator</a> to find out how much you can get.<br />
               Explore <a href="/ways-to-train">ways to train</a>.
@@ -50,7 +50,7 @@
             </div>
           </div>
           <div>
-            <h3>Next Steps</h3>
+            <h3>Next steps</h3>
             <div>
               Find out more about <a href="#bursaries-and-scholarships">bursaries and scholarships</a>, including T&Cs.<br />
               Explore <a href="/ways-to-train">ways to train</a>.

--- a/app/views/callbacks/steps/_form.html.erb
+++ b/app/views/callbacks/steps/_form.html.erb
@@ -9,7 +9,7 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <% button_text = safe_html_format(wizard.last_step? ? "Book your callback <span></span>" : "Next Step <span></span>") %>
+      <% button_text = safe_html_format(wizard.last_step? ? "Book your callback <span></span>" : "Next step <span></span>") %>
       <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
   <% end %>

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -12,7 +12,7 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next Step <span></span>") %>
+      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next step <span></span>") %>
       <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
   <% end %>

--- a/app/views/event_steps/_further_details.html.erb
+++ b/app/views/event_steps/_further_details.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% if f.object.can_subscribe_to_mailing_list? %>
-  <div data-controller="last-step" data-last-step-complete="Complete sign up<span></span>" data-last-step-continue="Next Step<span></span>">
+  <div data-controller="last-step" data-last-step-complete="Complete sign up<span></span>" data-last-step-continue="Next step<span></span>">
     <div data-action="click->last-step#updateSubmit">
       <%= f.govuk_radio_buttons_fieldset :subscribe_to_mailing_list, inline: true do %>
         <%= f.govuk_radio_button :subscribe_to_mailing_list, true, label: { text: "Yes" } %>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -9,7 +9,7 @@
     <%= render current_step.key, current_step: current_step, f: f %>
 
     <% if wizard.can_proceed? %>
-      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next Step <span></span>") %>
+      <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next step <span></span>") %>
       <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
   <% end %>

--- a/spec/components/funding_widget_component_spec.rb
+++ b/spec/components/funding_widget_component_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe FundingWidgetComponent, type: :component do
         expect(page).to have_css("h3", text: "Biology - Secondary")
       end
 
-      it "has the 'Next Steps' info" do
-        expect(page).to have_css("h3", text: "Next Steps")
+      it "has the 'Next steps' info" do
+        expect(page).to have_css("h3", text: "Next steps")
       end
 
       it "has additional info for extra support" do

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -40,21 +40,21 @@ RSpec.feature "Book a callback", type: :feature do
 
     expect(page).to have_text "Book a callback"
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to email@address.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Choose a time for your callback"
     expect(find_field("Phone number").value).to eq(response.address_telephone)
     # Select time in local time zone (London)
     select "11:00 am - 12:00 pm", from: "Select your preferred day and time for a callback"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Tell us what you’d like to talk to us about"
     select "Routes into teaching", from: "Choose an option"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     check "Yes"
@@ -84,17 +84,17 @@ RSpec.feature "Book a callback", type: :feature do
 
     expect(page).to have_text "Book a callback"
 
-    click_on "Next Step"
+    click_on "Next step"
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Enter your first name"
     expect(page).to have_text "Enter your last name"
     expect(page).to have_text "Enter your full email address"
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to email@address.com", with: "654321"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
@@ -102,24 +102,24 @@ RSpec.feature "Book a callback", type: :feature do
     expect(page).to have_text "We've sent you another email."
 
     fill_in "Check your email and enter the verification code sent to email@address.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Choose a time for your callback"
-    click_on "Next Step"
+    click_on "Next step"
     expect(page).to have_text "Enter your telephone number"
     fill_in "Phone number", with: "12"
-    click_on "Next Step"
+    click_on "Next step"
     expect(page).to have_text "Enter a valid phone number"
     fill_in "Phone number", with: "123456789"
     # Select time in local time zone (London)
     select "11:00 am - 12:00 pm", from: "Select your preferred day and time for a callback"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Tell us what you’d like to talk to us about"
-    click_on "Next Step"
+    click_on "Next step"
     expect(page).to have_text "Choose an option"
     select "Routes into teaching", from: "Choose an option"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     click_on "Book your callback"
@@ -146,18 +146,18 @@ RSpec.feature "Book a callback", type: :feature do
 
     expect(page).to have_text "Book a callback"
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "We didn’t recognise the first name, last name or email address you entered"
 
     click_link "Try entering your details again"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "We didn’t recognise the first name, last name or email address you entered"
     expect(page).to have_text "Try entering your details again"
 
     click_link "Try entering your details again"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "We didn’t recognise your first name, last name or email address"
     expect(page).to have_text "Once you’re registered, you can try again"
@@ -166,7 +166,7 @@ RSpec.feature "Book a callback", type: :feature do
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError.new(code: 500))
 
     visit callbacks_steps_path
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Sorry, a technical problem means we can’t book your callback right now."
   end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -30,10 +30,10 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     fill_in "Phone number (optional)", with: "01234567890"
-    click_on "Next Step"
+    click_on "Next step"
 
     within_fieldset "Would you like to receive email updates" do
       choose "No"
@@ -59,10 +59,10 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     fill_in "Phone number (optional)", with: "01234567890"
-    click_on "Next Step"
+    click_on "Next step"
 
     within_fieldset "Would you like to receive email updates" do
       choose "Yes"
@@ -97,10 +97,10 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     fill_in "Phone number (optional)", with: "01234567890"
-    click_on "Next Step"
+    click_on "Next step"
 
     within_fieldset "Would you like to receive email updates" do
       choose "No"
@@ -138,11 +138,11 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Are you over 16 and do you agree"
     expect(page).to have_text "Would you like to receive email updates"
@@ -193,11 +193,11 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "654321"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
@@ -205,7 +205,7 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "We've sent you another email."
 
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text("Phone number (optional)")
   end
@@ -227,14 +227,14 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text("Phone number (optional)")
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text("Are you over 16 and do you agree")
     expect(page).not_to have_text("Would you like to receive email updates")
@@ -273,14 +273,14 @@ RSpec.feature "Event wizard", type: :feature do
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text("Phone number (optional)")
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text("Are you over 16 and do you agree")
     expect(page).not_to have_text("Would you like to receive email updates")

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -13,25 +13,25 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to_not have_text "Tell us more about you so that you only get emails relevant to your circumstances."
 
     expect(page).to have_text "Do you have a degree?"
     choose "Not yet, I'm a first year student"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "How close are you to applying"
     choose "I’m not sure and finding out more"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Which subject do you want to teach"
     select "Maths"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "events in your area"
     fill_in "Your postcode (optional)", with: "TE57 1NG"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     click_on "Complete sign up"
@@ -55,23 +55,23 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
     choose "Not yet, I'm a first year student"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "How close are you to applying"
     choose "I’m not sure and finding out more"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Which subject do you want to teach"
     select "Maths"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "events in your area"
     fill_in "Your postcode (optional)", with: "TE57 1NG"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     click_on "Complete sign up"
@@ -102,30 +102,30 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
     expect(find("[name=\"mailing_list_steps_degree_status[degree_status_id]\"][checked]").value).to eq(
       response.degree_status_id.to_s,
     )
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "How close are you to applying"
     expect(find("[name=\"mailing_list_steps_teacher_training[consideration_journey_stage_id]\"][checked]").value).to eq(
       response.consideration_journey_stage_id.to_s,
     )
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Which subject do you want to teach"
     expect(page).to have_select(
       "Which subject do you want to teach?",
       selected: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.key(response.preferred_teaching_subject_id),
     )
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     click_on "Complete sign up"
@@ -153,11 +153,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "654321"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
@@ -165,7 +165,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "We've sent you another email."
 
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
   end
@@ -184,14 +184,14 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "You’ve already signed up"
-    expect(page).not_to have_button("Next Step")
+    expect(page).not_to have_button("Next step")
   end
 
   scenario "Full journey as an existing candidate that has already subscribed to a teacher training adviser" do
@@ -208,11 +208,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
   end
@@ -237,21 +237,21 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(find("[name=\"mailing_list_steps_degree_status[degree_status_id]\"][checked]").value).to eq(
       response.degree_status_id.to_s,
     )
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "How close are you to applying"
     expect(find("[name=\"mailing_list_steps_teacher_training[consideration_journey_stage_id]\"][checked]").value).to eq(
       response.consideration_journey_stage_id.to_s,
     )
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Which subject do you want to teach"
     select "Maths"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "events in your area"
     fill_in "Your postcode (optional)", with: "TE57 1NG"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
     check "Yes"
@@ -288,11 +288,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
     fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "You’ve already signed up"
     click_link("Back")
@@ -305,7 +305,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step(email: "test2@user.com")
-    click_on "Next Step"
+    click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
   end
@@ -321,7 +321,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_title(expected_title)
 
     # try incorrectly first so we can check error state
-    click_on "Next Step"
+    click_on "Next step"
     expect(page).to have_text "There is a problem"
     expect(page).to have_text "Enter your first name"
     expect(page).to have_text "Enter your last name"


### PR DESCRIPTION
The GOV.UK Design System strongly suggests that sentence rather than title case is used for headings, buttons and text in general:

> Write all headings in sentence case.

> Write button text in sentence case.
