### PR TITLE
Enable Rubocop/RSpec EmptyLine rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,18 +68,6 @@ RSpec/DescribeClass:
   Exclude:
     - spec/**/*.rb
 
-RSpec/EmptyLineAfterFinalLet:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/EmptyLineAfterHook:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/EmptyLineAfterSubject:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb

--- a/spec/components/calls_to_action/chat_online_component_spec.rb
+++ b/spec/components/calls_to_action/chat_online_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe CallsToAction::ChatOnlineComponent, type: :component do
   let(:component) { described_class.new }
+
   before { render_inline(component) }
 
   specify "renders a call to action" do

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
     let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target, image: image } }
 
     let(:component) { described_class.new(kwargs) }
+
     before { render_inline(component) }
 
     specify "renders the call to action" do

--- a/spec/components/calls_to_action/next_steps_component_spec.rb
+++ b/spec/components/calls_to_action/next_steps_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe CallsToAction::NextStepsComponent, type: :component do
   let(:component) { described_class.new }
+
   before { render_inline(component) }
 
   specify "renders the call to action" do

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
     let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target } }
 
     let(:component) { described_class.new(kwargs) }
+
     before { render_inline(component) }
 
     specify "renders the call to action" do

--- a/spec/components/calls_to_action/story_component_spec.rb
+++ b/spec/components/calls_to_action/story_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CallsToAction::StoryComponent, type: :component do
   let(:args) { { name: name, heading: heading, image: image_path, link: link, text: text } }
 
   let(:component) { described_class.new(args) }
+
   before { render_inline(component) }
 
   specify "renders the call to action" do

--- a/spec/components/cards/story_component_spec.rb
+++ b/spec/components/cards/story_component_spec.rb
@@ -57,6 +57,7 @@ describe Cards::StoryComponent, type: "component" do
 
   context "with no header and unknown page" do
     let(:page_data) { Pages::Data.new }
+
     it { is_expected.not_to have_css ".card header" }
   end
 end

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -47,6 +47,7 @@ describe Content::AccordionComponent, type: "component" do
 
     context "when there are no steps" do
       let(:steps) { {} }
+
       specify "nothing is rendered" do
         expect(page).not_to have_css(".accordions")
       end
@@ -65,6 +66,7 @@ describe Content::AccordionComponent, type: "component" do
 
       describe "when a call to action is specified" do
         let(:call_to_action) { "chat_online" }
+
         before { subject }
 
         specify "the title and content are rendered" do

--- a/spec/components/content/quote_component_spec.rb
+++ b/spec/components/content/quote_component_spec.rb
@@ -53,31 +53,37 @@ describe Content::QuoteComponent, type: :component do
 
   context "when name is not specified" do
     let(:name) { nil }
+
     it { is_expected.not_to have_css(".author cite.name") }
   end
 
   context "when job_title is not specified" do
     let(:job_title) { nil }
+
     it { is_expected.not_to have_css(".author cite.job-title") }
   end
 
   context "when cta is not specified" do
     let(:cta) { nil }
+
     it { is_expected.not_to have_link }
   end
 
   context "when image is not specified" do
     let(:image) { nil }
+
     it { is_expected.not_to have_css("img") }
   end
 
   context "when inline right" do
     let(:inline) { "right" }
+
     it { is_expected.to have_css(".quote--inline-right") }
   end
 
   context "when inline left" do
     let(:inline) { "left" }
+
     it { is_expected.to have_css(".quote--inline-left") }
   end
 
@@ -86,6 +92,7 @@ describe Content::QuoteComponent, type: :component do
     let(:job_title) { nil }
     let(:image) { nil }
     let(:cta) { nil }
+
     it { is_expected.not_to have_css(".footer") }
   end
 

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -5,7 +5,9 @@ describe Events::SearchComponent, type: "component" do
   let(:path) { "/some/path" }
 
   let(:component) { described_class.new(search, path) }
+
   subject! { render_inline(component) }
+
   before { freeze_time }
 
   specify "builds a search form" do
@@ -21,6 +23,7 @@ describe Events::SearchComponent, type: "component" do
 
     context "when overridden" do
       let(:new_heading) { "Search for Awesome events" }
+
       subject! { render_inline(described_class.new(search, path, heading: new_heading)) }
 
       specify %(the title is overridden) do

--- a/spec/components/footer/feedback_component_spec.rb
+++ b/spec/components/footer/feedback_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Footer::FeedbackComponent, type: "component" do
   subject! { render_inline(described_class.new) }
+
   let(:feedback_selector) { ".feedback-bar" }
 
   specify "renders the talk to us component" do

--- a/spec/components/footer/mailing_list_component_spec.rb
+++ b/spec/components/footer/mailing_list_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Footer::MailingListComponent, type: "component" do
   subject! { render_inline(described_class.new) }
+
   let(:mailing_list_selector) { ".mailing-list-bar" }
 
   specify "renders the mailing list component" do

--- a/spec/components/footer/talk_to_us_component_spec.rb
+++ b/spec/components/footer/talk_to_us_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Footer::TalkToUsComponent, type: "component" do
   subject! { render_inline(described_class.new) }
+
   let(:talk_to_us_selector) { ".talk-to-us" }
 
   specify "renders the talk to us component" do

--- a/spec/components/footer/video_player_component_spec.rb
+++ b/spec/components/footer/video_player_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Footer::VideoPlayerComponent, type: "component" do
   subject! { render_inline(described_class.new) }
+
   let(:video_component_selector) { ".video-overlay" }
 
   specify "renders the video player component" do

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -57,6 +57,7 @@ describe FooterComponent, type: "component" do
 
   context "when a lid_pixel_event is supplied" do
     let(:event) { "Success" }
+
     subject! { render_inline(described_class.new(lid_pixel_event: event)) }
 
     specify "renders the right analytics element" do

--- a/spec/components/funding_widget_component_spec.rb
+++ b/spec/components/funding_widget_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FundingWidgetComponent, type: :component do
     let(:path) { "/example-page" }
 
     let(:component) { described_class.new(funding_widget, path) }
+
     before { render_inline(component) }
 
     it "builds a funding_widget form" do

--- a/spec/components/grouped_cards/listing_component_spec.rb
+++ b/spec/components/grouped_cards/listing_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe GroupedCards::ListingComponent, type: "component" do
   subject { render_inline(instance) && page }
