### PR TITLE
Force digest refresh on assets

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -90,5 +90,8 @@ production:
   # Extract and emit a css file
   extract_css: true
 
+  # Output path
+  public_output_path: "packs/v1"
+
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
As the recent image optimisation tweaks happen on the precompiled assets they haven't refreshed. Updating the pack path to include an asset version will cause CloudFront to re-cache the assets (which are otherwise cached for 1 year).