### PR TITLE
Include Google structured data for events

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -6,6 +6,8 @@ module StructuredDataHelper
   EVENT_SCHEDULED = "https://schema.org/EventScheduled".freeze
 
   def structured_data(type, data)
+    return if Rails.env.production?
+
     output = {
       "@context": "https://schema.org",
       "@type": type,

--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -1,0 +1,81 @@
+module StructuredDataHelper
+  ONLINE_EVENT = "https://schema.org/OfflineEventAttendanceMode".freeze
+  OFFLINE_EVENT = "https://schema.org/OnlineEventAttendanceMode".freeze
+  IN_STOCK = "https://schema.org/InStock".freeze
+  SOLD_OUT = "https://schema.org/SoldOut".freeze
+  EVENT_SCHEDULED = "https://schema.org/EventScheduled".freeze
+
+  def structured_data(type, data)
+    output = {
+      "@context": "https://schema.org",
+      "@type": type,
+    }.merge(data)
+
+    tag.script(type: "application/ld+json") do
+      raw json_escape(output.to_json)
+    end
+  end
+
+  def event_structured_data(event)
+    building_data = event_building_data(event)
+    provider_data = event_provider_data(event)
+
+    data = {
+      name: event.name,
+      startDate: event.start_at,
+      endDate: event.end_at,
+      description: strip_tags(event.description).strip,
+      eventAttendanceMode: event.is_online ? ONLINE_EVENT : OFFLINE_EVENT,
+      eventStatus: EVENT_SCHEDULED,
+      offers: {
+        "@type": "Offer",
+        price: 0,
+        priceCurrency: "GBP",
+        availability: event_status_open?(event) ? IN_STOCK : SOLD_OUT,
+      },
+    }.merge(building_data, provider_data)
+
+    structured_data("Event", data)
+  end
+
+  def event_provider_data(event)
+    return {} unless event_has_provider_info?(event)
+
+    {
+      organizer: {
+        "@type": "Organization",
+        name: event.provider_organiser,
+        email: event.provider_contact_email,
+        url: event.provider_website_url,
+      },
+    }
+  end
+
+  def event_building_data(event)
+    building = event.building
+
+    return {} if building.nil? || event.is_online
+
+    street_address = [
+      building.address_line1,
+      building.address_line2,
+    ].compact.join(", ")
+
+    {
+      location: {
+        "@type": "Place",
+        name: building.venue,
+        address: {
+          "@type": "PostalAddress",
+          addressCountry: "GB",
+          streetAddress: street_address,
+          addressLocality: building.address_city,
+          addressRegion: building.address_line3,
+          postalCode: building.address_postcode,
+        },
+      },
+    }.tap do |data|
+      data[:image] = [building.image_url] if building.image_url.present?
+    end
+  end
+end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:head) do %>
+  <%= event_structured_data(@event) %>
+<% end %>
+
 <div class="event-info">
   <h1><%= @event.name %></h1>
 

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -10,6 +10,11 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
 
+    it "returns nil when in production" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect(script_tag).to be_nil
+    end
+
     it "wraps JSON in a script tag" do
       expect(script_tag).to be_present
       expect(script_tag[:type]).to eq("application/ld+json")
