### PR TITLE
Enable Rubocop/RSpec context/example wording rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,19 +60,11 @@ Style/ClassVars:
 
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
-RSpec/ContextWording:
-  Exclude:
-    - spec/support/*.rb
-
 RSpec/DescribeClass:
   Exclude:
     - spec/**/*.rb
 
 RSpec/ExampleLength:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/ExampleWording:
   Exclude:
     - spec/**/*.rb
 

--- a/spec/components/cards/latest_event_component_spec.rb
+++ b/spec/components/cards/latest_event_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
   end
 
   context "with unknown category" do
-    include_context "stub types api"
+    include_context "with stubbed types api"
 
     let(:card) { { "category" => "unknown" } }
 
@@ -51,7 +51,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
   end
 
   context "with no category" do
-    include_context "stub types api"
+    include_context "with stubbed types api"
 
     let(:card) { {} }
 

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Events::EventBoxComponent, type: "component" do
-  include_context "stub types api"
+  include_context "with stubbed types api"
   let(:event) { build(:event_api) }
   let(:date_text) { event.start_at.to_date.to_formatted_s(:long) }
   let(:start_at_text) { event.start_at.to_formatted_s(:time) }

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Book a callback", type: :feature do
-  include_context "wizard data"
+  include_context "with wizard data"
 
   let(:quota) do
     GetIntoTeachingApiClient::CallbackBookingQuota.new(

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Breadcrumbs", type: :feature do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:event) { GetIntoTeachingApiClient::TeachingEvent.new(statusId: 1) }
 

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -11,7 +11,7 @@ class StoredPage
 end
 
 RSpec.feature "content pages check", type: :feature, content: true do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:other_paths) { %w[/ /blog /search /tta-service /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }
   let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}] }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Event wizard", type: :feature do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:event_readable_id) { "123" }

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Finding an event", type: :feature do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:events) do
     11.times.collect do |index|

--- a/spec/features/mailing_list_signup_spec.rb
+++ b/spec/features/mailing_list_signup_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Mailing list signup", type: :feature do
-  include_context "stub types api"
-  include_context "stub candidate create access token api"
+  include_context "with stubbed types api"
+  include_context "with stubbed candidate create access token api"
 
   let(:qualification_id) { "QQQ" }
   let(:candidate_id) { "CCC" }

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Mailing list wizard", type: :feature do
-  include_context "wizard data"
+  include_context "with wizard data"
 
   scenario "Full journey as a new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -175,7 +175,7 @@ describe ApplicationHelper do
 
     after { subject }
 
-    it %(it returns a span with class 'fab') do
+    it "returns a span with class 'fab'" do
       expect(helper).to receive(:fa_icon).once.with(icon_name, style: "fab")
     end
   end
@@ -187,7 +187,7 @@ describe ApplicationHelper do
 
     after { subject }
 
-    it %(it returns a span with class 'fas') do
+    it "returns a span with class 'fas'" do
       expect(helper).to receive(:fa_icon).once.with(icon_name, style: "fas")
     end
   end
@@ -221,19 +221,19 @@ describe ApplicationHelper do
 
     subject { helper.chat_link(text, classes: extra_class) }
 
-    it %(generates a hyperlink) do
+    it "generates a hyperlink" do
       expect(subject).to have_css("a")
     end
 
-    it %(has the right data controller) do
+    it "has the right data controller" do
       expect(subject).to have_css(%(a[data-controller="talk-to-us"]))
     end
 
-    it %(has the right data action) do
+    it "has the right data action" do
       expect(subject).to have_css(%(a[data-action="talk-to-us#startChat"]))
     end
 
-    it %(applies the correct class) do
+    it "applies the correct class" do
       expect(subject).to have_css(%(a.button))
     end
   end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -125,11 +125,11 @@ describe EventsHelper, type: "helper" do
     let(:non_matching_type) { "Online event" }
     let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
 
-    it "should be truthy when the type matches" do
+    it "is truthy when the type matches" do
       expect(is_event_type?(event, matching_type)).to be_truthy
     end
 
-    it "should be falsy when the type matches" do
+    it "is falsy when the type matches" do
       expect(is_event_type?(event, non_matching_type)).to be_falsy
     end
   end

