### PR TITLE
Enable RSpec/NotToNot Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,7 +123,3 @@ RSpec/SubjectStub:
 RSpec/VerifiedDoubles:
   Exclude:
     - spec/**/*.rb
-
-RSpec/NotToNot:
-  Exclude:
-    - spec/**/*.rb

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
   context "when visiting the home page" do
     let(:path) { "/home-page" }
 
-    it { is_expected.to_not have_css(".breadcrumb") }
+    it { is_expected.not_to have_css(".breadcrumb") }
   end
 
   context "when visiting a content page" do

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -160,7 +160,7 @@ RSpec.feature "Event wizard", type: :feature do
     end
     click_on "Complete sign up"
 
-    expect(page).to_not have_text("What is your postcode? (optional)")
+    expect(page).not_to have_text("What is your postcode? (optional)")
     fill_in_personalised_updates
 
     expect_sign_up_with_attributes(

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Finding an event", type: :feature do
     visit events_path
 
     expect(page).to have_text "Search for events"
-    expect(page).to_not have_css ".pagination"
+    expect(page).not_to have_css ".pagination"
 
     click_on "Update results"
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next step"
 
-    expect(page).to_not have_text "Tell us more about you so that you only get emails relevant to your circumstances."
+    expect(page).not_to have_text "Tell us more about you so that you only get emails relevant to your circumstances."
 
     expect(page).to have_text "Do you have a degree?"
     choose "Not yet, I'm a first year student"

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -311,8 +311,8 @@ describe StructuredDataHelper, type: "helper" do
         },
       })
 
-      expect(data).to_not have_key(:organizer)
-      expect(data).to_not have_key(:location)
+      expect(data).not_to have_key(:organizer)
+      expect(data).not_to have_key(:location)
     end
 
     context "when the event is online" do

--- a/spec/models/callbacks/steps/callback_spec.rb
+++ b/spec/models/callbacks/steps/callback_spec.rb
@@ -12,12 +12,12 @@ describe Callbacks::Steps::Callback do
   end
 
   describe "#phone_call_scheduled_at" do
-    it { is_expected.to_not allow_values("", nil, "invalid_date").for :phone_call_scheduled_at }
+    it { is_expected.not_to allow_values("", nil, "invalid_date").for :phone_call_scheduled_at }
     it { is_expected.to allow_value(Time.zone.now).for :phone_call_scheduled_at }
   end
 
   describe "#address_telephone" do
-    it { is_expected.to_not allow_values(nil, "", "abc12345", "12", "1" * 21).for :address_telephone }
+    it { is_expected.not_to allow_values(nil, "", "abc12345", "12", "1" * 21).for :address_telephone }
     it { is_expected.to allow_values("123456789").for :address_telephone }
   end
 end

--- a/spec/models/callbacks/steps/talking_points_spec.rb
+++ b/spec/models/callbacks/steps/talking_points_spec.rb
@@ -9,7 +9,7 @@ describe Callbacks::Steps::TalkingPoints do
   end
 
   describe "#talking_points" do
-    it { is_expected.to_not allow_values(nil, "", "invalid value").for :talking_points }
+    it { is_expected.not_to allow_values(nil, "", "invalid value").for :talking_points }
     it { is_expected.to allow_values(described_class::OPTIONS).for :talking_points }
   end
 end

--- a/spec/models/concerns/api_model_convertible_spec.rb
+++ b/spec/models/concerns/api_model_convertible_spec.rb
@@ -30,7 +30,7 @@ describe ApiModelConvertible do
     end
 
     it "only returns attributes which are present on the model that includes ApiModelConvertable" do
-      expect(converted_hash).to_not have_key("readable_id")
+      expect(converted_hash).not_to have_key("readable_id")
     end
   end
 
@@ -44,7 +44,7 @@ describe ApiModelConvertible do
     it "only returns attributes that are present" do
       tester.status_id = ""
       hash = tester.convert_attributes_for_api_model
-      expect(hash).to_not have_key("statusId")
+      expect(hash).not_to have_key("statusId")
     end
   end
 end

