### PR TITLE
Put each structured data section behind feature flag

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -6,7 +6,7 @@ module StructuredDataHelper
   EVENT_SCHEDULED = "https://schema.org/EventScheduled".freeze
 
   def structured_data(type, data)
-    return if Rails.env.production?
+    return unless Rails.application.config.x.structured_data.send(type.underscore)
 
     output = {
       "@context": "https://schema.org",

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,11 @@ Rails.application.configure do
   config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
 
   config.x.basic_auth = ENV["BASIC_AUTH"]
+
+  config.x.structured_data.blog_posting = true
+  config.x.structured_data.web_site = true
+  config.x.structured_data.organization = true
+  config.x.structured_data.breadcrumb_list = true
+  config.x.structured_data.event = true
+  config.x.structured_data.how_to = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,4 +129,11 @@ Rails.application.configure do
     io: STDOUT,
     level: Rails.application.config.log_level,
     formatter: config.rails_semantic_logger.format
+
+  config.x.structured_data.blog_posting = false
+  config.x.structured_data.web_site = false
+  config.x.structured_data.organization = false
+  config.x.structured_data.breadcrumb_list = true
+  config.x.structured_data.event = false
+  config.x.structured_data.how_to = false
 end

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -13,8 +13,15 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:type) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:type)
+      expect(script_tag).to be_nil
+    end
+
+    it "returns nil when not set in config" do
+      disable_structured_data(:type, nil)
       expect(script_tag).to be_nil
     end
 
@@ -61,8 +68,10 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:how_to) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:how_to)
       expect(script_tag).to be_nil
     end
 
@@ -122,8 +131,10 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:blog_posting) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:blog_posting)
       expect(script_tag).to be_nil
     end
 
@@ -165,8 +176,10 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:web_site) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:web_site)
       expect(script_tag).to be_nil
     end
 
@@ -192,8 +205,10 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:organization) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:organization)
       expect(script_tag).to be_nil
     end
 
@@ -220,8 +235,10 @@ describe StructuredDataHelper, type: "helper" do
 
       subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-      it "returns nil when in production" do
-        allow(Rails).to receive(:env) { "production".inquiry }
+      before { enable_structured_data(:breadcrumb_list) }
+
+      it "returns nil when disabled by config" do
+        disable_structured_data(:breadcrumb_list)
         expect(script_tag).to be_nil
       end
 
@@ -270,8 +287,10 @@ describe StructuredDataHelper, type: "helper" do
 
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    it "returns nil when in production" do
-      allow(Rails).to receive(:env) { "production".inquiry }
+    before { enable_structured_data(:event) }
+
+    it "returns nil when disabled by config" do
+      disable_structured_data(:event)
       expect(script_tag).to be_nil
     end
 
@@ -356,5 +375,15 @@ describe StructuredDataHelper, type: "helper" do
         end
       end
     end
+  end
+
+  def enable_structured_data(type)
+    allow(Rails.application.config.x.structured_data).to \
+      receive(type) { true }
+  end
+
+  def disable_structured_data(type, value = false)
+    allow(Rails.application.config.x.structured_data).to \
+      receive(type) { value }
   end
 end

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -6,6 +6,13 @@ describe "Google Structured Data" do
 
   subject(:structured_data) { json_contents.map { |json| JSON.parse(json, symbolize_names: true) } }
 
+  before do
+    %i[how_to event blog_posting organization breadcrumb_list web_site].each do |type|
+      allow(Rails.application.config.x.structured_data).to \
+        receive(type) { true }
+    end
+  end
+
   context "when viewing an event page" do
     let(:event) { build(:event_api) }
     let(:path) { event_path(id: event.readable_id) }


### PR DESCRIPTION
### Trello card

[Trello-1926](https://trello.com/c/MIJstS3b/1926-split-feature-flags-for-structured-data)

### Context

Some of the structured data is fine to be shipped just now, but other sections (such as events and blogs) need more
discussion out-with our team to get a green light.

Wrap each section behind a feature flag and enable the breadcrumb list in production; we're going to use this one
to ensure its working and determine how long it would take for Google to realise the change (so we get an idea of how
long a 'revert' would take if we make a mistake elsewhere, as there's no way to preview what the search results will
look like ahead of making them live).

### Changes proposed in this pull request

- Put each structured data section behind feature flag

### Guidance to review