+
   let(:custom_description) { "a very nice card indeed" }
 
   let(:instance) { described_class.new data }

--- a/spec/components/header/extra_navigation_component_spec.rb
+++ b/spec/components/header/extra_navigation_component_spec.rb
@@ -4,6 +4,7 @@ describe Header::ExtraNavigationComponent, type: "component" do
   let(:custom_class) { "red-bg" }
   let(:custom_custom_search_input_id) { "do-a-search" }
   let(:component) { described_class.new(classes: Array.wrap(custom_class), search_input_id: custom_custom_search_input_id) }
+
   subject! { render_inline(component) }
 
   specify "renders the extra navigation container with contents" do

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -14,6 +14,7 @@ describe Header::HeroComponent, type: "component" do
     }.merge(extra_front_matter)
   end
   let(:component) { described_class.new(front_matter) }
+
   subject! { render_inline(component) }
 
   describe "rendering a hero section" do

--- a/spec/components/header/logo_component_spec.rb
+++ b/spec/components/header/logo_component_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Header::LogoComponent, type: "component" do
   let(:component) { described_class.new }
+
   subject! { render_inline(component) }
 
   specify "renders the logo wrapper with the get into teaching and DfE logos" do

--- a/spec/components/header/navigation_component_spec.rb
+++ b/spec/components/header/navigation_component_spec.rb
@@ -12,6 +12,7 @@ describe Header::NavigationComponent, type: "component" do
   end
 
   let(:component) { described_class.new(resources: resources, extra_resources: extra_resources) }
+
   subject! { render_inline(component) }
 
   specify "renders a primary navigation list" do

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -92,6 +92,7 @@ describe Stories::StoryComponent, type: "component" do
 
   describe "content" do
     let(:content) { "The quick brown fox" }
+
     subject do
       render_inline(described_class.new(front_matter)) do
         content

--- a/spec/controllers/concerns/static_pages_spec.rb
+++ b/spec/controllers/concerns/static_pages_spec.rb
@@ -75,42 +75,52 @@ describe StaticPages do
 
   describe "#filtered_page_template" do
     let(:params) { { page: template } }
+
     before { allow(tester).to receive(:params).and_return params }
+
     subject { tester.send :filtered_page_template }
 
     context "with valid page template" do
       let(:template) { "hello" }
+
       it { is_expected.to eql "hello" }
     end
 
     context "with nested template" do
       let(:template) { "hello/world" }
+
       it { is_expected.to eql "hello/world" }
     end
 
     context "with invalid page template" do
       let(:template) { "invalid!" }
+
       it { expect { subject }.to raise_exception StaticPages::InvalidTemplateName }
     end
 
     context "with param linking to parent page" do
       let(:template) { "../../secrets.txt" }
+
       it { expect { subject }.to raise_exception StaticPages::InvalidTemplateName }
     end
 
     context "with file extension" do
       let(:template) { "stories/how-i-got-into-teaching.html" }
+
       it { is_expected.to eql "stories/how-i-got-into-teaching.html" }
     end
 
     context "with numbers in name" do
       let(:template) { "stories/my-top-10" }
+
       it { is_expected.to eql "stories/my-top-10" }
     end
 
     context "with custom page value" do
       let(:params) { { story: "hello" } }
+
       subject { tester.send :filtered_page_template, :story }
+
       it { is_expected.to eql "hello" }
     end
   end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
   end
 
   before { visit path }
+
   subject { page }
 
   context "when visiting the home page" do

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -144,6 +144,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
     subject { page }
 
     before { visit "/" }
+
     let(:document) { Nokogiri.parse(page.body) }
 
     let(:navigation_pages) { Pages::Frontmatter.select(:navigation) }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -39,6 +39,7 @@ describe ApplicationHelper do
 
       context "with additional stimulus controller" do
         subject { analytics_body_tag(data: { controller: "atest" }) { tag.hr } }
+
         it { is_expected.to have_css "body[data-controller~=gtm]" }
         it { is_expected.to have_css "body[data-controller~=pinterest]" }
         it { is_expected.to have_css "body[data-controller~=snapchat]" }
@@ -61,6 +62,7 @@ describe ApplicationHelper do
 
       context "with blank service ids" do
         let(:id) { "" }
+
         it { is_expected.to have_css "body[data-analytics-gtm-id=\"\"]" }
         it { is_expected.to have_css "body[data-analytics-ga-id=\"\"]" }
         it { is_expected.to have_css "body[data-analytics-adwords-id=\"\"]" }
@@ -74,6 +76,7 @@ describe ApplicationHelper do
 
       context "with no service ids" do
         let(:id) { nil }
+
         it { is_expected.not_to have_css "body[data-analytics-gtm-id]" }
         it { is_expected.not_to have_css "body[data-analytics-ga-id]" }
         it { is_expected.not_to have_css "body[data-analytics-adwords-id]" }
@@ -97,6 +100,7 @@ describe ApplicationHelper do
 
     context "with other data attributes" do
       subject { analytics_body_tag(data: { timefmt: "24" }) { tag.hr } }
+
       it { is_expected.to have_css "body[data-controller~=gtm]" }
       it { is_expected.to have_css "body[data-analytics-gtm-id=1234]" }
       it { is_expected.to have_css "body[data-timefmt=24]" }
@@ -104,6 +108,7 @@ describe ApplicationHelper do
 
     context "with other attributes" do
       subject { analytics_body_tag(class: "homepage") { tag.hr } }
+
       it { is_expected.to have_css "body[data-controller~=gtm]" }
       it { is_expected.to have_css "body.homepage" }
     end
@@ -135,6 +140,7 @@ describe ApplicationHelper do
 
   describe "#fa_icon" do
     let(:icon_name) { "myspace" }
+
     subject { helper.fa_icon(icon_name) }
 
     it "returns an empty span with the default classes" do
@@ -143,6 +149,7 @@ describe ApplicationHelper do
 
     context "with FA styles" do
       let(:style) { "fad" }
+
       subject { helper.fa_icon(icon_name, style: style) }
 
       it "returns an empty span with provided style class" do
@@ -152,6 +159,7 @@ describe ApplicationHelper do
 
     context "with extra classes" do
       let(:extra_classes) { %w[abc def] }
+
       subject { helper.fa_icon(icon_name, *extra_classes) }
 
       it "returns an empty span with the extra classes" do
