### PR TITLE
Only show future pending events

### DIFF
--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -135,6 +135,7 @@ module Internal
       {
         type_id: event_type,
         status_ids: [pending_event_status_id],
+        start_after: DateTime.now.utc.beginning_of_day,
         quantity_per_type: 1_000,
       }
     end

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -75,14 +75,28 @@ describe Internal::EventsController do
       include_examples "pending events", "provider" do
         before(:each) do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-            .to receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
+            .to receive(:search_teaching_events_grouped_by_type)
+                  # .with({
+                  #   type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+                  #   status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                  #   start_after: DateTime.now.utc.beginning_of_day,
+                  #   quantity_per_type: 1_000,
+                  # })
+                  .and_return provider_events_by_type
         end
       end
 
       include_examples "pending events", "online" do
         before(:each) do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-            .to receive(:search_teaching_events_grouped_by_type) { online_events_by_type }
+            .to receive(:search_teaching_events_grouped_by_type)
+                  # .with({
+                  #   type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
+                  #   status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                  #   start_after: DateTime.now.utc.beginning_of_day,
+                  #   quantity_per_type: 1_000,
+                  # })
+                  .and_return online_events_by_type
         end
       end
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -55,7 +55,7 @@ describe Internal::EventsController do
 
       context "when there are pending #{event_params || default_event_type} events" do
         before do
-          get internal_events_path, headers: generate_auth_headers(:author), params: event_type
+          get internal_events_path, headers: generate_auth_headers(:author), params: { event_type: event_type }
         end
 
         it "shows pending #{event_params || default_event_type} events" do
@@ -76,12 +76,12 @@ describe Internal::EventsController do
         before(:each) do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
-                  # .with({
-                  #   type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-                  #   status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
-                  #   start_after: DateTime.now.utc.beginning_of_day,
-                  #   quantity_per_type: 1_000,
-                  # })
+                  .with({
+                    type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+                    status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                    start_after: DateTime.now.utc.beginning_of_day,
+                    quantity_per_type: 1_000,
+                  })
                   .and_return provider_events_by_type
         end
       end
@@ -90,12 +90,12 @@ describe Internal::EventsController do
         before(:each) do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
-                  # .with({
-                  #   type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
-                  #   status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
-                  #   start_after: DateTime.now.utc.beginning_of_day,
-                  #   quantity_per_type: 1_000,
-                  # })
+                  .with({
+                    type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
+                    status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                    start_after: DateTime.now.utc.beginning_of_day,
+                    quantity_per_type: 1_000,
+                  })
                   .and_return online_events_by_type
         end
       end


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/6N9robX0)

### Context
We have just had a discussion with the CRM team about whether we should be able delete events via the internal events form, deciding generally that we don't want to delete CRM entities via the API/Website.

Instead, to prevent the internal events index page getting cluttered with old withdrawn/incorrect events, we are going to only show future pending events. If users want events to be deleted properly they will still need contact the CRM team, but we may revisit this later if it becomes a bigger problem.

### Changes proposed in this pull request
- Show only future pending events