### PR TITLE
Enable hook-related RSpec Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,18 +64,6 @@ RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb
 
-RSpec/ExpectInHook:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/HookArgument:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/HooksBeforeExamples:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/InstanceVariable:
   Exclude:
     - spec/**/*.rb

--- a/spec/capybara_driver_helper.rb
+++ b/spec/capybara_driver_helper.rb
@@ -22,13 +22,13 @@ end
 
 Capybara.default_max_wait_time = 2
 RSpec.configure do |config|
-  config.before(:each) do |example|
+  config.before do |example|
     Capybara.current_driver = JS_DRIVER if example.metadata[:js]
     Capybara.current_driver = :selenium if example.metadata[:selenium]
     Capybara.current_driver = :selenium_chrome if example.metadata[:selenium_chrome]
   end
 
-  config.after(:each) do
+  config.after do
     Capybara.use_default_driver
   end
 end

--- a/spec/components/cards/latest_event_component_spec.rb
+++ b/spec/components/cards/latest_event_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
   context "with category" do
     before do
-      expect(page_data).to receive(:latest_event_for_category)
+      allow(page_data).to receive(:latest_event_for_category)
         .with("train to teach event")
         .and_return event
     end
@@ -45,7 +45,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     let(:card) { { "category" => "unknown" } }
 
-    before { expect(Sentry).to receive(:capture_exception).and_call_original }
+    before { allow(Sentry).to receive(:capture_exception).and_call_original }
 
     it { is_expected.to have_css ".card header", text: find_events_header }
   end
@@ -55,7 +55,7 @@ RSpec.describe Cards::LatestEventComponent, type: :component do
 
     let(:card) { {} }
 
-    before { expect(Sentry).to receive(:capture_exception).and_call_original }
+    before { allow(Sentry).to receive(:capture_exception).and_call_original }
 
     it { is_expected.to have_css ".card header", text: find_events_header }
   end

--- a/spec/lib/page_speed_score_spec.rb
+++ b/spec/lib/page_speed_score_spec.rb
@@ -16,7 +16,7 @@ describe PageSpeedScore do
     let(:prometheus) { Prometheus::Client.registry }
 
     before do
-      expect(Rails.application.credentials).to \
+      allow(Rails.application.credentials).to \
         receive(:page_speed_insights_key) { "12345" }
     end
 

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -40,8 +40,8 @@ describe Callbacks::Wizard do
 
     before do
       allow(subject).to receive(:valid?) { true }
-      expect_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
-        receive(:book_get_into_teaching_callback).with(request).once
+      allow_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
+        receive(:book_get_into_teaching_callback).with(request)
       allow(Rails.logger).to receive(:info)
       subject.complete!
     end
@@ -61,7 +61,7 @@ describe Callbacks::Wizard do
     let(:response) { GetIntoTeachingApiClient::GetIntoTeachingCallback.new(candidateId: "123", email: "12345") }
 
     before do
-      expect_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
+      allow_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
         receive(:exchange_access_token_for_get_into_teaching_callback)
         .with(totp, request) { response }
     end

--- a/spec/models/events/steps/further_details_spec.rb
+++ b/spec/models/events/steps/further_details_spec.rb
@@ -49,11 +49,12 @@ describe Events::Steps::FurtherDetails do
     context "when invalid" do
       before do
         subject.privacy_policy = nil
-        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).not_to \
-          receive(:get_latest_privacy_policy)
       end
 
       it "does not update the store" do
+        expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).not_to \
+          receive(:get_latest_privacy_policy)
+
         expect(subject).not_to be_valid
         subject.save
         expect(wizardstore["subscribe_to_mailing_list"]).to be_nil

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -37,8 +37,8 @@ describe Events::Wizard do
 
     before do
       allow(subject).to receive(:valid?) { true }
-      expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:add_teaching_event_attendee).with(request).once
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+        receive(:add_teaching_event_attendee).with(request)
       allow(Rails.logger).to receive(:info)
       subject.complete!
     end
@@ -58,7 +58,7 @@ describe Events::Wizard do
     let(:response) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", addressTelephone: "12345") }
 
     before do
-      expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:exchange_access_token_for_teaching_event_add_attendee)
         .with(totp, request) { response }
     end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -26,9 +26,6 @@ describe Healthcheck do
     end
   end
 
-  include_examples "reading git shas", "app_sha", "/etc/get-into-teaching-app-sha"
-  include_examples "reading git shas", "content_sha", "/etc/get-into-teaching-content-sha"
-
   before do
     stub_request(:get, "#{git_api_endpoint}/api/lookup_items/teaching_subjects")
       .to_return \
@@ -36,6 +33,9 @@ describe Healthcheck do
         headers: { "Content-type" => "application/json" },
         body: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map { |k, v| { id: v, value: k } }.to_json
   end
+
+  include_examples "reading git shas", "app_sha", "/etc/get-into-teaching-app-sha"
+  include_examples "reading git shas", "content_sha", "/etc/get-into-teaching-content-sha"
 
   describe "test_api" do
     subject { described_class.new.test_api }
