### PR TITLE
Include Google structured data for logo

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -18,6 +18,15 @@ module StructuredDataHelper
     end
   end
 
+  def logo_structured_data
+    data = {
+      url: root_url,
+      logo: asset_pack_path("media/images/getintoteachinglogo.svg"),
+    }
+
+    structured_data("Organization", data)
+  end
+
   def breadcrumbs_structured_data(breadcrumbs)
     return if breadcrumbs.blank?
 

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -16,6 +16,7 @@
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
+  <%= logo_structured_data %>
 
   <% if @front_matter && @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe StructuredDataHelper, type: "helper" do
   include ERB::Util
   include EventsHelper
+  include Webpacker::Helper
 
   describe ".structured_data" do
     let(:malicious_text) { "</script><script>alert('PWNED!')</script>" }
@@ -32,6 +33,26 @@ describe StructuredDataHelper, type: "helper" do
     it "outputs escaped JSON" do
       escaped_malicious_text = json_escape(malicious_text)
       expect(script_tag.content).to include(escaped_malicious_text)
+    end
+  end
+
+  describe ".logo_structured_data" do
+    let(:html) { logo_structured_data }
+    let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
+    it "returns nil when in production" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect(script_tag).to be_nil
+    end
+
+    it "includes logo information" do
+      expect(data).to include({
+        "@type": "Organization",
+        url: root_url,
+        logo: asset_pack_path("media/images/getintoteachinglogo.svg"),
+      })
     end
   end
 

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe "Google Structured Data" do
   let(:parsed_response) { Nokogiri.parse(response.body) }
-  let(:json) { parsed_response.at_css("script[type='application/ld+json']").content }
+  let(:json_contents) { parsed_response.css("script[type='application/ld+json']").map(&:content) }
 
-  subject(:structured_data) { JSON.parse(json, symbolize_names: true) }
+  subject(:structured_data) { json_contents.map { |json| JSON.parse(json, symbolize_names: true) } }
 
   context "when viewing an event page" do
     let(:event) { build(:event_api) }
@@ -16,7 +16,7 @@ describe "Google Structured Data" do
       get path
     end
 
-    it { is_expected.to include("@type": "Event") }
+    it { is_expected.to include(a_hash_including("@type": "Event")) }
   end
 
   context "when viewing a nested content page" do
@@ -24,6 +24,14 @@ describe "Google Structured Data" do
 
     before { get path }
 
-    it { is_expected.to include("@type": "BreadcrumbList") }
+    it { is_expected.to include(a_hash_including("@type": "BreadcrumbList")) }
+  end
+
+  context "when viewing a page" do
+    let(:path) { root_path }
+
+    before { get path }
+
+    it { is_expected.to include(a_hash_including("@type": "Organization")) }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Adding structured data for the logo enables Google to enhance the organization page in search results.

### Changes proposed in this pull request

- Include Google structured data for logo

### Guidance to review

Tested using the Google structured data tool:

<img width="1379" alt="Screenshot 2021-09-01 at 11 30 59" src="https://user-images.githubusercontent.com/29867726/131656435-2cbfae1d-00ee-4aa9-931a-a317539cd197.png">

Example of how the organization data will get displayed in Google search results:

![logo01](https://user-images.githubusercontent.com/29867726/131656480-9184727c-3892-4903-8a1a-7bfeb8c163ed.png)

