### PR TITLE
Improving 'ways to train' badge style

### DIFF
--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -91,10 +91,20 @@ Fees are usually around £9,250 but you can:
 <div class="training-attributes">
   <h4>University-led training</h4>
   <div class="badges">
-    <span class="badge pink">Costs £9,250</span>
-    <span class="badge dark-cyan">Funding available</span>
-    <span class="badge purple">Takes 1 year</span>
-    <span class="badge dark-blue">PGCE or PGDE</span>
+    <div class="badge pink">
+      <div class="badge-text">Costs £9,250</div>
+    </div>
+    <div class="badge dark-cyan">
+      <div class="badge-text">Funding available</div>
+    </div>
+
+    <div class="badge purple">
+      <div class="badge-text">Takes 1 year</div>
+    </div>
+
+    <div class="badge dark-blue">
+      <div class="badge-text">PGCE or PGDE</div>
+    </div>
   </div>
 </div>
 

--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -124,10 +124,26 @@ Fees are usually around £9,250 but you can:
 <div class="training-attributes">
   <h4>School direct<br/>(fee-funded)</h4>
   <div class="badges">
-    <span class="badge pink">Costs £9,250</span>
-    <span class="badge dark-cyan">Funding available</span>
-    <span class="badge purple">Takes 1 year</span>
-    <span class="badge dark-blue">Often a PGCE or PGDE</span>
+    <div class="badge pink">
+      <div class="badge-text">
+        Costs £9,250
+      </div>
+    </div>
+    <div class="badge dark-cyan">
+      <div class="badge-text">
+        Funding available
+      </div>
+    </div>
+    <div class="badge purple">
+      <div class="badge-text">
+        Takes 1 year
+      </div>
+    </div>
+    <div class="badge dark-blue">
+      <div class="badge-text">
+        Often a PGCE or PGDE
+      </div>
+    </div>
   </div>
 </div>
 
@@ -147,23 +163,43 @@ Courses typically take one year but you may be able to study part-time.
   <div class="training-option">
     <dt>School direct<br/>(salaried)</dt>
     <dd class="badges">
-      <span class="badge purple">Takes 1 year</span>
-      <span class="badge dark-blue">Often a PGCE or PGDE</span>
+      <div class="badge purple">
+        <div class="badge-text">
+          Takes 1 year
+        </div>
+      </div>
+      <div class="badge dark-blue">
+        <div class="badge-text">
+          Often a PGCE or PGDE
+        </div>
+      </div>
     </dd>
   </div>
 
   <div class="training-option">
     <dt>Postgraduate teaching apprenticeship</dt>
     <dd class="badges">
-      <span class="badge purple">Takes 1 year</span>
+      <div class="badge purple">
+        <div class="badge-text">
+          Takes 1 year
+        </div>
+      </div>
     </dd>
   </div>
 
   <div class="training-option">
     <dt>Teach First</dt>
     <dd class="badges">
-      <span class="badge purple">Takes 2 years</span>
-      <span class="badge dark-blue">PGDE</span>
+      <div class="badge purple">
+        <div class="badge-text">
+          Takes 2 years
+        </div>
+      </div>
+      <div class="badge dark-blue">
+        <div class="badge-text">
+          PGDE
+        </div>
+      </div>
     </dd>
   </div>
 </dl>
@@ -187,10 +223,26 @@ Qualifications vary depending on the course. For example, you could get QTS with
 <div class="training-attributes">
   <h4>Undergraduate teacher training</h4>
   <div class="badges">
-    <span class="badge pink">Costs £9,250 per year</span>
-    <span class="badge dark-cyan">Funding available</span>
-    <span class="badge purple">Up to 4 years</span>
-    <span class="badge dark-blue">Qualifications vary</span>
+    <div class="badge pink">
+      <div class="badge-text">
+        Costs £9,250 per year
+      </div>
+    </div>
+    <div class="badge dark-cyan">
+      <div class="badge-text">
+        Funding available
+      </div>
+    </div>
+    <div class="badge purple">
+      <div class="badge-text">
+        Up to 4 years
+      </div>
+    </div>
+    <div class="badge dark-blue">
+      <div class="badge-text">
+        Qualifications vary
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -16,6 +16,7 @@
     display: flex;
     gap: .4em;
     padding-block: .8em;
+    padding-right: 2em;
     flex-direction: column;
     align-items: flex-start;
     border-left: 1px solid $grey-mid;
@@ -33,11 +34,9 @@
     margin-left: -1em;
     padding-left: 1.5em;
     padding-right: 1em;
