### PR TITLE
Improve tab ordering in the cookie popup

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -13,7 +13,7 @@
       <div class="dialog__text">
 
         <p>
-          We use <a href="/cookies" class="dark-link">cookies</a> to collect information about how you use this website.
+          We use <a id="cookies-info" href="/cookies" class="dark-link" data-cookie-acceptance-target="info">cookies</a> to collect information about how you use this website.
           We use this information to make the website work as well as possible, and improve this website.
           We also share some of this information with our social media, advertising and analytics partners.
         </p>
@@ -25,7 +25,7 @@
           The id is `biscuits-agrees` instead of `cookies-agree`
           to prevent ad blockers from removing the button.
         -->
-        <a href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
+        <a tabindex="1" href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
           <span>Accept all cookies</span>
         </a>
         <a class="button button--secondary" href="/cookie_preference" data-cookie-acceptance-target="disagree" id="cookies-disagree">

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -2,7 +2,7 @@ import CookiePreferences from '../javascript/cookie_preferences';
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['modal', 'overlay', 'agree', 'disagree'];
+  static targets = ['modal', 'overlay', 'agree', 'disagree', 'info'];
 
   connect() {
     if (!this.isPrivacyPage()) {
@@ -27,16 +27,51 @@ export default class extends Controller {
 
   showDialog() {
     this.overlayTarget.style.display = 'flex';
-    document.getElementById('biscuits-agree').focus();
 
-    this.disagreeTarget.addEventListener('blur', function (e) {
-      e.preventDefault();
-      document.getElementById('biscuits-agree').focus();
+    const tabKey = 9;
+    const agreeButtonID = 'biscuits-agree';
+    const disagreeButtonID = 'cookies-disagree';
+    const infoLinkID = 'cookies-info';
+
+    // agree button is focussed on the first tab
+    // cookies (link) on the second
+    // disagree button on the third
+    // back to agree on the fourth, and so on
+
+    this.agreeTarget.addEventListener('keydown', function (e) {
+      if (e.keyCode === tabKey) {
+        e.preventDefault();
+
+        if (e.shiftKey) {
+          document.getElementById(disagreeButtonID).focus();
+        } else {
+          document.getElementById(infoLinkID).focus();
+        }
+      }
     });
 
-    this.agreeTarget.addEventListener('blur', function (e) {
-      e.preventDefault();
-      document.getElementById('cookies-disagree').focus();
+    this.infoTarget.addEventListener('keydown', function (e) {
+      if (e.keyCode === tabKey) {
+        e.preventDefault();
+
+        if (e.shiftKey) {
+          document.getElementById(agreeButtonID).focus();
+        } else {
+          document.getElementById(disagreeButtonID).focus();
+        }
+      }
+    });
+
+    this.disagreeTarget.addEventListener('keydown', function (e) {
+      if (e.keyCode === tabKey) {
+        e.preventDefault();
+
+        if (e.shiftKey) {
+          document.getElementById(infoLinkID).focus();
+        } else {
+          document.getElementById(agreeButtonID).focus();
+        }
+      }
     });
   }
 

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -5,6 +5,7 @@ import CookieAcceptanceController from 'cookie-acceptance_controller.js';
 describe('CookieAcceptanceController', () => {
   document.body.innerHTML = `<div data-controller="cookie-acceptance">
         <div id="overlay" class="cookie-acceptance" data-cookie-acceptance-target="overlay">
+            <a class="cookies-info" href="#" data-cookie-acceptance-target="info">some-link</a>
             <div class="cookie-acceptance__background"></div>
             <div class="cookie-acceptance__dialog">
                 <div class="cookie-acceptance__dialog__header">


### PR DESCRIPTION
### Trello card

https://trello.com/c/CCIJUUyS/1923-accessibility-fix-keyboard-focus-on-cookie-pop-up

### Context

The previous implementation had a couple of slight usability problems that this (hopefully) addresses.

One was that the 'cookies' link (to our cookies page) wasn't accessible via keyboard, tabbing only went between the acccpt/reject buttons.

The initial attempt to restrict tabbing to just one part of the page (the modal) failed, even when using the new Dialog API - as did adding `inert` in various places to prevent tabbing fron continuing to the obstructed background.

Additionally, any click to the modal would move focus onto the next element. This could have unintentional consequences for users who misclick.

### Changes

The approach I took was to just add a third target to the component and set up the tab order manually. It works for both <kbd>tab</kbd> and <kbd>shift+tab</kbd>

The event was changed from `blur` to `keydown` to stop clicking and other interactions moving the focus along unintentionally.

### Guidance to review

Testing tabbing also [appears to be painful](https://stackoverflow.com/questions/1601593/fire-tab-keypress-event-in-javascript) without bringing something that actually drives the browser along to the party.


### Preview


https://user-images.githubusercontent.com/128088/132350489-97e9f87d-cd90-4f55-8e64-28549f95ca97.mp4