@@ -57,7 +57,7 @@ describe Healthcheck do
 
     context "with an API error" do
       before do
-        expect_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
+        allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
           receive(:get_teaching_subjects).and_raise(GetIntoTeachingApiClient::ApiError)
       end
 

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -121,11 +121,11 @@ describe MailingList::Signup do
 
   describe "methods" do
     describe "#query_degree_status" do
+      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
+
       it { is_expected.to respond_to(:query_channels) }
 
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi) }
-
-      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_qualification_degree_status)
@@ -134,11 +134,11 @@ describe MailingList::Signup do
     end
 
     describe "#query_channels" do
+      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
+
       it { is_expected.to respond_to(:query_channels) }
 
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi) }
-
-      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_candidate_mailing_list_subscription_channels)
@@ -147,11 +147,11 @@ describe MailingList::Signup do
     end
 
     describe "#teaching_subjects" do
+      before { allow(GetIntoTeachingApiClient::LookupItemsApi).to receive(:new).and_return(api) }
+
       it { is_expected.to respond_to(:teaching_subjects) }
 
       let(:api) { instance_double(GetIntoTeachingApiClient::LookupItemsApi, get_teaching_subjects: []) }
-
-      before { allow(GetIntoTeachingApiClient::LookupItemsApi).to receive(:new).and_return(api) }
 
       specify "should call the LookupItemsApi" do
         expect(api).to receive(:get_teaching_subjects)
@@ -160,11 +160,11 @@ describe MailingList::Signup do
     end
 
     describe "#consideration_journey_stages" do
+      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
+
       it { is_expected.to respond_to(:consideration_journey_stages) }
 
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi, get_candidate_journey_stages: []) }
-
-      before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_candidate_journey_stages)

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe MailingList::Steps::DegreeStatus do
   include_context "with wizard step"
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
+  end
+
   it_behaves_like "a with wizard step"
 
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
-  end
-
-  before do
-    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
-      receive(:get_qualification_degree_status).and_return(degree_status_option_types)
   end
 
   it { is_expected.to respond_to :degree_status_id }

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe MailingList::Steps::Name do
   include_context "with wizard step"
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+      receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
+  end
+
   it_behaves_like "a with wizard step"
 
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
-  end
-
-  before do
-    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
-      receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
   end
 
   it { is_expected.to respond_to :first_name }

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe MailingList::Steps::Subject do
   include_context "with wizard step"
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
+      receive(:get_teaching_subjects).and_return(teaching_subject_types)
+  end
+
   it_behaves_like "a with wizard step"
 
   let(:teaching_subject_types) do
     GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
       GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k })
     end
-  end
-
-  before do
-    allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-      receive(:get_teaching_subjects).and_return(teaching_subject_types)
   end
 
   it { is_expected.to respond_to :preferred_teaching_subject_id }

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe MailingList::Steps::TeacherTraining do
   include_context "with wizard step"
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+      receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
+  end
+
   it_behaves_like "a with wizard step"
 
   let(:consideration_journey_stage_types) do
     GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
-  end
-
-  before do
-    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
-      receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
   end
 
   it { is_expected.to respond_to :consideration_journey_stage_id }

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -39,8 +39,8 @@ describe MailingList::Wizard do
 
     before do
       allow(subject).to receive(:valid?) { true }
-      expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
-        receive(:add_mailing_list_member).with(request).once
+      allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+        receive(:add_mailing_list_member).with(request)
       allow(Rails.logger).to receive(:info)
       subject.complete!
     end
@@ -60,7 +60,7 @@ describe MailingList::Wizard do
     let(:response) { GetIntoTeachingApiClient::MailingListAddMember.new(candidateId: "123", email: "12345") }
 
     before do
-      expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+      allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
         receive(:exchange_access_token_for_mailing_list_add_member)
         .with(totp, request) { response }
     end

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Pages::Data do
   describe "#featured_page" do
     subject { instance.featured_page }
 
-    before { expect(Pages::Page).to receive(:featured).and_call_original }
+    before { allow(Pages::Page).to receive(:featured).and_call_original }
 
     it { is_expected.to be_kind_of Pages::Page }
   end

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Pages::Frontmatter do
     context "when caching" do
       before do
         allow(described_class).to receive(:instance) { instance.preload }
-        expect(instance).to receive(:find_from_preloaded).and_call_original
+        allow(instance).to receive(:find_from_preloaded).and_call_original
       end
 
       it_behaves_like "page loading"
@@ -63,7 +63,7 @@ RSpec.describe Pages::Frontmatter do
   describe ".select" do
     subject { described_class.select :title, content_dir }
 
-    before { expect_any_instance_of(described_class).to receive(:select).and_call_original }
+    before { allow_any_instance_of(described_class).to receive(:select).and_call_original }
 
     it { is_expected.to include "/page1" }
   end
@@ -73,7 +73,7 @@ RSpec.describe Pages::Frontmatter do
 
     subject { described_class.select_by_path(wanted_path, content_dir) }
 