@@ -36,6 +41,11 @@ describe StructuredDataHelper, type: "helper" do
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
+    it "returns nil when in production" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect(script_tag).to be_nil
+    end
 
     it "includes event information" do
       expect(data).to include({

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+describe StructuredDataHelper, type: "helper" do
+  include ERB::Util
+  include EventsHelper
+
+  describe ".structured_data" do
+    let(:malicious_text) { "</script><script>alert('PWNED!')</script>" }
+    let(:html) { structured_data("Type", { text: malicious_text }) }
+
+    subject(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
+    it "wraps JSON in a script tag" do
+      expect(script_tag).to be_present
+      expect(script_tag[:type]).to eq("application/ld+json")
+      expect { JSON.parse(script_tag.content) }.not_to raise_error
+    end
+
+    it "includes the context, type and data" do
+      json = JSON.parse(script_tag.content)
+
+      expect(json["@context"]).to eq("https://schema.org")
+      expect(json["@type"]).to eq("Type")
+      expect(json["text"]).to eq(malicious_text)
+    end
+
+    it "outputs escaped JSON" do
+      escaped_malicious_text = json_escape(malicious_text)
+      expect(script_tag.content).to include(escaped_malicious_text)
+    end
+  end
+
+  describe ".event_structured_data" do
+    let(:event) { build(:event_api, building: nil) }
+    let(:html) { event_structured_data(event) }
+    let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
+    it "includes event information" do
+      expect(data).to include({
+        name: event.name,
+        startDate: event.start_at,
+        endDate: event.end_at,
+        description: strip_tags(event.description).strip,
+        eventStatus: described_class::EVENT_SCHEDULED,
+        eventAttendanceMode: described_class::OFFLINE_EVENT,
+        offers: {
+          "@type": "Offer",
+          price: 0,
+          priceCurrency: "GBP",
+          availability: described_class::IN_STOCK,
+        },
+      })
+
+      expect(data).to_not have_key(:organizer)
+      expect(data).to_not have_key(:location)
+    end
+
+    context "when the event is online" do
+      let(:event) { build(:event_api, :online) }
+
+      it { is_expected.to include({ eventAttendanceMode: described_class::ONLINE_EVENT }) }
+    end
+
+    context "when the event is closed" do
+      let(:event) { build(:event_api, :closed) }
+
+      it { expect(data[:offers]).to include({ availability: described_class::SOLD_OUT }) }
+    end
+
+    context "when there is provider information" do
+      let(:event) { build(:event_api, :with_provider_info) }
+
+      it "includes organizer" do
+        expect(data[:organizer]).to include({
+          "@type": "Organization",
+          name: event.provider_organiser,
+          email: event.provider_contact_email,
+          url: event.provider_website_url,
+        })
+      end
+    end
+
+    context "when there is a building" do
+      let(:event) { build(:event_api) }
+      let(:building) { event.building }
+      let(:street_address) do
+        [
+          building.address_line1,
+          building.address_line2,
+        ].compact.join(", ")
+      end
+
+      it "includes a location" do
+        expect(data[:location]).to include({
+          "@type": "Place",
+          name: building.venue,
+          address: {
+            "@type": "PostalAddress",
+            addressCountry: "GB",
+            streetAddress: street_address,
+            addressLocality: building.address_city,
+            addressRegion: building.address_line3,
+            postalCode: building.address_postcode,
+          },
+        })
+
+        expect(data[:image]).to contain_exactly(building.image_url)
+      end
+
+      context "when the building does not have an image" do
+        before { building.image_url = nil }
+
+        it "does not include the image" do
+          expect(data).not_to have_key(:image)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -234,6 +234,13 @@ describe EventsController do
 
           expect(actual_description).to eql(event.summary)
         end
+
+        it "has structured data" do
+          json = parsed_response.at_css("script[type='application/ld+json']").content
+          structured_data = JSON.parse(json, symbolize_names: true)
+
+          expect(structured_data).to include("@type": "Event", name: event.name)
+        end
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Google looks for structured data on a website and will render rich search results for any found. One such type is 'events', which will enable us to display rich search results for our teaching events.

### Changes proposed in this pull request

- Include Google structured data for events

Add helper to render structured data for events, including event details, offers + availability (free), attendance mode (online/offline), venue and provider information.

### Guidance to review

Tested using the Google structured data tool; the 4 warnings are for optional attributes that aren't applicable to our event types (such as 'performer'):

<img width="1467" alt="Screenshot 2021-08-31 at 11 51 01" src="https://user-images.githubusercontent.com/29867726/131489968-fbede155-5453-4f3f-9f93-a9a67cde5cf2.png">

Example of how events get displayed in Google search results:

![event-example](https://user-images.githubusercontent.com/29867726/131631751-3aa2f145-3503-4f4d-a01c-28433c99b5db.png)
