### PR TITLE
Include Google structured data for blogs

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -18,6 +18,25 @@ module StructuredDataHelper
     end
   end
 
+  def blog_structured_data(page)
+    frontmatter = page.frontmatter
+
+    data = {
+      headline: frontmatter[:title],
+      image: frontmatter[:images].values.map { |h| h["path"] },
+      datePublished: frontmatter[:date],
+      keywords: frontmatter[:keywords],
+      author: [
+        {
+          "@type": "Organization",
+          name: frontmatter[:author],
+        },
+      ],
+    }
+
+    structured_data("BlogPosting", data)
+  end
+
   def search_structured_data
     data = {
       url: root_url,

--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -20,6 +20,7 @@ module StructuredDataHelper
 
   def blog_structured_data(page)
     frontmatter = page.frontmatter
+    author_name = frontmatter[:author]
 
     data = {
       headline: frontmatter[:title],
@@ -28,8 +29,8 @@ module StructuredDataHelper
       keywords: frontmatter[:keywords],
       author: [
         {
-          "@type": "Organization",
-          name: frontmatter[:author],
+          "@type": author_name.present? ? "Person" : "Organization",
+          name: author_name || "Get Into Teaching",
         },
       ],
     }

--- a/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
@@ -1,7 +1,6 @@
 ---
 title: 5 reasons to attend a Train to Teach event
 date: "2021-08-26"
-author: Get Into Teaching
 images:
   train_to_teach:
     path: "media/images/content/blog/train-to-teach.jpg"

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:head) do %>
+  <%= blog_structured_data(@post) %>
+<% end %>
+
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -36,6 +36,48 @@ describe StructuredDataHelper, type: "helper" do
     end
   end
 
+  describe ".blog_structured_data" do
+    let(:frontmatter) do
+      {
+        title: "A title",
+        images: {
+          an_image: {
+            path: "/an/image.png",
+          },
+        },
+        date: "2021-01-25",
+        keywords: %w[one two],
+        author: "Get into Teaching",
+      }
+    end
+    let(:page) { Pages::Page.new("/blog/post", frontmatter) }
+    let(:html) { blog_structured_data(page) }
+    let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
+    it "returns nil when in production" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect(script_tag).to be_nil
+    end
+
+    it "includes blog post information" do
+      expect(data).to include({
+        "@type": "BlogPosting",
+        headline: frontmatter[:title],
+        image: frontmatter[:images].values.map { |h| h["path"] },
+        datePublished: frontmatter[:date],
+        keywords: frontmatter[:keywords],
+        author: [
+          {
+            "@type": "Organization",
+            name: frontmatter[:author],
+          },
+        ],
+      })
+    end
+  end
+
   describe ".search_structured_data" do
     let(:html) { search_structured_data }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -47,7 +47,7 @@ describe StructuredDataHelper, type: "helper" do
         },
         date: "2021-01-25",
         keywords: %w[one two],
-        author: "Get into Teaching",
+        author: "Ronald McDonald",
       }
     end
     let(:page) { Pages::Page.new("/blog/post", frontmatter) }
@@ -70,11 +70,26 @@ describe StructuredDataHelper, type: "helper" do
         keywords: frontmatter[:keywords],
         author: [
           {
-            "@type": "Organization",
+            "@type": "Person",
             name: frontmatter[:author],
           },
         ],
       })
+    end
+
+    context "when author is not present" do
+      before { frontmatter[:author] = nil }
+
+      it "defaults to the Get Into Teaching organization" do
+        expect(data).to include({
+          author: [
+            {
+              "@type": "Organization",
+              name: "Get Into Teaching",
+            },
+          ],
+        })
+      end
     end
   end
 

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -50,4 +50,12 @@ describe "Google Structured Data" do
 
     it { is_expected.not_to include(a_hash_including("@type": "WebSite")) }
   end
+
+  context "when viewing a blog page" do
+    let(:path) { "/blog/how-to-ace-a-video-interview" }
+
+    before { get path }
+
+    it { is_expected.to include(a_hash_including("@type": "BlogPosting")) }
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Adding structured data for the blogs enables Google to enhance the search results for blog pages.

### Changes proposed in this pull request

- Include Google structured data for blogs

### Guidance to review

Tested using the Google structured data tool (the warning doesn't apply as we don't have author pages):

<img width="1511" alt="Screenshot 2021-09-02 at 10 19 01" src="https://user-images.githubusercontent.com/29867726/131818093-1a1070dd-15c8-488d-acd2-275c4762c085.png">

Example of how the blog post will display in Google search results:

![non-amp-article](https://user-images.githubusercontent.com/29867726/131818201-c3b5d6e6-3392-425b-94ee-25cd0312c11f.png)