--- a/spec/models/callbacks/steps/callback_spec.rb
+++ b/spec/models/callbacks/steps/callback_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 describe Callbacks::Steps::Callback do
   it_behaves_like "exposes callback booking quotas"
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
   include_context "sanitize fields", %i[address_telephone]
 
   describe "attributes" do

--- a/spec/models/callbacks/steps/matchback_failed_spec.rb
+++ b/spec/models/callbacks/steps/matchback_failed_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe Callbacks::Steps::MatchbackFailed do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   describe "#can_proceed?" do
     it "returns false" do

--- a/spec/models/callbacks/steps/personal_details_spec.rb
+++ b/spec/models/callbacks/steps/personal_details_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Callbacks::Steps::PersonalDetails do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
-  it_behaves_like "an issue verification code wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
+  it_behaves_like "an issue verification code with wizard step"
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/callbacks/steps/privacy_policy_spec.rb
+++ b/spec/models/callbacks/steps/privacy_policy_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe Callbacks::Steps::PrivacyPolicy do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :accept_privacy_policy }
   it { is_expected.to respond_to :accepted_policy_id }

--- a/spec/models/callbacks/steps/talking_points_spec.rb
+++ b/spec/models/callbacks/steps/talking_points_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe Callbacks::Steps::TalkingPoints do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   describe "attributes" do
     it { is_expected.to respond_to :talking_points }

--- a/spec/models/events/category_spec.rb
+++ b/spec/models/events/category_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Events::Category do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:category_name) { "Train to Teach event" }
   let(:type_id) do
@@ -42,7 +42,7 @@ RSpec.describe Events::Category do
   end
 
   describe "#latest" do
-    include_context "stub upcoming events by category api", 1
+    include_context "with stubbed upcoming events by category api", 1
 
     subject { instance.latest }
 

--- a/spec/models/events/steps/contact_details_spec.rb
+++ b/spec/models/events/steps/contact_details_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Events::Steps::ContactDetails do
-  include_context "wizard step"
+  include_context "with wizard step"
 
-  it_behaves_like "a wizard step"
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :address_telephone }
   it { expect(subject).to be_optional }

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Events::Steps::FurtherDetails do
-  include_context "wizard step"
+  include_context "with wizard step"
 
-  it_behaves_like "a wizard step"
+  it_behaves_like "a with wizard step"
 
   describe "attributes" do
     it { is_expected.to respond_to :event_id }

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Events::Steps::PersonalDetails do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
-  it_behaves_like "an issue verification code wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
+  it_behaves_like "an issue verification code with wizard step"
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe Events::Steps::PersonalisedUpdates do
-  include_context "wizard step"
-  include_context "stub types api"
+  include_context "with wizard step"
+  include_context "with stubbed types api"
 
-  it_behaves_like "a wizard step"
+  it_behaves_like "a with wizard step"
 
   describe "attributes" do
     it { is_expected.to respond_to :address_postcode }

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -60,7 +60,7 @@ describe Internal::EventBuilding do
       )
     end
 
-    it "should have correct attributes" do
+    it "has correct attributes" do
       expect(described_class.initialize_with_api_building(api_building)).to have_attributes(expected_attributes)
     end
   end
@@ -80,7 +80,7 @@ describe Internal::EventBuilding do
       )
     end
 
-    it "should have correct attributes" do
+    it "has correct attributes" do
       expect(internal_building.to_api_building).to have_attributes(expected_api_building_attributes)
     end
   end

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -14,7 +14,7 @@ describe MailingList::Signup do
   end
 
   describe "validation" do
-    include_context "wizard data"
+    include_context "with wizard data"
 
     describe "#email" do
       it { is_expected.to validate_presence_of(:email) }

--- a/spec/models/mailing_list/steps/already_subscribed_spec.rb
+++ b/spec/models/mailing_list/steps/already_subscribed_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::AlreadySubscribed do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   it { is_expected.not_to be_can_proceed }
 

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::DegreeStatus do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::Name do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
@@ -50,6 +50,6 @@ describe MailingList::Steps::Name do
   end
 
   context "when the step is valid" do
