### PR TITLE
Tag Master Branch of Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
              if [ "${{github.ref}}" == "refs/heads/master" ]
              then
                 echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_EVENT::""
+                echo ::set-output name=DOCKER_EVENT::"MASTER"
              else
                 echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:review-${{steps.sha.outputs.short }}
                 echo ::set-output name=DOCKER_EVENT::${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}


### PR DESCRIPTION
Tag the latest master version of the Docker Image, so the Anchore Scanner knows and it can easily be pulled.
