### PR TITLE
Make some small tap targets bigger

### DIFF
--- a/app/components/footer/feedback_component.html.erb
+++ b/app/components/footer/feedback_component.html.erb
@@ -11,7 +11,7 @@
           <a href="javascript:void(0)" class="page-question__answer strong" data-feedback-target="link" data-action="feedback#answer">No</a>
         </div>
       </div>
-      <div>
+      <div id="tell-us-what-you-think">
         <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think about this service</a>
       </div>
     </div>

--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -55,16 +55,21 @@ $space-between-sections: 3.7em;
       list-style: none;
       padding: 0;
 
-      li > a {
-        @include font-size('xsmall');
-        color: $black;
-        line-height: 1.8em;
-        text-underline-offset: .2em;
+      li {
+        margin: 1em 0;
 
-        &:hover {
-          color: $purple;
-          text-decoration: underline;
-          text-decoration-thickness: .12em;
+        > a {
+          @include font-size('xsmall');
+          color: $black;
+          line-height: 1.8em;
+          text-underline-offset: .2em;
+          padding: .6em 0;
+
+          &:hover {
+            color: $purple;
+            text-decoration: underline;
+            text-decoration-thickness: .12em;
+          }
         }
       }
     }

--- a/app/webpacker/styles/feedback-bar.scss
+++ b/app/webpacker/styles/feedback-bar.scss
@@ -47,6 +47,16 @@
     #page-helpful {
       a {
         margin-left: .5em;
+        padding: 2em .5em;
+      }
+    }
+
+    #tell-us-what-you-think {
+      margin: .5em 0;
+
+      a {
+        padding: .5em 0;
+        line-height: 2.6;
       }
     }
 

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -65,6 +65,12 @@ footer.site-footer {
     &__social {
       flex: 33% 0 0;
       display: flex;
+      margin-right: 1em;
+
+      a {
+        max-height: 2em;
+        padding: .5em;
+      }
 
       // gap: 1em;
       a + a {

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -30,6 +30,7 @@ footer.site-footer {
 
         color: $grey-mid;
         margin-bottom: .5em;
+        padding: .5em 0;
 
         &:focus {
           color: $black;


### PR DESCRIPTION
### Trello card

https://trello.com/c/GFx0a9u1/1889-mobile-usability-clickable-elements-too-close-on-home-page

### Context

Some of the tap targets have been highlighted as being too small by Lighthouse. This removes all of the offending ones from the common elements used on every page, plus a few extras from the homepage (in the link blocks).

### Changes proposed in this pull request

- Increase padding around footer links
- Increase padding around homepage block links
- Add some padding around tell-us-what-you-think
- Add padding around social icons


### Previews

| Before | After |
| ------ | ------ |
| ![Screenshot from 2021-09-02 11-54-21](https://user-images.githubusercontent.com/128088/131847805-b68449d6-2c56-4d9d-8d5b-922be1de445a.png)| ![Screenshot from 2021-09-02 11-53-57](https://user-images.githubusercontent.com/128088/131847830-54f68a4d-3f77-489d-9f6d-3e1dc69432ab.png) |
| ![Screenshot from 2021-09-02 11-54-31](https://user-images.githubusercontent.com/128088/131848190-68d6c982-9772-458c-9e48-a9c33c02a78a.png) |![Screenshot from 2021-09-02 11-55-17](https://user-images.githubusercontent.com/128088/131848184-b2a7dab5-6c7b-421f-9014-513a6e6ef93b.png) |
| ![Screenshot from 2021-09-02 13-54-07](https://user-images.githubusercontent.com/128088/131848272-88317741-9198-4c90-9f66-ce7af4a4f616.png)| ![Screenshot from 2021-09-02 13-53-50](https://user-images.githubusercontent.com/128088/131848286-b47326ab-135d-497b-846e-2a1087fc5449.png) |
|  ![Screenshot from 2021-09-02 14-04-24](https://user-images.githubusercontent.com/128088/131848570-4e07b0fe-0bfc-445f-9c08-f71246d2b673.png) | ![Screenshot from 2021-09-02 14-04-17](https://user-images.githubusercontent.com/128088/131848575-3716b1e8-d60d-445b-8fe1-d29dd6c67f72.png) |

