### PR TITLE
Remove closing </source> tag from within <picture> elements

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,11 @@ private
     response.body = NextGenImages.new(response.body).html
     response.body = ResponsiveImages.new(response.body).html
     response.body = LazyLoadImages.new(response.body).html
+
+    # <source> has no content so should be self-closing; configuring Nokogiri
+    # to remove the closing tags results in breakages elsewhere in the document,
+    # so we have to remove them manually post image processing.
+    response.body = response.body.gsub("</source>", "")
   end
 
   def process_links

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -11,7 +11,7 @@ describe "Next Gen Images", type: :request do
 
   it do
     is_expected.to match(
-      /<picture><source .*><\/source><img .*><noscript><img .*><\/noscript><\/picture>/,
+      /<picture><source .*><img .*><noscript><img .*><\/noscript><\/picture>/,
     )
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-346](https://trello.com/c/9yrX1WTw/346-development-implement-md-erb-and-html-linters-in-ruby-code)

### Context

When we perform image processing we manually modify the HTML response with Nokogiri to inject `<source>` tags. By default Nokogiri will render closing tags for empty elements, resulting in `<source></source>` which is not valid HTML 5 (tags with no content should be self-closing).

It is possible to configure Nokogiri to self-close empty tags, however in doing so it completely trashes other parts of the HTML document (we probably have invalid HTML/an unclosed tag somewhere that's causing this). For now we can manually remove the closing `</source>` tags.

### Changes proposed in this pull request

- Remove closing `</source>` tags

### Guidance to review

