### PR TITLE
Update RSpec subject-related Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,10 +68,6 @@ RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb
 
-RSpec/LeadingSubject:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/LetBeforeExamples:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,10 @@ RSpec/NamedSubject:
   Exclude:
     - spec/**/*.rb
 
+RSpec/SubjectStub:
+  Exclude:
+    - spec/**/*.rb
+
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/ExampleLength:
@@ -100,6 +104,4 @@ RSpec/ScatteredSetup:
   Exclude:
     - spec/**/*.rb
 
-RSpec/SubjectStub:
-  Exclude:
-    - spec/**/*.rb
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,10 @@ RSpec/InstanceVariable:
   Exclude:
     - spec/features/content_pages_spec.rb
 
+RSpec/NamedSubject:
+  Exclude:
+    - spec/**/*.rb
+
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/ExampleLength:
@@ -77,10 +81,6 @@ RSpec/MessageSpies:
     - spec/**/*.rb
 
 RSpec/MultipleExpectations:
-  Exclude:
-    - spec/**/*.rb
-
-RSpec/NamedSubject:
   Exclude:
     - spec/**/*.rb
 

--- a/spec/components/arrow_component_spec.rb
+++ b/spec/components/arrow_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe ArrowComponent, type: :component do
+  subject(:render) do
+    render_inline(component)
+    page
+  end
+
   let(:component) do
     described_class.new(
       width: 200,
@@ -13,11 +18,6 @@ describe ArrowComponent, type: :component do
       cy: 0.1,
       arrow_size: 0.1,
     )
-  end
-
-  subject(:render) do
-    render_inline(component)
-    page
   end
 
   it "draws an SVG arrow" do

