### PR TITLE
Remove VWO from pages

### DIFF
--- a/config/vwo.yml
+++ b/config/vwo.yml
@@ -7,6 +7,4 @@
 #   - /
 
 paths:
-  - /
-  - /mailinglist/signup/name
-  - /steps-to-become-a-teacher
+


### PR DESCRIPTION
### Trello card

[Trello-1894](https://trello.com/c/eXIvQ2u1/1894-seo-investigate-possible-core-web-vitals-improvements)

### Context

We are no longer running any experiments on these pages so we don't need to be loading VWO, which impacts our page speed.

### Changes proposed in this pull request

- Remove VWO from pages

### Guidance to review

