### PR TITLE
Fix Covid banner not appearing

### DIFF
--- a/app/webpacker/styles/header/covid.scss
+++ b/app/webpacker/styles/header/covid.scss
@@ -11,7 +11,7 @@ html:not(.js-enabled) {
   padding: 10px 20px;
   display: none;
 
-  .visible {
+  &.visible {
     display: block;
   }
 


### PR DESCRIPTION
The selector to make this visible was slightly off after I did a refactoring the other day.
