### PR TITLE
Reduce Content Layout Shift in header on desktop

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div aria-label="main">
-  <section class="covid" data-controller="banner" data-banner-name="Covid">
+  <section class="covid" data-controller="banner" data-banner-name-value="Covid">
     <div class="limit-content-width">
       <span class="covid__header"><a href="/covid-19">Find out how coronavirus is affecting teacher training</a></span>
       <a href="#" data-action="click->banner#hide" class="covid__close"><span class="visually-hidden">Hide this message</span></a>

--- a/app/webpacker/controllers/banner_controller.js
+++ b/app/webpacker/controllers/banner_controller.js
@@ -3,15 +3,17 @@ import CookiePreferences from '../javascript/cookie_preferences';
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
+  static values = { name: String };
+
   cookieCategory = 'functional';
 
   connect() {
-    this.hideOnLoad();
+    this.showOnLoad();
   }
 
-  hideOnLoad() {
-    if (Cookies.get(this.cookieName) === 'Hidden') {
-      this.hideBanner();
+  showOnLoad() {
+    if (Cookies.get(this.cookieName) !== 'Hidden') {
+      this.showBanner();
     }
   }
 
@@ -22,19 +24,20 @@ export default class extends Controller {
   }
 
   hideBanner() {
-    this.element.style.display = 'none';
+    this.element.classList.remove('visible');
+  }
+
+  showBanner() {
+    this.element.classList.add('visible');
   }
 
   setCookie() {
-    if (new CookiePreferences().allowed(this.cookieCategory))
+    if (new CookiePreferences().allowed(this.cookieCategory)) {
       Cookies.set(this.cookieName, 'Hidden');
+    }
   }
 
   get cookieName() {
-    return `GiTBetaBanner${this.name}`;
-  }
-
-  get name() {
-    return this.data.get('name');
+    return `GiTBetaBanner${this.nameValue}`;
   }
 }

--- a/app/webpacker/styles/header/covid.scss
+++ b/app/webpacker/styles/header/covid.scss
@@ -1,3 +1,7 @@
+html:not(.js-enabled) {
+  display: block;
+}
+
 .covid {
   @include font;
   @include font-size("xsmall");
@@ -5,6 +9,11 @@
   background-color: $black;
   color: $white;
   padding: 10px 20px;
+  display: none;
+
+  .visible {
+    display: block;
+  }
 
   .limit-content-width {
     display: flex;

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -22,8 +22,15 @@ html.js-enabled {
   background-color: $grey;
   border-bottom: 1px solid $green;
   padding: .25em 0;
-  //font-weight: bold;
   margin-bottom: 1em;
+
+  // Avoids content layout shift when autocomplete
+  // search input is injected into the navigation bar.
+  height: 48px;
+
+  .fas {
+    width: 22px;
+  }
 
   @include mq($from: desktop) {
     margin: 0;
@@ -41,6 +48,8 @@ html.js-enabled {
     padding: 0;
     position: relative;
     min-width: 240px;
+    width: 240px;
+    height: 36px;
 
     input {
       @include reset;

--- a/spec/javascript/controllers/banner_controller_spec.js
+++ b/spec/javascript/controllers/banner_controller_spec.js
@@ -3,43 +3,53 @@ import { Application } from 'stimulus';
 import BannerController from 'banner_controller';
 
 describe('BannerController', () => {
-  document.body.innerHTML = `
-  <div data-controller="banner" id="banner" data-banner-name="Name">
-    <a href="#" id="hideButton" data-action="banner#hide">Hide</a>
-  </div>
-  `;
+  let banner;
 
-  let banner = '';
+  const setBannerHidden = (hidden) => {
+    Cookies.set("GitBetaBannerName", hidden ? "Hidden" : null);
+  }
 
-  beforeEach(() => {
-    Cookies.remove('GiTBetaBannerName');
-
+  const registerController = () => {
     const application = Application.start();
     application.register('banner', BannerController);
     banner = document.getElementById('banner');
-  });
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="banner" id="banner" data-banner-name-value="Name">
+        <a href="#" id="hideButton" data-action="banner#hide">Hide</a>
+      </div>
+    `;
+  })
 
   describe('when the cookie is not yet set', () => {
+    beforeEach(() => {
+      registerController(false)
+    })
+
     it('shows the banner', () => {
-      expect(banner.style.display).not.toContain('none');
+      expect(banner.classList.contains('visible')).toBe(true);
     });
 
     describe('clicking the hide button', () => {
       it('hides the banner', () => {
         const hideButton = document.getElementById('hideButton');
         hideButton.click();
-        expect(banner.style.display).toContain('none');
+        expect(banner.classList.contains('visible')).toBe(false);
+        expect(Cookies.get("GiTBetaBannerName")).toEqual("Hidden")
       });
     });
   });
 
   describe('when the cookie has been set', () => {
     beforeEach(() => {
-      Cookies.set("GiTBetaBannerName', 'Hidden");
+      setBannerHidden(true)
+      registerController(true)
     });
 
     it('hides the banner', () => {
-      expect(banner.style.display).toContain('none');
+      expect(banner.classList.contains('visible')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Trello card

[Trello-1938](https://trello.com/c/3TWYT44i/1938-seo-fix-cumulative-layout-shift-cls-issue-core-web-vitals)

### Context

We are seeing a small amount of Content Layout Shift caused by the header section and Google is flagging this in Search Console. We want to remove the CLS if possible to improve our scores/rankings.

### Changes proposed in this pull request

- Set navigation height to avoid layout shift

When the autocomplete loads it injects an input into the navigation bar, which changes its height. Instead, we can fix the height so that it doesn't shift on load.

- Hide covid banner by default

The covid banner is in a dismissed state for the Google Page Speed checker and because we show it by default and hide it with Javascript we get a content layout shift reported. To avoid this we can hide it by default and show it only when it has not been dismissed.

Minor refactoring to the `BannerController` to use the new `*-value` syntax.

If Javascript is disabled we show the banner (which maintains the current behaviour).

### Guidance to review

There is still a very small amount of CLS (~0.001) from the autocomplete loading in via Javascript; I've tried to minimise this by setting the bounds of the auto-complete but it doesn't appear to eradicate it completely.