### PR TITLE
Swap out `type_id` event search param for `type_ids`

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -64,11 +64,9 @@ module Internal
                  .new
                  .search_teaching_events_grouped_by_type(quantity_per_type: 1_000,
                                                          start_after: DateTime.now.utc.beginning_of_day,
-                                                         status_ids: [open_event_status_id])
+                                                         status_ids: [open_event_status_id],
+                                                         type_ids: [event_types[:provider], event_types[:online]])
 
-      events = events.select do |key|
-        key.type_id == event_types[:provider] || key.type_id == event_types[:online]
-      end
       @open_events = events.map(&:teaching_events).flatten
     end
 
@@ -133,7 +131,7 @@ module Internal
 
     def events_search_params(event_type)
       {
-        type_id: event_type,
+        type_ids: [event_type],
         status_ids: [pending_event_status_id],
         start_after: DateTime.now.utc.beginning_of_day,
         quantity_per_type: 1_000,

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -77,7 +77,7 @@ describe Internal::EventsController do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
-                    type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+                    type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]],
                     status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
                     start_after: DateTime.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
@@ -91,7 +91,7 @@ describe Internal::EventsController do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
-                    type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
+                    type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]],
                     status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
                     start_after: DateTime.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
@@ -637,14 +637,21 @@ describe Internal::EventsController do
         [
           build(:event_api, :online_event, name: "Open online event", start_at: start_at),
           build(:event_api, :school_or_university_event, name: "Open provider event", start_at: start_at),
-          build(:event_api, :train_to_teach_event, name: "Open train to teach event", start_at: start_at),
         ]
       end
       let(:events_by_type) { group_events_by_type(events) }
 
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-          .to receive(:search_teaching_events_grouped_by_type) { events_by_type }
+          .to receive(:search_teaching_events_grouped_by_type)
+                .with({
+                  type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+                             GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]],
+                  status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]],
+                  start_after: DateTime.now.utc.beginning_of_day,
+                  quantity_per_type: 1_000,
+                })
+                .and_return events_by_type
       end
 
       it "shows a table of events" do
@@ -655,7 +662,6 @@ describe Internal::EventsController do
         expect(response.body).to include("Open events")
         expect(response.body).to include("Open online event")
         expect(response.body).to include("Open provider event")
-        expect(response.body).to_not include("Open train to teach event")
       end
     end
   end


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/qbuoFw8L)

### Context
We have added a new param to the event search endpoint of type_ids so that we can search by multiple event types.

### Changes proposed in this pull request
- Swap out any remaining uses of the `type_id` event search param for `type_ids`
- Search by Type IDs for internal open events, instead of filtering results