### PR TITLE
Remaining Rubocop/RSpec rule fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,11 +70,11 @@ RSpec/SubjectStub:
   Exclude:
     - spec/**/*.rb
 
-# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
-
 RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb
+
+# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/MessageSpies:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,11 +84,3 @@ RSpec/MultipleExpectations:
 
 RSpec/NestedGroups:
   Max: 6
-
-# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
-
-RSpec/ScatteredSetup:
-  Exclude:
-    - spec/**/*.rb
-
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,10 +76,6 @@ RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb
 
-RSpec/LetBeforeExamples:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/MessageSpies:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,11 +74,11 @@ RSpec/ExampleLength:
   Exclude:
     - spec/**/*.rb
 
-# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
-
 RSpec/MessageSpies:
   Exclude:
     - spec/**/*.rb
+
+# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/MultipleExpectations:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,11 +78,11 @@ RSpec/MessageSpies:
   Exclude:
     - spec/**/*.rb
 
-# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
-
 RSpec/MultipleExpectations:
   Exclude:
     - spec/**/*.rb
+
+# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/NestedGroups:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,11 +82,10 @@ RSpec/MultipleExpectations:
   Exclude:
     - spec/**/*.rb
 
-# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
-
 RSpec/NestedGroups:
-  Exclude:
-    - spec/**/*.rb
+  Max: 6
+
+# FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
 RSpec/ScatteredLet:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,10 +92,6 @@ RSpec/NestedGroups:
   Exclude:
     - spec/**/*.rb
 
-RSpec/ReturnFromStub:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ScatteredLet:
   Exclude:
     - spec/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,10 +87,6 @@ RSpec/NestedGroups:
 
 # FIXME Temporary whilst updating specs - to be removed in subsequent PRs
 
-RSpec/ScatteredLet:
-  Exclude:
-    - spec/**/*.rb
-
 RSpec/ScatteredSetup:
   Exclude:
     - spec/**/*.rb

--- a/spec/components/footer/cookie_acceptance_component_spec.rb
+++ b/spec/components/footer/cookie_acceptance_component_spec.rb
@@ -20,9 +20,8 @@ describe Footer::CookieAcceptanceComponent, type: "component" do
       allow_any_instance_of(ActionDispatch::TestRequest).to(
         receive(:user_agent).and_return("a-user-agent-string-that-ends-in-Silktide"),
       )
+      subject
     end
-
-    before { subject }
 
     specify "nothing is rendered" do
       expect(rendered_component).to be_empty

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { event }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_grouped_by_type) { [] }
+      receive(:search_teaching_events_grouped_by_type).and_return([])
   end
 
   before { visit path }

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -12,9 +12,9 @@ RSpec.feature "Breadcrumbs", type: :feature do
       receive(:get_teaching_event) { event }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type).and_return([])
-  end
 
-  before { visit path }
+    visit path
+  end
 
   context "when visiting the home page" do
     let(:path) { "/home-page" }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Event wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
       receive(:get_latest_privacy_policy).and_return(latest_privacy_policy)
     allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
-      receive(:get_teaching_event_types) { [] }
+      receive(:get_teaching_event_types).and_return([])
   end
 
   scenario "Full journey as a walk-in candidate (closed event)" do

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -36,10 +36,10 @@ RSpec.feature "Internal section", type: :feature do
     end
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi).to \
-      receive(:get_teaching_event_buildings) { [] }
+      receive(:get_teaching_event_buildings).and_return([])
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:upsert_teaching_event) { [] }
+      receive(:upsert_teaching_event).and_return([])
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { pending_provider_event }

--- a/spec/helpers/callback_helper_spec.rb
+++ b/spec/helpers/callback_helper_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe CallbackHelper, type: :helper do
   around do |example|
-    travel_to(utc_today) { example.run }
+    travel_to(utc_today) do
+      Time.use_zone(time_zone) { example.run }
+    end
   end
 
   let(:time_zone) { "UTC" }
@@ -21,10 +23,6 @@ RSpec.describe CallbackHelper, type: :helper do
     )
   end
   let(:quotas) { [quota_today, quota_tomorrow] }
-
-  around do |example|
-    Time.use_zone(time_zone) { example.run }
-  end
 
   describe "#callback_options" do
     subject { callback_options(quotas) }

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -70,7 +70,7 @@ describe EventsHelper, type: "helper" do
     subject { event_location_map(event) }
 
     before do
