### PR TITLE
Prevent cookie banner from being the LCP element

### DIFF
--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -19,14 +19,14 @@ export default class extends Controller {
 
   accept(event) {
     event.preventDefault();
-    this.overlayTarget.style.display = 'none';
+    this.overlayTarget.classList.remove('visible');
 
     const cookiePrefs = new CookiePreferences();
     cookiePrefs.allowAll();
   }
 
   showDialog() {
-    this.overlayTarget.style.display = 'flex';
+    this.overlayTarget.classList.add('visible');
 
     const tabKey = 9;
     const agreeButtonID = 'biscuits-agree';

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -1,13 +1,27 @@
+@keyframes slide-up {
+  0% {
+    transform: translateY(110vh);
+  }
+  100% {
+    transform: translateY(0vh);
+  }
+}
+
 .dialog {
-  display: none;
+  display: flex;
   position: fixed;
-  top: 0;
   left: 0;
+  top: 0;
   width: 100%;
   min-height: 100vh;
   z-index: 1000;
   justify-content: center;
   align-items: center;
+  transform: translateY(110vh);
+
+  &.visible {
+    animation: slide-up 0s forwards;
+  }
 
   &__background {
     opacity: .8;

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -41,7 +41,7 @@ describe('CookieAcceptanceController', () => {
 
     it('does not show the cookie acceptance dialog', () => {
       const overlay = document.getElementById('overlay');
-      expect(overlay.style.display).toBe('');
+      expect(overlay.classList.contains('visible')).toBe(false);
     });
   });
 
@@ -52,7 +52,7 @@ describe('CookieAcceptanceController', () => {
 
     it('shows the cookie acceptance dialog', () => {
       const overlay = document.getElementById('overlay');
-      expect(overlay.style.display).toBe('flex');
+      expect(overlay.classList.contains('visible')).toBe(true);
     });
   });
 
@@ -70,7 +70,7 @@ describe('CookieAcceptanceController', () => {
 
     it('hides the dialog', () => {
       const overlay = document.getElementById('overlay');
-      expect(overlay.style.display).toBe('none');
+      expect(overlay.classList.contains('visible')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Trello card

[Trello-1934](https://trello.com/c/TFY33143/1934-seo-fix-largest-contentful-paint-lcp-issue-core-web-vitals)

### Context

Currently, if a user has not accepted our cookie policy the banner text gets classified as the Largest Contentful Paint
element on pages without a hero image or a lot of text above the fold (i.e. most event pages).

The only way I've found to get around this is to load the banner visible but off-screen and then transition the banner to the
main viewport with a CSS animation (of 0s duration) by adding the class in JS if the user hasn't accepted cookies yet.

### Changes proposed in this pull request

- Prevent cookie banner from being the LCP element

### Guidance to review

