### PR TITLE
Increase PNG/JPG image compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,12 @@ RUN bundle install --jobs=$(nproc --all) && \
 COPY . .
 RUN bundle exec rake assets:precompile
 
+# Cap images to have a max width of 1000px
+RUN find public -type f \( -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" \) -exec convert --resize '1000' {} \;
 # Lossless optimize PNGs
 RUN find public -type f -iname "*.png" -exec pngquant --quality=65-80 {} \;
 # Optimize JPEG at 90% quality
-RUN find public -type f \( -iname "*.jpg" -o -iname "*.jpg" \) -exec jpegoptim -m75 --strip-all {} \;
-RUN find public -type f \( -iname "*.jpeg" -o -iname "*.jpeg" \) -exec jpegoptim -m75 --strip-all {} \;
+RUN find public -type f \( -iname "*.jpg" -o -iname "*.jpeg" \) -exec jpegoptim -m75 --strip-all {} \;
 
 # Convert to WebP/JPEG-2000 formats (size constraint avoids an error on empty images)
 # At 75% quality the images still look good and they are roughly half the size.


### PR DESCRIPTION
[Trello-1894](https://trello.com/c/eXIvQ2u1/1894-seo-investigate-possible-core-web-vitals-improvements)

We are being flagged in search console for having a high LCP (largest contentful paint). This appears to be due to large/hero images on the pages.

Increase the optimisation around these images in an effort to make them smaller and the subsequent loading quicker.

Also cap the max width of these images to a max width of 1000px; short of manually resizing all of them depending on how they are used this should at least prevent extreme outliers.
