### PR TITLE
Swap order of page title so the name of the individual page comes first

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
 
   def prefix_title(title)
     if title
-      "Get Into Teaching: #{title}"
+      "#{title} | Get Into Teaching"
     else
       "Get Into Teaching"
     end

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -10,6 +10,8 @@ RSpec.feature "Book a callback", type: :feature do
     )
   end
 
+  let(:callback_page_title) { "Callback confirmed | Get Into Teaching" }
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \
       receive(:get_callback_booking_quotas) { [quota] }
@@ -25,7 +27,7 @@ RSpec.feature "Book a callback", type: :feature do
     }
     allow_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
       receive(:book_get_into_teaching_callback)
-        .with(having_attributes(callback_attrs))
+      .with(having_attributes(callback_attrs))
   end
 
   scenario "Full journey as an existing candidate" do
@@ -60,7 +62,7 @@ RSpec.feature "Book a callback", type: :feature do
     check "Yes"
     click_on "Book your callback"
 
-    expect(page).to have_title("Get Into Teaching: Callback confirmed")
+    expect(page).to have_title(callback_page_title)
     expect(page).to have_text "Callback confirmed"
 
     start_at = quota.start_at.in_time_zone("London")
@@ -77,8 +79,8 @@ RSpec.feature "Book a callback", type: :feature do
       receive(:exchange_access_token_for_get_into_teaching_callback).with("654321", anything).and_raise(GetIntoTeachingApiClient::ApiError)
     allow_any_instance_of(GetIntoTeachingApiClient::GetIntoTeachingApi).to \
       receive(:exchange_access_token_for_get_into_teaching_callback).with("123456", anything) do
-        GetIntoTeachingApiClient::GetIntoTeachingCallback.new
-      end
+      GetIntoTeachingApiClient::GetIntoTeachingCallback.new
+    end
 
     visit callbacks_steps_path
 
@@ -127,7 +129,7 @@ RSpec.feature "Book a callback", type: :feature do
     check "Yes"
     click_on "Book your callback"
 
-    expect(page).to have_title("Get Into Teaching: Callback confirmed")
+    expect(page).to have_title(callback_page_title)
     expect(page).to have_text "Callback confirmed"
 
     start_at = quota.start_at.in_time_zone("London")
@@ -142,7 +144,7 @@ RSpec.feature "Book a callback", type: :feature do
 
     visit callbacks_steps_path
 
-    expect(page).to have_title("Get Into Teaching: Book a callback, personal details step")
+    expect(page).to have_title("Book a callback, personal details step | Get Into Teaching")
 
     expect(page).to have_text "Book a callback"
     fill_in_personal_details_step

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature "Event wizard", type: :feature do
   let(:event_name) { "Event Name" }
   let(:latest_privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new({ id: 123 }) }
   let(:event) { build(:event_api, readable_id: event_readable_id, name: event_name) }
+  let(:individual_event_page_title) { "Sign up for #{event.name}, personal details step | Get Into Teaching" }
+  let(:sign_up_complete_page_title) { "Sign up complete | Get Into Teaching" }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -26,7 +28,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     visit event_steps_path(event_id: event_readable_id, walk_in: true)
 
-    expect(page).to have_title("Get Into Teaching: Sign up for #{event.name}, personal details step")
+    expect(page).to have_title(individual_event_page_title)
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
@@ -46,7 +48,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     click_on "Complete sign up"
 
-    expect(page).to have_title("Get Into Teaching: Sign up complete")
+    expect(page).to have_title(sign_up_complete_page_title)
   end
 
   scenario "Full journey as a new candidate" do
@@ -55,7 +57,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     visit event_steps_path(event_id: event_readable_id)
 
-    expect(page).to have_title("Get Into Teaching: Sign up for #{event.name}, personal details step")
+    expect(page).to have_title(individual_event_page_title)
     expect(page).to have_text "Sign up for this event"
     expect(page).to have_text event_name
     fill_in_personal_details_step
@@ -83,7 +85,7 @@ RSpec.feature "Event wizard", type: :feature do
 
     click_on "Complete sign up"
 
-    expect(page).to have_title("Get Into Teaching: Sign up complete")
+    expect(page).to have_title(sign_up_complete_page_title)
     expect(page).to have_text "What happens next"
     expect(page).to have_text "signed up for email updates"
   end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -3,13 +3,15 @@ require "rails_helper"
 RSpec.feature "Mailing list wizard", type: :feature do
   include_context "with wizard data"
 
+  let(:mailing_list_page_title) { "Get personalised guidance to your inbox, name step | Get Into Teaching" }
+
   scenario "Full journey as a new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
     visit mailing_list_steps_path
 
-    expect(page).to have_title("Get Into Teaching: Get personalised guidance to your inbox, name step")
+    expect(page).to have_title(mailing_list_page_title)
 
     expect(page).to have_text "Get personalised guidance to your inbox"
     fill_in_name_step
@@ -42,7 +44,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_title("Get Into Teaching: You've signed up")
+    expect(page).to have_title("You've signed up | Get Into Teaching")
     expect(page).to have_text "You've signed up"
   end
 
@@ -311,14 +313,12 @@ RSpec.feature "Mailing list wizard", type: :feature do
   end
 
   scenario "Partial journey with candidate encountering an error" do
-    expected_title = "Get Into Teaching: Get personalised guidance to your inbox, name step"
-
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
     visit mailing_list_steps_path
 
-    expect(page).to have_title(expected_title)
+    expect(page).to have_title(mailing_list_page_title)
 
     # try incorrectly first so we can check error state
     click_on "Next step"
@@ -326,7 +326,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "Enter your first name"
     expect(page).to have_text "Enter your last name"
     expect(page).to have_text "Enter your full email address"
-    expect(page).to have_title(expected_title)
+    expect(page).to have_title(mailing_list_page_title)
   end
 
   def fill_in_name_step(

--- a/spec/requests/frontmatter_content_spec.rb
+++ b/spec/requests/frontmatter_content_spec.rb
@@ -32,7 +32,7 @@ describe "ensuring frontmatter from content pages is rendered", type: :request d
     it { expect(response).to have_http_status(200) }
 
     specify "sets both the title and heading correctly" do
-      expect(document.css("title").text).to end_with("Title goes here")
+      expect(document.css("title").text).to start_with("Title goes here")
       expect(document.css("h1").text).to eql("Heading goes here")
     end
   end


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/xjNidiD4)

### Context
The page title is shown in the browser's tab or as the window heading, and will be truncated if longer than the space available. 

### Changes proposed in this pull request
Put the name of the individual page before `Get into Teaching` (instead of after) so that users can more easily see which page they are on when only the first part of the title is visible.

Before on the left, after on the right:
![image](https://user-images.githubusercontent.com/47089130/133619895-0cd3bc9a-85e5-4e2a-9c7d-f94f36a09f17.png)
