### PR TITLE
Improve back link text on cookie prefs page

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -183,8 +183,7 @@
       </p>
 
       <p>
-        <%= link_to "Find out more", cookies_path %>
-        about cookies on this service
+        <%= link_to "Find out more about cookies on this service", cookies_path %>
       </p>
     </div>
   </form>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -174,7 +174,12 @@
         </span>
 
         <br />
-        <%= link_to "Back to page", internal_referer || root_path, class: "secondary-button" %>
+
+        <% if internal_referer.present? && internal_referer != root_path %>
+          <%= link_to "Back to page", internal_referer, class: "secondary-button" %>
+        <% else %>
+          <%= link_to "Go to home page", root_path, class: "secondary-button" %>
+        <% end %>
       </p>
 
       <p>

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -1,12 +1,19 @@
 require "rails_helper"
 
 describe CookiePreferencesController, type: :request do
-  subject { response }
-
   describe "#show" do
-    before { get cookie_preference_path }
+    let(:referer) { nil }
 
-    it { is_expected.to have_http_status :success }
-    it { expect(subject.body).to match "Cookie settings" }
+    before { get cookie_preference_path, params: {}, headers: { "HTTP_REFERER" => referer } }
+
+    it { expect(response).to have_http_status :success }
+    it { expect(response.body).to match "Cookie settings" }
+    it { expect(response.body).to include("Go to home page") }
+
+    context "when there is an internal referrer" do
+      let(:referer) { "http://www.example.com/ways-to-train" }
+
+      it { expect(response.body).to include("Back to page") }
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-1868](https://trello.com/c/SNAhkS5L/1868-back-to-page-button-is-misleading-on-cookie-preferences-page)

### Context

When someone comes from an external referrer/unknown source or directly onto the cookie preferences page we show 'Back to page' even though we take them to the homepage and not where they came from.

Instead, we can change this text to be 'Go to home page' for better clarity and only show 'Back to page' if we actually know
the page they came from. 

### Changes proposed in this pull request

- Improve back link text on cookie prefs page

### Guidance to review



| When we know the page they came from      | When we don't know the page they came from |
| ----------- | ----------- |
| <img width="394" alt="Screenshot 2021-09-21 at 13 46 34" src="https://user-images.githubusercontent.com/29867726/134172939-4d04a30e-acca-4da1-bc34-20f6f3c5018d.png">      | <img width="390" alt="Screenshot 2021-09-21 at 13 46 44" src="https://user-images.githubusercontent.com/29867726/134172962-8394db0d-f994-4715-962c-e117ef8dd85b.png">      |


