### PR TITLE
Enable Markdown linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,14 @@ jobs:
 
       - name: Lint Markdown
         run: |-
-          docker run -t --rm ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec mdl app/views/**/*.md"
+          docker run -t --rm -v ${PWD}/out:/app/out ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec mdl app/views/**/*.md | tee /app/out/mdl-result.txt"
+
+      - name: Keep Lint Markdown output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Rubocop_results
+          path: ${{ github.workspace }}/out/mdl-result.txt
 
       - name: Run Specs
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,10 @@ jobs:
         run: |-
           docker run -t --rm ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec erblint --lint-all"
 
+      - name: Lint Markdown
+        run: |-
+          docker run -t --rm ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec mdl app/views/**/*.md"
+
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test ${{needs.build.outputs.DOCKER_IMAGE}} \

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,46 @@
+rules "MD001", # Header levels should only increment by one level at a time
+      "MD003", # Header style
+      "MD004", # Unordered list style
+      "MD005", # Inconsistent indentation for list items at the same level
+      "MD006", # Consider starting bulleted lists at the beginning of the line
+      "MD007", # Unordered list indentation
+      "MD010", # Hard tabs
+      "MD011", # Reversed link syntax
+      "MD012", # Multiple consecutive blank lines
+      "MD014", # Dollar signs used before commands without showing output
+      "MD018", # No space after hash on atx style header
+      "MD019", # Multiple spaces after hash on atx style header
+      "MD020", # No space inside hashes on closed atx style header
+      "MD021", # Multiple spaces inside hashes on closed atx style header
+      "MD022", # Headers should be surrounded by blank lines
+      "MD023", # Headers must start at the beginning of the line
+      "MD024", # Multiple headers with the same content
+      "MD025", # Multiple top level headers in the same document
+      "MD027", # Multiple spaces after blockquote symbol
+      "MD028", # Blank line inside blockquote
+      "MD029", # Ordered list item prefix
+      "MD030", # Spaces after list markers
+      "MD031", # Fenced code blocks should be surrounded by blank lines
+      "MD032", # Lists should be surrounded by blank lines
+      "MD034", # Bare URL used
+      "MD035", # Horizontal rule style
+      "MD036", # Emphasis used instead of a header
+      "MD037", # Spaces inside emphasis markers
+      "MD038", # Spaces inside code span elements
+      "MD039", # Spaces inside link text
+      "MD040", # Fenced code blocks should have a language specified
+      "MD041", # First line in file should be a top level header
+      "MD046", # Code block style
+      "MD047"  # File should end with a single newline character
+
+# Trailing punctuation in header
+rule "MD026", :punctuation => "'.,;:!'"
+
+# Ignore frontmatter
+ignore_front_matter true
+
+# Disabled rules
+# MD002 - First header should be a top level header
+# MD009 - Trailing spaces
+# MD013 - Line length
+# MD033 - Inline HTML

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :development, :test do
 
   # Linting
   gem "erb_lint", require: false
+  gem "mdl"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chef-utils (17.5.22)
+      concurrent-ruby
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -239,6 +241,8 @@ GEM
     kaminari-core (1.2.1)
     kramdown (2.3.1)
       rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -252,11 +256,22 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     matrix (0.4.2)
+    mdl (0.11.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.9)
+      tomlrb
+    mixlib-shellout (3.2.5)
+      chef-utils
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -432,6 +447,7 @@ GEM
     stoplight (2.2.1)
     text (1.3.1)
     thor (1.1.0)
