### PR TITLE
Make the TTA redirect use :moved_permanently

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -58,7 +58,7 @@ class PagesController < ApplicationController
       url += "?" + session[:utm].to_param
     end
 
-    redirect_to(url, turbolinks: false)
+    redirect_to(url, turbolinks: false, status: :moved_permanently)
   end
 
 private

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -83,6 +83,7 @@ describe PagesController, type: :request do
       before { get "/tta-service" }
 
       it { is_expected.to redirect_to "https://tta-service/" }
+      it { expect(response).to have_http_status(:moved_permanently) }
     end
 
     context "with /tta url" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/a7o07kuv/1917-review-if-302-redirect-for-get-an-adviser-should-be-replaced-with-301

### Context

We were marked down on using a 302 by Wavemaker. As this is a permanent location it makes more sense for it to be a `301 moved permanently`
