### PR TITLE
Fix right column cta indentation on funding page

### DIFF
--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -11,14 +11,14 @@
   backlink: "../"
   navigation: 25
   right_column:
-  ctas:
-    - title: New events added.
-      text: Turn your questions into confidence. Decide how to fund your training at our next event.  
-      link_text: "Events near you"
-      link_target: "/event-categories/train-to-teach"
-      icon: "icon-calendar"
-      hide_on_mobile: Yes
-      hide_on_tablet: Yes
+    ctas:
+      - title: New events added.
+        text: Turn your questions into confidence. Decide how to fund your training at our next event.
+        link_text: "Events near you"
+        link_target: "/event-categories/train-to-teach"
+        icon: "icon-calendar"
+        hide_on_mobile: Yes
+        hide_on_tablet: Yes
   lid_pixel_event: "Funding"
   jump_links:
     Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"


### PR DESCRIPTION
Small fix, just make the CTA show on the funding page. It's currently skipped due to it not being nested inside `right_column`. Refs #1772
