### PR TITLE
Include Google structured data for breadcrumbs

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -18,6 +18,21 @@ module StructuredDataHelper
     end
   end
 
+  def breadcrumbs_structured_data(breadcrumbs)
+    return if breadcrumbs.blank?
+
+    items = breadcrumbs.each_with_index.map do |crumb, index|
+      {
+        "@type": "ListItem",
+        position: index + 1,
+        name: crumb.name,
+        item: root_url.chomp("/") + crumb.path,
+      }
+    end
+
+    structured_data("BreadcrumbList", { itemListElement: items })
+  end
+
   def event_structured_data(event)
     building_data = event_building_data(event)
     provider_data = event_provider_data(event)

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -15,6 +15,7 @@
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>
+  <%= breadcrumbs_structured_data(breadcrumb_trail) %>
 
   <% if @front_matter && @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -234,13 +234,6 @@ describe EventsController do
 
           expect(actual_description).to eql(event.summary)
         end
-
-        it "has structured data" do
-          json = parsed_response.at_css("script[type='application/ld+json']").content
-          structured_data = JSON.parse(json, symbolize_names: true)
-
-          expect(structured_data).to include("@type": "Event", name: event.name)
-        end
       end
     end
 

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "Google Structured Data" do
+  let(:parsed_response) { Nokogiri.parse(response.body) }
+  let(:json) { parsed_response.at_css("script[type='application/ld+json']").content }
+
+  subject(:structured_data) { JSON.parse(json, symbolize_names: true) }
+
+  context "when viewing an event page" do
+    let(:event) { build(:event_api) }
+    let(:path) { event_path(id: event.readable_id) }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:get_teaching_event) { event }
+      get path
+    end
+
+    it { is_expected.to include("@type": "Event") }
+  end
+
+  context "when viewing a nested content page" do
+    let(:path) { "/steps-to-become-a-teacher" }
+
+    before { get path }
+
+    it { is_expected.to include("@type": "BreadcrumbList") }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Adding structured data for the breadcrumbs enables Google to enhance the search results to include the hierachy of the page.

### Changes proposed in this pull request

- Include Google structured data for breadcrumbs

### Guidance to review

Tested using the Google structured data tool:

<img width="1296" alt="Screenshot 2021-09-01 at 09 13 27" src="https://user-images.githubusercontent.com/29867726/131636576-8384c7cd-f56f-4cc7-a1bf-46fef24b0bbb.png">

Example of how breadcrumbs get displayed in Google search results (the top one doesn't have breadcrumb structured data, the bottom does):

![URL-Search-Result](https://user-images.githubusercontent.com/29867726/131636615-86d37ec1-e5a9-4abf-8a44-21198bd859c5.png)