--- a/spec/models/funding_widget_spec.rb
+++ b/spec/models/funding_widget_spec.rb
@@ -8,7 +8,7 @@ describe FundingWidget do
   describe "validations" do
     describe "#subject" do
       it { is_expected.to allow_value("test").for :subject }
-      it { is_expected.to_not allow_values("", nil).for :subject }
+      it { is_expected.not_to allow_values("", nil).for :subject }
     end
   end
 end

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -14,8 +14,8 @@ describe Internal::EventBuilding do
   describe "validations" do
     describe "#venue" do
       it { is_expected.to allow_value("test").for :venue }
-      it { is_expected.to_not allow_value("").for :venue }
-      it { is_expected.to_not allow_value(nil).for :venue }
+      it { is_expected.not_to allow_value("").for :venue }
+      it { is_expected.not_to allow_value(nil).for :venue }
       it { is_expected.to validate_length_of(:venue).is_at_most(100) }
     end
 
@@ -37,9 +37,9 @@ describe Internal::EventBuilding do
 
     describe "#address_postcode" do
       it { is_expected.to allow_value("M1 7AX").for :address_postcode }
-      it { is_expected.to_not allow_value("not a postcode").for :address_postcode }
-      it { is_expected.to_not allow_value("").for :address_postcode }
-      it { is_expected.to_not allow_value(nil).for :address_postcode }
+      it { is_expected.not_to allow_value("not a postcode").for :address_postcode }
+      it { is_expected.not_to allow_value("").for :address_postcode }
+      it { is_expected.not_to allow_value(nil).for :address_postcode }
       it { is_expected.to validate_length_of(:address_postcode).is_at_most(100) }
     end
   end

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -22,45 +22,45 @@ describe Internal::Event do
 
     describe "#name" do
       it { is_expected.to allow_value("test").for :name }
-      it { is_expected.to_not allow_values("", nil).for :name }
+      it { is_expected.not_to allow_values("", nil).for :name }
       it { is_expected.to validate_length_of(:name).is_at_most(300) }
     end
 
     describe "#readable_id" do
       it { is_expected.to allow_value("test").for :readable_id }
-      it { is_expected.to_not allow_values("", nil).for :readable_id }
+      it { is_expected.not_to allow_values("", nil).for :readable_id }
       it { is_expected.to validate_length_of(:readable_id).is_at_most(300) }
     end
 
     describe "#summary" do
       it { is_expected.to allow_value("test").for :summary }
-      it { is_expected.to_not allow_values("", nil).for :summary }
+      it { is_expected.not_to allow_values("", nil).for :summary }
       it { is_expected.to validate_length_of(:summary).is_at_most(1000) }
     end
 
     describe "#description" do
       it { is_expected.to allow_value("test").for :description }
-      it { is_expected.to_not allow_values("", nil).for :description }
+      it { is_expected.not_to allow_values("", nil).for :description }
       it { is_expected.to validate_length_of(:description).is_at_most(2000) }
     end
 
     describe "#start_at" do
-      it { is_expected.to_not allow_values(nil, now - 1.minute, now).for :start_at }
+      it { is_expected.not_to allow_values(nil, now - 1.minute, now).for :start_at }
       it { is_expected.to allow_value(Time.zone.now + 1.minute).for :start_at }
     end
 
     describe "#end_at" do
-      it { is_expected.to_not allow_values(nil, now - 1.minute, now).for :end_at }
+      it { is_expected.not_to allow_values(nil, now - 1.minute, now).for :end_at }
       it { is_expected.to allow_value(now + 1.minute).for :end_at }
 
       it "is expected not to allow end at to be the same as start at" do
         subject.start_at = now + 1.minute
-        is_expected.to_not allow_value(subject.start_at).for :end_at
+        is_expected.not_to allow_value(subject.start_at).for :end_at
       end
 
       it "is expected not to allow end at to be earlier than start at" do
         subject.start_at = now + 2.minutes
-        is_expected.to_not allow_value(now + 1.minute).for :end_at
+        is_expected.not_to allow_value(now + 1.minute).for :end_at
       end
 
       it "is expected to allow end at to be later than start at" do
@@ -83,30 +83,30 @@ describe Internal::Event do
 
       describe "#is_online" do
         it { is_expected.to allow_values(true, false).for :is_online }
