### PR TITLE
Include Google structured data for how-to

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -24,7 +24,7 @@ module StructuredDataHelper
 
     data = {
       headline: frontmatter[:title],
-      image: frontmatter[:images].values.map { |h| h["path"] },
+      image: frontmatter[:images].values.map { |h| asset_pack_url(h["path"]) },
       datePublished: frontmatter[:date],
       keywords: frontmatter[:keywords],
       author: [
@@ -36,6 +36,38 @@ module StructuredDataHelper
     }
 
     structured_data("BlogPosting", data)
+  end
+
+  def how_to_structured_data(page)
+    frontmatter = page.frontmatter
+
+    steps = frontmatter[:how_to].with_indifferent_access.map do |name, step|
+      {
+        "@type": "HowToStep",
+        url: "#{root_url.chomp('/')}#{page.path}##{step[:id]}",
+        name: name,
+        itemListElement: step[:directions].map { |text| { "@type": "HowToDirection", text: text } },
+        image: {
+          "@type": "ImageObject",
+          url: asset_pack_url(step[:image]),
+        },
+      }
+    end
+
+    data = {
+      name: frontmatter[:title],
+      description: frontmatter[:description],
+      step: steps,
+    }
+
+    if frontmatter[:image]
+      data[:image] = {
+        "@type": "ImageObject",
+        url: asset_pack_url(frontmatter[:image]),
+      }
+    end
+
+    structured_data("HowTo", data)
   end
 
   def search_structured_data
@@ -57,7 +89,7 @@ module StructuredDataHelper
   def logo_structured_data
     data = {
       url: root_url,
-      logo: asset_pack_path("media/images/getintoteachinglogo.svg"),
+      logo: asset_pack_url("media/images/getintoteachinglogo.svg"),
     }
 
     structured_data("Organization", data)

--- a/app/views/content/steps-to-become-a-teacher.md
+++ b/app/views/content/steps-to-become-a-teacher.md
@@ -19,6 +19,32 @@
       partial: content/steps-to-become-a-teacher/step_4_find_the_right_training
     Apply for your course:
       partial: content/steps-to-become-a-teacher/step_5_apply_for_your_course
+  how_to:
+    Decide who to teach:
+      id: "step-1"
+      image: "media/images/content/hero-images/0017.jpg"
+      directions:
+        - Get school experience or attend events.
+    Check your qualifications:
+      id: "step-2"
+      image: "media/images/content/hero-images/0017.jpg"
+      directions:
+        - Once you have a degree or equivalent qualification you’re ready for postgraduate primary or secondary initial teacher training courses.
+    Learn about funding:
+      id: "step-3"
+      image: "media/images/content/hero-images/0017.jpg"
+      directions:
+        - You can get funding that you do not have to pay back if you train to teach certain subjects.
+    Find the right training:
+      id: "step-4"
+      image: "media/images/content/hero-images/0017.jpg"
+      directions:
+        - Explore your options, find out how to train to teach primary or secondary (for example a PGCE or directly in a school).
+    Apply for your course:
+      id: "step-5"
+      image: "media/images/content/hero-images/0017.jpg"
+      directions:
+        - Get tips on applying, including finding the right referees and writing a personal statement.
   keywords:
     - QTS
     - Qualified Teacher Status

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -18,6 +18,7 @@
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>
   <%= search_structured_data if current_page?(root_path) %>
+  <%= how_to_structured_data(@page) if @page.present? && @front_matter.key?("how_to") %>
 
   <% if @front_matter && @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -58,4 +58,20 @@ describe "Google Structured Data" do
 
     it { is_expected.to include(a_hash_including("@type": "BlogPosting")) }
   end
+
+  context "when viewing a page with a how_to section of frontmatter" do
+    let(:path) { "/steps-to-become-a-teacher" }
+
+    before { get path }
+
+    it { is_expected.to include(a_hash_including("@type": "HowTo")) }
+  end
+
+  context "when viewing a page without a how_to section of frontmatter" do
+    let(:path) { "/ways-to-train" }
+
+    before { get path }
+
+    it { is_expected.not_to include(a_hash_including("@type": "HowTo")) }
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-1895](https://trello.com/c/k7r8173i/1895-seo-investigate-structured-data)

### Context

Adding structured data for 'how-tos' enables Google to enhance the search results for certain pages, showing the steps in the results.

Initially I've added this to the Steps to Become a Teacher page with mostly dummy data; it'll need running past a content designer and designer for the text/images, but it's behind a feature flag just now. 

### Changes proposed in this pull request

- Include Google structured data for how-to

### Guidance to review

Tested using the Google structured data tool (the warnings don't really apply to our how-to here):

<img width="1616" alt="Screenshot 2021-09-02 at 14 17 30" src="https://user-images.githubusercontent.com/29867726/131850443-c6c0f937-1408-4eec-a10a-68256a57b1b3.png">

Example of how a how-to page will display in Google search results:

![howto-example2](https://user-images.githubusercontent.com/29867726/131850565-b0320837-5735-4e0a-a436-fc98e7fcc549.png)

