### PR TITLE
Update several gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem "redis"
 
 gem "kaminari", "~> 1.2", ">= 1.2.1"
-gem "view_component", "~> 2.36.0"
+gem "view_component", "~> 2.39.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem "listen", "~> 3.6.0"
+  gem "listen", "~> 3.7.0"
   gem "web-console", ">= 4.1.0"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "loaf", ">= 0.10.0"
 gem "prometheus-client"
 
 gem "sentry-rails", ">= 4.6.0"
-gem "sentry-ruby", "~> 4.6.4"
+gem "sentry-ruby", "~> 4.6.5"
 
 gem "skylight", "~> 5.1.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :development, :test do
   gem "pry-rails"
 
   # Testing framework
-  gem "rspec-rails", "~> 5.0.1"
+  gem "rspec-rails", "~> 5.0.2"
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.35", ">= 3.35.3"
   gem "factory_bot_rails", ">= 6.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 394921fa4d11b7a6e48f8490182d74d22eea6313
+  revision: bbc8ee5dd787401b0e6216e34e690e643f8dc19b
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.41)
+    get_into_teaching_api_client_faraday (0.1.43)
       activesupport
       faraday
       faraday-encoding

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     kaminari-core (1.2.1)
     kramdown (2.3.1)
       rexml
-    listen (3.6.0)
+    listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loaf (0.10.0)
@@ -475,7 +475,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (>= 2.7.2)
   kaminari (~> 1.2, >= 1.2.1)
   kramdown (>= 2.3.1)
-  listen (~> 3.6.0)
+  listen (~> 3.7.0)
   loaf (>= 0.10.0)
   logger (>= 1.4.3)
   matrix (>= 0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.0.1)
+    rspec-rails (5.0.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -491,7 +491,7 @@ DEPENDENCIES
   redis
   rexml (>= 3.2.5)
   rinku
-  rspec-rails (~> 5.0.1)
+  rspec-rails (~> 5.0.2)
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk (~> 3.14.0)
   secure_headers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,11 +378,11 @@ GEM
     sentry-rails (4.6.4)
       railties (>= 5.0)
       sentry-ruby-core (~> 4.6.0)
-    sentry-ruby (4.6.4)
+    sentry-ruby (4.6.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.6.4)
-    sentry-ruby-core (4.6.4)
+      sentry-ruby-core (= 4.6.5)
+    sentry-ruby-core (4.6.5)
       concurrent-ruby
       faraday
     shoulda-matchers (5.0.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   secure_headers
   selenium-webdriver (~> 3.142)
   sentry-rails (>= 4.6.0)
-  sentry-ruby (~> 4.6.4)
+  sentry-ruby (~> 4.6.5)
   shoulda-matchers
   simplecov
   skylight (~> 5.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,7 +422,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (1.7.0)
     victor (0.3.3)
-    view_component (2.36.0)
+    view_component (2.39.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.1.0)
@@ -506,7 +506,7 @@ DEPENDENCIES
   text
   tzinfo-data
   victor
-  view_component (~> 2.36.0)
+  view_component (~> 2.39.0)
   web-console (>= 4.1.0)
   webmock (>= 3.12.2)
   webpacker (>= 5.4.0)


### PR DESCRIPTION
This supersedes and combines a bunch of @dependabot ones:

- Update ViewComponent to 2.39.0
- Update sentry-ruby to 4.6.5
- Update listen to 3.7.0
- Update rspec-rails to 5.0.2
- Update get_into_teaching_api_client_faraday gem