@@ -162,7 +170,9 @@ describe ApplicationHelper do
 
   describe "#fab_icon" do
     let(:icon_name) { "friendster" }
+
     subject { helper.fab_icon(icon_name) }
+
     after { subject }
 
     it %(it returns a span with class 'fab') do
@@ -172,7 +182,9 @@ describe ApplicationHelper do
 
   describe "#fas_icon" do
     let(:icon_name) { "orkut" }
+
     subject { helper.fas_icon(icon_name) }
+
     after { subject }
 
     it %(it returns a span with class 'fas') do
@@ -206,6 +218,7 @@ describe ApplicationHelper do
   describe "#chat_link" do
     let(:text) { "Chat with us" }
     let(:extra_class) { "button" }
+
     subject { helper.chat_link(text, classes: extra_class) }
 
     it %(generates a hyperlink) do

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -30,6 +30,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#format_event_date" do
     let(:stacked) { true }
+
     subject { format_event_date event, stacked: stacked }
 
     context "with a single day event" do
@@ -38,6 +39,7 @@ describe EventsHelper, type: "helper" do
 
     context "with a multi day event" do
       let(:enddate) { DateTime.new(2020, 6, 4, 14) }
+
       it { is_expected.to eql "1 June 2020 10:00 to 4 June 2020 14:00" }
     end
 

--- a/spec/helpers/searches_helper_spec.rb
+++ b/spec/helpers/searches_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchesHelper do
 
     context "with custom separator" do
       subject { humanize_path(path, separator: ".", &:upcase) }
+
       it { is_expected.to be_html_safe }
       it { is_expected.to eql "FOO.FOO-BAR" }
     end
@@ -18,6 +19,7 @@ RSpec.describe SearchesHelper do
 
   describe "humanize_path_segment" do
     subject { humanize_path_segment "foo-bar" }
+
     it { is_expected.to be_html_safe }
     it { is_expected.to eql "<span>Foo bar &rsaquo;</span>" }
   end

--- a/spec/helpers/stories_helper_spec.rb
+++ b/spec/helpers/stories_helper_spec.rb
@@ -18,6 +18,7 @@ describe StoriesHelper, type: "helper" do
 
   describe "#story_image_alt" do
     let(:name) { "David" }
+
     subject { helper.story_image_alt(name) }
 
     specify %(returns string 'A photograph of' followed by the supplied name) do
@@ -27,6 +28,7 @@ describe StoriesHelper, type: "helper" do
 
   describe "#youtube" do
     let(:url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
+
     subject { helper.youtube(url) }
 
     specify %(should generate an iframe with the data-src attribute set to the video's URL) do
@@ -36,6 +38,7 @@ describe StoriesHelper, type: "helper" do
 
   describe "#more_stories_thumbnail" do
     let(:path) { "/assets/mugshots/elizabeth_hoover.jpg" }
+
     subject { helper.more_stories_thumbnail(path) }
 
     specify %(should generate a div with the background image set to the provided path) do

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -6,11 +6,13 @@ describe TextFormattingHelper, type: :helper do
 
     context "with new lines" do
       let(:content) { "hello\r\n\r\nworld" }
+
       it { is_expected.to eql "<p>hello</p>\n\n<p>world</p>" }
     end
 
     context "with html content" do
       let(:content) { "<strong>hello</strong> <em>world</em>" }
+
       it { is_expected.to eql "<p>hello world</p>" }
     end
   end
@@ -20,21 +22,25 @@ describe TextFormattingHelper, type: :helper do
 
     context "with allowed HTML" do
       let(:html) { "<div>test</div><p><strong>hello</strong> <a href=\"http://test.com\">world</a></p><ul><li>test</li></ul><span>test</span>" }
+
       it { is_expected.to eql html }
     end
 
     context "with disallowed HTML" do
       let(:html) { "<script>malicious</script>" }
+
       it { is_expected.to eql "malicious" }
     end
 
     context "with malicious anchor tags" do
       let(:html) { "<a href=\"http://test.com\" onclick=\"somethingNasty();\">boom</a>" }
+
       it { is_expected.to eql "<a href=\"http://test.com\">boom</a>" }
     end
 
     context "with anchor tags" do
       let(:html) { "<a href=\"http://test.com\" target=\"blank\">open</a>" }
+
       it { is_expected.to eql html }
     end
   end

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -6,33 +6,39 @@ describe Acronyms, type: :helper do
   let(:acronyms) { { "VAT" => "Value added tax", "HMRC" => "Her Majesty's Revenue and Customs" } }
 
   subject { described_class.new(content, acronyms).render }
+
   it { is_expected.to match "marked exVAT" }
   it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
 
   context "with HTML content" do
     let(:content) { "<span id=\"#vat\" title=\"VAT information\">VAT</span>" }
+
     it { is_expected.to have_css "span abbr[title=\"Value added tax\"]", text: "VAT" }
     it { is_expected.to have_css "span[title=\"VAT information\"]" }
   end
 
   context "with unknown acronym" do
     let(:content) { "<p>Payments are deducted as part of PAYE</p>" }
+
     it { is_expected.to have_css "p", text: "Payments are deducted as part of PAYE" }
   end
 
   context "with nil acronyms" do
     let(:acronyms) { nil }
+
     it { is_expected.to have_css "p", text: "All prices include VAT except where marked exVAT" }
   end
 
   context "with multiple acronyms in the same node" do
     let(:content) { "Taxes you may encounter include VAT and PAYE" }
+
     it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }
     it { is_expected.to match "and PAYE" }
   end
 
   context "when the acronym is surrounded by brackets" do
     let(:content) { "Taxes you may encounter include Value Added Tax (VAT) and Pay as you earn (PAYE)." }
+
     it "remains unchanged" do
       is_expected.to match(content)
     end
@@ -40,6 +46,7 @@ describe Acronyms, type: :helper do
 
   context "when the acronym is within a hyperlink" do
     let(:content) { "<span><a href=\"#hmrc\" title=\"Her Majesty's Revenue and Customs\">HMRC</a> have a new VAT system</span>" }
+
     it { is_expected.to have_css("abbr", count: 1) }
     it { is_expected.not_to have_css("abbr", text: "HMRC") }
   end

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe BasicAuth do
 
   describe ".env_requires_auth?" do
     before { allow(Rails.application.config.x).to receive(:basic_auth) { basic_auth } }
+
     subject { instance.env_requires_auth? }
 
     basic_auth_values = {

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -8,6 +8,7 @@ describe NextGenImages do
     let(:instance) { described_class.new(body) }
 
     before { allow(File).to receive(:exist?) { false } }
+
     before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
 
     subject { instance.html }

--- a/spec/models/callbacks/steps/personal_details_spec.rb
+++ b/spec/models/callbacks/steps/personal_details_spec.rb
@@ -11,7 +11,9 @@ describe Callbacks::Steps::PersonalDetails do
 
   describe "validations" do
     before { instance.valid? }
+
     subject { instance.errors.messages }
+
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
     it { is_expected.to include(:email) }

--- a/spec/models/callbacks/steps/privacy_policy_spec.rb
+++ b/spec/models/callbacks/steps/privacy_policy_spec.rb
@@ -9,6 +9,7 @@ describe Callbacks::Steps::PrivacyPolicy do
 
   describe "validations" do
     subject { instance.tap(&:valid?).errors.messages }
+
     it { is_expected.to include(:accept_privacy_policy) }
   end
 

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -13,6 +13,7 @@ describe Callbacks::Wizard do
     }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
+
   subject { described_class.new wizardstore, "privacy_policy" }
 
   describe ".steps" do

--- a/spec/models/events/category_spec.rb
+++ b/spec/models/events/category_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Events::Category do
 
     context "with no events for category id" do
       let(:category_name) { "Online event" }
+
       it { is_expected.to be_nil }
     end
   end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -13,16 +13,19 @@ describe Events::Search do
 
   describe "#period" do
     subject { described_class.new.period }
+
     it { is_expected.to eq(:future) }
   end
 
   describe ".available_distance_keys" do
     subject { described_class.new.available_distance_keys }
+
     it { is_expected.to eql [nil, 10, 25] }
   end
 
   describe ".available_event_type_ids" do
     subject { described_class.new.available_event_type_ids }
+
     it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.except("Question Time").values }
   end
 