-      allow(Rails.application.config.x).to receive(:google_maps_key) { "12345" }
+      allow(Rails.application.config.x).to receive(:google_maps_key).and_return("12345")
     end
 
     it { is_expected.to match(/data-map-description=\"Line 1,\nLine 2,\nManchester,\nMA1 1AM\" /) }

--- a/spec/helpers/maps_helper_spec.rb
+++ b/spec/helpers/maps_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MapsHelper, type: :helper do
   let(:zoom) { 8 }
 
   before do
-    allow(Rails.application.config.x).to receive(:google_maps_key) { "12345" }
+    allow(Rails.application.config.x).to receive(:google_maps_key).and_return("12345")
   end
 
   describe ".static_map_url" do

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -379,7 +379,7 @@ describe StructuredDataHelper, type: "helper" do
 
   def enable_structured_data(type)
     allow(Rails.application.config.x.structured_data).to \
-      receive(type) { true }
+      receive(type).and_return(true)
   end
 
   def disable_structured_data(type, value = false)

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -9,9 +9,9 @@ describe NextGenImages do
     let(:body) { "<img src=\"#{original_src}\">" }
     let(:instance) { described_class.new(body) }
 
-    before { allow(File).to receive(:exist?) { false } }
+    before { allow(File).to receive(:exist?).and_return(false) }
 
-    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}") { true } }
+    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}").and_return(true) }
 
     context "when the original image is a jpg" do
       let(:original_src) { "path/to/image.jpg" }
@@ -37,7 +37,7 @@ describe NextGenImages do
 
         before do
           next_gen_imgs.values.each do |src|
-            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}") { true }
+            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}").and_return(true)
           end
         end
 

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -9,9 +9,10 @@ describe NextGenImages do
     let(:body) { "<img src=\"#{original_src}\">" }
     let(:instance) { described_class.new(body) }
 
-    before { allow(File).to receive(:exist?).and_return(false) }
-
-    before { allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}").and_return(true) }
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}").and_return(true)
+    end
 
     context "when the original image is a jpg" do
       let(:original_src) { "path/to/image.jpg" }

--- a/spec/lib/page_speed_score_spec.rb
+++ b/spec/lib/page_speed_score_spec.rb
@@ -17,7 +17,7 @@ describe PageSpeedScore do
 
     before do
       allow(Rails.application.credentials).to \
-        receive(:page_speed_insights_key) { "12345" }
+        receive(:page_speed_insights_key).and_return("12345")
     end
 
     it "retrieves the scores for each page/strategy combination and sends them to prometheus" do

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -98,9 +98,8 @@ describe TemplateHandlers::Markdown, type: :view do
       MARKDOWN
     end
 
-    before { view.instance_variable_set("@front_matter", original_front_matter) }
-
     before do
+      view.instance_variable_set("@front_matter", original_front_matter)
       stub_template "test.md" => markdown
       render template: "test"
     end
@@ -216,9 +215,6 @@ describe TemplateHandlers::Markdown, type: :view do
 
     before do
       allow(described_class).to receive(:global_front_matter).and_return(front_matter_with_calls_to_action)
-    end
-
-    before do
       stub_template "page_with_rich_content.md" => markdown
       render template: "page_with_rich_content"
     end
@@ -257,9 +253,6 @@ describe TemplateHandlers::Markdown, type: :view do
 
     before do
       allow(described_class).to receive(:global_front_matter).and_return(front_matter_with_images)
-    end
-
-    before do
       stub_template "page_with_rich_content.md" => markdown
       render template: "page_with_rich_content"
     end

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -39,7 +39,7 @@ describe Callbacks::Wizard do
     end
 
     before do
-      allow(subject).to receive(:valid?) { true }
+      allow(subject).to receive(:valid?).and_return(true)
       allow_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
         receive(:book_get_into_teaching_callback).with(request)
       allow(Rails.logger).to receive(:info)

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -145,9 +145,6 @@ describe Events::Search do
     subject { build :events_search }
 
     let(:default_limit) { described_class::RESULTS_PER_TYPE }
-
-    before { allow(subject).to receive(:valid?).and_return is_valid }
-
     let(:expected_attributes) do
       {
         type_ids: [subject.type],
@@ -158,6 +155,8 @@ describe Events::Search do
         quantity_per_type: default_limit,
       }
     end