-    it_behaves_like "an issue verification code wizard step"
+    it_behaves_like "an issue verification code with wizard step"
   end
 end

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::Postcode do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   let(:msg) { "Enter a valid postcode" }
 

--- a/spec/models/mailing_list/steps/privacy_policy_spec.rb
+++ b/spec/models/mailing_list/steps/privacy_policy_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::PrivacyPolicy do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :accept_privacy_policy }
   it { is_expected.to respond_to :accepted_policy_id }

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::Subject do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   let(:teaching_subject_types) do
     GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Steps::TeacherTraining do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   let(:consideration_journey_stage_types) do
     GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Pages::Data do
-  include_context "use fixture markdown pages"
+  include_context "with fixture markdown pages"
 
   let(:instance) { described_class.new }
 
   describe "#find_page" do
-    include_context "use fixture markdown pages"
+    include_context "with fixture markdown pages"
 
     subject { instance.find_page "/page1" }
 
@@ -14,8 +14,8 @@ RSpec.describe Pages::Data do
   end
 
   describe "#latest_event_for_category" do
-    include_context "stub types api"
-    include_context "stub upcoming events by category api", 1
+    include_context "with stubbed types api"
+    include_context "with stubbed upcoming events by category api", 1
 
     subject { instance.latest_event_for_category category }
 

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Pages::Frontmatter do
     context "with unknown page" do
       let(:page) { "/unknown" }
 
-      it "should raise an exception" do
+      it "raises an exception" do
         expect { subject }.to raise_exception Pages::Frontmatter::NotMarkdownTemplate
       end
     end

--- a/spec/models/pages/page_spec.rb
+++ b/spec/models/pages/page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Pages::Page do
-  include_context "use fixture markdown pages"
+  include_context "with fixture markdown pages"
 
   shared_examples "a page" do |title, path, template|
     it { is_expected.to be_instance_of described_class }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Search do
-  include_context "use fixture markdown pages"
+  include_context "with fixture markdown pages"
 
   describe "#results" do
     subject { described_class.new(search: search).results }

--- a/spec/models/wizard/base_spec.rb
+++ b/spec/models/wizard/base_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Wizard::Base do
-  include_context "wizard store"
+  include_context "with wizard store"
 
   let(:wizardclass) { TestWizard }
   let(:wizard) { wizardclass.new wizardstore, "age" }

--- a/spec/models/wizard/step_spec.rb
+++ b/spec/models/wizard/step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Wizard::Step do
-  include_context "wizard store"
+  include_context "with wizard store"
 
   class FirstStep < Wizard::Step
     attribute :name

--- a/spec/models/wizard/steps/authenticate_spec.rb
+++ b/spec/models/wizard/steps/authenticate_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe Wizard::Steps::Authenticate do
-  include_context "wizard step"
-  it_behaves_like "a wizard step"
+  include_context "with wizard step"
+  it_behaves_like "a with wizard step"
 
   before { allow(wizard).to receive(:exchange_access_token) { {} } }
 

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Callbacks::StepsController do
-  include_context "stub candidate create access token api"
-  include_context "stub latest privacy policy api"
-  include_context "stub book callback api"
+  include_context "with stubbed candidate create access token api"
+  include_context "with stubbed latest privacy policy api"
+  include_context "with stubbed book callback api"
 
   it_behaves_like "a controller with a #resend_verification action" do
     def perform_request

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe EventStepsController do
-  include_context "stub types api"
-  include_context "stub candidate create access token api"
-  include_context "stub latest privacy policy api"
-  include_context "stub event add attendee api"
+  include_context "with stubbed types api"
+  include_context "with stubbed candidate create access token api"
+  include_context "with stubbed latest privacy policy api"
+  include_context "with stubbed event add attendee api"
 
   it_behaves_like "a controller with a #resend_verification action" do
     def perform_request

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "View events by category" do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:expected_limit) { EventCategoriesController::MAXIMUM_EVENTS_IN_CATEGORY }
 

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe EventsController do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   describe "#index" do
-    include_context "stub upcoming events by category api", EventsController::UPCOMING_EVENTS_PER_TYPE
+    include_context "with stubbed upcoming events by category api", EventsController::UPCOMING_EVENTS_PER_TYPE
     let(:parsed_response) { Nokogiri.parse(response.body) }
     let(:expected_description) { "Get your questions answered at an event." }
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Find an event near you" do
-  include_context "stub types api"
+  include_context "with stubbed types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }
   let(:no_ttt_events_regex) { /There are no Train to Teach events in your chosen month/ }

