### PR TITLE
Extend nightly link checker to ensure internal links work too

### DIFF
--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -1,16 +1,40 @@
 require "rails_helper"
 
-RSpec.feature "external links check", :onschedule do
-  describe "all pages" do
-    it "will have no broken links" do
+RSpec.feature "link checks", :onschedule do
+  describe "all pages (external)" do
+    specify "all linked-to pages exist" do
       results = LinkChecker::Results.new
 
       PageLister.content_urls.each do |current_page|
         visit(current_page)
-        checker = LinkChecker.new(current_page, page.body)
+        checker = LinkChecker::External.new(current_page, page.body)
 
         WebMock.enable_net_connect!
         checker.check_links(results)
+        WebMock.disable_net_connect!
+      end
+
+      failures = results.reject do |_page, response|
+        (200..299).include? response[:status]
+      end
+
+      # comparing to hash instead of checking .empty? so the failures dump
+      # the difference in the hashes
+      expect(failures).to eql({})
+    end
+  end
+
+  describe "all pages (internal)" do
+    let(:production_url) { "https://getintoteaching.education.gov.uk" }
+
+    specify "all linked-to pages exist" do
+      results = LinkChecker::Results.new
+
+      PageLister.content_urls.map { |path| production_url + path }.each do |current_page|
+        WebMock.enable_net_connect!
+        visit(current_page)
+        checker = LinkChecker::Internal.new(current_page, page.body, adjust_packs_path: %w[packs-test packs])
+        checker.check_links(production_url, results)
         WebMock.disable_net_connect!
       end
 

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -34,79 +34,120 @@ class PageLister
   end
 end
 
-class LinkChecker
-  IGNORE = %w[
-    127.0.0.1
-    localhost
-    ::1
-    www.linkedin.com
-    linkedin.com
-    www.exetermathematicsschool.ac.uk
-    www.ringwood.hants.sch.uk
-    www.sjctsa.co.uk
-    tommyflowersscitt.co.uk
-    www.nett.org.uk
-    www.2schools.org
-  ].freeze
-
-  attr_reader :page, :document
-
+module LinkChecker
   class Results < Hash; end
   Result = Struct.new(:status, :pages)
 
-  def initialize(page, body)
-    @page = page
-    @document = Nokogiri.parse(body)
-  end
+  class Base
+    attr_reader :page, :document
 
-  def check_links(results = Results.new)
-    external_links.each do |link|
-      next if ignored?(link)
+    IGNORE = %w[
+      127.0.0.1
+      localhost
+      ::1
+      www.linkedin.com
+      linkedin.com
+      www.exetermathematicsschool.ac.uk
+      www.ringwood.hants.sch.uk
+      www.sjctsa.co.uk
+      tommyflowersscitt.co.uk
+      www.nett.org.uk
+      www.2schools.org
+    ].freeze
 
-      results[link] ||= Result.new(check(link), [])
-      results[link].pages << page
+    def initialize(page, body)
+      @page = page
+      @document = Nokogiri.parse(body)
     end
 
-    results
-  end
+  private
 
-private
+    def links
+      document.css("a").pluck("href")
+    end
 
-  def links
-    document.css("a").pluck("href")
-  end
+    def faraday(link)
+      ::Faraday.new(link) do |f|
+        f.request :retry, max: 2
+        f.use ::FaradayMiddleware::FollowRedirects
+      end
+    end
 
-  def external_links
-    links.select { |href| href.starts_with? %r{https?://} }
-  end
+    def check(link)
+      status = faraday(link).head.status
+      return status if (200..299).include?(status)
 
-  def faraday(link)
-    ::Faraday.new(link) do |f|
-      f.request :retry, max: 2
-      f.use ::FaradayMiddleware::FollowRedirects
+      fallback_check(link)
+    rescue ::Faraday::Error
+      fallback_check(link)
+    end
+
+    def fallback_check(link)
+      # Not all websites respond to a HEAD request,
+      # so we do a GET request as a fallback check.
+      faraday(link).get.status
+    rescue ::Faraday::Error
+      nil
     end
   end
 
-  def check(link)
-    status = faraday(link).head.status
-    return status if (200..299).include?(status)
+  class External < Base
+    def check_links(results = Results.new)
+      external_links.each do |link|
+        next if ignored?(link)
 
-    fallback_check(link)
-  rescue ::Faraday::Error
-    fallback_check(link)
+        results[link] ||= Result.new(check(link), [])
+        results[link].pages << page
+      end
+
+      results
+    end
+
+    def ignored?(link)
+      IGNORE.any? do |ignore|
+        link.starts_with? %r{https?://#{ignore}/}
+      end
+    end
+
+    def external_links
+      links.select { |href| href.starts_with? %r{https?://} }
+    end
   end
 
-  def fallback_check(link)
-    # Not all websites respond to a HEAD request,
-    # so we do a GET request as a fallback check.
-    faraday(link).get.status
-  rescue ::Faraday::Error
-    nil
-  end
+  class Internal < Base
+    IGNORE_PREFIX = %r{^/welcome}.freeze
 
-  def ignored?(link)
-    IGNORE.any? do |ignore|
-      link.starts_with? %r{https?://#{ignore}/}
+    def initialize(page, body, adjust_packs_path: [])
+      @page = page
+      @document = Nokogiri.parse(body)
+
+      # we need to adjust the packs URL when testing against prod
+      @adjust_packs_path = adjust_packs_path
+    end
+
+    def check_links(host, results = Results.new)
+      internal_links.each do |link|
+        next if link =~ IGNORE_PREFIX
+
+        results[link] ||= Result.new(check(build_url(host, link)), [])
+        results[link].pages << page
+      end
+
+      results
+    end
+
+    def internal_links
+      links.select { |href| href.starts_with?("/") }
+    end
+
+  private
+
+    def build_url(host, link)
+      url = host + link
+
+      return url if @adjust_packs_path.blank?
+
+      url.gsub(*@adjust_packs_path)
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/VNjS4sNU/1943-expand-broken-link-checker-to-cover-all-links-in-prod

### Context and changes

Currently we run a nightly check of our external links to ensure they resolve. Our internal link checker only runs as part of the CI process where we don't talk to the API, so links to API-requiring pages like events and the privacy policy are skipped.

This lead to a recent problem (#1749) where we had a broken link that wasn't picked up.

Here we're extending the link checker to do an internal run too. Internal links are identified by starting with a `/`. Instead of a single `LinkChecker` class we now have `LinkChecker::External` and `LinkChecker::Internal`. They work in mostly the same way but have slightly different `IGNORE` mechanisms and the internal checker also requires an extra step for 'translating' pack paths. As there's only one substitution required currently this is done by passing an array of args into `gsub` but this can be extended if needed.