+
+    before { allow(subject).to receive(:valid?).and_return is_valid }
 
     context "when valid" do
       let(:is_valid) { true }

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -36,7 +36,7 @@ describe Events::Wizard do
     end
 
     before do
-      allow(subject).to receive(:valid?) { true }
+      allow(subject).to receive(:valid?).and_return(true)
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:add_teaching_event_attendee).with(request)
       allow(Rails.logger).to receive(:info)

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -249,7 +249,7 @@ describe Internal::Event do
 
     context "when the result is invalid" do
       it "returns false" do
-        allow_any_instance_of(described_class).to receive(:invalid?) { true }
+        allow_any_instance_of(described_class).to receive(:invalid?).and_return(true)
         expect(described_class.new.save).to be false
       end
     end
@@ -261,7 +261,7 @@ describe Internal::Event do
         let(:api_error) { GetIntoTeachingApiClient::ApiError.new(code: 400, response_body: json_error) }
 
         before do
-          allow_any_instance_of(described_class).to receive(:invalid?) { false }
+          allow_any_instance_of(described_class).to receive(:invalid?).and_return(false)
 
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event) { raise api_error }
@@ -284,7 +284,7 @@ describe Internal::Event do
         let(:api_error) { GetIntoTeachingApiClient::ApiError.new(code: 500) }
 
         before do
-          allow_any_instance_of(described_class).to receive(:invalid?) { false }
+          allow_any_instance_of(described_class).to receive(:invalid?).and_return(false)
 
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:upsert_teaching_event).and_raise(api_error)
@@ -370,7 +370,7 @@ describe Internal::Event do
 
     context "when event is valid" do
       it "returns false when building is invalid" do
-        allow_any_instance_of(Internal::EventBuilding).to receive(:invalid?) { true }
+        allow_any_instance_of(Internal::EventBuilding).to receive(:invalid?).and_return(true)
         expect(event.invalid?).to be true
       end
 
@@ -381,14 +381,14 @@ describe Internal::Event do
 
       it "returns false when building is valid" do
         event.venue_type = described_class::VENUE_TYPES[:existing]
-        allow_any_instance_of(Internal::EventBuilding).to receive(:invalid?) { false }
+        allow_any_instance_of(Internal::EventBuilding).to receive(:invalid?).and_return(false)
         expect(event.invalid?).to be false
       end
     end
 
     context "when event is invalid" do
       it "returns true" do
-        allow_any_instance_of(described_class).to receive(:invalid?) { true }
+        allow_any_instance_of(described_class).to receive(:invalid?).and_return(true)
         expect(event.invalid?).to be true
       end
     end

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -121,9 +121,9 @@ describe MailingList::Signup do
     describe "#query_degree_status" do
       before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
-      it { is_expected.to respond_to(:query_channels) }
-
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi) }
+
+      it { is_expected.to respond_to(:query_channels) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_qualification_degree_status)
@@ -134,9 +134,9 @@ describe MailingList::Signup do
     describe "#query_channels" do
       before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
-      it { is_expected.to respond_to(:query_channels) }
-
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi) }
+
+      it { is_expected.to respond_to(:query_channels) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_candidate_mailing_list_subscription_channels)
@@ -147,9 +147,9 @@ describe MailingList::Signup do
     describe "#teaching_subjects" do
       before { allow(GetIntoTeachingApiClient::LookupItemsApi).to receive(:new).and_return(api) }
 
-      it { is_expected.to respond_to(:teaching_subjects) }
-
       let(:api) { instance_double(GetIntoTeachingApiClient::LookupItemsApi, get_teaching_subjects: []) }
+
+      it { is_expected.to respond_to(:teaching_subjects) }
 
       specify "should call the LookupItemsApi" do
         expect(api).to receive(:get_teaching_subjects)
@@ -160,9 +160,9 @@ describe MailingList::Signup do
     describe "#consideration_journey_stages" do
       before { allow(GetIntoTeachingApiClient::PickListItemsApi).to receive(:new).and_return(api) }
 
-      it { is_expected.to respond_to(:consideration_journey_stages) }
-
       let(:api) { instance_double(GetIntoTeachingApiClient::PickListItemsApi, get_candidate_journey_stages: []) }
+
+      it { is_expected.to respond_to(:consideration_journey_stages) }
 
       specify "should call the PickListItemsApi" do
         expect(api).to receive(:get_candidate_journey_stages)