@@ -33,6 +36,7 @@ describe Events::Search do
 
   describe "#available_months" do
     before { travel_to(DateTime.new(2020, 11, 10)) }
+
     subject { described_class.new(period: period).available_months }
 
     context "when period is future" do
@@ -141,6 +145,7 @@ describe Events::Search do
     let(:default_limit) { described_class::RESULTS_PER_TYPE }
 
     subject { build :events_search }
+
     before { allow(subject).to receive(:valid?).and_return is_valid }
 
     let(:expected_attributes) do
@@ -156,6 +161,7 @@ describe Events::Search do
 
     context "when valid" do
       let(:is_valid) { true }
+
       after { subject.send(:query_events) }
 
       it "calls the API" do
@@ -186,6 +192,7 @@ describe Events::Search do
 
       context "when searching a future period" do
         let(:travel_date) { DateTime.new(2020, 1, 10).utc }
+
         before { travel_to(travel_date) }
 
         context "when the month is nil" do
@@ -200,6 +207,7 @@ describe Events::Search do
 
         context "when the month is the current month" do
           let(:date) { travel_date }
+
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear)).tap(&:validate) }
 
           it "searches from the beginning of today to the end of the current month" do
@@ -211,6 +219,7 @@ describe Events::Search do
 
         context "when the month is the next month" do
           let(:date) { travel_date.advance(months: 1) }
+
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear)).tap(&:validate) }
 
           it "searches from the start of the next month to the end" do
@@ -224,6 +233,7 @@ describe Events::Search do
       context "when searching a past period" do
         let(:travel_date) { DateTime.new(2020, 1, 10).utc }
         let(:day_before_travel_date) { travel_date.advance(days: -1) }
+
         before { travel_to(travel_date) }
 
         context "when the month is nil" do
@@ -238,6 +248,7 @@ describe Events::Search do
 
         context "when the month is the current month" do
           let(:date) { travel_date }
+
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear), period: :past).tap(&:validate) }
 
           it "searches from the beginning of the month to the end of yesterday" do
@@ -249,6 +260,7 @@ describe Events::Search do
 
         context "when the month is the previous month" do
           let(:date) { travel_date.advance(months: -1) }
+
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear), period: :past).tap(&:validate) }
 
           it "searches from the start of the previous month to the end" do

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -30,6 +30,7 @@ describe Events::Steps::FurtherDetails do
 
     describe "#already_subscribed_to_mailing_list" do
       let(:backingstore) { { "already_subscribed_to_mailing_list" => true } }
+
       it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("").for :subscribe_to_mailing_list }
@@ -37,6 +38,7 @@ describe Events::Steps::FurtherDetails do
 
     describe "#already_subscribed_to_teacher_training_adviser" do
       let(:backingstore) { { "already_subscribed_to_teacher_training_adviser" => true } }
+
       it { is_expected.to allow_value("1").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("0").for :subscribe_to_mailing_list }
       it { is_expected.to allow_value("").for :subscribe_to_mailing_list }

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -12,7 +12,9 @@ describe Events::Steps::PersonalDetails do
 
   describe "validations" do
     before { instance.valid? }
+
     subject { instance.errors.messages }
+
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
     it { is_expected.to include(:email) }
@@ -41,16 +43,19 @@ describe Events::Steps::PersonalDetails do
 
     context "when is_walk_in is nil" do
       before { instance.is_walk_in = nil }
+
       it { is_expected.to be(false) }
     end
 
     context "when is_walk_in is false" do
       before { instance.is_walk_in = false }
+
       it { is_expected.to be(false) }
     end
 
     context "when is_walk_in is true" do
       before { instance.is_walk_in = true }
+
       it { is_expected.to be(true) }
     end
   end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -73,11 +73,13 @@ describe Events::Steps::PersonalisedUpdates do
 
     context "with mailing_list question answered as yes" do
       let(:mailing_list) { true }
+
       it { is_expected.not_to be_skipped }
     end
 
     context "with mailing_list question answered as no" do
       let(:mailing_list) { false }
+
       it { is_expected.to be_skipped }
     end
   end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -11,6 +11,7 @@ describe Events::Wizard do
     } }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
