### PR TITLE
Include Google structured data for site search

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -18,6 +18,22 @@ module StructuredDataHelper
     end
   end
 
+  def search_structured_data
+    data = {
+      url: root_url,
+      potentialAction: {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": CGI.unescape(search_url(search: { search: "{search_term_string}" })),
+        },
+        "query-input": "required name=search_term_string",
+      },
+    }
+
+    structured_data("WebSite", data)
+  end
+
   def logo_structured_data
     data = {
       url: root_url,

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -17,6 +17,7 @@
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>
+  <%= search_structured_data if current_page?(root_path) %>
 
   <% if @front_matter && @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -36,6 +36,33 @@ describe StructuredDataHelper, type: "helper" do
     end
   end
 
+  describe ".search_structured_data" do
+    let(:html) { search_structured_data }
+    let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
+    it "returns nil when in production" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect(script_tag).to be_nil
+    end
+
+    it "includes search information" do
+      expect(data).to include({
+        "@type": "WebSite",
+        url: root_url,
+        potentialAction: {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "http://test.host/search?search[search]={search_term_string}",
+          },
+          "query-input": "required name=search_term_string",
+        },
+      })
+    end
+  end
+
   describe ".logo_structured_data" do
     let(:html) { logo_structured_data }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -34,4 +34,20 @@ describe "Google Structured Data" do
 
     it { is_expected.to include(a_hash_including("@type": "Organization")) }
   end
+
+  context "when viewing the home page" do
+    let(:path) { root_path }
+
+    before { get path }
+
+    it { is_expected.to include(a_hash_including("@type": "WebSite")) }
+  end
+
+  context "when not viewing the home page" do
+    let(:path) { "/ways-to-train" }
+
+    before { get path }
+
+    it { is_expected.not_to include(a_hash_including("@type": "WebSite")) }
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Adding structured data for the site search enables Google to enhance the search results with an inline search box that, when used, will direct the user to our native search results page for their query.

### Changes proposed in this pull request

- Include Google structured data for site search

### Guidance to review

Tested using the Google structured data tool:

<img width="1379" alt="Screenshot 2021-09-01 at 14 39 37" src="https://user-images.githubusercontent.com/29867726/131681667-3ac67b6c-0f1d-4a0a-b355-d8c82bd747d7.png">

Example of how the site search data will display in Google search results:

![sitelinks01](https://user-images.githubusercontent.com/29867726/131681723-176afd0e-6296-405f-a762-e69ac6c24a8c.png)