@@ -172,8 +172,6 @@ describe MailingList::Signup do
 
     describe "export_data" do
       subject { described_class.new(**attributes) }
-
-      it { is_expected.to respond_to(:consideration_journey_stages) }
 
       let(:attributes) do
         {
@@ -189,6 +187,8 @@ describe MailingList::Signup do
           address_postcode: "M1 2EJ",
         }
       end
+
+      it { is_expected.to respond_to(:consideration_journey_stages) }
 
       specify "returns a hash with correct data" do
         expect(subject.export_data).to eql(attributes.transform_keys(&:to_s))

--- a/spec/models/mailing_list/signup_spec.rb
+++ b/spec/models/mailing_list/signup_spec.rb
@@ -106,9 +106,7 @@ describe MailingList::Signup do
       subject { described_class.new(email: "test@test.org") }
 
       before do
-        allow_any_instance_of(described_class).to receive(:verify_timed_one_password_and_update_identification_info) do
-          true
-        end
+        allow_any_instance_of(described_class).to receive(:verify_timed_one_password_and_update_identification_info).and_return(true)
       end
 
       it { is_expected.to allow_value("000000").for(:timed_one_time_password).on(:verify) }

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -7,13 +7,13 @@ describe MailingList::Steps::DegreeStatus do
       receive(:get_qualification_degree_status).and_return(degree_status_option_types)
   end
 
-  it_behaves_like "a with wizard step"
-
   let(:degree_status_option_types) do
     GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
+
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :degree_status_id }
 

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -7,13 +7,13 @@ describe MailingList::Steps::Name do
       receive(:get_candidate_mailing_list_subscription_channels).and_return(channels)
   end
 
-  it_behaves_like "a with wizard step"
-
   let(:channels) do
     GetIntoTeachingApiClient::Constants::CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
+
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe MailingList::Steps::Postcode do
   include_context "with wizard step"
-  it_behaves_like "a with wizard step"
-
   let(:msg) { "Enter a valid postcode" }
+
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :address_postcode }
   it { expect(subject).to be_optional }

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -7,13 +7,13 @@ describe MailingList::Steps::Subject do
       receive(:get_teaching_subjects).and_return(teaching_subject_types)
   end
 
-  it_behaves_like "a with wizard step"
-
   let(:teaching_subject_types) do
     GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
       GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k })
     end
   end
+
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :preferred_teaching_subject_id }
 

--- a/spec/models/mailing_list/steps/teacher_training_spec.rb
+++ b/spec/models/mailing_list/steps/teacher_training_spec.rb
@@ -7,13 +7,13 @@ describe MailingList::Steps::TeacherTraining do
       receive(:get_candidate_journey_stages).and_return(consideration_journey_stage_types)
   end
 
-  it_behaves_like "a with wizard step"
-
   let(:consideration_journey_stage_types) do
     GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end
+
+  it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :consideration_journey_stage_id }
 

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -38,7 +38,7 @@ describe MailingList::Wizard do
     end
 
     before do
-      allow(subject).to receive(:valid?) { true }
+      allow(subject).to receive(:valid?).and_return(true)
       allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
         receive(:add_mailing_list_member).with(request)
       allow(Rails.logger).to receive(:info)

--- a/spec/models/pages/navigation_spec.rb
+++ b/spec/models/pages/navigation_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Pages::Navigation do
       let(:front_matter) { {} }
 
       before do
-        allow(Rails.logger).to receive(:warn) { true }
+        allow(Rails.logger).to receive(:warn).and_return(true)
       end
 
       specify "title is nil and warning logged" do

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Basic auth", type: :request do
   end
 
   context "when basic auth is disabled" do
-    before { allow(Rails.application.config.x).to receive(:basic_auth) { "0" } }
+    before { allow(Rails.application.config.x).to receive(:basic_auth).and_return("0") }
 
     it "is not enforced" do
       get root_path
@@ -18,7 +18,7 @@ RSpec.describe "Basic auth", type: :request do
   end
 
   context "when basic auth is enabled" do
-    before { allow(Rails.application.config.x).to receive(:basic_auth) { "1" } }
+    before { allow(Rails.application.config.x).to receive(:basic_auth).and_return("1") }
 
     it "returns unauthorized if credentials do not match" do
       get root_path, params: {}, headers: basic_auth_headers(username, "wrong-password")

