### PR TITLE
Fix map image size on desktop

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -80,7 +80,7 @@ module EventsHelper
     ajax_map(
       address,
       zoom: 10,
-      mapsize: [628, 420],
+      mapsize: [732, 490],
       title: event.name,
       description: address,
     )

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -1,3 +1,9 @@
+html.js-enabled {
+  .embedded-map .embedded-map__inner-container img.embedded-map__nojs-img {
+    display: none;
+  }
+}
+
 .embedded-map {
   box-sizing: border-box;
   position: relative;

--- a/app/webpacker/styles/components/map.scss
+++ b/app/webpacker/styles/components/map.scss
@@ -1,7 +1,7 @@
 .embedded-map {
   box-sizing: border-box;
   position: relative;
-  width: 100%;
+  width: 732px;
   margin-left: auto;
   margin-right: auto;
   margin-top: 0;
@@ -23,13 +23,20 @@
     img.embedded-map__nojs-img {
       display: block;
       margin: auto;
-      width: 100%;
-      height: auto;
+      width: 732px;
+      height: 490px;
     }
   }
 
-  @include mq($from: tablet) {
+  @include mq($until: desktop) {
     width: 100%;
+
+    .embedded-map__inner-container {
+      img.embedded-map__nojs-img {
+        width: 100%;
+        height: auto;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Trello card

[Trello-1934](https://trello.com/c/TFY33143/1934-seo-fix-largest-contentful-paint-lcp-issue-core-web-vitals)

### Context

Page insights is flagging the unknown width/height of the image as an issue; we can resolve this on desktop as the width of the content is a static value, but we're stuck with a responsive image on tablet/mobile.

### Changes proposed in this pull request

- Fix map image size on desktop

### Guidance to review

