### PR TITLE
Load JS enabled async

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -11,7 +11,7 @@
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
-  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: false %>
+  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>


### PR DESCRIPTION
### Trello card

[Trello-1897](https://trello.com/c/0E1mVHgC/1897-performance-investigate-removing-unused-javascript)

### Context

We currently load this synchronously, which delays the first contentful paint of the page by ~150ms. Loading it async will prevent this delay and doesn't appear to cause any noticeable flash of layout/content change.

### Changes proposed in this pull request

- Load JS enabled script async

### Guidance to review

