### PR TITLE
Remove 'Read more' and make heading links clearer

### DIFF
--- a/app/views/blog/_post_preview.html.erb
+++ b/app/views/blog/_post_preview.html.erb
@@ -11,6 +11,4 @@
     <p><%= first_image_from_post(fm[:images]) %></p>
   <% end %>
   <p><%= fm[:description] %></p>
-
-  <%= link_to "Read more", path %>
 </article>

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -68,11 +68,6 @@
       h2 {
         @include font-size(large);
         @include reset;
-
-        a {
-          text-decoration: none;
-          color: $black;
-        }
       }
 
       header {

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -13,6 +13,5 @@ describe "reading the blog", type: :feature do
     expect(page).to have_current_path("/blog/tag/#{tag.parameterize}")
 
     expect(page).to have_content("Blog posts about #{tag}")
-    expect(page).to have_link("Read more", minimum: 1)
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/rAAcA3xI

### Context and changes

There were a couple of usability fails here, firstly that the 'Read more' link was in isolation so it wouldn't be clear to screenreader users _what_ they'd be reading.

Secondly, because the headings were links too we were repeating links to the same page in quick succession.


| Mobile | Desktop |
| ------ | -------|
| ![Screenshot-2021-09-17-13:45:54](https://user-images.githubusercontent.com/128088/133784713-d2c25a5d-7470-4540-98b3-41d25046c740.png) | ![Screenshot-2021-09-17-13:46:02](https://user-images.githubusercontent.com/128088/133784724-1dd6fa3f-d672-4b19-8634-c1a13b9ef785.png) |
