### PR TITLE
Enable RSpec/VerifiedDoubles Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,7 +107,3 @@ RSpec/ScatteredSetup:
 RSpec/SubjectStub:
   Exclude:
     - spec/**/*.rb
-
-RSpec/VerifiedDoubles:
-  Exclude:
-    - spec/**/*.rb

--- a/spec/components/cards/renderer_component_spec.rb
+++ b/spec/components/cards/renderer_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Cards::RendererComponent, type: :component do
   context "with card type specified" do
     let(:card) { { "category" => "Train to Teach event", "card_type" => "latest_event" } }
     let(:event) { build(:event_api, name: "Test event") }
-    let(:page_data) { double Pages::Data, latest_event_for_category: event }
+    let(:page_data) { instance_double(Pages::Data, latest_event_for_category: event) }
 
     it { is_expected.to have_css ".card" }
     it { is_expected.to have_css ".card.card--no-border" }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,7 +115,7 @@ describe ApplicationHelper do
   end
 
   describe "#internal_referer" do
-    before { helper.request = double("request") }
+    before { helper.request = instance_double("ActionDispatch::Request") }
 
     it "returns nil if the referrer is not set" do
       allow(helper.request).to receive(:referer).and_return nil

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -76,7 +76,7 @@ describe Healthcheck do
 
     context "with working connection" do
       before do
-        allow(Redis).to receive(:current).and_return double(Redis, ping: "PONG")
+        allow(Redis).to receive(:current).and_return instance_double(Redis, ping: "PONG")
       end
 
       it { is_expected.to be true }

--- a/spec/validators/number_of_words_validator_spec.rb
+++ b/spec/validators/number_of_words_validator_spec.rb
@@ -1,12 +1,19 @@
 require "rails_helper"
 
+class TestModel
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :description, :string
+end
+
 describe NumberOfWordsValidator do
   let :errors do
-    double "errors", add: true
+    instance_double(ActiveModel::Errors, add: true)
   end
 
   let :model do
-    double "model", description: description, errors: errors
+    instance_double(TestModel, description: description, errors: errors)
   end
 
   let :validator do


### PR DESCRIPTION
### Trello card

[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

### Context

Enable RSpec/VerifiedDoubles Rubocop rule and fix violations.

### Changes proposed in this pull request

- Enable RSpec/VerifiedDoubles Rubocop rule

### Guidance to review