--- a/spec/requests/internal_controller_spec.rb
+++ b/spec/requests/internal_controller_spec.rb
@@ -17,19 +17,19 @@ describe InternalController do
     end
   end
 
-  it "should reject unauthenticated users" do
+  it "rejects unauthenticated users" do
     get internal_events_path, headers: generate_auth_headers(:bad_credentials)
 
     assert_response :unauthorized
   end
 
-  it "should reject no authentication" do
+  it "rejects no authentication" do
     get internal_events_path
 
     assert_response :unauthorized
   end
 
-  it "should set the account role of publishers" do
+  it "sets the account role of publishers" do
     get internal_events_path, headers: generate_auth_headers(:publisher)
 
     expect(session[:user].username).to eq(publisher_username)
@@ -37,7 +37,7 @@ describe InternalController do
     assert_response :success
   end
 
-  it "should set the account role of authors" do
+  it "sets the account role of authors" do
     get internal_events_path, headers: generate_auth_headers(:author)
 
     expect(session[:user].username).to eq(author_username)

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe MailingList::StepsController do
-  include_context "stub types api"
-  include_context "stub candidate create access token api"
-  include_context "stub latest privacy policy api"
-  include_context "stub mailing list add member api"
+  include_context "with stubbed types api"
+  include_context "with stubbed candidate create access token api"
+  include_context "with stubbed latest privacy policy api"
+  include_context "with stubbed mailing list add member api"
 
   it_behaves_like "a controller with a #resend_verification action" do
     def perform_request

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe PagesController do
   describe "#show" do
     context "without caching enabled" do
-      it "Should not have cache headers" do
+      it "does not have cache headers" do
         get "/test"
 
         expect(response).to have_http_status 200
@@ -25,7 +25,7 @@ describe PagesController do
         allow(cache_config).to receive(:last_modified).and_return 2.minutes.ago
       end
 
-      it "should utilise cached version" do
+      it "utilises cached version" do
         get "/test"
         expect(response).to have_http_status 200
 
@@ -76,7 +76,7 @@ describe PagesController do
   end
 
   describe "redirect to TTA site" do
-    include_context "stub env vars", "TTA_SERVICE_URL" => "https://tta-service/"
+    include_context "with stubbed env vars", "TTA_SERVICE_URL" => "https://tta-service/"
     subject { response }
 
     context "with /tta-service url" do

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe "Rate limiting" do
-  include_context "stub types api"
-  include_context "stub candidate create access token api"
+  include_context "with stubbed types api"
+  include_context "with stubbed candidate create access token api"
 
   let(:ip) { "1.2.3.4" }
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -1,4 +1,4 @@
-shared_context "stub types api" do
+shared_context "with stubbed types api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:stub_types) { [{ "id" => 1, "value" => "First type" }] }
 
@@ -35,7 +35,7 @@ shared_context "stub types api" do
   end
 end
 
-shared_context "stub candidate create access token api" do
+shared_context "with stubbed candidate create access token api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
 
   before do
@@ -43,7 +43,7 @@ shared_context "stub candidate create access token api" do
   end
 end
 
-shared_context "stub latest privacy policy api" do
+shared_context "with stubbed latest privacy policy api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:policy) { [{ "id" => "abc123" }] }
 
@@ -52,7 +52,7 @@ shared_context "stub latest privacy policy api" do
   end
 end
 
-shared_context "stub event add attendee api" do
+shared_context "with stubbed event add attendee api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
 
   before do
@@ -60,7 +60,7 @@ shared_context "stub event add attendee api" do
   end
 end
 
-shared_context "stub mailing list add member api" do
+shared_context "with stubbed mailing list add member api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
 
   before do
