### PR TITLE
Various HTML validation fixes

### DIFF
--- a/app/components/footer/video_player_component.html.erb
+++ b/app/components/footer/video_player_component.html.erb
@@ -3,19 +3,18 @@
   </div>
   <div class='video-overlay__video-container'>
     <div class="video-overlay__video-container__wrapper">
+      <!-- 'about:blank' as a placeholder src to avoid HTML 5 validation error -->
       <iframe data-video-target="iframe"
               title="Get Into Teaching Video Player"
               width="800"
               height="450"
-              src=""
-              alt="Watch a video for more information about becoming a teacher"
+              src="about:blank"
               allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-              playsinline="false">
+              allowfullscreen>
       </iframe>
     </div>
     <button id="close-button" class="video-overlay__video-container__dismiss" data-video-target="close" data-action="click->video#close">
-      <div class="icon-video-close"><span class="visually-hidden">Close video</span></div>
+      <span class="icon-video-close"><span class="visually-hidden">Close video</span></span>
     </button>
     <a class="visually-hidden" href="#">
       Close

--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -1,4 +1,4 @@
-<nav role="nav" class="hidden-mobile" data-navigation-target="nav">
+<nav class="hidden-mobile" data-navigation-target="nav">
   <%= render Header::ExtraNavigationComponent.new(classes: %w[hide-on-desktop], search_input_id: "searchbox__input--mobile") %>
   <ol class="primary" data-navigation-target="primary">
     <% all_resources.each do |resource| %>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 
-<div aria-label="main">
+<div>
   <section class="covid" data-controller="banner" data-banner-name-value="Covid">
     <div class="limit-content-width">
       <span class="covid__header"><a href="/covid-19">Find out how coronavirus is affecting teacher training</a></span>

--- a/app/views/content/blog/top-tips-for-returning-teachers.md
+++ b/app/views/content/blog/top-tips-for-returning-teachers.md
@@ -21,8 +21,8 @@ If you’re thinking of returning to the classroom, now could be a great time. A
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen
@@ -53,8 +53,8 @@ From helping you to brush up on your subject knowledge to preparing for intervie
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen

--- a/app/views/content/returning-to-teaching.md
+++ b/app/views/content/returning-to-teaching.md
@@ -71,8 +71,8 @@ If you’re considering coming back to the profession, or if you’re qualified 
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/_oQ4DTXkGHk" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen
@@ -106,8 +106,8 @@ If you have '[qualified teacher status](https://www.gov.uk/guidance/qualified-te
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen

--- a/app/views/content/teacher-training-advisers.md
+++ b/app/views/content/teacher-training-advisers.md
@@ -69,8 +69,8 @@ Our advisers can help you at any time, even if you're a year or more away from a
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/ZaGL8c4FkLA" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/ZaGL8c4FkLA" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen
@@ -89,8 +89,8 @@ Your adviser can help you navigate your path into teaching, and make sure you ge
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
   <iframe 
-    class="lazyload"
-    data-src="https://www.youtube-nocookie.com/embed/T9Bhcaa6LJ4" 
+    loading="lazy"
+    src="https://www.youtube-nocookie.com/embed/T9Bhcaa6LJ4" 
     frameborder="0" 
     allow="autoplay; encrypted-media" 
     allowfullscreen

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
+  <nav class="pagination" aria-label="pager">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <% unless @fullwidth %>
           <aside></aside>

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -5,7 +5,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container blog">
         <header class="list-header">
           <%= tag.h1(@front_matter["title"]) %>

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -9,7 +9,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <article class="markdown blog longform">
           <header>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <article class="markdown hero-nav">
           <%= yield %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -7,7 +7,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <% if !@front_matter["image"] %>
           <header>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -5,7 +5,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <article class="markdown disclaimer fullwidth">
           <% if !@front_matter["image"] %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -7,7 +7,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container events">
         <article class="markdown<%= " fullwidth" if @before_search_fullwidth %> ">
           <%= yield :before_search %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -7,7 +7,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main class="home" role="main" id="main-content">
+    <main class="home" id="main-content">
       <% @front_matter["content"]&.each do |partial| %>
         <%= render(partial) %>
       <% end %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -14,7 +14,7 @@
   </div>
 
 
-  <main role="main" id="main-content" class="<%= class_names("internal", action_name ) %>">
+  <main id="main-content" class="<%= class_names("internal", action_name ) %>">
     <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -9,7 +9,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="feature registration container">
         <%= yield %>
       </section>