+
   subject { described_class.new wizardstore, "personalised_updates" }
 
   describe ".steps" do

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -92,12 +92,14 @@ describe Healthcheck do
 
     context "with no configured connection" do
       before { allow(ENV).to receive(:[]).with("REDIS_URL").and_return nil }
+
       it { is_expected.to be nil }
     end
   end
 
   describe "#to_h" do
     subject { described_class.new.to_h }
+
     it { is_expected.to include :app_sha }
     it { is_expected.to include :content_sha }
     it { is_expected.to include :api }
@@ -106,6 +108,7 @@ describe Healthcheck do
 
   describe "#to_json" do
     subject { JSON.parse described_class.new.to_json }
+
     it { is_expected.to include "app_sha" }
     it { is_expected.to include "content_sha" }
     it { is_expected.to include "api" }

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -59,6 +59,7 @@ describe Internal::EventBuilding do
         image_url: api_building.image_url,
       )
     end
+
     it "should have correct attributes" do
       expect(described_class.initialize_with_api_building(api_building)).to have_attributes(expected_attributes)
     end
@@ -78,6 +79,7 @@ describe Internal::EventBuilding do
         address_postcode: internal_building.address_postcode,
       )
     end
+
     it "should have correct attributes" do
       expect(internal_building.to_api_building).to have_attributes(expected_api_building_attributes)
     end

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -150,6 +150,7 @@ describe Internal::Event do
           provider_website_url: api_event.provider_website_url,
         ).slice(described_class.attribute_names)
       end
+
       context "with building" do
         let(:expected_building_attributes) { attributes_for(:event_building_api, id: api_event.building.id) }
 
@@ -236,6 +237,7 @@ describe Internal::Event do
   describe "#type_id=" do
     context "when event is initialised with 'online' event_type" do
       subject { described_class.new({ type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }) }
+
       it "sets 'is_online' to true" do
         expect(subject.is_online).to be true
       end
@@ -319,6 +321,7 @@ describe Internal::Event do
       context "when id is present" do
         let(:building) { build(:event_building_api) }
         let(:attributes) { attributes_for(:event_building_api, id: building.id) }
+
         it "sets building based on id" do
           event = described_class.new
           event.venue_type = described_class::VENUE_TYPES[:existing]
@@ -329,6 +332,7 @@ describe Internal::Event do
 
         context "when id is not present" do
           let(:building) { build(:event_building_api, id: nil) }
+
           it "returns nil" do
             event = described_class.new
             event.venue_type = described_class::VENUE_TYPES[:existing]
@@ -340,6 +344,7 @@ describe Internal::Event do
 
     context "when the venue type is add and an id is present" do
       let(:building) { attributes_for(:event_building) }
+
       it "sets building with no id" do
         event = described_class.new
         event.venue_type = described_class::VENUE_TYPES[:add]
@@ -351,6 +356,7 @@ describe Internal::Event do
 
     context "when the venue type is none" do
       let(:building) { attributes_for(:event_building) }
+
       it "returns nil" do
         event = described_class.new
         event.venue_type = described_class::VENUE_TYPES[:none]

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -38,6 +38,7 @@ describe MailingList::Signup do
 
     describe "#channel_id" do
       let(:options) { channels.map(&:id) }
+
       it { is_expected.to allow_values(options).for(:channel_id) }
       it { is_expected.to allow_value(nil, "").for(:channel_id) }
       it { is_expected.not_to allow_value(12_345).for(:channel_id) }
@@ -96,6 +97,7 @@ describe MailingList::Signup do
 
     describe "#accept_privacy_policy" do
       let(:message) { "Accept the terms and conditions to continue" }
+
       it { is_expected.to validate_presence_of(:accept_privacy_policy).with_message(message) }
       it { is_expected.to validate_acceptance_of(:accept_privacy_policy).with_message(message) }
     end

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -19,11 +19,13 @@ describe MailingList::Steps::DegreeStatus do
 
   describe "validations" do
     subject { instance.tap(&:valid?).errors.messages }
+
     it { is_expected.to include(:degree_status_id) }
   end
 
   describe "#degree_status_id" do
     let(:options) { degree_status_option_types.map(&:id) }
+
     it { is_expected.to allow_value(options.first).for :degree_status_id }
     it { is_expected.to allow_value(options.last).for :degree_status_id }
     it { is_expected.not_to allow_value(nil).for :degree_status_id }

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -21,6 +21,7 @@ describe MailingList::Steps::Name do
 
   describe "validations" do
     subject { instance.tap(&:valid?).errors.messages }
+
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }
     it { is_expected.to include(:email) }
@@ -42,6 +43,7 @@ describe MailingList::Steps::Name do
 
   describe "validations for channel_id" do
     let(:options) { channels.map(&:id) }
+
     it { is_expected.to allow_values(options).for :channel_id }
     it { is_expected.to allow_value(nil, "").for :channel_id }
     it { is_expected.not_to allow_value(12_345).for :channel_id }

--- a/spec/models/mailing_list/steps/privacy_policy_spec.rb
+++ b/spec/models/mailing_list/steps/privacy_policy_spec.rb
@@ -9,6 +9,7 @@ describe MailingList::Steps::PrivacyPolicy do
 
   describe "validations" do
     subject { instance.tap(&:valid?).errors.messages }
+
     it { is_expected.to include(:accept_privacy_policy) }
   end
 

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -19,6 +19,7 @@ describe MailingList::Steps::Subject do
 
   describe "#preferred_teaching_subject_id" do
     let(:options) { teaching_subject_types.map(&:id) }
+
     it { is_expected.to allow_value(options.first).for :preferred_teaching_subject_id }
     it { is_expected.to allow_value(options.last).for :preferred_teaching_subject_id }
     it { is_expected.not_to allow_value(nil).for :preferred_teaching_subject_id }

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -19,6 +19,7 @@ describe MailingList::Steps::TeacherTraining do
 
   describe "#consideration_journey_stage_id" do
     let(:options) { consideration_journey_stage_types.map(&:id) }
+
     it { is_expected.to allow_value(options.first).for :consideration_journey_stage_id }
     it { is_expected.to allow_value(options.last).for :consideration_journey_stage_id }
     it { is_expected.not_to allow_value(nil).for :consideration_journey_stage_id }

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -10,6 +10,7 @@ describe MailingList::Wizard do
     } }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
+
   subject { described_class.new wizardstore, "privacy_policy" }
 
   describe ".steps" do

