### PR TITLE
Remove dependency on Luxon

### DIFF
--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from 'stimulus';
-import { DateTime } from 'luxon';
 
 export default class extends Controller {
   static targets = ['name', 'startAt', 'partialUrl', 'errorMessage'];
@@ -32,7 +31,12 @@ export default class extends Controller {
   }
 
   formatDate(dateTimeString) {
-    return DateTime.fromJSDate(new Date(dateTimeString)).toFormat('yyMMdd');
+    const date = new Date(dateTimeString);
+    const year = date.getFullYear().toString().slice(-2);
+    const month = `0${date.getMonth() + 1}`.slice(-2);
+    const day = `0${date.getDate()}`.slice(-2);
+
+    return `${year}${month}${day}`;
   }
 
   formatName(name) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.0",
     "lazysizes": "^5.3.2",
-    "luxon": "^2.0.1",
     "rails-ujs": "^5.2.5",
     "sass-mq": "^5.0.1",
     "serialize-javascript": "^6.0.0",


### PR DESCRIPTION
### Trello card

[Trello-1894](https://trello.com/c/eXIvQ2u1/1894-seo-investigate-possible-core-web-vitals-improvements)

### Context

The Luxon lib makes the date formatting easier in JS; I think we used it more heavily in a previous iteration of the internal events controller, but as we're only formatting a single date - and because it ends up getting pulled into the main application pack - I'm removing it in favour of doing manual date formatting in vanilla JS. It saves around 16kb from our pack size.

### Changes proposed in this pull request

- Remove dependency on Luxon

### Guidance to review

