### PR TITLE
Defer loading of Zendesk Chat Widget

### DIFF
--- a/app/views/sections/_zendesk_chat.html.erb
+++ b/app/views/sections/_zendesk_chat.html.erb
@@ -1,13 +1,15 @@
-<%= javascript_include_tag("https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37", id: "ze-snippet", async: true) %>
-
 <script type="text/javascript">
   window.zESettings = {
     webWidget: {
       chat: {
         departments: {
           enabled: []
-        }
+        },
+        connectOnPageLoad: false
       }
     }
   };
 </script>
+
+<%= javascript_include_tag("https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37", id: "ze-snippet", defer: true) %>
+


### PR DESCRIPTION
### Trello card

[Trello-2479](https://trello.com/c/fUi5y1l3/2479-optimise-loading-of-zendesk-widget)

### Context

We can defer the loading of the Zendesk Chat Widget JS and set `connectOnPageLoad: false` to cause the widget code not to fire until the user interacts with the chat button.

### Changes proposed in this pull request

- Defer loading of Zendesk Chat Widget

### Guidance to review