--- a/spec/models/pages/blog_spec.rb
+++ b/spec/models/pages/blog_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Pages::Blog do
 
   describe ".find" do
     before { allow(Pages::Page).to receive(:find).with("/some/template").and_return("/some_template.md") }
+
     subject { described_class }
 
     specify "calls the other method" do
@@ -44,6 +45,7 @@ RSpec.describe Pages::Blog do
 
     context "when filtering by a single tag" do
       let(:wanted_tag) { "august" }
+
       subject { described_class.new(pages) }
 
       specify "return the right number of posts" do
@@ -101,6 +103,7 @@ RSpec.describe Pages::Blog do
 
     context "when a limit is applied" do
       let(:limit) { 2 }
+
       subject { described_class.new(pages).similar_posts(origin, limit) }
 
       specify "only the right number of posts are returned" do

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Pages::Data do
     include_context "use fixture markdown pages"
 
     subject { instance.find_page "/page1" }
+
     it { is_expected.to include title: "Hello World 1 Upwards" }
   end
 

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Pages::Frontmatter do
 
   describe ".select_by_path" do
     let(:wanted_path) { "/subfolder" }
+
     subject { described_class.select_by_path(wanted_path, content_dir) }
 
     before { expect_any_instance_of(described_class).to receive(:select_by_path).and_call_original }

--- a/spec/models/pages/navigation_spec.rb
+++ b/spec/models/pages/navigation_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Pages::Navigation do
 
   describe "#root_pages" do
     subject { described_class.new(nav).root_pages }
+
     let(:actual_pages) { subject.map(&:path) }
 
     specify "contains only the root pages" do
@@ -169,6 +170,7 @@ RSpec.describe Pages::Navigation do
 
     describe "#children" do
       let(:nav) { Pages::Navigation.new(page_five_subpages.merge(page_six_subpages)) }
+
       subject { described_class.new(nav, "/page-five", { title: "Five", rank: 5, menu: true }) }
 
       specify "contains the right number of children" do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Search do
 
     context "with mismatched case" do
       let(:search) { "tEaCh" }
+
       it { is_expected.to have_attributes length: 3 }
       it { is_expected.to include(a_hash_including(path: "/first")) }
       it { is_expected.to include(a_hash_including(path: "/second")) }

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -75,6 +75,7 @@ describe Events::GroupPresenter do
 
       context "when descending" do
         let(:ascending) { false }
+
         it "sorts events of the same type by date, descending" do
           expect(subject.sorted_events_by_type.to_h[type_id]).to eql([late, middle, early])
         end

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -16,13 +16,17 @@ describe Callbacks::StepsController do
 
   describe "#index" do
     before { get callbacks_steps_path(query: "param") }
+
     subject { response }
+
     it { is_expected.to redirect_to(callbacks_step_path({ id: :personal_details, query: "param" })) }
   end
 
   describe "#show" do
     before { get step_path }
+
     subject { response }
+
     it { is_expected.to have_http_status :success }
 
     context "with an invalid step" do
@@ -42,16 +46,19 @@ describe Callbacks::StepsController do
 
     context "with valid data" do
       let(:details_params) { attributes_for(:callbacks_personal_details) }
+
       it { is_expected.to redirect_to callbacks_step_path("authenticate") }
     end
 
     context "with invalid data" do
       let(:details_params) { { "first_name" => "test" } }
+
       it { is_expected.to have_http_status :success }
     end
 
     context "with no data" do
       let(:details_params) { {} }
+
       it { is_expected.to have_http_status :success }
     end
 
@@ -80,7 +87,9 @@ describe Callbacks::StepsController do
         before do
           allow_any_instance_of(model).to receive(:valid?).and_return true
         end
+
         let(:details_params) { attributes_for :"callbacks_#{model.key}" }
+
         it { is_expected.to redirect_to callbacks_step_path steps.first.key }
       end
     end
@@ -91,6 +100,7 @@ describe Callbacks::StepsController do
       get completed_callbacks_steps_path
       response
     end
+
     it { is_expected.to have_http_status :success }
   end
 end

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -5,6 +5,7 @@ describe CookiePreferencesController do
 
   describe "#show" do
     before { get cookie_preference_path }
+
     it { is_expected.to have_http_status :success }
     it { expect(subject.body).to match "Cookie settings" }
   end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -25,13 +25,17 @@ describe EventStepsController do
 
   describe "#index" do
     before { get event_steps_path("123", query: "param") }
+
     subject { response }
+
     it { is_expected.to redirect_to(event_step_path("123", { id: :personal_details, query: "param" })) }
   end
 
   describe "#show" do
     before { get step_path }
+
     subject { response }
+
     it { is_expected.to have_http_status :success }
 
     context "when the event is closed" do
@@ -60,6 +64,7 @@ describe EventStepsController do
       end
 
       before { get event_steps_path("456") }
+
       subject { response }
 
       it { is_expected.to have_http_status :not_found }
@@ -68,6 +73,7 @@ describe EventStepsController do
 
   describe "#update" do
     let(:key) { model.model_name.param_key }
+
     subject do
       patch step_path, params: { key => details_params }
       response
@@ -75,16 +81,19 @@ describe EventStepsController do
 
     context "with valid data" do
       let(:details_params) { attributes_for(:events_personal_details) }
+
       it { is_expected.to redirect_to authenticate_path }
     end
 
     context "with invalid data" do
       let(:details_params) { { "first_name" => "test" } }
+
       it { is_expected.to have_http_status :success }
     end
 
     context "with no data" do
       let(:details_params) { {} }
+
       it { is_expected.to have_http_status :success }
     end
 
@@ -106,14 +115,17 @@ describe EventStepsController do
           allow_any_instance_of(Events::Wizard).to \
             receive(:add_attendee_to_event).and_return true
         end
+
         let(:model) { Events::Steps::PersonalisedUpdates }
         let(:details_params) { attributes_for(:events_personalised_updates) }
+
         it { is_expected.to redirect_to completed_event_steps_path(readable_event_id) }
       end
 
       context "when invalid steps" do
         let(:model) { Events::Steps::PersonalisedUpdates }
         let(:details_params) { attributes_for(:events_personalised_updates) }
+
         it do
           is_expected.to redirect_to \
             event_step_path(readable_event_id, "personal_details")
