### PR TITLE
Force height on external link icons

### DIFF
--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -34,6 +34,7 @@ a {
 .external-link-icon {
   margin-left: .2em;
   width: .8em !important;
+  height: .8em !important;
 }
 
 .button {


### PR DESCRIPTION
[Trello-1934](https://trello.com/c/TFY33143/1934-seo-fix-largest-contentful-paint-lcp-issue-core-web-vitals)

We get a warning in Page Insights about this icon; forcing the height in addition to the width will resolve it. The `important!` appears necessary to avoid other styles overriding it; I may investigate this more in another PR to see if they can be safely removed.