### PR TITLE
Hide default Zendesk chat button

### DIFF
--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -99,3 +99,8 @@ a {
 .dark-link {
   color: #005487;
 }
+
+// Default Zendesk chat button (hidden as we use our own).
+iframe#launcher {
+  display: none;
+}


### PR DESCRIPTION
Hide the default button that Zendesk show on a page to let the user open a new chat session; we provide our own buttons instead.
