### PR TITLE
Adding section for Apply

### DIFF
--- a/app/views/content/tips-on-applying-for-teacher-training.md
+++ b/app/views/content/tips-on-applying-for-teacher-training.md
@@ -49,6 +49,12 @@ interviews. A [teacher training adviser](/tta-service) can help you with all of 
 
 You can [search for most postgraduate teacher training courses on GOV.UK](https://www.gov.uk/find-postgraduate-teacher-training-courses).
 
+## Where to apply
+
+You can use [Apply for teacher training](https://www.gov.uk/apply-for-teacher-training) to apply for any postgraduate teacher training course.
+
+This service has replaced the UCAS postgraduate teacher training application. 
+
 ## When to apply
 
 Courses usually open for applications in October for entry the following year


### PR DESCRIPTION
Adding a section "where to apply" to point people to Apply for teacher training. Keeping a reference to the UCAS service too.

### Trello card

https://trello.com/c/2q0ZdA7j/1610-ucas-switchover

### Context

Adding reference to Apply / keeping a reference to UCAS for SEO

### Changes proposed in this pull request

Adding section "Where to apply"

