### PR TITLE
Fix HTML validation warnings

### DIFF
--- a/app/components/footer/mailing_list_component.html.erb
+++ b/app/components/footer/mailing_list_component.html.erb
@@ -1,5 +1,5 @@
 <div class="mailing-list-bar" data-controller="mailing-list" data-banner-name="MailingList">
-  <section class="mailing-list-bar__inner limit-content-width">
+  <div class="mailing-list-bar__inner limit-content-width">
     <div class="mailing-list-bar__left">
       Whether you're ready to apply, or simply exploring teaching as an option, we'll send you all the information you need
     </div>
@@ -7,5 +7,5 @@
       <a id="mailing-list-bar-accept" href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
       <a id="mailing-list-bar-dismiss" href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
     </div>
-  </section>
+  </div>
 </div>

--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -1,10 +1,10 @@
 <div>
-  <section class="talk-to-us">
+  <div class="talk-to-us">
     <section class="container">
       <div>
         <h2 class="purple" id="talk-to-us">Talk to us</h2>
         <div class="content">
-          <section class="contact">
+          <div class="contact">
             <p>Monday to Friday between <strong>8:30am and 5:30pm</strong></p>
             <div class="options">
               <div class="live-chat">
@@ -16,8 +16,8 @@
                 <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
               </div>
             </div>
-          </section>
-          <section>
+          </div>
+          <div>
             <h3>Get a teacher training adviser</h3>
             <p>
               An experienced teaching professional can help if you're ready to get into
@@ -27,9 +27,9 @@
             <a href="/tta-service" class="button">
               Get an adviser
             </a>
-          </section>
+          </div>
         </div>
       </div>
     </section>
-  </section>
+  </div>
 </div>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -5,12 +5,12 @@
 </div>
 
 <div>
-  <section class="covid" data-controller="banner" data-banner-name-value="Covid">
+  <div class="covid" data-controller="banner" data-banner-name-value="Covid">
     <div class="limit-content-width">
       <span class="covid__header"><a href="/covid-19">Find out how coronavirus is affecting teacher training</a></span>
       <a href="#" data-action="click->banner#hide" class="covid__close"><span class="visually-hidden">Hide this message</span></a>
     </div>
-  </section>
+  </div>
 </div>
 
 <header class="limit-content-width" data-controller="navigation">

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,4 +1,4 @@
-<section class="homepage-feature blocks">
+<div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
     title: "Have all your questions answered at an event.",
@@ -14,4 +14,4 @@
     link_target: "/tta-service",
     image: "media/images/content/piclink2.jpg")
   %>
-</section>
+</div>

--- a/app/views/sections/_zendesk_chat.html.erb
+++ b/app/views/sections/_zendesk_chat.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag("https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37", id: "ze-snippet", async: true) %>
 
-<script type="text/javascript">
+<script>
   window.zESettings = {
     webWidget: {
       chat: {

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: column;
 
-    section {
+    > div {
       flex: 1 0;
       margin: $indent-amount;
 
@@ -69,7 +69,7 @@
     .content {
       flex-direction: row;
 
-      section {
+      > div {
         &:first-child {
           margin: 0 $indent-amount $indent-amount 0;
         }


### PR DESCRIPTION
Fixes various minor HTML validation warnings. Mostly areas that are `section`s but have no headings. Some of these could possibly have headings where they currently don't, but for now this is the easiest fix; we can introduce better markup as a follow up.