+    tomlrb (2.0.1)
     trailblazer-option (0.1.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
@@ -499,6 +515,7 @@ DEPENDENCIES
   loaf (>= 0.10.0)
   logger (>= 1.4.3)
   matrix (>= 0.4.2)
+  mdl
   observer (>= 0.1.0)
   parallel_split_test
   prometheus-client

--- a/app/views/content/a-day-in-the-life-of-a-teacher.md
+++ b/app/views/content/a-day-in-the-life-of-a-teacher.md
@@ -58,9 +58,11 @@ $q-sarah-primary$
 There may be staff meetings in the morning to catch up with all staff, year group, or faculty members.
 
 #### 8:30 - The day begins
+
 The day begins with form time. This might include uniform and planner checks, or even some numeracy and literacy skills activities.
 
 #### 9:00 - Morning lessons start
+
 Not every day is a full timetable of lessons. Teachers have free periods which are spread across the week. These are used to catch up on marking or planning.
 
 $q-sarah-geography-1$

--- a/app/views/content/become-a-further-education-teacher.md
+++ b/app/views/content/become-a-further-education-teacher.md
@@ -27,7 +27,6 @@ You could teach a diverse set of learners, including young people and adults.
 
 You do not need a degree to start teaching in further education. 
 
-
 ## Training to teach in further education
 
 To find out more, visit the [teach in further education website](https://www.teach-in-further-education.campaign.gov.uk/).

--- a/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
@@ -25,26 +25,31 @@ $train_to_teach$
 If you’re interested in training to teach but not sure on your next steps, then our popular Train to Teach events are for you. Whether you’re ready to apply or it’s just an idea, here are five reasons why a Train to Teach event can help you on your journey to the classroom.
 
 ## 1. Save some time
+
 A Train to Teach event offers you a one-stop shop of information and support.  There are a number of different zones you can visit where our expert advisers will help you understand the qualifications you need and the range of different ways you can train.  
 
 Whether you’ve recently graduated or you’re looking to change your career, in as little as two hours you will be able to gain clarity and confidence in your steps to becoming a teacher.
 
 ## 2. Get answers tailored to your circumstances
+
 We understand that everyone’s journey into the classroom is different and your questions may be unique to you and your circumstances. You may have questions about your eligibility or a query about the extra financial support available if you’re a parent or a carer. 
 
 At a Train to Teach event we can answer all your questions and maybe some you didn’t know you had!  
 
 ## 3. Make connections
+
 A Train to Teach event is a great way of making new connections. You can meet like-minded individuals on their teaching journey and stay in touch with each other through our [Aspiring Teacher Forum](https://www.facebook.com/groups/1357146377672255) or [Career Change to Teaching](https://www.facebook.com/groups/CareerChangetoTeaching) Facebook groups. 
 
 You can also speak to teacher training providers for advice on how to find the right course for you, as well as meeting potential future course leaders or employers. These connections could help you in your journey to a rewarding career in teaching.
 
 ## 4. Meet the experts
+
 At each of our events there are a range of experts to speak to including [Teacher Training Advisers](/teacher-training-advisers). Our advisers are former teachers with lots of experience, who know the application process and teacher training experience inside out. 
 
 Sign up for your own adviser at one of our events and have a one-to-one conversation about everything from reassurance about how to stand at the front of a classroom to how to fund your training. The support won’t stop at the end of the event – they can give you as much or as little help as you need.
 
 ## 5. Chat with current teachers
+
 You can have a one-to-one chat with a current teacher who can provide you with insight into what it is really like to train and to be a teacher. You may wish to ask them to describe their experiences including any fears they had when they started out and how they overcame these challenges. 
 
 They can also talk about why they love teaching and how rewarding it is, giving you a balanced view and insight into what the life of a teacher is really like.

--- a/app/views/content/blog/abigails-career-progression-story.md
+++ b/app/views/content/blog/abigails-career-progression-story.md
@@ -60,8 +60,6 @@ And finally, I do love the holidays! I try to switch off outside of term time an
 
 My advice for anyone thinking of getting into teaching is to remember that you will make a difference, even though it might be challenging at times! When pupils are in your classroom, you have the opportunity to grow their minds and improve their understanding of the world. You are responsible for helping pupils achieve the best possible outcomes and for inspiring them to build their resilience and determination.
 
-
-
 _For the first 2 years in the classroom, during their induction, teachers are called 'early career teachers' (ECTs). 
 It's a time when you get lots of extra support to help establish yourself as a teacher._
 

--- a/app/views/content/blog/teachers-pension-scheme.md
+++ b/app/views/content/blog/teachers-pension-scheme.md
@@ -21,11 +21,12 @@ $whiteboard$
 
 A teaching career offers a range of benefits, including a [competitive salary](/salaries-and-benefits), opportunities for career progression, and a support package for [early career teachers](https://www.gov.uk/government/collections/early-career-framework-reforms). It also comes with a secure pension that will help you save for your future. Here are six things that you need to know about the Teachers’ Pension Scheme.
 
-
 ## 1. All teachers are automatically enrolled
+
 You will be enrolled automatically in the Teachers’ Pension Scheme from the start of your career and each time you start a new contract. The pension is yours, so you can add to it throughout your career, even when you move teaching jobs. You also have the flexibility to opt out of the scheme if you wish to. It’s important to take independent financial advice when making any decisions regarding your pension.
 
 ## 2. Your employer and the government contribute too
+
 Each time you are paid, you contribute part of your salary to your pension. In addition, your employer also puts a percentage of your salary into the Scheme. As the Scheme is registered with HM Revenue and Customs, your contributions are tax-free, so you are able to keep more of your income.
 
 > We have a superb pension package.
@@ -33,17 +34,21 @@ Each time you are paid, you contribute part of your salary to your pension. In a
 > _Katie, Assistant Principal_
 
 ## 3. Your contributions are based on what you earn
+
 A percentage of your pay is automatically placed into your pension pot each month. If your salary increases, this percentage will increase too. If you wish to, you can also opt to pay extra contributions.
 
 _Find out more about the benefits of the [Teachers’ Pension Scheme](https://www.teacherspensions.co.uk/-/media/documents/member/factsheets/joining-or-leaving-the-scheme/opt-out-factsheet.ashx?rev=a5fc4ec0eb9149d9af2d77fe8f2b1a2d&hash=6DA68B46766108AAB59ED00BBCEBDDD4&)._
 
 ## 4. The Scheme is very secure
+
 The Teachers’ Pension Scheme is one of only eight schemes backed by the government. This means that it is not reliant on your money being invested elsewhere.
 
 ## 5. The Scheme is flexible
+
 If you wish to, you can convert part of your pension early as a tax-free lump sum. If you were to become ill during your career, you could apply for early ill-health retirement. You can also manage your pension online in a way that suits you.
 
 ## 6. Your family will be protected
+
 If you were to die while actively paying into your pension, a nominated beneficiary would receive a death grant. After two years of paying in to your pension, a nominated beneficiary would also receive a pension after you die.
 
 To find out more about the Teachers’ Pension Scheme, visit the [Teachers' Pensions website now](https://www.teacherspensions.co.uk/members/new-starter.aspx).

--- a/app/views/content/early-years-teaching-training.md
+++ b/app/views/content/early-years-teaching-training.md
@@ -65,7 +65,7 @@ As an early years teacher you'll work with young children up to the age of 5. Yo
 
 The early years are critical in children's development. You’ll use your knowledge and skills to help young children enjoy high standards of teaching and open their minds to new ideas every day.
 
-###How to become an early years teacher
+### How to become an early years teacher
 
 You’ll need to do 'early years initial teacher training' (EYITT) to achieve 'early years teacher status' (EYTS).
 
@@ -96,9 +96,9 @@ $EY-graduate$
 
 Bursaries are available, including:
 
- * £5,000 if you have a first class degree
- * £4,000 if you have a 2:1 degree
- * £2,000 if you have a 2:2 degree
+* £5,000 if you have a first class degree
+* £4,000 if you have a 2:1 degree
+* £2,000 if you have a 2:2 degree
 
 $EY-graduate-employment$
 

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -120,7 +120,6 @@ You will only have to make loan repayments once you're earning. Your repayments 
 
 $student-finance-calculator$
 
-
 ## Bursaries and scholarships
 
 You may be eligible for a teaching bursary or scholarship when training to teach.
@@ -153,7 +152,6 @@ below. You cannot receive both a teaching bursary and a scholarship.
 | **Languages** | £10,000  | *N/A*            |
 | **Biology**   | £7,000   | *N/A*            |
 
-
 ### Non-graduate bursaries
 
 #### If you're a final year undergraduate student
@@ -169,7 +167,6 @@ You may be eligible for a [Troops to Teachers](https://www.ucas.com/teaching-opt
 * training to teach secondary biology, physics, chemistry, computing, maths or modern foreign languages
 * doing an undergraduate degree leading to QTS in England
 
-
 $chat$
 
 ## If you're a parent or carer
@@ -180,7 +177,6 @@ $chat$
 * [Parents' Learning Allowance](https://www.gov.uk/parents-learning-allowance)
 * [Adult Dependants’ Grant](https://www.gov.uk/adult-dependants-grant)
 
-
 ## If you're disabled
 
 You may be able to [get support if you’re a student and you’re disabled, have a learning difficulty or health problem](https://www.gov.uk/disabled-students-allowance-dsa/how-to-claim).
@@ -188,7 +184,6 @@ You may be able to [get support if you’re a student and you’re disabled, hav
 [If you do paid training you may also be eligible for support](https://www.gov.uk/access-to-work).
 
 [Learn more about training to teach if you're disabled](/get-support-training-to-teach-if-you-are-disabled).
-
 
 ## If you come from outside England
 

--- a/app/views/content/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher.md
+++ b/app/views/content/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher.md
@@ -28,6 +28,7 @@ I was instantly hooked after gaining school experience. The inspirational teache
 $q-helen$
 
 ### 100% job satisfaction
+
 It is the only job where I can honestly say you get 100% job satisfaction. It is lovely to watch your pupils grow into young adults and when they receive their exam results, and realise it was all worthwhile, there is no greater pleasure. Being part of helping shape a young person's future is very humbling as well as fulfilling.
 
 Two years after I qualified as a teacher, I was head of a department and learning to learn coordinator. The following 2 years I continued to progress and now I'm the director of teaching school and assistant headteacher.

--- a/app/views/content/salaries-and-benefits-simplified.md
+++ b/app/views/content/salaries-and-benefits-simplified.md
@@ -68,20 +68,16 @@ There are different ways to progress and increase your salary.
 
 For example, you can move into a more senior role, or take on additional responsibilities that help your school.
 
-
-
 ### Qualified teacher pay
 
 The school you teach in will have their own pay scales for qualified teachers. Pay increases will always be linked to performance, not length of service.
 
 Annual salary ranges for qualified teachers are:
 
-
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
 | London                                   | £26,948 | £42,624 |
 | Rest of England and Wales                | £25,714 | £36,961 |
-
 
 ### Senior teacher pay
 
@@ -95,8 +91,6 @@ Annual salary ranges for senior teachers are:
 | -------                       | -----   | -----    |
 | London                        | £39,864 | £50,935  |
 | Rest of England and Wales     | £38,690 | £41,604  |
-
-
 
 ### Leading practitioner pay
 
@@ -123,7 +117,6 @@ Annual salary ranges for headteachers are:
 | -------                       | -----   | -----     |
 | London                        | £43,356 | £125,098  |
 | Rest of England and Wales     | £47,195 | £117,197  |
-
 
 ### Other payments
 

--- a/app/views/content/teacher-training-advisers.md
+++ b/app/views/content/teacher-training-advisers.md
@@ -47,7 +47,6 @@ Teacher training advisers give you free, one-to-one help and support.
 
 They're all former teachers with lots of experience, so they know the process inside out.  
 
-
 $get-a-tta$
 
 ## What an adviser can do for you

--- a/app/views/content/three-things-to-help-you-get-into-teaching.md
+++ b/app/views/content/three-things-to-help-you-get-into-teaching.md
@@ -62,10 +62,10 @@ All our teacher training advisers are experienced teachers who can provide you w
 
 Advisers can:
 
-- help you choose the right training
-- offer advice on financial support
-- give you practical advice and guidance at every stage of your application
-- offer support when you write your personal statement and prepare for interview
+* help you choose the right training
+* offer advice on financial support
+* give you practical advice and guidance at every stage of your application
+* offer support when you write your personal statement and prepare for interview
 
 Whatever you need, your adviser will be just a phone call, text, or email away.
 

--- a/app/views/content/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/train-to-teach-in-england-as-an-international-student.md
@@ -81,7 +81,7 @@ You usually need the equivalent of a GCSE (grade 4) in English and maths.
 To teach children aged 3 to 11, you also need the equivalent of a GCSE (grade 4) in a science subject.
 
 #### Help with international qualifications
- 
+
 If your qualifications come from a non-UK institution, your teacher training provider may want to see a ‘[statement of comparability](https://enic.org.uk/Qualifications/SOC/Default.aspx)’ showing their equivalence to UK qualifications.
 
 Call us on [0800 389 2500](tel://08003892500) for:

--- a/app/views/pages/cookies.md
+++ b/app/views/pages/cookies.md
@@ -21,13 +21,13 @@ information about you.
 
 Some examples of these cookies include:
 
-  - enabling a service to recognise your device so you don’t have to
-    give the same information several times during one task
-  - recognising that you may already have given a username and password
-    so that you don’t need to do so for every webpage requested
-  - measuring how many people are using our services so that we can make
-    them easier to use and ensure that there is enough capacity to make
-    sure they are fast
+- enabling a service to recognise your device so you don’t have to
+  give the same information several times during one task
+- recognising that you may already have given a username and password
+  so that you don’t need to do so for every webpage requested
+- measuring how many people are using our services so that we can make
+  them easier to use and ensure that there is enough capacity to make
+  sure they are fast
 
 | Name                         | Purpose                                            | Expires                   |
 | ---------------------------- | -------------------------------------------------- | ------------------------- |
@@ -64,7 +64,6 @@ gather this data.
 | `_ga`            | Helps count how many people visit this site by tracking if you’ve visited before | 2 years  |
 | `UA-179982899-1` | Registers a unique ID to generate statistics about how you use the website       | 1 minute |
 | `_gid`           | Helps count how many people visit this site by tracking if you’ve visited before | 24 hours |
-
 
 #### Hotjar cookies
 
@@ -132,11 +131,11 @@ You can delete or manage all cookies from your browser. The links below
 take you to the ‘Help' sections for each of the major browsers, so that
 you can find out more about how to manage your cookies.
 
-  - [**Google Chrome**](https://support.google.com/chrome/answer/95647?hl=en-GB&p=cpn_cookies)
-  - [**Microsoft Edge**](https://support.microsoft.com/en-us/help/4468242/microsoft-edge-browsing-data-and-privacy)
-  - [**Microsoft Internet Explorer**](https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies#ie=ie-11)
-  - [**Mozilla Firefox**](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer?redirectlocale=en-US&redirectslug=Cookies)
-  - [**Safari**](https://support.apple.com/kb/ph21411?locale=en_GB)
+- [**Google Chrome**](https://support.google.com/chrome/answer/95647?hl=en-GB&p=cpn_cookies)
+- [**Microsoft Edge**](https://support.microsoft.com/en-us/help/4468242/microsoft-edge-browsing-data-and-privacy)
+- [**Microsoft Internet Explorer**](https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies#ie=ie-11)
+- [**Mozilla Firefox**](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer?redirectlocale=en-US&redirectslug=Cookies)
+- [**Safari**](https://support.apple.com/kb/ph21411?locale=en_GB)
 
 Find out [how we use your personal data](/privacy-policy) when you sign up for our services.
 


### PR DESCRIPTION
### Trello card

[Trello-346](https://trello.com/c/9yrX1WTw/346-development-implement-md-erb-and-html-linters-in-ruby-code)

### Context

We want to lint our Markdown files to keep them consistent and avoid potential errors.

### Changes proposed in this pull request

- Add Markdown linter and configure

Adds a Markdown linter and configures it so that it by-en-large passes on our set of Markdown files.

The linter can be ran with:

```
mdl app/views/content/**/*.md
```

It is set to run during CI and fail if there are any linting errors present. This may be too heavy-handed and blocking for content editors so we may end up switching it off and running it nightly instead.

- Various Markdown linting fixes

### Guidance to review

