### PR TITLE
Fix position search box on mobile

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -24,10 +24,6 @@ html.js-enabled {
   padding: .25em 0;
   margin-bottom: 1em;
 
-  // Avoids content layout shift when autocomplete
-  // search input is injected into the navigation bar.
-  height: 48px;
-
   .fas {
     width: 22px;
   }
@@ -37,6 +33,9 @@ html.js-enabled {
     padding: 0;
     padding-right: 2em;
     border-bottom: none;
+    // Avoids content layout shift when autocomplete
+    // search input is injected into the navigation bar.
+    height: 48px;
   }
 
   .fas {


### PR DESCRIPTION
Apply height to the search box on desktop only. The `extra-navigation` component takes up a lot more space on mobile and was spilling over onto the hero.

![image](https://user-images.githubusercontent.com/47089130/134002482-01a9250c-c934-44b9-b6f4-022640f50df0.png)

