### PR TITLE
Fix broken train to teach events link

### DIFF
--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -15,7 +15,7 @@
       - title: New events added.
         text: Turn your questions into confidence. Decide how to fund your training at our next event.
         link_text: "Events near you"
-        link_target: "/event-categories/train-to-teach"
+        link_target: "/event-categories/train-to-teach-events"
         icon: "icon-calendar"
         hide_on_mobile: Yes
         hide_on_tablet: Yes


### PR DESCRIPTION
The events link in the funding your training CTA was incorrect.
