### PR TITLE
Changing for UCAS switch over (Sept 2021)

### DIFF
--- a/app/views/content/teacher-training-advisers/_matt.md
+++ b/app/views/content/teacher-training-advisers/_matt.md
@@ -2,6 +2,6 @@ After 25 years in industry, Matt wanted to switch careers and do something where
 
 “The Teacher Training Adviser service is an essential advisory programme which answers all the questions that a potential trainee may need assistance with at every stage of moving into teaching. It’s also free, so don’t think twice about using this service.” 
 
-“I wouldn’t have known where to go or what to do without my adviser, Simon. I was taken through the detailed requirements of my UCAS Teacher Training application, which is a vast document to navigate through.  Additionally, I received significant advice on the two routes into teaching and the tax-free bursaries. Importantly, I was provided with advice on my personal statement where you have to write about why you want to become a teacher."
+“I wouldn’t have known where to go or what to do without my adviser, Simon. He took me through the requirements of my teacher training application. Additionally, I received significant advice on the two routes into teaching and the tax-free bursaries. Importantly, I was provided with advice on my personal statement where you have to write about why you want to become a teacher."
 
 The advice provided was invaluable. The service took my application from good to excellent.

--- a/app/views/content/teacher-training-advisers/_matt.md
+++ b/app/views/content/teacher-training-advisers/_matt.md
@@ -4,4 +4,4 @@ After 25 years in industry, Matt wanted to switch careers and do something where
 
 “I wouldn’t have known where to go or what to do without my adviser, Simon. He took me through the requirements of my teacher training application. Additionally, I received significant advice on the two routes into teaching and the tax-free bursaries. Importantly, I was provided with advice on my personal statement where you have to write about why you want to become a teacher."
 
-The advice provided was invaluable. The service took my application from good to excellent.
+“The advice provided was invaluable. The service took my application from good to excellent."


### PR DESCRIPTION
Removing reference to UCAS

### Trello card

https://trello.com/c/2q0ZdA7j/1610-ucas-switchover

### Context

Removing reference to postgrad teacher training applications being made through UCAS

Small change - likely to have no impact on keywords or site performance.