-    @include font-size("xsmall");
 
     .badge-text {
       transform: skew($unskew-amount);
-      font-weight: 900;
     }
 
     &.pink {

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -35,6 +35,7 @@
     margin-left: -1em;
     padding-left: 1.5em;
     padding-right: 1em;
+    font-weight: bold;
 
     .badge-text {
       transform: skew($unskew-amount);

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -5,7 +5,7 @@
     gap: 1em;
 
     h4 {
-      margin-top: 0;
+      margin-top: .6em;
       padding-top: 0;
       flex-shrink: 0;
       flex-basis: 33%;
@@ -15,48 +15,58 @@
   .badges {
     display: flex;
     gap: .4em;
+    padding-block: .8em;
     flex-direction: column;
     align-items: flex-start;
+    border-left: 1px solid $grey-mid;
+    overflow-x: hidden;
+    min-width: 20em;
   }
 
   .badge {
-    padding: .2em .4em;
+    $skew-amount: -10deg;
+    $unskew-amount: 10deg;
+
+    padding: .4em;
     display: inline-block;
-    border-radius: 5px;
+    transform: skewx($skew-amount);
+    margin-left: -1em;
+    padding-left: 1.5em;
+    padding-right: 1em;
     @include font-size("xsmall");
+
+    .badge-text {
+      transform: skew($unskew-amount);
+      font-weight: 900;
+    }
 
     &.pink {
       color: $white;
       border: 1px solid $pink-dark;
-      font-weight: 900;
       background: $pink-dark;
     }
 
     &.dark-cyan {
       color: $white;
       border: 1px solid $dark-cyan;
-      font-weight: 900;
       background: $dark-cyan;
     }
 
     &.yellow {
       color: $black;
       border: 1px solid $yellow;
-      font-weight: 900;
       background: $yellow;
     }
 
     &.dark-blue {
       color: $white;
       border: 1px solid $blue-dark;
-      font-weight: 900;
       background: $blue-dark;
     }
 
     &.purple {
       color: $white;
       border: 1px solid $purple;
-      font-weight: 900;
       background: $purple;
     }
   }

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -4,6 +4,10 @@
     padding: 1em 0 2em;
     gap: 1em;
 
+    @include mq($until: mobile) {
+      flex-direction: column;
+    }
+
     h4 {
       margin-top: 1em;
       padding-top: 0;

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -21,7 +21,6 @@
     align-items: flex-start;
     border-left: 1px solid $grey-mid;
     overflow-x: hidden;
-    min-width: 20em;
     min-height: 4em;
   }
 

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -37,6 +37,10 @@
 
     .badge-text {
       transform: skew($unskew-amount);
+
+      abbr {
+        text-underline-offset: .2em;
+      }
     }
 
     &.pink {

--- a/app/webpacker/styles/ways-to-train.scss
+++ b/app/webpacker/styles/ways-to-train.scss
@@ -5,7 +5,7 @@
     gap: 1em;
 
     h4 {
-      margin-top: .6em;
+      margin-top: 1em;
       padding-top: 0;
       flex-shrink: 0;
       flex-basis: 33%;
@@ -22,6 +22,7 @@
     border-left: 1px solid $grey-mid;
     overflow-x: hidden;
     min-width: 20em;
+    min-height: 4em;
   }
 
   .badge {
@@ -81,7 +82,6 @@
     margin-bottom: 3em;
 
     .training-option {
-      align-items: baseline;
       display: flex;
       padding-bottom: $space-between-definitions;
 
@@ -99,6 +99,7 @@
       }
 
       dt {
+        margin-top: 1em;
         flex-basis: 30%;
         @include font-size(small);
         font-weight: 900;


### PR DESCRIPTION
### Trello card

https://trello.com/b/lRXllOHK/get-into-teaching-public-beta

### Context

The current badges aren't really 'on brand' or accessible. @gazcarr suggested some updated styles in the above Trello ticket and this is a quick look at a potential implementation.

| Current | New without bold text | New with bold text |
| ----- | ------ | ------ |
| ![Screenshot-2021-09-10-12:18:56](https://user-images.githubusercontent.com/128088/132845775-d9a88f38-0a58-454b-a3d4-3f0cb99e5b31.png) | ![Screenshot-2021-09-10-11:59:05](https://user-images.githubusercontent.com/128088/132845784-35ee186b-337b-4287-8aaf-0204f5a0b715.png) | ![Screenshot-2021-09-10-12:20:10](https://user-images.githubusercontent.com/128088/132845888-1a83ea34-4500-4cd8-ba5b-dad19977a7a7.png) |