-    before { expect_any_instance_of(described_class).to receive(:select_by_path).and_call_original }
+    before { allow_any_instance_of(described_class).to receive(:select_by_path).and_call_original }
 
     it "only returns pages that start with the supplied path" do
       expect(subject.keys).to all(start_with(wanted_path))
@@ -87,7 +87,7 @@ RSpec.describe Pages::Frontmatter do
 
     context "when preloaded" do
       before do
-        expect(instance).to receive(:find_from_preloaded).and_call_original
+        allow(instance).to receive(:find_from_preloaded).and_call_original
         instance.preload
       end
 

--- a/spec/models/pages/page_spec.rb
+++ b/spec/models/pages/page_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Pages::Page do
 
       before do
         page = described_class.find("/subfolder/page2")
-        expect(page).to receive(:path) { deep_path }
+        allow(page).to receive(:path) { deep_path }
         allow(described_class).to receive(:find).and_raise(described_class::PageNotFoundError)
         page.parent
       end

--- a/spec/requests/circuit_breaker_spec.rb
+++ b/spec/requests/circuit_breaker_spec.rb
@@ -14,7 +14,7 @@ describe "Circuit breaker", type: :request do
   end
 
   context "when the API returns a CircuitBrokenError" do
-    before { expect(Sentry).to receive(:capture_exception).with(error) }
+    before { allow(Sentry).to receive(:capture_exception).with(error) }
 
     it "the EventsController redirects to an error page" do
       get event_path("event-id")

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -47,7 +47,7 @@ describe EventsController, type: :request do
     let(:parsed_response) { Nokogiri.parse(response.body) }
 
     before do
-      expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type)
         .with(a_hash_including(expected_request_attributes)) { events_by_type }
     end

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -74,7 +74,7 @@ describe Internal::EventsController, type: :request do
       include_examples "no pending events", "online"
 
       include_examples "pending events", "provider" do
-        before(:each) do
+        before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
@@ -88,7 +88,7 @@ describe Internal::EventsController, type: :request do
       end
 
       include_examples "pending events", "online" do
-        before(:each) do
+        before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
@@ -105,7 +105,7 @@ describe Internal::EventsController, type: :request do
         default_event_type = "provider".freeze
 
         include_examples "pending events", nil, default_event_type do
-          before(:each) do
+          before do
             allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
               .to receive(:search_teaching_events_grouped_by_type) { provider_events_by_type }
           end

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -52,7 +52,7 @@ describe MailingList::StepsController, type: :request do
       end
 
       before do
-        expect_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+        allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
           receive(:exchange_magic_link_token_for_mailing_list_add_member).with(token) { stub_response }
         allow(Rails.logger).to receive(:info)
         get step_path
@@ -71,7 +71,7 @@ describe MailingList::StepsController, type: :request do
       let(:exchange_result) { GetIntoTeachingApiClient::CandidateMagicLinkExchangeResult.new(success: false, status: status) }
 
       before do
-        expect_any_instance_of(MailingList::Wizard).to \
+        allow_any_instance_of(MailingList::Wizard).to \
           receive(:exchange_magic_link_token).with(token)
             .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 401, response_body: exchange_result.to_json))
         get step_path

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -62,7 +62,7 @@ describe PagesController, type: :request do
 
     context "with invalid page" do
       before do
-        expect_any_instance_of(described_class).to \
+        allow_any_instance_of(described_class).to \
           receive(:render).with(status: :not_found, body: nil).and_call_original
 
         get "/../../secrets.txt"

--- a/spec/requests/pagespeed_spec.rb
+++ b/spec/requests/pagespeed_spec.rb
@@ -18,7 +18,7 @@ describe "Page Speed Task", type: :request do
     let(:pagespeed_env) { true }
 
     before do
-      expect_any_instance_of(PageSpeedScore).to receive(:fetch)
+      allow_any_instance_of(PageSpeedScore).to receive(:fetch)
     end
 
     it "returns 204" do

--- a/spec/requests/vwo_spec.rb
+++ b/spec/requests/vwo_spec.rb
@@ -16,7 +16,7 @@ describe "VWO", type: :request do
     allow(ENV).to receive(:[]).with("VWO_ID").and_return("12345")
 
     allow(File).to receive(:read).and_call_original
-    expect(File).to receive(:read).with(config_path) { yaml }
+    allow(File).to receive(:read).with(config_path) { yaml }
   end
 
   subject { response.body }

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -88,7 +88,7 @@ shared_context "with stubbed upcoming events by category api" do |results_per_ty
   before { travel_to(DateTime.new(2020, 11, 1, 10)) }
 
   before do
-    expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type)
       .with(a_hash_including(expected_request_attributes)) { events_by_type }
   end

--- a/spec/validators/number_of_words_validator_spec.rb
+++ b/spec/validators/number_of_words_validator_spec.rb
@@ -13,7 +13,7 @@ describe NumberOfWordsValidator do
     described_class.new attributes: :description, less_than: 150
   end
 
-  before :each do
+  before do
     validator.validate_each model, :description, description
   end
 


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

Enable the hook-related Rubocop/RSpec rules and fix violations:

```
RSpec/ExpectInHook
RSpec/HookArgument
RSpec/HooksBeforeExamples
```
