### PR TITLE
Fix the Scribble iFrame height

### DIFF
--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -115,3 +115,8 @@ $chevron-direction-map: (
 img.lazyload:not([src]) {
   visibility: hidden;
 }
+
+div.scrbbl-embed {
+  height: 380px;
+  overflow-y: scroll;
+}

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -52,6 +52,8 @@ default: &default
 development:
   <<: *default
   compile: true
+  extract_css: true
+
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
The Scribble iFrames are dynamic/variable height which causes massive cumulative layout shift in some cases (as they can be
10,000px high). 

The only work around for this I can think of is to wrap them in a fixed-height div that scrolls. For all open events the iFrame should not change (as we fix it to that height anyway), so its only archived events that are effected, which tend to have the much higher iFrame sizes and will result in a scroll.