### PR TITLE
Fix possible error on search param

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -17,7 +17,13 @@ private
   end
 
   def search_params
-    params.fetch(:search, {}).permit(:search)
+    search_param = params.fetch(:search, {})
+
+    # Covers the case when someone manually enters
+    # /search?search or /search?search= into the address bar.
+    return nil unless search_param.is_a?(ActionController::Parameters)
+
+    search_param.permit(:search)
   end
 
   def autocomplete_results(results)

--- a/spec/requests/searches_controller_spec.rb
+++ b/spec/requests/searches_controller_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe SearchesController, type: :request do
         it { is_expected.to have_attributes media_type: "application/json" }
         it { expect(json).to be_empty }
       end
+
+      context "with a search key but no value" do
+        before { get search_path(search: "", format: :json), xhr: true }
+
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_attributes media_type: "application/json" }
+        it { expect(json).to be_empty }
+      end
     end
 
     describe "HTML format" do
@@ -35,6 +43,13 @@ RSpec.describe SearchesController, type: :request do
 
       context "without search term" do
         before { get search_path }
+
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_attributes media_type: "text/html" }
+      end
+
+      context "with a search key but no value" do
+        before { get search_path(search: "") }
 
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: "text/html" }


### PR DESCRIPTION
If a user manually enters `/search?search` then the `params.fetch` returns `nil` and if they enter `/search?search=` then `params.fetch` will be an empty string. We need to ensure that we don't call `permit` on either of these values as it will result in an exception. Instead, we check the type is `ActionController::Parameters` and, if not, we return `nil` to give an empty
result.