### PR TITLE
Stop the auto-addition of `noreferrer` to external links

### DIFF
--- a/app/components/footer/feedback_component.html.erb
+++ b/app/components/footer/feedback_component.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
       <div>
-        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think about this service</a>
+        <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Tell us what you think about this service</a>
       </div>
     </div>
   </section>

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -17,23 +17,23 @@
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">
-        <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.facebook.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener">
           <%= helpers.fab_icon("facebook-f", "icon") %>
           <span class="visually-hidden">Facebook - opens in a new tab</span>
         </a>
-        <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.instagram.com/get_into_teaching/" class="site-footer-top__social__link" target="_blank" rel="noopener">
           <%= helpers.fab_icon("instagram", "icon") %>
           <span class="visually-hidden">Instagram - opens in a new tab</span>
         </a>
-        <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching" class="site-footer-top__social__link" target="_blank" rel="noopener">
           <%= helpers.fab_icon("linkedin-in", "icon") %>
           <span class="visually-hidden">LinkedIn - opens in a new tab</span>
         </a>
-        <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+        <a href="https://twitter.com/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener">
           <%= helpers.fab_icon("twitter", "icon") %>
           <span class="visually-hidden">Twitter - opens in a new tab</span>
         </a>
-        <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener noreferrer">
+        <a href="http://www.youtube.com/user/getintoteaching" class="site-footer-top__social__link" target="_blank" rel="noopener">
           <%= helpers.fab_icon("youtube", "icon") %>
           <span class="visually-hidden">Youtube - opens in a new tab</span>
         </a>
@@ -54,11 +54,11 @@
         <%= image_pack_tag 'media/images/plan-for-jobs.svg', alt: "Plan for jobs", size: "124x73" %>
       </div>
       <div class="site-footer-bottom__links-container">
-        <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Feedback</a>
+        <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Feedback</a>
         <%= link_to "Cookies", cookies_path %>
         <%= link_to "Privacy notice", privacy_policy_path %>
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>
-        <a target="_blank" rel="noopener noreferrer" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
+        <a target="_blank" rel="noopener" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
         <div class="site-footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated.</div>
       </div>
     </div>

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
     links.forEach((l) => {
       if (l.getAttribute('href')?.startsWith('http')) {
         l.setAttribute('target', '_blank');
-        l.setAttribute('rel', 'noopener noreferrer');
+        l.setAttribute('rel', 'noopener');
 
         // add hidden text to inform screen reader users that
         // link will open in a new window

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -70,12 +70,12 @@ describe('LinkController', () => {
         expect(contentExternalLink.getAttribute('target')).toEqual('_blank');
       });
 
-      it("adds rel='noopener noreferrer' to the content external link", () => {
+      it("adds rel='noopener' to the content external link", () => {
         const contentExternalLink = document.getElementById(
           'content-external-link'
         );
         expect(contentExternalLink.getAttribute('rel')).toEqual(
-          'noopener noreferrer'
+          'noopener'
         );
       });
 


### PR DESCRIPTION
`noopener` is now [supported by all the supported browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) so we no longer need to keep using `noreferrer` which affects the analytics of sites we link to.

Also remove it from the static links in the footer.
