### PR TITLE
Fix search icon being pushed onto next line

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -48,7 +48,6 @@ html.js-enabled {
     padding: 0;
     position: relative;
     min-width: 240px;
-    width: 240px;
     height: 36px;
 
     input {


### PR DESCRIPTION
The width of the search bar has been fixed to prevent content shift, however, this is pushing the search icon onto the next line. Remove `width` to prevent, as `min-width` should help minimise content shift anyway.

![image](https://user-images.githubusercontent.com/47089130/133990758-b8801796-d012-47da-8157-978bf9b737da.png)