--- a/spec/requests/beta_redirect_spec.rb
+++ b/spec/requests/beta_redirect_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 describe "Redirecting beta-getintoteaching.education.gov.uk to getintoteaching.education.gov.uk", type: :request do
-  before { allow(Rails.configuration.x).to receive(:enable_beta_redirects).and_return(true) }
-
-  before { host!("beta-getintoteaching.education.gov.uk") }
+  before do
+    allow(Rails.configuration.x).to receive(:enable_beta_redirects).and_return(true)
+    host!("beta-getintoteaching.education.gov.uk")
+  end
 
   it "redirects content pages" do
     get "/a-very-nice-page?something=value"

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -63,9 +63,8 @@ describe EventStepsController, type: :request do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
           receive(:get_teaching_event).with("456")
           .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
+        get event_steps_path("456")
       end
-
-      before { get event_steps_path("456") }
 
       it { is_expected.to have_http_status :not_found }
     end

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -25,9 +25,8 @@ describe "Find an event near you", type: :request do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type)
         .with(a_hash_including(expected_request_attributes)) { events_by_type }
+      get events_path
     end
-
-    before { get events_path }
 
     it { is_expected.to have_http_status :success }
 
@@ -71,9 +70,8 @@ describe "Find an event near you", type: :request do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
+      get search_events_path(events_search: { type: type_id, month: "2020-07" })
     end
-
-    before { get search_events_path(events_search: { type: type_id, month: "2020-07" }) }
 
     it "displays only the category filtered to" do
       headings = response.body.scan(category_headings_regex).flatten
@@ -126,9 +124,8 @@ describe "Find an event near you", type: :request do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type) { events_by_type }
+      get search_events_path(events_search: { month: "2020-07" })
     end
-
-    before { get search_events_path(events_search: { month: "2020-07" }) }
 
     it "displays events" do
       expect(response.body.scan(/Event \d/).count).to eq(events.count)

--- a/spec/requests/healthchecks_controller_spec.rb
+++ b/spec/requests/healthchecks_controller_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe HealthchecksController, type: :request do
   before do
-    allow_any_instance_of(Healthcheck).to receive(:test_api) { true }
-    allow_any_instance_of(Healthcheck).to receive(:test_redis) { false }
-    allow_any_instance_of(Healthcheck).to receive(:content_sha) { "abc" }
-    allow_any_instance_of(Healthcheck).to receive(:app_sha) { "123" }
+    allow_any_instance_of(Healthcheck).to receive(:test_api).and_return(true)
+    allow_any_instance_of(Healthcheck).to receive(:test_redis).and_return(false)
+    allow_any_instance_of(Healthcheck).to receive(:content_sha).and_return("abc")
+    allow_any_instance_of(Healthcheck).to receive(:app_sha).and_return("123")
     allow(Rails.logger).to receive(:info)
   end
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -39,7 +39,7 @@ describe Internal::EventsController, type: :request do
       context "when there are no pending #{event_type || default_event_type} events" do
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-            .to receive(:search_teaching_events_grouped_by_type) { [] }
+            .to receive(:search_teaching_events_grouped_by_type).and_return([])
 
           get internal_events_path, headers: generate_auth_headers(:author), params: { event_type: event_type }
         end
@@ -214,7 +214,7 @@ describe Internal::EventsController, type: :request do
   describe "#new" do
     before do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-        .to receive(:get_teaching_event_buildings) { [] }
+        .to receive(:get_teaching_event_buildings).and_return([])
     end
 
     shared_examples "new event" do |event_params|
@@ -232,7 +232,7 @@ describe Internal::EventsController, type: :request do
 
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-            .to receive(:get_teaching_event_buildings) { [] }
+            .to receive(:get_teaching_event_buildings).and_return([])
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:get_teaching_event).with(event_to_duplicate_readable_id) { pending_online_event }
         end
@@ -275,7 +275,7 @@ describe Internal::EventsController, type: :request do
     context "when any user type" do
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-          .to receive(:get_teaching_event_buildings) { [] }
+          .to receive(:get_teaching_event_buildings).and_return([])
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
           .to receive(:get_teaching_event).with(event_to_edit_readable_id) { pending_provider_event }
 
@@ -457,7 +457,7 @@ describe Internal::EventsController, type: :request do
       context "when provider event" do
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-            .to receive(:get_teaching_event_buildings) { [] }
+            .to receive(:get_teaching_event_buildings).and_return([])
         end
 
         let(:event) { pending_provider_event }