-        it { is_expected.to_not allow_value(nil).for :is_online }
+        it { is_expected.not_to allow_value(nil).for :is_online }
       end
 
       describe "#provider contact email" do
         it { is_expected.to allow_value("test@test.com").for :provider_contact_email }
-        it { is_expected.to_not allow_values("test", "", nil).for :provider_contact_email }
+        it { is_expected.not_to allow_values("test", "", nil).for :provider_contact_email }
         it { is_expected.to validate_length_of(:provider_contact_email).is_at_most(100) }
       end
 
       describe "#provider organiser" do
         it { is_expected.to allow_value("test").for :provider_organiser }
-        it { is_expected.to_not allow_value("", nil).for :provider_organiser }
+        it { is_expected.not_to allow_value("", nil).for :provider_organiser }
         it { is_expected.to validate_length_of(:provider_organiser).is_at_most(300) }
       end
 
       describe "#provider target audience" do
         it { is_expected.to allow_value("test").for :provider_target_audience }
-        it { is_expected.to_not allow_value("", nil).for :provider_target_audience }
+        it { is_expected.not_to allow_value("", nil).for :provider_target_audience }
         it { is_expected.to validate_length_of(:provider_target_audience).is_at_most(500) }
       end
 
       describe "#provider website url" do
         it { is_expected.to allow_value("test").for :provider_website_url }
-        it { is_expected.to_not allow_value("", nil).for :provider_website_url }
+        it { is_expected.not_to allow_value("", nil).for :provider_website_url }
         it { is_expected.to validate_length_of(:provider_website_url).is_at_most(300) }
       end
     end
@@ -118,13 +118,13 @@ describe Internal::Event do
       context "when building is nil" do
         before { subject.building = nil }
 
-        it { is_expected.to_not allow_value(described_class::VENUE_TYPES[:existing]).for :venue_type }
+        it { is_expected.not_to allow_value(described_class::VENUE_TYPES[:existing]).for :venue_type }
       end
 
       context "when building.id is nil" do
         before { subject.building = build(:event_building, id: nil) }
 
-        it { is_expected.to_not allow_value(described_class::VENUE_TYPES[:existing]).for :venue_type }
+        it { is_expected.not_to allow_value(described_class::VENUE_TYPES[:existing]).for :venue_type }
       end
     end
   end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Pages::Frontmatter do
     it { expect(subject.keys).to include "/page1" }
     it { expect(subject.keys).to include "/subfolder/page2" }
     it { expect(subject["/page1"]).to include title: "Hello World 1 Upwards" }
-    it { expect(subject.keys).to_not include "/_partial" }
+    it { expect(subject.keys).not_to include "/_partial" }
   end
 
   describe ".perform_caching" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -139,7 +139,7 @@ describe "Find an event near you", type: :request do
     end
 
     it "does not display the discover events heading" do
-      expect(response.body).to_not include("Discover events")
+      expect(response.body).not_to include("Discover events")
     end
 
     it "categorises the results" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -139,7 +139,7 @@ describe Internal::EventsController, type: :request do
         get internal_events_path, headers: generate_auth_headers(:author)
 
         assert_response :success
-        expect(response.body).to_not include("Edit a published event?")
+        expect(response.body).not_to include("Edit a published event?")
       end
     end
   end
@@ -189,7 +189,7 @@ describe Internal::EventsController, type: :request do
 
         it "does not have a final submit button" do
           assert_response :success
-          expect(response.body).to_not include "Submit this provider event"
+          expect(response.body).not_to include "Submit this provider event"
         end
       end
     end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -113,7 +113,7 @@ shared_examples "an issue verification code with wizard step" do
 
     it "will skip the authenticate step for new candidates" do
       expect(Rails.logger).to receive(:info).with("#{described_class} requesting access code")
-      expect(Rails.logger).to_not receive(:info).with("#{described_class} potential duplicate (response code 404)")
+      expect(Rails.logger).not_to receive(:info).with("#{described_class} potential duplicate (response code 404)")
       allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to receive(:create_candidate_access_token).with(request)
         .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
       subject.save


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

Enable the RSpec/NotToNot Rubocop rule and fix errors.