--- a/app/views/layouts/registration_attractive.html.erb
+++ b/app/views/layouts/registration_attractive.html.erb
@@ -9,7 +9,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main role="main" id="main-content" class="attractive-layout">
+    <main id="main-content" class="attractive-layout">
       <section class="signup-container">
 
         <%= image_pack_tag 'content/mailing-list-signup/left.jpg', class: 'left-img hide-on-mobile hide-on-tablet', alt: "" %>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -7,7 +7,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <% if !@front_matter["image"] %>
           <header>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -7,7 +7,7 @@
         <%= c.hero(@front_matter) %>
       <% end %>
 
-      <main class="story-landing" role="main" id="main-content">
+      <main class="story-landing" id="main-content">
         <section class="container">
           <% if @front_matter.key?("featured_page") %>
             <section class="stories-feature">

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -6,7 +6,7 @@
       <%= c.hero(@front_matter) %>
     <% end %>
 
-    <main role="main" id="main-content">
+    <main id="main-content">
       <section class="container">
         <section class="feature">
           <%= yield %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -4,7 +4,7 @@
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
       <%= render HeaderComponent.new %>
 
-      <main role="main" id="main-content">
+      <main id="main-content">
         <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
           <%= render Header::BreadcrumbComponent.new %>
           <%= yield %>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -8,7 +8,7 @@
     <%# FIXME: remove this to enable the page in prod %>
     <% raise(ActionController::RoutingError.new("Not found")) if Rails.env.production? %>
 
-    <main class="welcome-guide" role="main" id="main-content">
+    <main class="welcome-guide" id="main-content">
       <%= yield %>
 
       <% @front_matter["content"]&.each do |partial| %>

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -1,5 +1,5 @@
 <head>
-  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
 
   <%= render "sections/vwo_code" if @render_vwo %>

