### PR TITLE
Attempt to stop Google CSP violations

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -64,6 +64,7 @@ SecureHeaders::Configuration.default do |config|
     manifest_src: ["'self'"],
     media_src: ["'self'"].concat(zendesk),
     script_src: ["'self'"].concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, hotjar, scribble, twitter, snapchat, vwo, youtube, zendesk),
+    script_src_elem: ["'self'"].concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, hotjar, scribble, twitter, snapchat, vwo, youtube, zendesk),
     style_src: ["'self'"].concat(quoted_unsafe_inline, govuk, google_apis, google_supported),
     worker_src: ["'self'"].concat(vwo, blob),
   }


### PR DESCRIPTION
We are getting CSP violation reports from https://www.googleadservices.com/pagead/conversion_async.js and https://www.googletagmanager.com/gtm.js under the `script-src-elem` directive.

These are already in the whitelist and `script-src-elem` is supposed to fall back to `script-src`, but adding these explicitly here to see if it helps.