@@ -68,7 +68,7 @@ shared_context "stub mailing list add member api" do
   end
 end
 
-shared_context "stub book callback api" do
+shared_context "with stubbed book callback api" do
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
 
   before do
@@ -76,7 +76,7 @@ shared_context "stub book callback api" do
   end
 end
 
-shared_context "stub upcoming events by category api" do |results_per_type|
+shared_context "with stubbed upcoming events by category api" do |results_per_type|
   let(:events) { [build(:event_api, name: "First"), build(:event_api, name: "Second")] }
   let(:events_by_type) { group_events_by_type(events) }
   let(:expected_request_attributes) do
@@ -91,21 +91,5 @@ shared_context "stub upcoming events by category api" do |results_per_type|
     expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type)
       .with(a_hash_including(expected_request_attributes)) { events_by_type }
-  end
-end
-
-shared_context "api support" do
-  let(:token) { "test123" }
-  let(:endpoint) { "http://my.api/api" }
-  let(:response_headers) { { "Content-Type" => "application/json" } }
-  let(:client) { described_class.new(token: token, endpoint: endpoint) }
-
-  subject { client.call }
-
-  before do
-    stub_request(:get, "#{endpoint}/#{apicall}").to_return \
-      status: 200,
-      headers: response_headers,
-      body: testdata.to_json
   end
 end

--- a/spec/support/env_var_support.rb
+++ b/spec/support/env_var_support.rb
@@ -1,4 +1,4 @@
-shared_context "stub env vars" do |envvars|
+shared_context "with stubbed env vars" do |envvars|
   before do
     allow(ENV).to receive(:[]).and_call_original
 

--- a/spec/support/page_support.rb
+++ b/spec/support/page_support.rb
@@ -1,19 +1,5 @@
-shared_context "use fixture markdown pages" do
+shared_context "with fixture markdown pages" do
   let(:md_files) { "#{file_fixture_path}/markdown_content" }
   let(:frontmatter) { Pages::Frontmatter.new md_files }
   before { allow(Pages::Frontmatter).to receive(:instance).and_return frontmatter }
-end
-
-shared_context "always render testing page" do
-  let(:template) { "testing/markdown_test" }
-  let(:page_data) { Pages::Data.new }
-  let(:page_frontmatter) { {} }
-  let(:page) { double Pages::Page, template: template, data: page_data, frontmatter: page_frontmatter }
-  before { allow(Pages::Page).to receive(:find) { page } }
-
-  before { allow(page).to receive(:ancestors) { [] } }
-
-  before { allow(page).to receive(:title) { "Test" } }
-
-  before { allow(page).to receive(:path) { "/test" } }
 end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -1,11 +1,11 @@
-shared_context "wizard store" do
+shared_context "with wizard store" do
   let(:backingstore) { { "name" => "Joe", "age" => 35 } }
   let(:crm_backingstore) { {} }
   let(:wizardstore) { Wizard::Store.new backingstore, crm_backingstore }
 end
 
-shared_context "wizard step" do
-  include_context "wizard store"
+shared_context "with wizard step" do
+  include_context "with wizard store"
   let(:attributes) { {} }
   let(:wizard) { TestWizard.new(wizardstore, TestWizard::Name.key) }
   let(:instance) do
@@ -14,7 +14,7 @@ shared_context "wizard step" do
   subject { instance }
 end
 
-shared_context "wizard data" do
+shared_context "with wizard data" do
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
@@ -57,12 +57,12 @@ shared_context "wizard data" do
   end
 end
 
-shared_examples "a wizard step" do
+shared_examples "a with wizard step" do
   it { expect(subject.class).to respond_to :key }
   it { is_expected.to respond_to :save }
 end
 
-shared_examples "an issue verification code wizard step" do
+shared_examples "an issue verification code with wizard step" do
   describe "#save" do
     before do
       subject.email = "email@address.com"


### PR DESCRIPTION
### Trello card

[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

### Context

Enable the Rubocop/RSpec context/example wording rules and fix infractions:

```
RSpec/ContextWording
RSpec/ExampleWording
```

### Changes proposed in this pull request

- Enable Rubocop/RSpec context/example wording rule

### Guidance to review

