### PR TITLE
Add Google Tag Manager nonce

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -11,6 +11,7 @@
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
+  <%= javascript_pack_tag 'google_tag_manager', 'data-turbolinks-track': 'reload', async: true, nonce: true %>
   <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>

--- a/app/webpacker/packs/google_tag_manager.js
+++ b/app/webpacker/packs/google_tag_manager.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+document.addEventListener(
+  'turbolinks:load',
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    var n = d.querySelector('[nonce]');
+    n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce'));
+    f.parentNode.insertBefore(j, f);
+  })(window, document, 'script', 'dataLayer', 'GTM-{YOUR-CONTAINER-ID}')
+);


### PR DESCRIPTION
We are getting alerts that our CSP policy is blocking https://www.googletagmanager.com/gtm.js. Add nonce as suggested in https://developers.google.com/tag-manager/web/csp