@@ -560,7 +560,7 @@ describe Internal::EventsController, type: :request do
       context "when provider event" do
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-            .to receive(:get_teaching_event_buildings) { [] }
+            .to receive(:get_teaching_event_buildings).and_return([])
         end
 
         let(:event) { pending_provider_event }
@@ -634,7 +634,7 @@ describe Internal::EventsController, type: :request do
     context "when there a no events" do
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-          .to receive(:search_teaching_events_grouped_by_type) { [] }
+          .to receive(:search_teaching_events_grouped_by_type).and_return([])
       end
 
       it "shows 'no open events'" do

--- a/spec/requests/internal_controller_spec.rb
+++ b/spec/requests/internal_controller_spec.rb
@@ -10,7 +10,7 @@ describe InternalController, type: :request do
     BasicAuth.class_variable_set(:@@credentials, nil)
 
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
-      .to receive(:search_teaching_events_grouped_by_type) { [] }
+      .to receive(:search_teaching_events_grouped_by_type).and_return([])
 
     allow(Rails.application.config.x).to receive(:http_auth) do
       "#{publisher_username}|#{publisher_password}|publisher,#{author_username}|#{author_password}|author"

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -5,7 +5,7 @@ describe "LID tracking pixels", type: :request do
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-      receive(:search_teaching_events_grouped_by_type) { [] }
+      receive(:search_teaching_events_grouped_by_type).and_return([])
   end
 
   before { get path }

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -6,9 +6,8 @@ describe "LID tracking pixels", type: :request do
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type).and_return([])
+    get path
   end
-
-  before { get path }
 
   context "when visiting /events" do
     let(:path) { events_path }

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -5,7 +5,7 @@ describe "Next Gen Images", type: :request do
 
   before do
     allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with(/.*\.svg/) { true }
+    allow(File).to receive(:exist?).with(/.*\.svg/).and_return(true)
     get root_path
   end
 

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -80,7 +80,7 @@ describe "Rate limiting", type: :request do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:upsert_teaching_event).and_return event
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi)
-        .to receive(:get_teaching_event_buildings) { [] }
+        .to receive(:get_teaching_event_buildings).and_return([])
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
         .to receive(:get_teaching_event).with(event[:id]) { build(:event_api) }
 

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe SitemapController, type: :request do
     }
   end
 
-  before { allow(Pages::Frontmatter).to receive(:list) { content_pages } }
-
-  before { get("/sitemap.xml") }
+  before do
+    allow(Pages::Frontmatter).to receive(:list) { content_pages }
+    get("/sitemap.xml")
+  end
 
   describe "#show" do
     let(:sitemap_namespace) { "http://www.sitemaps.org/schemas/sitemap/0.9" }

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -9,7 +9,7 @@ describe "Google Structured Data", type: :request do
   before do
     %i[how_to event blog_posting organization breadcrumb_list web_site].each do |type|
       allow(Rails.application.config.x.structured_data).to \
-        receive(type) { true }
+        receive(type).and_return(true)
     end
   end
 

--- a/spec/support/spec_helpers/basic_auth.rb
+++ b/spec/support/spec_helpers/basic_auth.rb
@@ -1,10 +1,10 @@
 module SpecHelpers
   module BasicAuth
     def allow_basic_auth_users(credentials = [])
-      allow(::BasicAuth).to receive(:authenticate) { false }
+      allow(::BasicAuth).to receive(:authenticate).and_return(false)
 
       credentials.each do |c|
-        allow(::BasicAuth).to receive(:authenticate).with(c[:username], c[:password]) { true }
+        allow(::BasicAuth).to receive(:authenticate).with(c[:username], c[:password]).and_return(true)
       end
     end
 

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 describe "searches/show.html.erb", type: :view do
   subject { rendered }
 
-  before { allow(model).to receive(:results).and_return results }
-
-  before { assign(:search, model) && render }
+  before do
+    allow(model).to receive(:results).and_return results
+    assign(:search, model) && render
+  end
 
   let(:model) { Search.new }
   let(:results) { nil }


### PR DESCRIPTION
[Trello-1860](https://trello.com/c/4MTThVnJ/1860-enable-the-rubocop-rspec-rules-and-fix-the-offences)

Either fixes or disables the remaining Rubocop RSpec rules.