--- a/app/webpacker/styles/application-no-js.scss
+++ b/app/webpacker/styles/application-no-js.scss
@@ -1,3 +1,3 @@
-img.lazyload:not([src]) {
-  display: none;
+img.lazyload {
+  display: none !important;
 }

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -112,10 +112,6 @@ $chevron-direction-map: (
   clear: both;
 }
 
-img.lazyload:not([src]) {
-  visibility: hidden;
-}
-
 div.scrbbl-embed {
   height: 380px;
   overflow-y: scroll;

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -58,7 +58,7 @@ SecureHeaders::Configuration.default do |config|
     connect_src: ["'self'"].concat(pinterest, hotjar, google_analytics, google_supported, google_doubleclick, vwo, facebook, tta_service_hosts, zendesk),
     font_src: ["'self'"].concat(govuk, data, %w[fonts.gstatic.com]),
     form_action: ["'self'"].concat(snapchat, facebook, vwo, govuk),
-    frame_src: ["'self'"].concat(scribble, snapchat, facebook, youtube, hotjar, google_doubleclick, vwo, google_analytics),
+    frame_src: ["'self'"].concat(scribble, snapchat, facebook, youtube, hotjar, google_doubleclick, vwo, google_analytics, data),
     frame_ancestors: ["'self'"],
     img_src: ["'self'"].concat(govuk, pinterest, facebook, vwo, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, %w[cx.atdmt.com linkbam.uk]),
     manifest_src: ["'self'"],

--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -1,4 +1,7 @@
 class LazyLoadImages
+  # Used as a placeholder to prevent invalid HTML.
+  TINY_GIF = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=".freeze
+
   def initialize(page)
     @page = page
   end
@@ -12,7 +15,7 @@ class LazyLoadImages
       img.after(noscript_image(img, doc))
 
       img["data-src"] = img.attribute("src")
-      img.remove_attribute("src")
+      img["src"] = TINY_GIF
 
       img["class"] ||= ""
       img["class"] = img["class"] << " lazyload"
@@ -23,7 +26,7 @@ class LazyLoadImages
 
       picture.css("source").each do |source|
         source["data-srcset"] = source.attribute("srcset")
-        source.remove_attribute("srcset")
+        source["srcset"] = TINY_GIF
       end
     end
 

--- a/spec/javascript/controllers/navigation_controller_spec.js
+++ b/spec/javascript/controllers/navigation_controller_spec.js
@@ -11,7 +11,7 @@ describe('NavigationController', () => {
           <span class="menu-button__text">Menu</span>
         </button>
       </div>
-      <nav role="nav" class="hidden-mobile" data-navigation-target="nav">
+      <nav class="hidden-mobile" data-navigation-target="nav">
         <ol class="primary" data-navigation-target="primary">
           <li class="active">One</li>
           <li>Two</li>

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -12,8 +12,8 @@ describe LazyLoadImages do
     let(:instance) { described_class.new(picture) }
 
     it do
-      lazy_image = "<img class=\"test lazyload\" data-src=\"#{original_src}\">"
-      lazy_source = "<source data-srcset=\"#{original_src}\"></source>"
+      lazy_image = "<img class=\"test lazyload\" src=\"#{LazyLoadImages::TINY_GIF}\" data-src=\"#{original_src}\">"
+      lazy_source = "<source srcset=\"#{LazyLoadImages::TINY_GIF}\" data-srcset=\"#{original_src}\"></source>"
       is_expected.to include("<picture>#{lazy_image}<noscript>#{img}</noscript>#{lazy_source}</picture>")
     end
 

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -8,19 +8,22 @@ describe LazyLoadImages do
     let(:original_src) { "image.jpg" }
     let(:original_ext) { File.extname(original_src) }
     let(:img) { "<img class=\"test\" src=\"#{original_src}\">" }
-    let(:picture) { "<picture>#{img}<source srcset=\"#{original_src}\"></source></picture>" }
+    let(:source) { "<source srcset=\"#{original_src}\"></source>" }
+    let(:picture) { "<picture>#{img}#{source}</picture>" }
+    let(:no_js_picture) { "<noscript><picture class=\"no-js\">#{img}#{source}</picture></noscript>" }
     let(:instance) { described_class.new(picture) }
 
     it do
       lazy_image = "<img class=\"test lazyload\" src=\"#{LazyLoadImages::TINY_GIF}\" data-src=\"#{original_src}\">"
       lazy_source = "<source srcset=\"#{LazyLoadImages::TINY_GIF}\" data-srcset=\"#{original_src}\"></source>"
-      is_expected.to include("<picture>#{lazy_image}<noscript>#{img}</noscript>#{lazy_source}</picture>")
+      is_expected.to include("<picture>#{lazy_image}#{lazy_source}</picture>#{no_js_picture}")
     end
 
     context "when lazy-loading is disabled on the image" do
       let(:img) { "<img class=\"test\" src=\"#{original_src}\" data-lazy-disable=\"true\">" }
 
       it { is_expected.to include(picture) }
+      it { is_expected.not_to include(no_js_picture) }
     end
   end
 end

--- a/spec/requests/next_gen_images_spec.rb
+++ b/spec/requests/next_gen_images_spec.rb
@@ -11,7 +11,7 @@ describe "Next Gen Images", type: :request do
 
   it do
     is_expected.to match(
-      /<picture><source .*><img .*><noscript><img .*><\/noscript><\/picture>/,
+      /<picture><source .*><img .*><\/picture><noscript><picture class="no-js"><source .*><img .*><\/picture><\/noscript>/,
     )
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-346](https://trello.com/c/9yrX1WTw/346-development-implement-md-erb-and-html-linters-in-ruby-code)

### Context

Ahead of turning on HTML linting I'm working through the majority of the validation issues; these are a bunch of quick fixes - there are more to follow that are a little harder to unpick.

### Changes proposed in this pull request

- Fix duplicate meta/charset

It looks like our current `<meta>` tag specifying the `charset` is not recognised by Nokogiri so our image processing adds a second, which causes invalid HTML (we have both). Updating our `<meta>` to be more complete seems to prevent Nokogiri from adding a second one.

- Fix <nav> role attribute value

Our `<nav>` tag has a `role` attribute of `nav` which is not valid; it should be `navigation`, but that is also no longer necessary (and provokes a warning) so it can just be omitted.

- Remove misuse of aria-label on Covid banner

Flagged in the HTML validator; the content of the banner is screen-reader friendly so this isn't necessary.

- Remove unnecessary role attribute from main element

The HTML validator flags this as a warning; its no longer necessary to specify it.

- Prevent empty src/srcset attributes

When we lazy load images we move the `src` to `data-src`; this means the `src` is initially empty, which is not valid HTML. To get around this we can load a tiny base-64 GIF that will then be replaced when the lazy image is loaded.

- Move <noscript> outside of <picture> tag

We currently have a `<noscript>` inside a `<picture>` element, which is not valid HTML 5. Instead, we can duplicate the `<picture>` tag and add it to a `<noscript>` sibling to get the same result.

- Set src of video iframe

An iframe without a `src` attribute is not valid; instead, we can set it to be a tiny GIF. Switch other iframes to using the native `loading` attribute to support lazy loading. Also incides some minor tweaks to the markdown to make the video player more semantically correct.

### Guidance to review

