### PR TITLE
Stop the purple header hanging outside the checker

### DIFF
--- a/app/views/eligibility_checker/show.html.erb
+++ b/app/views/eligibility_checker/show.html.erb
@@ -3,6 +3,7 @@
     <header>
       <h1>Are you qualified to start teacher training?</h1>
     </header>
+
     <p>Find out instantly if you have what you need to start postgraduate training for teaching in English primary or secondary schools. You'll also see your next steps for qualifying.</p>
 
     <%= form_with(object: @eligibility, method: :get, url: "#", data: { remote: false }) do |form| %>

--- a/app/webpacker/styles/eligibility-checker.scss
+++ b/app/webpacker/styles/eligibility-checker.scss
@@ -1,16 +1,23 @@
 .eligibility-checker {
   background-color: $grey;
   padding: 1em;
+  overflow: hidden;
 
-  h1 {
+  header {
     @include rotated-block;
+
     background-color: $purple-dark;
     color: $white;
-    @include font-size("medium");
-    padding: .3em;
     margin-left: -2em;
     padding-left: 2em;
-    overflow: hidden;
+    margin-block: 1em;
+
+    h1 {
+      @include font-size("large");
+      @include reset;
+      margin-block: 1em 2em;
+      padding: .3em;
+    }
   }
 
   p.eligibility-checker-disclaimer {


### PR DESCRIPTION
### Trello card

N/A

### Context

The header in the eligibility checker didn't look finished as it was protruding from the box.


| Before | After |
|------| ------| 
| ![Screenshot from 2021-09-16 09-18-55](https://user-images.githubusercontent.com/128088/133577583-4d47c03b-78e8-4d93-b213-5c6d6b19265c.png) | ![Screenshot from 2021-09-16 09-24-31](https://user-images.githubusercontent.com/128088/133577671-c93ccd56-acb4-44c8-8b2a-eedefcb064d2.png) |