@@ -127,6 +139,7 @@ describe EventStepsController do
       get completed_event_steps_path(readable_event_id)
       response
     end
+
     it { is_expected.to have_http_status :success }
   end
 end

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -20,6 +20,7 @@ describe "View events by category" do
 
   context "when viewing a category archive" do
     let(:category) { "online-q-as" }
+
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -138,6 +138,7 @@ describe EventsController do
 
       describe "the response body" do
         subject { response.body }
+
         let(:parsed_response) { Nokogiri.parse(response.body) }
 
         it { is_expected.to include(event.name) }

--- a/spec/requests/external_links_image_spec.rb
+++ b/spec/requests/external_links_image_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "External link images" do
   excluded_classes = %w[button]
   before { get "/ways-to-train" }
+
   subject { response.body }
 
   context "when external link and not #{excluded_classes.join(' ')}" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -20,6 +20,7 @@ describe "Find an event near you" do
 
   context "when landing on the page initially" do
     let(:expected_request_attributes) { { start_after: DateTime.now.utc.beginning_of_day } }
+
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type)

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "ensuring frontmatter from content pages is rendered" do
   context "with an accordion layout" do
     before { get "/content-page" }
+
     subject { response.body }
 
     it { expect(response).to have_http_status(200) }
@@ -23,7 +24,9 @@ describe "ensuring frontmatter from content pages is rendered" do
 
   context "with a different heading and title" do
     before { get "/custom-heading" }
+
     subject { response.body }
+
     let(:document) { Nokogiri.parse(response.body) }
 
     it { expect(response).to have_http_status(200) }

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -43,6 +43,7 @@ describe Internal::EventsController do
 
           get internal_events_path, headers: generate_auth_headers(:author), params: { event_type: event_type }
         end
+
         it "shows a no events banner" do
           assert_response :success
           expect(response.body).to include("No pending events")
@@ -145,6 +146,7 @@ describe Internal::EventsController do
 
   describe "#show" do
     let(:event_to_get_readable_id) { "1" }
+
     context "when any user type" do
       context "when the event is pending" do
         before do
@@ -153,6 +155,7 @@ describe Internal::EventsController do
 
           get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:author)
         end
+
         it "shows pending events" do
           assert_response :success
           expect(response.body).to include("This is a pending event")
@@ -167,6 +170,7 @@ describe Internal::EventsController do
 
           get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:author)
         end
+
         it "redirects to not found" do
           assert_response :not_found
           expect(response.body).to include "Page not found"
@@ -182,6 +186,7 @@ describe Internal::EventsController do
 
           get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:author)
         end
+
         it "does not have a final submit button" do
           assert_response :success
           expect(response.body).to_not include "Submit this provider event"
@@ -197,6 +202,7 @@ describe Internal::EventsController do
 
           get internal_event_path(event_to_get_readable_id), headers: generate_auth_headers(:publisher)
         end
+
         it "has a final submit button" do
           assert_response :success
           expect(response.body).to include "Set event status to Open"
@@ -223,6 +229,7 @@ describe Internal::EventsController do
     context "when any user type" do
       context "when event is duplicated" do
         let(:event_to_duplicate_readable_id) { "1" }
+
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
             .to receive(:get_teaching_event_buildings) { [] }
@@ -264,6 +271,7 @@ describe Internal::EventsController do
 
   describe "#edit" do
     let(:event_to_edit_readable_id) { "1" }
+
     context "when any user type" do
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
@@ -290,6 +298,7 @@ describe Internal::EventsController do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
             .to receive(:get_teaching_event_buildings) { [pending_provider_event.building] }
         end
+
         let(:building_id) { pending_provider_event.building.id }
         let(:expected_request_body) do
           build(:event_api,
@@ -319,6 +328,7 @@ describe Internal::EventsController do
                            :provider_event,
                            { "venue_type": Internal::Event::VENUE_TYPES[:existing], "building": { "id": building_id } }
           end
+
           it "posts the event and an existing building" do
             expected_request_body.building =
               build(:event_building_api, { id: params[:building][:id] })
@@ -340,6 +350,7 @@ describe Internal::EventsController do
                              :provider_event,
                              { "venue_type": Internal::Event::VENUE_TYPES[:none], "building": { "id": "" } })
             end
+
             it "does not post a building" do
               expected_request_body.building = nil
 
@@ -367,6 +378,7 @@ describe Internal::EventsController do
                                    "venue": expected_venue,
                                    "address_postcode": expected_postcode } }
             end
