### PR TITLE
Enable RSpec/InstanceVariables rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,13 +58,13 @@ Style/EmptyMethod:
 Style/ClassVars:
   Enabled: false
 
+RSpec/InstanceVariable:
+  Exclude:
+    - spec/features/content_pages_spec.rb
+
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/ExampleLength:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/InstanceVariable:
   Exclude:
     - spec/**/*.rb
 

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "CSP violation reporting", type: :request do
   let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
+  let(:events) { [] }
 
   before do
     record_csp_violation_events
@@ -33,17 +34,16 @@ describe "CSP violation reporting", type: :request do
   end
 
   def has_recorded_csp_violation?(report = nil)
-    return @events.any? if report.nil?
+    return events.any? if report.nil?
 
-    @events.any? { |event| event.payload == report }
+    events.any? { |event| event.payload == report }
   end
 
 private
 
   def record_csp_violation_events
-    @events = []
     ActiveSupport::Notifications.subscribe("app.csp_violation") do |*args|
-      @events << ActiveSupport::Notifications::Event.new(*args)
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
   end
 end


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

Enable the Rubocop `RSpec/InstanceVariables` rule and fix the violations.


