### PR TITLE
Enable the RSpec/DescribeClass Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,10 +60,6 @@ Style/ClassVars:
 
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
-RSpec/DescribeClass:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "reading the blog" do
+describe "reading the blog", type: :feature do
   let(:tag) { Pages::Blog.popular_tags(1).first }
 
   scenario "browsing to a popular tag" do

--- a/spec/requests/beta_redirect_spec.rb
+++ b/spec/requests/beta_redirect_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Redirecting beta-getintoteaching.education.gov.uk to getintoteaching.education.gov.uk", type: "request" do
+describe "Redirecting beta-getintoteaching.education.gov.uk to getintoteaching.education.gov.uk", type: :request do
   before { allow(Rails.configuration.x).to receive(:enable_beta_redirects).and_return(true) }
 
   before { host!("beta-getintoteaching.education.gov.uk") }

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Callbacks::StepsController do
+describe Callbacks::StepsController, type: :request do
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed latest privacy policy api"
   include_context "with stubbed book callback api"

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Circuit breaker" do
+describe "Circuit breaker", type: :request do
   let(:error) { GetIntoTeachingApiClient::CircuitBrokenError }
 
   before do

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CookiePreferencesController do
+describe CookiePreferencesController, type: :request do
   subject { response }
 
   describe "#show" do

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "CSP violation reporting" do
+describe "CSP violation reporting", type: :request do
   let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
 
   before do

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe EventStepsController do
+describe EventStepsController, type: :request do
   include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed latest privacy policy api"

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "View events by category" do
+describe "View events by category", type: :request do
   include_context "with stubbed types api"
 
   let(:expected_limit) { EventCategoriesController::MAXIMUM_EVENTS_IN_CATEGORY }

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe EventsController do
+describe EventsController, type: :request do
   include_context "with stubbed types api"
 
   describe "#index" do

--- a/spec/requests/external_links_image_spec.rb
+++ b/spec/requests/external_links_image_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "External link images" do
+describe "External link images", type: :request do
   excluded_classes = %w[button]
   before { get "/ways-to-train" }
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Find an event near you" do
+describe "Find an event near you", type: :request do
   include_context "with stubbed types api"
 
   let(:no_events_regex) { /Sorry your search has not found any events/ }

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "ensuring frontmatter from content pages is rendered" do
+describe "ensuring frontmatter from content pages is rendered", type: :request do
   context "with an accordion layout" do
     before { get "/content-page" }
 

--- a/spec/requests/healthchecks_controller_spec.rb
+++ b/spec/requests/healthchecks_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe HealthchecksController do
+describe HealthchecksController, type: :request do
   before do
     allow_any_instance_of(Healthcheck).to receive(:test_api) { true }
     allow_any_instance_of(Healthcheck).to receive(:test_redis) { false }

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Instrumentation" do
+describe "Instrumentation", type: :request do
   let(:registry) { Prometheus::Client.registry }
 
   describe "process_action.action_controller" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Internal::EventsController do
+describe Internal::EventsController, type: :request do
   let(:pending_provider_event) do
     build(:event_api,
           :with_provider_info,

--- a/spec/requests/internal_controller_spec.rb
+++ b/spec/requests/internal_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe InternalController do
+describe InternalController, type: :request do
   let(:publisher_username) { "publisher_username" }
   let(:publisher_password) { "publisher_password" }
   let(:author_username) { "author_username" }

--- a/spec/requests/lazy_load_images_spec.rb
+++ b/spec/requests/lazy_load_images_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Lazy Load Images" do
+describe "Lazy Load Images", type: :request do
   before do
     get root_path
   end

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "LID tracking pixels" do
+describe "LID tracking pixels", type: :request do
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type) { [] }

--- a/spec/requests/mailing_list/calls_to_action_spec.rb
+++ b/spec/requests/mailing_list/calls_to_action_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Mailing list calls to action" do
+describe "Mailing list calls to action", type: :request do
   describe "banner" do
     before { get root_path }
 

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe MailingList::StepsController do
+describe MailingList::StepsController, type: :request do
   include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed latest privacy policy api"

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Next Gen Images" do
+describe "Next Gen Images", type: :request do
   before do
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with(/.*\.svg/) { true }

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "rendering pages with a custom layout" do
+describe "rendering pages with a custom layout", type: :request do
   context "with a home page layout" do
     before { get "/home-page" }
 

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe PagesController do
+describe PagesController, type: :request do
   describe "#show" do
     context "without caching enabled" do
       it "does not have cache headers" do

--- a/spec/requests/pagespeed_spec.rb
+++ b/spec/requests/pagespeed_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "page_speed_score"
 
-describe "Page Speed Task" do
+describe "Page Speed Task", type: :request do
   let(:run_pagespeed_path) { "/pagespeed/run" }
 
   before { allow(Rails.env).to receive(:pagespeed?) { pagespeed_env } }

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "GET /privacy-policy" do
+describe "GET /privacy-policy", type: :request do
   let(:policy) { GetIntoTeachingApiClient::PrivacyPolicy.new(id: "123", text: "Latest privacy policy") }
 
   context "when viewing the latest privacy policy" do

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Rate limiting" do
+describe "Rate limiting", type: :request do
   include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
 

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Redirects", content: true do
+describe "Redirects", content: true, type: :request do
   let(:query_string) { "abc=def&ghi=jkl" }
 
   redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")

--- a/spec/requests/robots_controller_spec.rb
+++ b/spec/requests/robots_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe RobotsController do
+describe RobotsController, type: :request do
   before { get("/robots.txt") }
 
   subject { response.body }

--- a/spec/requests/searches_controller_spec.rb
+++ b/spec/requests/searches_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SearchesController do
+RSpec.describe SearchesController, type: :request do
   subject { response }
 
   describe "#show" do

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SitemapController do
+RSpec.describe SitemapController, type: :request do
   subject { Nokogiri::XML(response.body) }
 
   let(:content_pages) do

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Google Structured Data" do
+describe "Google Structured Data", type: :request do
   let(:parsed_response) { Nokogiri.parse(response.body) }
   let(:json_contents) { parsed_response.css("script[type='application/ld+json']").map(&:content) }
 

--- a/spec/requests/vwo_spec.rb
+++ b/spec/requests/vwo_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "VWO" do
+describe "VWO", type: :request do
   let(:config_path) { Rails.root.join("config/vwo.yml") }
   let(:yaml) do
     <<-YAML

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "searches/show.html.erb" do
+describe "searches/show.html.erb", type: :view do
   subject { rendered }
 
   before { allow(model).to receive(:results).and_return results }


### PR DESCRIPTION
### Trello card

[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

### Context

Enable the RSpec/DescribeClass Rubocop rule and fix the errors; we could have changed the config to infer the type from the directory as well, but since we are explicit in most cases I went with that.

### Changes proposed in this pull request

- Enable the RSpec/DescribeClass Rubocop rule

### Guidance to review