+
             it "does not post a building" do
               expected_request_body.building =
                 build(:event_building_api, {
@@ -447,6 +459,7 @@ describe Internal::EventsController do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
             .to receive(:get_teaching_event_buildings) { [] }
         end
+
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
           event.tap do |event|
@@ -549,6 +562,7 @@ describe Internal::EventsController do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
             .to receive(:get_teaching_event_buildings) { [] }
         end
+
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
           event.tap do |event|

--- a/spec/requests/lazy_load_images_spec.rb
+++ b/spec/requests/lazy_load_images_spec.rb
@@ -4,6 +4,7 @@ describe "Lazy Load Images" do
   before do
     get root_path
   end
+
   subject { response.body }
 
   it { is_expected.to include("data-src") }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -7,6 +7,7 @@ describe "LID tracking pixels" do
   end
 
   before { get path }
+
   subject { response.body }
 
   context "when visiting /events" do

--- a/spec/requests/mailing_list/calls_to_action_spec.rb
+++ b/spec/requests/mailing_list/calls_to_action_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "Mailing list calls to action" do
   describe "banner" do
     before { get root_path }
+
     subject { Nokogiri.parse(response.body) }
 
     it "the mailing list banner has a close link" do

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -17,13 +17,17 @@ describe MailingList::StepsController do
 
   describe "#index" do
     before { get mailing_list_steps_path(query: "param") }
+
     subject { response }
+
     it { is_expected.to redirect_to(mailing_list_step_path({ id: :name, query: "param" })) }
   end
 
   describe "#show" do
     before { get step_path }
+
     subject { response }
+
     it { is_expected.to have_http_status :success }
 
     context "with an invalid step" do
@@ -91,16 +95,19 @@ describe MailingList::StepsController do
 
     context "with valid data" do
       let(:details_params) { attributes_for(:mailing_list_name) }
+
       it { is_expected.to redirect_to mailing_list_step_path("authenticate") }
     end
 
     context "with invalid data" do
       let(:details_params) { { "first_name" => "test" } }
+
       it { is_expected.to have_http_status :success }
     end
 
     context "with no data" do
       let(:details_params) { {} }
+
       it { is_expected.to have_http_status :success }
     end
 
@@ -126,7 +133,9 @@ describe MailingList::StepsController do
         before do
           allow_any_instance_of(model).to receive(:valid?).and_return true
         end
+
         let(:details_params) { attributes_for :"mailing_list_#{model.key}" }
+
         it { is_expected.to redirect_to mailing_list_step_path steps.first.key }
       end
     end
@@ -137,6 +146,7 @@ describe MailingList::StepsController do
       get completed_mailing_list_steps_path
       response
     end
+
     it { is_expected.to have_http_status :success }
   end
 end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -6,6 +6,7 @@ describe "Next Gen Images" do
     allow(File).to receive(:exist?).with(/.*\.svg/) { true }
     get root_path
   end
+
   subject { response.body }
 
   it do

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "rendering pages with a custom layout" do
   context "with a home page layout" do
     before { get "/home-page" }
+
     subject { response.body }
 
     it { expect(response).to have_http_status(200) }
@@ -14,6 +15,7 @@ describe "rendering pages with a custom layout" do
 
   context "with a stories/story layout" do
     before { get "/stories/story-page" }
+
     subject { response.body }
 
     it { expect(response).to have_http_status(200) }
@@ -24,6 +26,7 @@ describe "rendering pages with a custom layout" do
 
   context "with a stories/list layout" do
     before { get "/stories/list-page" }
+
     subject { response.body }
 
     it { expect(response).to have_http_status(200) }
@@ -37,6 +40,7 @@ describe "rendering pages with a custom layout" do
 
   context "with a stories/landing layout" do
     before { get "/stories/landing-page" }
+
     subject { response.body }
 
     it { expect(response).to have_http_status(200) }

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -45,14 +45,18 @@ describe PagesController do
 
     context "with unknown page" do
       before { get "/testing/unknown" }
+
       subject { response }
+
       it { is_expected.to have_http_status :not_found }
       it { is_expected.to have_attributes body: %r{Page not found} }
     end
 
     context "with cookies page" do
       before { get "/cookies" }
+
       subject { response }
+
       it { is_expected.to have_http_status(:success) }
     end
 
@@ -77,16 +81,19 @@ describe PagesController do
 
     context "with /tta-service url" do
       before { get "/tta-service" }
+
       it { is_expected.to redirect_to "https://tta-service/" }
     end
 
     context "with /tta url" do
       before { get "/tta" }
+
       it { is_expected.to redirect_to "https://tta-service/" }
     end
 
     context "with utm params" do
       before { get "/tta-service?utm_test=abc&test=def" }
+
       it { is_expected.to redirect_to "https://tta-service/?utm_test=abc" }
     end
   end

--- a/spec/requests/robots_controller_spec.rb
+++ b/spec/requests/robots_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe RobotsController do
   before { get("/robots.txt") }
+
   subject { response.body }
 
   it do

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe SitemapController do
 
   describe "#show" do
     let(:sitemap_namespace) { "http://www.sitemaps.org/schemas/sitemap/0.9" }
+
     specify "the document should have the correct namespace" do
       expect(subject.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
     end

--- a/spec/support/page_support.rb
+++ b/spec/support/page_support.rb
@@ -10,7 +10,10 @@ shared_context "always render testing page" do
   let(:page_frontmatter) { {} }
   let(:page) { double Pages::Page, template: template, data: page_data, frontmatter: page_frontmatter }
   before { allow(Pages::Page).to receive(:find) { page } }
+
   before { allow(page).to receive(:ancestors) { [] } }
+
   before { allow(page).to receive(:title) { "Test" } }
+
   before { allow(page).to receive(:path) { "/test" } }
 end

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -14,6 +14,7 @@ describe EmailFormatValidator do
   end
 
   before { instance.valid? }
+
   subject { instance.errors.to_hash }
 
   context "with invalid addresses" do

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -14,12 +14,14 @@ describe PostcodeValidator do
   end
 
   before { instance.valid? }
+
   subject { instance.errors.to_hash }
 
   context "with invalid full postcodes" do
     ["F00BAR", "123ABC", "TE57 ING"].each do |postcode|
       context "checking '#{postcode}'" do
         let(:instance) { test_model.new(postcode: postcode) }
+
         it { is_expected.to include postcode: ["is invalid"] }
       end
     end
@@ -29,6 +31,7 @@ describe PostcodeValidator do
     ["M1 2WD", "TE57 1NG", ""].each do |postcode|
       context "checking '#{postcode}'" do
         let(:instance) { test_model.new(postcode: postcode) }
+
         it { is_expected.not_to include :postcode }
       end
     end
@@ -38,6 +41,7 @@ describe PostcodeValidator do
     %w[ST6 M1 TE57].each do |postcode|
       context "checking '#{postcode}'" do
         let(:instance) { test_model.new(postcode: postcode, accept_partial_postcode: true) }
+
         it { is_expected.not_to include :postcode }
       end
     end

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -15,11 +15,13 @@ describe TelephoneValidator do
   end
 
   before { instance.valid? }
+
   subject { instance.errors.to_hash }
 
   %w[1234 123456789123456789123 1feg313153gewg1 random].each do |number|
     context "checking '#{number}'" do
       let(:instance) { test_model.new(telephone: number) }
+
       it { is_expected.to include telephone: ["is invalid"] }
     end
   end
@@ -27,6 +29,7 @@ describe TelephoneValidator do
   %w[12345 01234567890 07123456789 +448574837584 555.3442.3516 (5835)533-6326-3525].each do |number|
     context "checking '#{number}'" do
       let(:instance) { test_model.new(telephone: number) }
+
       it { is_expected.not_to include :telephone }
     end
   end

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe "searches/show.html.erb" do
   subject { rendered }
 
   before { allow(model).to receive(:results).and_return results }
+
   before { assign(:search, model) && render }
 
   let(:model) { Search.new }


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

Enable the empty line rules for Rubocop/RSpec and update the specs to adhere to the rules. Rules enabled:

```
RSpec/EmptyLineAfterFinalLet
RSpec/EmptyLineAfterHook
RSpec/EmptyLineAfterSubject
```