--- a/spec/components/calls_to_action/attachment_component_spec.rb
+++ b/spec/components/calls_to_action/attachment_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe CallsToAction::AttachmentComponent, type: :component do
+  subject do
+    render_inline described_class.new(args)
+    page
+  end
+
   let(:basic_args) do
     {
       text: "Lorem ipsum ....",
@@ -9,11 +14,6 @@ RSpec.describe CallsToAction::AttachmentComponent, type: :component do
   end
 
   let(:args) { basic_args }
-
-  subject do
-    render_inline described_class.new(args)
-    page
-  end
 
   specify "renders the component" do
     is_expected.to have_css(".attachment")

--- a/spec/components/calls_to_action/ect_component_spec.rb
+++ b/spec/components/calls_to_action/ect_component_spec.rb
@@ -1,16 +1,14 @@
 require "rails_helper"
 
 RSpec.describe CallsToAction::EctComponent, type: :component do
-  before do
-    render_inline(described_class.new)
-  end
+  subject! { Capybara.string(component) }
 
-  subject! { Capybara.string(rendered_component) }
+  let(:component) { render_inline(described_class.new) }
 
   it "renders a component with information about early career and newly qualified teachers" do
-    expect(subject).to have_css(".call-to-action") do |component|
-      expect(component).to have_text(/early career/)
-      expect(component).to have_text(/newly qualified/)
+    expect(subject).to have_css(".call-to-action") do |c|
+      expect(c).to have_text(/early career/)
+      expect(c).to have_text(/newly qualified/)
     end
   end
 end

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe CardComponent, type: "component" do
+  subject do
+    render_inline described_class.new(card: card)
+    page
+  end
+
   let(:base) do
     {
       "snippet" => "Lorem ipsum ....",
@@ -12,11 +17,6 @@ describe CardComponent, type: "component" do
   end
 
   let(:card) { base }
-
-  subject do
-    render_inline described_class.new(card: card)
-    page
-  end
 
   specify "renders a card" do
     is_expected.to have_css(".card")

--- a/spec/components/cards/story_component_spec.rb
+++ b/spec/components/cards/story_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Cards::StoryComponent, type: "component" do
+  subject do
+    render_inline(described_class.new(card: story, page_data: page_data))
+    page
+  end
+
   let :edna do
     {
       title: "Edna's career in teaching",
@@ -19,11 +24,6 @@ describe Cards::StoryComponent, type: "component" do
 
   let(:story) { base }
   let(:page_data) { nil }
-
-  subject do
-    render_inline(described_class.new(card: story, page_data: page_data))
-    page
-  end
 
   it { is_expected.to have_css ".card" }
   it { is_expected.to have_css ".card.card--no-border" }

--- a/spec/components/content/accordion_component_spec.rb
+++ b/spec/components/content/accordion_component_spec.rb
@@ -5,20 +5,20 @@ describe Content::AccordionComponent, type: "component" do
   let(:text) { "some text" }
 
   describe "Rending the accordion" do
-    let(:steps) do
-      {
-        "Step one" => "some content",
-        "Step two" => "some other content",
-        "Step three" => "even more content",
-      }
-    end
-
     subject! do
       render_inline(described_class.new) do |accordion|
         steps.each do |title, content|
           accordion.step(title: title) { content }
         end
       end
+    end
+
+    let(:steps) do
+      {
+        "Step one" => "some content",
+        "Step two" => "some other content",
+        "Step three" => "even more content",
+      }
     end
 
     specify "renders an accordion container" do
@@ -135,8 +135,6 @@ describe Content::AccordionComponent, type: "component" do
   end
 
   describe "Setting the active step via a data attribute" do
-    let(:active_step) { 3 }
-
     subject! do
       render_inline(described_class.new(active_step: active_step)) do |accordion|
         1.upto(3).each do |i|
@@ -144,6 +142,8 @@ describe Content::AccordionComponent, type: "component" do
         end
       end
     end
+
+    let(:active_step) { 3 }
 
     specify "the active step data attribute is set" do
       expect(page).to have_css(%(.accordions[data-accordion-active-step-value="#{active_step}"]))

--- a/spec/components/content/feature_table_component_spec.rb
+++ b/spec/components/content/feature_table_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Content::FeatureTableComponent, type: "component" do
+  subject! do
+    render_inline(described_class.new(data, title))
+    page
+  end
+
   let(:title) { "Features" }
   let(:data) do
     {
@@ -8,11 +13,6 @@ describe Content::FeatureTableComponent, type: "component" do
       "Feature 2" => "Value 2",
       "Feature 3" => "Value 3",
     }
-  end
-
-  subject! do
-    render_inline(described_class.new(data, title))
-    page
   end
 
   it { is_expected.to have_css(".feature-table") }

--- a/spec/components/content/generic_block_component_spec.rb
+++ b/spec/components/content/generic_block_component_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
 
 describe Content::GenericBlockComponent, type: "component" do
-  let(:title) { "Block of content" }
-  let(:content) { "Some content" }
-  let(:icon_image) { "icon-school-black.svg" }
-  let(:icon_alt) { "description of image" }
-  let(:custom_class) { "purple" }
-  let(:icon_size) { "30x50" }
-
   subject! do
     render_inline(described_class.new(title: title, icon_image: icon_image, icon_alt: icon_alt, icon_size: icon_size, classes: Array.wrap(custom_class))) do
       content
     end
     page
   end
+
+  let(:title) { "Block of content" }
+  let(:content) { "Some content" }
+  let(:icon_image) { "icon-school-black.svg" }
+  let(:icon_alt) { "description of image" }
+  let(:custom_class) { "purple" }
+  let(:icon_size) { "30x50" }
 
   it { is_expected.to have_css("div.#{custom_class}") }
   it { is_expected.to have_css("h3", text: title) }

--- a/spec/components/content/quote_component_spec.rb
+++ b/spec/components/content/quote_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Content::QuoteComponent, type: :component do
+  subject do
+    render_inline(component)
+    page
+  end
+
   let(:component) do
     described_class.new(
       text: text,
@@ -19,11 +24,6 @@ describe Content::QuoteComponent, type: :component do
   let(:image) { "media/images/featured-3.jpg" }
   let(:hang) { "left" }
   let(:inline) { nil }
-
-  subject do
-    render_inline(component)
-    page
-  end
 
   describe "quote classes" do
     it { is_expected.to have_css(".quote.quote--hang-#{hang}") }

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 describe Events::EventBoxComponent, type: "component" do
   include_context "with stubbed types api"
+  subject! { render_inline(described_class.new(event)) }
+
   let(:event) { build(:event_api) }
   let(:date_text) { event.start_at.to_date.to_formatted_s(:long) }
   let(:start_at_text) { event.start_at.to_formatted_s(:time) }
   let(:end_at_text) { event.end_at.to_formatted_s(:time) }
-
-  subject! { render_inline(described_class.new(event)) }
 
   specify "renders an event box" do
     expect(page).to have_css(".event-box")

--- a/spec/components/events/no_results_component_spec.rb
+++ b/spec/components/events/no_results_component_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe Events::NoResultsComponent, type: "component" do
-  let(:message) { "no results message" }
-  let(:component) { described_class.new }
-
   subject do
     render_inline(component) { message }
     page
   end
+
+  let(:message) { "no results message" }
+  let(:component) { described_class.new }
 
   it { is_expected.to have_css(".no-results") }
   it { is_expected.to have_text(message) }

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 describe Events::SearchComponent, type: "component" do
+  subject! { render_inline(component) }
+
   let(:search) { build(:events_search, :invalid) }
   let(:path) { "/some/path" }
 
   let(:component) { described_class.new(search, path) }
-
-  subject! { render_inline(component) }
 
   before { freeze_time }
 
@@ -22,9 +22,9 @@ describe Events::SearchComponent, type: "component" do
     end
 
     context "when overridden" do
-      let(:new_heading) { "Search for Awesome events" }
-
       subject! { render_inline(described_class.new(search, path, heading: new_heading)) }
+
+      let(:new_heading) { "Search for Awesome events" }
 
       specify %(the title is overridden) do
         expect(page).to have_css("h2", text: new_heading)

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Events::TypeDescriptionComponent, type: "component" do
-  let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
-
   subject! { render_inline(described_class.new(type)) }
+
+  let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
 
   it "has a containing div" do
     expect(page).to have_css("div.type-description")

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -56,9 +56,9 @@ describe FooterComponent, type: "component" do
   end
 
   context "when a lid_pixel_event is supplied" do
-    let(:event) { "Success" }
-
     subject! { render_inline(described_class.new(lid_pixel_event: event)) }
+
+    let(:event) { "Success" }
 
     specify "renders the right analytics element" do
       expect(rendered_component).to include_analytics("lid", { action: "track", event: event })

--- a/spec/components/header/extra_navigation_component_spec.rb
+++ b/spec/components/header/extra_navigation_component_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe Header::ExtraNavigationComponent, type: "component" do
+  subject! { render_inline(component) }
+
   let(:custom_class) { "red-bg" }
   let(:custom_custom_search_input_id) { "do-a-search" }
   let(:component) { described_class.new(classes: Array.wrap(custom_class), search_input_id: custom_custom_search_input_id) }
-
-  subject! { render_inline(component) }
 
   specify "renders the extra navigation container with contents" do
     expect(page).to have_css(".extra-navigation") do |en|

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Header::HeroComponent, type: "component" do
+  subject! { render_inline(component) }
+
   let(:extra_front_matter) { {} }
   let(:front_matter) do
     {
@@ -14,8 +16,6 @@ describe Header::HeroComponent, type: "component" do
     }.merge(extra_front_matter)
   end
   let(:component) { described_class.new(front_matter) }
-
-  subject! { render_inline(component) }
 
   describe "rendering a hero section" do
     describe "title and subtitle" do
@@ -36,6 +36,8 @@ describe Header::HeroComponent, type: "component" do
       end
 
       context "when a subtitle link exists" do
+        subject! { render_inline(component) }
+
         let(:front_matter) do
           {
             "title" => "Teaching, it's pretty awesome",
@@ -45,8 +47,6 @@ describe Header::HeroComponent, type: "component" do
             "image" => "media/images/content/hero-images/0012.jpg",
           }
         end
-
-        subject! { render_inline(component) }
 
         specify "renders the subtitle button" do
           expect(page).to have_css(".hero__subtitle") do |div|
@@ -74,13 +74,13 @@ describe Header::HeroComponent, type: "component" do
     end
 
     describe "rendering block content" do
+      subject! do
+        render_inline(component) { sample }
+      end
+
       let(:sample) { "some content" }
       let(:component) do
         described_class.new(front_matter)
-      end
-
-      subject! do
-        render_inline(component) { sample }
       end
 
       specify "the block content should be rendered by the component" do

--- a/spec/components/header/logo_component_spec.rb
+++ b/spec/components/header/logo_component_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Header::LogoComponent, type: "component" do
-  let(:component) { described_class.new }
-
   subject! { render_inline(component) }
+
+  let(:component) { described_class.new }
 
   specify "renders the logo wrapper with the get into teaching and DfE logos" do
     expect(page).to have_css(".logo-wrapper") do |wrapper|

--- a/spec/components/header/navigation_component_spec.rb
+++ b/spec/components/header/navigation_component_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 describe Header::NavigationComponent, type: "component" do
   # these are built from the markdown frontmatter
+  subject! { render_inline(component) }
+
   let(:resources) do
     [OpenStruct.new(path: "/one", title: "One"), OpenStruct.new(path: "/two", title: "Two")]
   end
@@ -12,8 +14,6 @@ describe Header::NavigationComponent, type: "component" do
   end
 
   let(:component) { described_class.new(resources: resources, extra_resources: extra_resources) }
-
-  subject! { render_inline(component) }
 
   specify "renders a primary navigation list" do
     expect(page).to have_css("nav > ol.primary")
@@ -30,6 +30,8 @@ describe Header::NavigationComponent, type: "component" do
   end
 
   describe "rendering menus" do
+    subject! { render_inline(component) }
+
     let(:children) do
       [
         OpenStruct.new(path: "/five/part-one", title: "Five: part one"),
@@ -42,8 +44,6 @@ describe Header::NavigationComponent, type: "component" do
     end
 
     let(:component) { described_class.new(resources: resources) }
-
-    subject! { render_inline(component) }
 
     specify "the secondary navigatoin has right number of links" do
       expect(page).to have_css("ol.primary > li > ol.secondary > li", count: children.size)

--- a/spec/components/header_component_spec.rb
+++ b/spec/components/header_component_spec.rb
@@ -32,14 +32,14 @@ describe HeaderComponent, type: "component" do
   end
 
   context "when the hero slot is called with valid front matter" do
-    let(:front_matter) do
-      { title: "What a nice page", image: "media/images/content/hero-images/0012.jpg" }
-    end
-
     subject! do
       render_inline(described_class.new) do |component|
         component.hero(front_matter)
       end
+    end
+
+    let(:front_matter) do
+      { title: "What a nice page", image: "media/images/content/hero-images/0012.jpg" }
     end
 
     specify "renders the hero" do

--- a/spec/components/stories/card_component_spec.rb
+++ b/spec/components/stories/card_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Stories::CardComponent, type: "component" do
+  subject do
+    render_inline(described_class.new(card: story))
+    page
+  end
+
   let(:story) do
     {
       "name" => "Edna Krabappel",
@@ -8,11 +13,6 @@ describe Stories::CardComponent, type: "component" do
       "link" => "/stories/edna-k",
       "image" => "media/images/dfelogo.png",
     }
-  end
-
-  subject do
-    render_inline(described_class.new(card: story))
-    page
   end
 
   specify "renders a card" do
@@ -42,13 +42,13 @@ describe Stories::CardComponent, type: "component" do
   end
 
   context "with video stories" do
-    let(:video) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
-    let(:video_story) { story.merge("video" => video) }
-
     subject do
       render_inline(described_class.new(card: video_story))
       page
     end
+
+    let(:video) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
+    let(:video_story) { story.merge("video" => video) }
 
     specify "the image links to the video instead of the story" do
       is_expected.to have_link(href: video_story["video"]) do |anchor|

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe Stories::StoryComponent, type: "component" do
+  subject do
+    render_inline(described_class.new(front_matter))
+    page
+  end
+
   let(:default_front_matter) do
     {
       "title" => "Swapping senior management for students",
@@ -35,11 +40,6 @@ describe Stories::StoryComponent, type: "component" do
   end
 
   let(:front_matter) { default_front_matter }
-
-  subject do
-    render_inline(described_class.new(front_matter))
-    page
-  end
 
   describe "layout elements" do
     it { is_expected.to have_css(".container .markdown") }
@@ -91,8 +91,6 @@ describe Stories::StoryComponent, type: "component" do
   end
 
   describe "content" do
-    let(:content) { "The quick brown fox" }
-
     subject do
       render_inline(described_class.new(front_matter)) do
         content
@@ -100,6 +98,8 @@ describe Stories::StoryComponent, type: "component" do
 
       page
     end
+
+    let(:content) { "The quick brown fox" }
 
     specify "the content is rendered" do
       is_expected.to have_content(content)

--- a/spec/controllers/concerns/static_pages_spec.rb
+++ b/spec/controllers/concerns/static_pages_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe StaticPages do
+  subject { tester.tap(&:render) }
+
   let(:testing_class) do
     Class.new do
       include StaticPages
@@ -45,8 +47,6 @@ describe StaticPages do
     allow(tester).to receive(:fetch_content).and_call_original
   end
 
-  subject { tester.tap(&:render) }
-
   context "with caching disabled" do
     it { is_expected.to have_received :fetch_content }
     it { is_expected.not_to have_received :stale? }
@@ -74,11 +74,11 @@ describe StaticPages do
   end
 
   describe "#filtered_page_template" do
+    subject { tester.send :filtered_page_template }
+
     let(:params) { { page: template } }
 
     before { allow(tester).to receive(:params).and_return params }
-
-    subject { tester.send :filtered_page_template }
 
     context "with valid page template" do
       let(:template) { "hello" }
@@ -117,9 +117,9 @@ describe StaticPages do
     end
 
     context "with custom page value" do
-      let(:params) { { story: "hello" } }
-
       subject { tester.send :filtered_page_template, :story }
+
+      let(:params) { { story: "hello" } }
 
       it { is_expected.to eql "hello" }
     end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "Breadcrumbs", type: :feature do
   include_context "with stubbed types api"
 
+  subject { page }
+
   let(:event) { GetIntoTeachingApiClient::TeachingEvent.new(statusId: 1) }
 
   before do
@@ -13,8 +15,6 @@ RSpec.feature "Breadcrumbs", type: :feature do
   end
 
   before { visit path }
-
-  subject { page }
 
   context "when visiting the home page" do
     let(:path) { "/home-page" }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 describe ApplicationHelper do
   describe "#analytics_body_tag" do
+    subject { analytics_body_tag { "<h1>TEST</h1>".html_safe } }
+
     let(:id) { "1234" }
     let(:gtm_id) { id }
     let(:ga_id) { id }
@@ -25,8 +27,6 @@ describe ApplicationHelper do
       allow(ENV).to receive(:[]).with("BAM_ID").and_return bam_id
       allow(ENV).to receive(:[]).with("LID_ID").and_return lid_id
     end
-
-    subject { analytics_body_tag { "<h1>TEST</h1>".html_safe } }
 
     it { is_expected.to have_css "body h1" }
 
@@ -139,18 +139,18 @@ describe ApplicationHelper do
   end
 
   describe "#fa_icon" do
-    let(:icon_name) { "myspace" }
-
     subject { helper.fa_icon(icon_name) }
+
+    let(:icon_name) { "myspace" }
 
     it "returns an empty span with the default classes" do
       expect(subject).to have_css("span.fas.fa-#{icon_name}")
     end
 
     context "with FA styles" do
-      let(:style) { "fad" }
-
       subject { helper.fa_icon(icon_name, style: style) }
+
+      let(:style) { "fad" }
 
       it "returns an empty span with provided style class" do
         expect(subject).to have_css("span.#{style}.fa-#{icon_name}")
@@ -158,9 +158,9 @@ describe ApplicationHelper do
     end
 
     context "with extra classes" do
-      let(:extra_classes) { %w[abc def] }
-
       subject { helper.fa_icon(icon_name, *extra_classes) }
+
+      let(:extra_classes) { %w[abc def] }
 
       it "returns an empty span with the extra classes" do
         expect(subject).to have_css(%(span.fa-#{icon_name}.#{extra_classes.join('.')}))
@@ -169,9 +169,9 @@ describe ApplicationHelper do
   end
 
   describe "#fab_icon" do
-    let(:icon_name) { "friendster" }
-
     subject { helper.fab_icon(icon_name) }
+
+    let(:icon_name) { "friendster" }
 
     after { subject }
 
@@ -181,9 +181,9 @@ describe ApplicationHelper do
   end
 
   describe "#fas_icon" do
-    let(:icon_name) { "orkut" }
-
     subject { helper.fas_icon(icon_name) }
+
+    let(:icon_name) { "orkut" }
 
     after { subject }
 
@@ -216,10 +216,10 @@ describe ApplicationHelper do
   end
 
   describe "#chat_link" do
+    subject { helper.chat_link(text, classes: extra_class) }
+
     let(:text) { "Chat with us" }
     let(:extra_class) { "button" }
-
-    subject { helper.chat_link(text, classes: extra_class) }
 
     it "generates a hyperlink" do
       expect(subject).to have_css("a")

--- a/spec/helpers/blog_helper_spec.rb
+++ b/spec/helpers/blog_helper_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe BlogHelper, type: "helper" do
   describe "#format_blog_date" do
-    let(:markdown_date) { "2019-03-04" }
-
     subject { format_blog_date(markdown_date) }
+
+    let(:markdown_date) { "2019-03-04" }
 
     specify "formats the date in the GOV.UK short style" do
       expect(subject).to eql("4 March 2019")

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -29,9 +29,9 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#format_event_date" do
-    let(:stacked) { true }
-
     subject { format_event_date event, stacked: stacked }
+
+    let(:stacked) { true }
 
     context "with a single day event" do
       it { is_expected.to eql "1 June 2020 <br> 10:00 - 12:00" }

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe NavigationHelper, type: :helper do
   describe "#navigation_resources" do
-    before { allow(Pages::Navigation).to receive(:root_pages) }
-
-    subject! { helper.navigation_resources }
+    before do
+      allow(Pages::Navigation).to receive(:root_pages)
+      helper.navigation_resources
+    end
 
     specify "calls Pages::Navigation.root_pages" do
       expect(Pages::Navigation).to have_received(:root_pages).with(no_args)

--- a/spec/helpers/stories_helper_spec.rb
+++ b/spec/helpers/stories_helper_spec.rb
@@ -17,9 +17,9 @@ describe StoriesHelper, type: "helper" do
   end
 
   describe "#story_image_alt" do
-    let(:name) { "David" }
-
     subject { helper.story_image_alt(name) }
+
+    let(:name) { "David" }
 
     specify %(returns string 'A photograph of' followed by the supplied name) do
       is_expected.to match("A photograph of #{name}")
@@ -27,9 +27,9 @@ describe StoriesHelper, type: "helper" do
   end
 
   describe "#youtube" do
-    let(:url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
-
     subject { helper.youtube(url) }
+
+    let(:url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
 
     specify %(should generate an iframe with the data-src attribute set to the video's URL) do
       expect(subject).to have_css(%(iframe[data-src='#{url}']), class: "story__video lazyload")
@@ -37,9 +37,9 @@ describe StoriesHelper, type: "helper" do
   end
 
   describe "#more_stories_thumbnail" do
-    let(:path) { "/assets/mugshots/elizabeth_hoover.jpg" }
-
     subject { helper.more_stories_thumbnail(path) }
+
+    let(:path) { "/assets/mugshots/elizabeth_hoover.jpg" }
 
     specify %(should generate a div with the background image set to the provided path) do
       expect(subject).to have_css(%(div[style="background-image:url('#{path}')"]), class: "stories__thumbs__thumb__img")

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -8,10 +8,10 @@ describe StructuredDataHelper, type: "helper" do
   let(:image_path) { "media/images/getintoteachinglogo.svg" }
 
   describe ".structured_data" do
+    subject(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
+
     let(:malicious_text) { "</script><script>alert('PWNED!')</script>" }
     let(:html) { structured_data("Type", { text: malicious_text }) }
-
-    subject(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
 
     before { enable_structured_data(:type) }
 
@@ -46,6 +46,8 @@ describe StructuredDataHelper, type: "helper" do
   end
 
   describe ".how_to_structured_data" do
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
     let(:frontmatter) do
       {
         title: "Title",
@@ -65,8 +67,6 @@ describe StructuredDataHelper, type: "helper" do
     let(:page) { Pages::Page.new("/how-to-page", frontmatter) }
     let(:html) { how_to_structured_data(page) }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
     before { enable_structured_data(:how_to) }
 
@@ -112,6 +112,8 @@ describe StructuredDataHelper, type: "helper" do
   end
 
   describe ".blog_structured_data" do
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
     let(:frontmatter) do
       {
         title: "A title",
@@ -128,8 +130,6 @@ describe StructuredDataHelper, type: "helper" do
     let(:page) { Pages::Page.new("/blog/post", frontmatter) }
     let(:html) { blog_structured_data(page) }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
     before { enable_structured_data(:blog_posting) }
 
@@ -171,10 +171,10 @@ describe StructuredDataHelper, type: "helper" do
   end
 
   describe ".search_structured_data" do
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
     let(:html) { search_structured_data }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
     before { enable_structured_data(:web_site) }
 
@@ -200,10 +200,10 @@ describe StructuredDataHelper, type: "helper" do
   end
 
   describe ".logo_structured_data" do
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
     let(:html) { logo_structured_data }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
     before { enable_structured_data(:organization) }
 
@@ -225,6 +225,8 @@ describe StructuredDataHelper, type: "helper" do
     let(:html) { breadcrumbs_structured_data(breadcrumbs) }
 
     context "when there are breadcrumbs" do
+      subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
       let(:breadcrumbs) do
         [
           Loaf::Breadcrumb.new("Page 1", "/page1", false),
@@ -232,8 +234,6 @@ describe StructuredDataHelper, type: "helper" do
         ]
       end
       let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-      subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
       before { enable_structured_data(:breadcrumb_list) }
 
@@ -281,11 +281,11 @@ describe StructuredDataHelper, type: "helper" do
   end
 
   describe ".event_structured_data" do
+    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
+
     let(:event) { build(:event_api, building: nil) }
     let(:html) { event_structured_data(event) }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
-
-    subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
     before { enable_structured_data(:event) }
 

--- a/spec/lib/acronyms_spec.rb
+++ b/spec/lib/acronyms_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 require "acronyms"
 
 describe Acronyms, type: :helper do
+  subject { described_class.new(content, acronyms).render }
+
   let(:content) { "All prices include VAT except where marked exVAT" }
   let(:acronyms) { { "VAT" => "Value added tax", "HMRC" => "Her Majesty's Revenue and Customs" } }
-
-  subject { described_class.new(content, acronyms).render }
 
   it { is_expected.to match "marked exVAT" }
   it { is_expected.to have_css "abbr[title=\"Value added tax\"]", text: "VAT" }

--- a/spec/lib/asset_checker_spec.rb
+++ b/spec/lib/asset_checker_spec.rb
@@ -18,11 +18,11 @@ describe AssetChecker do
   let(:instance) { described_class.new(root_url) }
 
   describe "#run" do
+    subject(:run) { instance.run }
+
     before do
       stub_request(:get, root_url).to_return(status: 200, body: html)
     end
-
-    subject(:run) { instance.run }
 
     context "when the assets are available" do
       before do

--- a/spec/lib/attribute_filter_spec.rb
+++ b/spec/lib/attribute_filter_spec.rb
@@ -3,10 +3,10 @@ require "attribute_filter"
 
 describe AttributeFilter, type: :helper do
   describe ".filtered_json" do
+    subject { described_class.filtered_json(input) }
+
     let(:model) { GetIntoTeachingApiClient::TeachingEventAddAttendee.new(candidateId: "123", addressTelephone: "1234567") }
     let(:expected_json) { { "candidateId" => "123", "addressTelephone" => "[FILTERED]" }.to_json }
-
-    subject { described_class.filtered_json(input) }
 
     context "with an object" do
       let(:input) { model }

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe BasicAuth do
   end
 
   describe ".env_requires_auth?" do
-    before { allow(Rails.application.config.x).to receive(:basic_auth) { basic_auth } }
-
     subject { instance.env_requires_auth? }
+
+    before { allow(Rails.application.config.x).to receive(:basic_auth) { basic_auth } }
 
     basic_auth_values = {
       nil => false,
@@ -52,10 +52,10 @@ RSpec.describe BasicAuth do
   end
 
   describe ".authenticate" do
+    subject { instance.authenticate(username, password) }
+
     let(:username) { "" }
     let(:password) { "" }
-
-    subject { instance.authenticate(username, password) }
 
     it { is_expected.to be_falsy }
 

--- a/spec/lib/cloud_front_ip_filter_spec.rb
+++ b/spec/lib/cloud_front_ip_filter_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 require "cloud_front_ip_filter"
 
 RSpec.describe CloudFrontIpFilter do
+  subject { described_class.new original }
+
   before do
     stub_request(:get, "https://ip-ranges.amazonaws.com/ip-ranges.json")
       .to_return(status: 401) # will fallback to copy in Gem
   end
-
-  subject { described_class.new original }
 
   let(:original) { ->(ip) { /192\.168\.1\./.match?(ip) } }
 

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -3,13 +3,13 @@ require "lazy_load_images"
 
 describe LazyLoadImages do
   describe "#html" do
+    subject { instance.html }
+
     let(:original_src) { "image.jpg" }
     let(:original_ext) { File.extname(original_src) }
     let(:img) { "<img class=\"test\" src=\"#{original_src}\">" }
     let(:picture) { "<picture>#{img}<source srcset=\"#{original_src}\"></source></picture>" }
     let(:instance) { described_class.new(picture) }
-
-    subject { instance.html }
 
     it do
       lazy_image = "<img class=\"test lazyload\" data-src=\"#{original_src}\">"

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -3,6 +3,8 @@ require "next_gen_images"
 
 describe NextGenImages do
   describe "#html" do
+    subject { instance.html }
+
     let(:original_ext) { File.extname(original_src) }
     let(:body) { "<img src=\"#{original_src}\">" }
     let(:instance) { described_class.new(body) }
@@ -10,8 +12,6 @@ describe NextGenImages do
     before { allow(File).to receive(:exist?) { false } }
 
     before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
-
-    subject { instance.html }
 
     context "when the original image is a jpg" do
       let(:original_src) { "path/to/image.jpg" }

--- a/spec/lib/page_speed_score_spec.rb
+++ b/spec/lib/page_speed_score_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 require "page_speed_score"
 
 describe PageSpeedScore do
+  subject { described_class.new(sitemap_url) }
+
   let(:host) { "https://example.com" }
   let(:sitemap_url) { "#{host}/sitemap.xml" }
-
-  subject { described_class.new(sitemap_url) }
 
   describe "#sitemap_url" do
     it { expect(subject.sitemap_url).to eq(sitemap_url) }

--- a/spec/lib/responsive_images_spec.rb
+++ b/spec/lib/responsive_images_spec.rb
@@ -3,6 +3,8 @@ require "responsive_images"
 
 describe ResponsiveImages do
   describe "#html" do
+    subject { instance.html }
+
     let(:fingerprint) { "-fingerprint1" }
     let(:src) { "media/images/content/an-image#{fingerprint}.jpg" }
     let(:body) do
@@ -14,8 +16,6 @@ describe ResponsiveImages do
     let(:instance) { described_class.new(body) }
 
     before { allow(Dir).to receive(:glob).and_call_original }
-
-    subject { instance.html }
 
     it { is_expected.to include(body) }
 

--- a/spec/models/callbacks/steps/personal_details_spec.rb
+++ b/spec/models/callbacks/steps/personal_details_spec.rb
@@ -10,9 +10,9 @@ describe Callbacks::Steps::PersonalDetails do
   it { is_expected.to respond_to :email }
 
   describe "validations" do
-    before { instance.valid? }
-
     subject { instance.errors.messages }
+
+    before { instance.valid? }
 
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Callbacks::Wizard do
+  subject { described_class.new wizardstore, "privacy_policy" }
+
   let(:uuid) { SecureRandom.uuid }
   let(:store) do
     {
@@ -13,8 +15,6 @@ describe Callbacks::Wizard do
     }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
-
-  subject { described_class.new wizardstore, "privacy_policy" }
 
   describe ".steps" do
     subject { described_class.steps }

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -35,9 +35,9 @@ describe Events::Search do
   end
 
   describe "#available_months" do
-    before { travel_to(DateTime.new(2020, 11, 10)) }
-
     subject { described_class.new(period: period).available_months }
+
+    before { travel_to(DateTime.new(2020, 11, 10)) }
 
     context "when period is future" do
       let(:period) { :future }
@@ -115,11 +115,11 @@ describe Events::Search do
       end
 
       context "with assigned distance" do
-        let(:msg) { "Enter valid full postcode or first part" }
-
         subject do
           described_class.new distance: described_class::DISTANCES.first
         end
+
+        let(:msg) { "Enter valid full postcode or first part" }
 
         it { is_expected.not_to allow_value("").for :postcode }
         it { is_expected.not_to allow_value(nil).for :postcode }
@@ -142,9 +142,9 @@ describe Events::Search do
   end
 
   describe "#query_events" do
-    let(:default_limit) { described_class::RESULTS_PER_TYPE }
-
     subject { build :events_search }
+
+    let(:default_limit) { described_class::RESULTS_PER_TYPE }
 
     before { allow(subject).to receive(:valid?).and_return is_valid }
 
@@ -206,9 +206,9 @@ describe Events::Search do
         end
 
         context "when the month is the current month" do
-          let(:date) { travel_date }
-
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear)).tap(&:validate) }
+
+          let(:date) { travel_date }
 
           it "searches from the beginning of today to the end of the current month" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -218,9 +218,9 @@ describe Events::Search do
         end
 
         context "when the month is the next month" do
-          let(:date) { travel_date.advance(months: 1) }
-
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear)).tap(&:validate) }
+
+          let(:date) { travel_date.advance(months: 1) }
 
           it "searches from the start of the next month to the end" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -247,9 +247,9 @@ describe Events::Search do
         end
 
         context "when the month is the current month" do
-          let(:date) { travel_date }
-
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear), period: :past).tap(&:validate) }
+
+          let(:date) { travel_date }
 
           it "searches from the beginning of the month to the end of yesterday" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -259,9 +259,9 @@ describe Events::Search do
         end
 
         context "when the month is the previous month" do
-          let(:date) { travel_date.advance(months: -1) }
-
           subject { build(:events_search, month: date.to_formatted_s(:humanmonthyear), period: :past).tap(&:validate) }
+
+          let(:date) { travel_date.advance(months: -1) }
 
           it "searches from the start of the previous month to the end" do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -11,9 +11,9 @@ describe Events::Steps::PersonalDetails do
   it { is_expected.to respond_to :is_walk_in }
 
   describe "validations" do
-    before { instance.valid? }
-
     subject { instance.errors.messages }
+
+    before { instance.valid? }
 
     it { is_expected.to include(:first_name) }
     it { is_expected.to include(:last_name) }

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -85,10 +85,10 @@ describe Events::Steps::PersonalisedUpdates do
   end
 
   describe "#export" do
+    subject { instance.export["address_postcode"] }
+
     let(:backingstore) { { "subscribe_to_mailing_list" => true, "address_postcode" => "app-postcode" } }
     let(:crm_backingstore) { {} }
-
-    subject { instance.export["address_postcode"] }
 
     it { is_expected.to eq("app-postcode") }
 
@@ -100,6 +100,8 @@ describe Events::Steps::PersonalisedUpdates do
   end
 
   describe "#teaching_subject_options" do
+    subject { instance.teaching_subject_options }
+
     let(:teaching_subject_types) do
       subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
         GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
@@ -111,8 +113,6 @@ describe Events::Steps::PersonalisedUpdates do
       allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
         receive(:get_teaching_subjects).and_return(teaching_subject_types)
     end
-
-    subject { instance.teaching_subject_options }
 
     it { expect(subject.map(&:id)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
     it { expect(subject.map(&:value)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.keys) }

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Events::Wizard do
+  subject { described_class.new wizardstore, "personalised_updates" }
+
   let(:uuid) { SecureRandom.uuid }
   let(:store) do
     { uuid => {
@@ -11,8 +13,6 @@ describe Events::Wizard do
     } }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
-
-  subject { described_class.new wizardstore, "personalised_updates" }
 
   describe ".steps" do
     subject { described_class.steps }

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -66,13 +66,13 @@ describe Healthcheck do
   end
 
   describe "#test_redis" do
+    subject { described_class.new.test_redis }
+
     before do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("REDIS_URL").and_return \
         "redis://localhost:6379/1"
     end
-
-    subject { described_class.new.test_redis }
 
     context "with working connection" do
       before do

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -279,6 +279,8 @@ describe Internal::Event do
       end
 
       context "when the API raises a server error" do
+        subject { described_class.new }
+
         let(:api_error) { GetIntoTeachingApiClient::ApiError.new(code: 500) }
 
         before do
@@ -287,8 +289,6 @@ describe Internal::Event do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event).and_raise(api_error)
         end
-
-        subject { described_class.new }
 
         it "re-raises the error" do
           expect { subject.save }.to raise_error api_error

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -173,6 +173,8 @@ describe MailingList::Signup do
     end
 
     describe "export_data" do
+      subject { described_class.new(**attributes) }
+
       it { is_expected.to respond_to(:consideration_journey_stages) }
 
       let(:attributes) do
@@ -189,8 +191,6 @@ describe MailingList::Signup do
           address_postcode: "M1 2EJ",
         }
       end
-
-      subject { described_class.new(**attributes) }
 
       specify "returns a hash with correct data" do
         expect(subject.export_data).to eql(attributes.transform_keys(&:to_s))

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -28,14 +28,14 @@ describe MailingList::Steps::Subject do
   end
 
   describe "#teaching_subject_ids" do
+    subject { instance.teaching_subject_ids }
+
     let(:teaching_subject_types) do
       subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
         GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
       )
       subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
     end
-
-    subject { instance.teaching_subject_ids }
 
     it { is_expected.to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
   end

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe MailingList::Wizard do
+  subject { described_class.new wizardstore, "privacy_policy" }
+
   let(:uuid) { SecureRandom.uuid }
   let(:store) do
     { uuid => {
@@ -10,8 +12,6 @@ describe MailingList::Wizard do
     } }
   end
   let(:wizardstore) { Wizard::Store.new store[uuid], {} }
-
-  subject { described_class.new wizardstore, "privacy_policy" }
 
   describe ".steps" do
     subject { described_class.steps }

--- a/spec/models/pages/blog_spec.rb
+++ b/spec/models/pages/blog_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Pages::Blog do
   end
 
   describe ".find" do
-    before { allow(Pages::Page).to receive(:find).with("/some/template").and_return("/some_template.md") }
-
     subject { described_class }
+
+    before { allow(Pages::Page).to receive(:find).with("/some/template").and_return("/some_template.md") }
 
     specify "calls the other method" do
       described_class.find("/some/template")
@@ -44,9 +44,9 @@ RSpec.describe Pages::Blog do
     end
 
     context "when filtering by a single tag" do
-      let(:wanted_tag) { "august" }
-
       subject { described_class.new(pages) }
+
+      let(:wanted_tag) { "august" }
 
       specify "return the right number of posts" do
         expect(subject.posts(wanted_tag).size).to be 2
@@ -77,12 +77,12 @@ RSpec.describe Pages::Blog do
   end
 
   describe "#similar_posts" do
+    subject { described_class.new(pages).similar_posts(origin) }
+
     let(:origin_tags) { %w[june july] }
     let(:origin_path) { :f }
     let(:origin_fm) { OpenStruct.new(tags: origin_tags) }
     let(:origin) { OpenStruct.new(path: origin_path, frontmatter: origin_fm) }
-
-    subject { described_class.new(pages).similar_posts(origin) }
 
     specify "returns pages that have overlapping tags" do
       tags = subject.values.map { |fm| fm[:tags] }
@@ -102,9 +102,9 @@ RSpec.describe Pages::Blog do
     end
 
     context "when a limit is applied" do
-      let(:limit) { 2 }
-
       subject { described_class.new(pages).similar_posts(origin, limit) }
+
+      let(:limit) { 2 }
 
       specify "only the right number of posts are returned" do
         expect(subject.size).to be(limit)

--- a/spec/models/pages/frontmatter_spec.rb
+++ b/spec/models/pages/frontmatter_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Pages::Frontmatter do
   end
 
   describe ".select_by_path" do
-    let(:wanted_path) { "/subfolder" }
-
     subject { described_class.select_by_path(wanted_path, content_dir) }
+
+    let(:wanted_path) { "/subfolder" }
 
     before { allow_any_instance_of(described_class).to receive(:select_by_path).and_call_original }
 

--- a/spec/models/pages/navigation_spec.rb
+++ b/spec/models/pages/navigation_spec.rb
@@ -68,14 +68,14 @@ RSpec.describe Pages::Navigation do
   end
 
   describe Pages::Navigation::Node do
+    subject { described_class.new(outer_navigation, path, front_matter) }
+
     let(:outer_navigation) { Pages::Navigation.new }
     let(:path) { "/an-amazing-page" }
     let(:title) { "Page five" }
     let(:navigation) { 5 }
     let(:menu) { true }
     let(:front_matter) { { title: title, navigation: navigation, menu: menu } }
-
-    subject { described_class.new(outer_navigation, path, front_matter) }
 
     specify "assigns the path" do
       expect(subject.path).to eql(path)
@@ -94,10 +94,10 @@ RSpec.describe Pages::Navigation do
     end
 
     context "when the navigation path is overridden" do
+      subject { described_class.new(outer_navigation, path, front_matter) }
+
       let(:custom_navigation_path) { "/sales" }
       let(:front_matter) { { title: title, navigation: navigation, menu: menu, navigation_path: custom_navigation_path } }
-
-      subject { described_class.new(outer_navigation, path, front_matter) }
 
       specify "assigns the custom path to :path attr" do
         expect(subject.path).to eql(custom_navigation_path)
@@ -106,10 +106,10 @@ RSpec.describe Pages::Navigation do
 
     context "when the title is overridden" do
       context "when a 'navigation_title' is set" do
+        subject { described_class.new(outer_navigation, path, front_matter) }
+
         let(:custom_navigation_title) { "January sales!" }
         let(:front_matter) { { title: title, navigation: navigation, menu: menu, navigation_title: custom_navigation_title } }
-
-        subject { described_class.new(outer_navigation, path, front_matter) }
 
         specify "assigns the custom path to :path attr" do
           expect(subject.title).to eql(custom_navigation_title)
@@ -117,10 +117,10 @@ RSpec.describe Pages::Navigation do
       end
 
       context "when the page 'heading' has been set" do
+        subject { described_class.new(outer_navigation, path, front_matter) }
+
         let(:custom_heading) { "Sale on nowheading" }
         let(:front_matter) { { title: title, navigation: navigation, menu: menu, heading: custom_heading } }
-
-        subject { described_class.new(outer_navigation, path, front_matter) }
 
         specify "assigns the custom path to :path attr" do
           expect(subject.title).to eql(custom_heading)
@@ -169,9 +169,9 @@ RSpec.describe Pages::Navigation do
     end
 
     describe "#children" do
-      let(:nav) { Pages::Navigation.new(page_five_subpages.merge(page_six_subpages)) }
-
       subject { described_class.new(nav, "/page-five", { title: "Five", rank: 5, menu: true }) }
+
+      let(:nav) { Pages::Navigation.new(page_five_subpages.merge(page_six_subpages)) }
 
       specify "contains the right number of children" do
         expect(subject.children.size).to eql(page_five_subpages.size)

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Events::GroupPresenter do
+  subject { described_class.new(events_by_type, display_empty: display_empty_types) }
+
   let(:train_to_teach_events) { build_list(:event_api, 5, :train_to_teach_event) }
   let(:question_time_events) { build_list(:event_api, 5, :question_time_event) }
   let(:online_events) { build_list(:event_api, 2, :online_event) }
@@ -8,8 +10,6 @@ describe Events::GroupPresenter do
   let(:all_events) { [train_to_teach_events, online_events, school_and_university_events, question_time_events].flatten }
   let(:events_by_type) { group_events_by_type(all_events) }
   let(:display_empty_types) { false }
-
-  subject { described_class.new(events_by_type, display_empty: display_empty_types) }
 
   describe "#sorted_events_by_type" do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
@@ -60,14 +60,14 @@ describe Events::GroupPresenter do
     end
 
     describe "sorting within an event type" do
+      subject { described_class.new(group_events_by_type(unsorted_events), display_empty: false, ascending: ascending) }
+
       let(:early) { build(:event_api, :online_event, start_at: 1.week.from_now) }
       let(:middle) { build(:event_api, :online_event, start_at: 2.weeks.from_now) }
       let(:late) { build(:event_api, :online_event, start_at: 3.weeks.from_now) }
       let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
       let(:unsorted_events) { [middle, late, early] }
       let(:ascending) { true }
-
-      subject { described_class.new(group_events_by_type(unsorted_events), display_empty: false, ascending: ascending) }
 
       it "sorts events of the same type by date, ascending" do
         expect(subject.sorted_events_by_type.to_h[type_id]).to eql([early, middle, late])

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -15,17 +15,17 @@ describe Callbacks::StepsController, type: :request do
   let(:step_path) { callbacks_step_path model.key }
 
   describe "#index" do
-    before { get callbacks_steps_path(query: "param") }
-
     subject { response }
+
+    before { get callbacks_steps_path(query: "param") }
 
     it { is_expected.to redirect_to(callbacks_step_path({ id: :personal_details, query: "param" })) }
   end
 
   describe "#show" do
-    before { get step_path }
-
     subject { response }
+
+    before { get step_path }
 
     it { is_expected.to have_http_status :success }
 
@@ -37,12 +37,12 @@ describe Callbacks::StepsController, type: :request do
   end
 
   describe "#update" do
-    let(:key) { model.model_name.param_key }
-
     subject do
       patch step_path, params: { key => details_params }
       response
     end
+
+    let(:key) { model.model_name.param_key }
 
     context "with valid data" do
       let(:details_params) { attributes_for(:callbacks_personal_details) }

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "CSP violation reporting", type: :request do
+  subject { response }
+
   let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
   let(:events) { [] }
 
@@ -9,8 +11,6 @@ describe "CSP violation reporting", type: :request do
     allow(Rails.logger).to receive(:error)
     post csp_reports_path, params: params.to_json
   end
-
-  subject { response }
 
   it { is_expected.to have_http_status(:success) }
   it { expect(Rails.logger).to have_received(:error).with(params).once }

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -24,17 +24,17 @@ describe EventStepsController, type: :request do
   end
 
   describe "#index" do
-    before { get event_steps_path("123", query: "param") }
-
     subject { response }
+
+    before { get event_steps_path("123", query: "param") }
 
     it { is_expected.to redirect_to(event_step_path("123", { id: :personal_details, query: "param" })) }
   end
 
   describe "#show" do
-    before { get step_path }
-
     subject { response }
+
+    before { get step_path }
 
     it { is_expected.to have_http_status :success }
 
@@ -57,6 +57,8 @@ describe EventStepsController, type: :request do
     end
 
     context "when the event does not exist" do
+      subject { response }
+
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
           receive(:get_teaching_event).with("456")
@@ -65,19 +67,17 @@ describe EventStepsController, type: :request do
 
       before { get event_steps_path("456") }
 
-      subject { response }
-
       it { is_expected.to have_http_status :not_found }
     end
   end
 
   describe "#update" do
-    let(:key) { model.model_name.param_key }
-
     subject do
       patch step_path, params: { key => details_params }
       response
     end
+
+    let(:key) { model.model_name.param_key }
 
     context "with valid data" do
       let(:details_params) { attributes_for(:events_personal_details) }

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -19,6 +19,8 @@ describe "View events by category", type: :request do
   end
 
   context "when viewing a category archive" do
+    subject { response }
+
     let(:category) { "online-q-as" }
 
     before do
@@ -26,8 +28,6 @@ describe "View events by category", type: :request do
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
       get archive_event_category_path(category)
     end
-
-    subject { response }
 
     it { is_expected.to have_http_status :success }
     it { expect(response.body).to include "Past online Q&amp;As" }
@@ -44,13 +44,13 @@ describe "View events by category", type: :request do
   end
 
   context "when viewing a category" do
+    subject { response }
+
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
       get event_category_path("train-to-teach-events")
     end
-
-    subject { response }
 
     it { is_expected.to have_http_status :success }
 
@@ -164,10 +164,10 @@ describe "View events by category", type: :request do
     end
 
     context "when there are no results" do
+      subject { parsed_response.css(".no-results").first }
+
       let(:path) { event_category_path("train-to-teach-events") }
       let(:events) { [] }
-
-      subject { parsed_response.css(".no-results").first }
 
       it { is_expected.not_to be_nil }
       it { expect(subject.text).to include("Sorry your search has not found any events") }
@@ -175,11 +175,11 @@ describe "View events by category", type: :request do
   end
 
   context "when a category does not exist" do
+    subject { response }
+
     before do
       get event_category_path("non-existant")
     end
-
-    subject { response }
 
     it { is_expected.to have_http_status :not_found }
   end

--- a/spec/requests/external_links_image_spec.rb
+++ b/spec/requests/external_links_image_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe "External link images", type: :request do
   excluded_classes = %w[button]
-  before { get "/ways-to-train" }
-
   subject { response.body }
+
+  before { get "/ways-to-train" }
 
   context "when external link and not #{excluded_classes.join(' ')}" do
     it "adds an external link icon" do

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe "Find an event near you", type: :request do
   include_context "with stubbed types api"
 
+  subject { response }
+
   let(:no_events_regex) { /Sorry your search has not found any events/ }
   let(:no_ttt_events_regex) { /There are no Train to Teach events in your chosen month/ }
   let(:category_headings_regex) { /<h3>(Train to Teach events|Online Q&amp;As|School and University events)<\/h3>/ }
@@ -15,8 +17,6 @@ describe "Find an event near you", type: :request do
     end
   end
   let(:events_by_type) { group_events_by_type(events) }
-
-  subject { response }
 
   context "when landing on the page initially" do
     let(:expected_request_attributes) { { start_after: DateTime.now.utc.beginning_of_day } }

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe "ensuring frontmatter from content pages is rendered", type: :request do
   context "with an accordion layout" do
-    before { get "/content-page" }
-
     subject { response.body }
+
+    before { get "/content-page" }
 
     it { expect(response).to have_http_status(200) }
 
@@ -23,9 +23,9 @@ describe "ensuring frontmatter from content pages is rendered", type: :request d
   end
 
   context "with a different heading and title" do
-    before { get "/custom-heading" }
-
     subject { response.body }
+
+    before { get "/custom-heading" }
 
     let(:document) { Nokogiri.parse(response.body) }
 

--- a/spec/requests/lazy_load_images_spec.rb
+++ b/spec/requests/lazy_load_images_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe "Lazy Load Images", type: :request do
+  subject { response.body }
+
   before do
     get root_path
   end
-
-  subject { response.body }
 
   it { is_expected.to include("data-src") }
   it { is_expected.to include("lazyload") }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 describe "LID tracking pixels", type: :request do
+  subject { response.body }
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type) { [] }
   end
 
   before { get path }
-
-  subject { response.body }
 
   context "when visiting /events" do
     let(:path) { events_path }

--- a/spec/requests/mailing_list/calls_to_action_spec.rb
+++ b/spec/requests/mailing_list/calls_to_action_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe "Mailing list calls to action", type: :request do
   describe "banner" do
-    before { get root_path }
-
     subject { Nokogiri.parse(response.body) }
+
+    before { get root_path }
 
     it "the mailing list banner has a close link" do
       link = subject.at_css("#mailing-list-bar-dismiss")

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -16,17 +16,17 @@ describe MailingList::StepsController, type: :request do
   let(:step_path) { mailing_list_step_path model.key }
 
   describe "#index" do
-    before { get mailing_list_steps_path(query: "param") }
-
     subject { response }
+
+    before { get mailing_list_steps_path(query: "param") }
 
     it { is_expected.to redirect_to(mailing_list_step_path({ id: :name, query: "param" })) }
   end
 
   describe "#show" do
-    before { get step_path }
-
     subject { response }
+
+    before { get step_path }
 
     it { is_expected.to have_http_status :success }
 
@@ -86,12 +86,12 @@ describe MailingList::StepsController, type: :request do
   end
 
   describe "#update" do
-    let(:key) { model.model_name.param_key }
-
     subject do
       patch step_path, params: { key => details_params }
       response
     end
+
+    let(:key) { model.model_name.param_key }
 
     context "with valid data" do
       let(:details_params) { attributes_for(:mailing_list_name) }

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe "Next Gen Images", type: :request do
+  subject { response.body }
+
   before do
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with(/.*\.svg/) { true }
     get root_path
   end
-
-  subject { response.body }
 
   it do
     is_expected.to match(

--- a/spec/requests/page_with_custom_layout_spec.rb
+++ b/spec/requests/page_with_custom_layout_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe "rendering pages with a custom layout", type: :request do
   context "with a home page layout" do
-    before { get "/home-page" }
-
     subject { response.body }
+
+    before { get "/home-page" }
 
     it { expect(response).to have_http_status(200) }
     it { is_expected.to include("Home Page Test") }
@@ -14,9 +14,9 @@ describe "rendering pages with a custom layout", type: :request do
   end
 
   context "with a stories/story layout" do
-    before { get "/stories/story-page" }
-
     subject { response.body }
+
+    before { get "/stories/story-page" }
 
     it { expect(response).to have_http_status(200) }
     it { is_expected.to include("Story Page Test") }
@@ -25,9 +25,9 @@ describe "rendering pages with a custom layout", type: :request do
   end
 
   context "with a stories/list layout" do
-    before { get "/stories/list-page" }
-
     subject { response.body }
+
+    before { get "/stories/list-page" }
 
     it { expect(response).to have_http_status(200) }
     it { is_expected.to include("List Page Test") }
@@ -39,9 +39,9 @@ describe "rendering pages with a custom layout", type: :request do
   end
 
   context "with a stories/landing layout" do
-    before { get "/stories/landing-page" }
-
     subject { response.body }
+
+    before { get "/stories/landing-page" }
 
     it { expect(response).to have_http_status(200) }
     it { is_expected.to include("Landing Page Test") }

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -44,31 +44,31 @@ describe PagesController, type: :request do
     end
 
     context "with unknown page" do
-      before { get "/testing/unknown" }
-
       subject { response }
+
+      before { get "/testing/unknown" }
 
       it { is_expected.to have_http_status :not_found }
       it { is_expected.to have_attributes body: %r{Page not found} }
     end
 
     context "with cookies page" do
-      before { get "/cookies" }
-
       subject { response }
+
+      before { get "/cookies" }
 
       it { is_expected.to have_http_status(:success) }
     end
 
     context "with invalid page" do
+      subject { response }
+
       before do
         allow_any_instance_of(described_class).to \
           receive(:render).with(status: :not_found, body: nil).and_call_original
 
         get "/../../secrets.txt"
       end
-
-      subject { response }
 
       it { is_expected.to have_http_status :not_found }
       it { is_expected.to have_attributes body: "" }

--- a/spec/requests/robots_controller_spec.rb
+++ b/spec/requests/robots_controller_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe RobotsController, type: :request do
-  before { get("/robots.txt") }
-
   subject { response.body }
+
+  before { get("/robots.txt") }
 
   it do
     is_expected.to eq(

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe "Google Structured Data", type: :request do
+  subject(:structured_data) { json_contents.map { |json| JSON.parse(json, symbolize_names: true) } }
+
   let(:parsed_response) { Nokogiri.parse(response.body) }
   let(:json_contents) { parsed_response.css("script[type='application/ld+json']").map(&:content) }
-
-  subject(:structured_data) { json_contents.map { |json| JSON.parse(json, symbolize_names: true) } }
 
   before do
     %i[how_to event blog_posting organization breadcrumb_list web_site].each do |type|

--- a/spec/requests/vwo_spec.rb
+++ b/spec/requests/vwo_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "VWO", type: :request do
+  subject { response.body }
+
   let(:config_path) { Rails.root.join("config/vwo.yml") }
   let(:yaml) do
     <<-YAML
@@ -18,8 +20,6 @@ describe "VWO", type: :request do
     allow(File).to receive(:read).and_call_original
     allow(File).to receive(:read).with(config_path) { yaml }
   end
-
-  subject { response.body }
 
   context "when the path exists in the VWO config" do
     before { get "/vwo-test" }

--- a/spec/support/callback_booking_quotas.rb
+++ b/spec/support/callback_booking_quotas.rb
@@ -20,9 +20,9 @@ RSpec.shared_examples "exposes callback booking quotas" do
   let(:quotas) { [quota_in_30_minutes, quota_in_90_minutes] }
 
   describe "#callback_booking_quotas" do
-    let(:time_zone) { "UTC" }
-
     subject { described_class.callback_booking_quotas }
+
+    let(:time_zone) { "UTC" }
 
     around do |example|
       Time.use_zone(time_zone) { example.run }

--- a/spec/support/rate_limiting_support.rb
+++ b/spec/support/rate_limiting_support.rb
@@ -1,5 +1,7 @@
 shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
   describe desc do
+    subject { response.status }
+
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
     before do
@@ -7,8 +9,6 @@ shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
       freeze_time
       request_count.times { perform_request }
     end
-
-    subject { response.status }
 
     context "when fewer than rate limit" do
       let(:request_count) { limit - 1 }

--- a/spec/support/resend_verification_support.rb
+++ b/spec/support/resend_verification_support.rb
@@ -6,8 +6,6 @@ shared_examples "a controller with a #resend_verification action" do
     end
 
     context "when the API returns 429 too many requests" do
-      let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
-
       subject! do
         allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
           receive(:create_candidate_access_token).and_raise(too_many_requests_error)
@@ -15,18 +13,20 @@ shared_examples "a controller with a #resend_verification action" do
         response.body
       end
 
+      let(:too_many_requests_error) { GetIntoTeachingApiClient::ApiError.new(code: 429) }
+
       it { is_expected.to match(/Error 429/) }
       it { is_expected.to match(/Too many requests/) }
     end
 
     context "when the API returns 400 bad request" do
-      let(:bad_request_error) { GetIntoTeachingApiClient::ApiError.new(code: 400) }
-
       subject! do
         allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
           receive(:create_candidate_access_token).and_raise(bad_request_error)
         perform_request
       end
+
+      let(:bad_request_error) { GetIntoTeachingApiClient::ApiError.new(code: 400) }
 
       it { is_expected.to redirect_to(controller.send(:step_path, controller.wizard_class.steps.first.key)) }
     end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -6,12 +6,13 @@ end
 
 shared_context "with wizard step" do
   include_context "with wizard store"
+  subject { instance }
+
   let(:attributes) { {} }
   let(:wizard) { TestWizard.new(wizardstore, TestWizard::Name.key) }
   let(:instance) do
     described_class.new wizard, wizardstore, attributes
   end
-  subject { instance }
 end
 
 shared_context "with wizard data" do

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe EmailFormatValidator do
+  subject { instance.errors.to_hash }
+
   let :test_model do
     Class.new do
       include ActiveModel::Model
@@ -14,8 +16,6 @@ describe EmailFormatValidator do
   end
 
   before { instance.valid? }
-
-  subject { instance.errors.to_hash }
 
   context "with invalid addresses" do
     %w[test.com test@@test.com test@test test@test.].each do |email|

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe PostcodeValidator do
+  subject { instance.errors.to_hash }
+
   let(:test_model) do
     Class.new do
       include ActiveModel::Model
@@ -14,8 +16,6 @@ describe PostcodeValidator do
   end
 
   before { instance.valid? }
-
-  subject { instance.errors.to_hash }
 
   context "with invalid full postcodes" do
     ["F00BAR", "123ABC", "TE57 ING"].each do |postcode|

--- a/spec/validators/telephone_validator_spec.rb
+++ b/spec/validators/telephone_validator_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe TelephoneValidator do
+  subject { instance.errors.to_hash }
+
   let :test_model do
     Class.new do
       include ActiveModel::Model
@@ -15,8 +17,6 @@ describe TelephoneValidator do
   end
 
   before { instance.valid? }
-
-  subject { instance.errors.to_hash }
 
   %w[1234 123456789123456789123 1feg313153gewg1 random].each do |number|
     context "checking '#{number}'" do


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

- Enable RSpec/LeadingSubject Rubocop rule

Enable the `RSpec/LeadingSubject` Rubocop rule and fix the violations.

- Ignore RSpec/NamedSubject Rubocop rule

In trying to enable this it flags up >200 violations and I don't think its worth fixing these; its not a particularly bad one anyway.

- Disable RSpec/SubjectStub Rubocop rule

We stub the subject under test in a couple of places to avoid complex setup; I think the benefit here outweighs the issues with this cop.