### PR TITLE
Add a new mailing list completed page

### DIFF
--- a/app/components/registration/mailing_list_signup_confirmation_component.html.erb
+++ b/app/components/registration/mailing_list_signup_confirmation_component.html.erb
@@ -1,0 +1,14 @@
+<section class="text-content mailing-list__completed">
+  <%= tag.h2(heading_text, class: 'green') %>
+
+  <p>
+    We'll send your first email shortly. From teacher stories to practical
+    information, we've got all the info you need to become a teacher.
+  </p>
+
+  <p>
+    You can unsubscribe at any time.
+  </p>
+
+  <%= link_to "Continue your journey", "/welcome", class: "button" %>
+</section>

--- a/app/components/registration/mailing_list_signup_confirmation_component.rb
+++ b/app/components/registration/mailing_list_signup_confirmation_component.rb
@@ -1,0 +1,15 @@
+class Registration::MailingListSignupConfirmationComponent < ViewComponent::Base
+  attr_reader :mailing_list_session
+
+  def initialize(mailing_list_session)
+    @first_name = mailing_list_session["first_name"]
+  end
+
+  def heading_text
+    if @first_name.present?
+      %(#{@first_name}, you're signed up)
+    else
+      %(You've signed up)
+    end
+  end
+end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -20,7 +20,11 @@ module MailingList
         break unless result
 
         add_member_to_mailing_list
-        @store.purge!
+
+        # we're taking the last name too so if people restart the wizard
+        # both are filled rather than just their first name, which looks
+        # a bit odd
+        @store.prune!(leave: %w[first_name last_name])
       end
     end
 

--- a/app/models/wizard/store.rb
+++ b/app/models/wizard/store.rb
@@ -46,6 +46,13 @@ module Wizard
       @crm_data.clear
     end
 
+    # purges the CRM data but leaves a subset of app data
+    # that might be used on or after the completion page
+    def prune!(leave: [])
+      @app_data.slice!(*Array.wrap(leave))
+      @crm_data.clear
+    end
+
   private
 
     def store(source)

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -70,22 +70,7 @@
   </div>
 
 <% else %>
-
-  <section class="text-content mailing-list__completed">
-    <%= tag.h2(%(#{mailing_list_session["first_name"]}, you're signed up), class: 'green') %>
-
-    <p>
-      We'll send your first email shortly. From teacher stories to practical
-      information, we've got all the info you need to become a teacher.
-    </p>
-
-    <p>
-      You can unsubscribe at any time.
-    </p>
-
-    <%= link_to "Continue your journey", "/welcome", class: "button" %>
-  </section>
-
+  <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% end %>
 
 <span data-controller="pinterest"

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,97 +1,106 @@
 <% @hide_page_helpful_question = true %>
 
-<section class="text-content">
-  <h2 class="green">You've signed up</h2>
+<% if Rails.env.test? || Rails.env.production? %>
 
-  <p>
-    You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.
-  </p>
-
-  <% unless Rails.env.production? %>
+  <section class="text-content">
+    <h2 class="green">You've signed up</h2>
 
     <p>
-      In the meantime you can explore your personalised welcome guide to give you a flavour of what the world of teaching is like.
+      You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.
     </p>
 
-    <%= link_to("View your personalised Welcome Guide", "/welcome", class: "button button--secondary button--inline") %>
+    <h3>Want to talk to someone?</h3>
 
-  <% end %>
+    <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
 
-  <h3>Want to talk to someone?</h3>
-
-  <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
-
-  <div class="mailing-list__actions">
-    <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
-    <div>
-      <small>or call us now:</small>
-      <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+    <div class="mailing-list__actions">
+      <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
+      <div>
+        <small>or call us now:</small>
+        <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+      </div>
     </div>
+
+    <p>Monday - Friday between 8:30am and 5:30pm.</p>
+  </section>
+
+  <div class="blocks">
+    <%= render Content::GenericBlockComponent.new(
+      title: "Life as a teacher",
+      icon_image: "icon-school-black.svg",
+      icon_alt: "mortarboard icon",
+      icon_size: "40x30",
+      classes: "blocks__directory"
+    ) do %>
+      <ul>
+        <li><a href="/my-story-into-teaching">Read teachers' stories</a></li>
+        <li><a href="https://schoolexperience.education.gov.uk/">Experience a real school</a></li>
+        <li><a href="/salaries-and-benefits">Teachers' salaries</a></li>
+      </ul>
+    <% end %>
+    <%= render Content::GenericBlockComponent.new(
+      title: "Your next steps",
+      icon_image: "icon-doc-black.svg",
+      icon_alt: "icon containing learning materials",
+      icon_size: "40x35",
+      classes: "blocks__directory"
+    ) do %>
+      <ul>
+        <li><a href="/steps-to-become-a-teacher">How to become a teacher</a></li>
+        <li><a href="/ways-to-train">Explore ways to train</a></li>
+        <li><a href="/funding-your-training">Find your funding options</a></li>
+      </ul>
+    <% end %>
+    <%= render Content::GenericBlockComponent.new(
+      title: "Speak to teachers",
+      icon_image: "icon-git-black.svg",
+      icon_alt: "site icon logo checkmark",
+      icon_size: "33x33",
+      classes: "blocks__directory"
+    ) do %>
+      <p class="block__text">
+        Attend an event and speak to current teachers or get your
+        questions answered by our expert advisers. You can
+        also find out what it's like to train and be in the
+        classroom.
+      </p>
+
+      <%= link_to "Find an event", events_path, class: "button button--white button--unpadded" %>
+    <% end %>
   </div>
 
-  <p>Monday - Friday between 8:30am and 5:30pm.</p>
+<% else %>
 
-  <span data-controller="pinterest"
-        data-pinterest-action="track"
-        data-pinterest-event="lead"
-        data-pinterest-event-data="<%= { "lead-type": "Newsletter" }.to_json %>"></span>
+  <section class="text-content mailing-list__completed">
+    <%= tag.h2(%(#{mailing_list_session["first_name"]}, you're signed up), class: 'green') %>
 
-  <span data-controller="snapchat"
-        data-snapchat-action="track"
-        data-snapchat-event="SUBSCRIBE"></span>
-
-  <span data-controller="facebook"
-        data-facebook-action="trackCustom"
-        data-facebook-event="Newsletter_Subscribers"></span>
-
-  <span data-controller="bam" data-bam-action="track"></span>
-
-  <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
-</section>
-
-<div class="blocks">
-  <%= render Content::GenericBlockComponent.new(
-    title: "Life as a teacher",
-    icon_image: "icon-school-black.svg",
-    icon_alt: "mortarboard icon",
-    icon_size: "40x30",
-    classes: "blocks__directory"
-  ) do %>
-    <ul>
-      <li><a href="/my-story-into-teaching">Read teachers' stories</a></li>
-      <li><a href="https://schoolexperience.education.gov.uk/">Experience a real school</a></li>
-      <li><a href="/salaries-and-benefits">Teachers' salaries</a></li>
-    </ul>
-  <% end %>
-
-  <%= render Content::GenericBlockComponent.new(
-    title: "Your next steps",
-    icon_image: "icon-doc-black.svg",
-    icon_alt: "icon containing learning materials",
-    icon_size: "40x35",
-    classes: "blocks__directory"
-  ) do %>
-    <ul>
-      <li><a href="/steps-to-become-a-teacher">How to become a teacher</a></li>
-      <li><a href="/ways-to-train">Explore ways to train</a></li>
-      <li><a href="/funding-your-training">Find your funding options</a></li>
-    </ul>
-  <% end %>
-
-  <%= render Content::GenericBlockComponent.new(
-    title: "Speak to teachers",
-    icon_image: "icon-git-black.svg",
-    icon_alt: "site icon logo checkmark",
-    icon_size: "33x33",
-    classes: "blocks__directory"
-  ) do %>
-    <p class="block__text">
-      Attend an event and speak to current teachers or get your
-      questions answered by our expert advisers. You can
-      also find out what it's like to train and be in the
-      classroom.
+    <p>
+      We'll send your first email shortly. From teacher stories to practical
+      information, we've got all the info you need to become a teacher.
     </p>
 
-    <%= link_to "Find an event", events_path, class: "button button--white button--unpadded" %>
-  <% end %>
-</div>
+    <p>
+      You can unsubscribe at any time.
+    </p>
+
+    <%= link_to "Continue your journey", "/welcome", class: "button" %>
+  </section>
+
+<% end %>
+
+<span data-controller="pinterest"
+      data-pinterest-action="track"
+      data-pinterest-event="lead"
+      data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
+
+<span data-controller="snapchat"
+      data-snapchat-action="track"
+      data-snapchat-event="SUBSCRIBE"></span>
+
+<span data-controller="facebook"
+      data-facebook-action="trackCustom"
+      data-facebook-event="Newsletter_Subscribers"></span>
+
+<span data-controller="bam" data-bam-action="track"></span>
+
+<span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -76,7 +76,7 @@
 <span data-controller="pinterest"
       data-pinterest-action="track"
       data-pinterest-event="lead"
-      data-pinterest-event-data='{"lead-type" : "Newsletter"}'></span>
+      data-pinterest-event-data="{'lead-type' : 'Newsletter'}"></span>
 
 <span data-controller="snapchat"
       data-snapchat-action="track"

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -44,4 +44,15 @@
       color: $black;
     }
   }
+
+  .mailing-list__completed {
+    * + p {
+      margin-top: 2em;
+      max-width: 60ch;
+    }
+
+    .button {
+      margin-top: 1em;
+    }
+  }
 }

--- a/spec/components/registration/mailing_list_signup_confirmation_component_spec.rb
+++ b/spec/components/registration/mailing_list_signup_confirmation_component_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe Registration::MailingListSignupConfirmationComponent, type: :component do
+  subject! { render_inline(component) }
+
+  let(:mailing_list_session) { { "first_name" => "Joey" } }
+
+  let(:component) { described_class.new(mailing_list_session) }
+
+  specify "renders a button-style link to the welcome guide" do
+    expect(Capybara.string(rendered_component)).to have_link("Continue your journey", href: "/welcome")
+  end
+
+  describe "#heading_text" do
+    subject { component }
+
+    context "when the mailing_list_session has a first_name" do
+      specify "the header includes the first name" do
+        expect(subject.heading_text).to eql("Joey, you're signed up")
+      end
+    end
+
+    context "when the mailing_list_session has no first_name" do
+      let(:mailing_list_session) { {} }
+
+      specify "the header is generic" do
+        expect(subject.heading_text).to eql("You've signed up")
+      end
+    end
+  end
+end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_title("You've signed up | Get Into Teaching")
-    expect(page).to have_text "You've signed up"
+    expect(page).to have_text "you're signed up"
   end
 
   scenario "Full journey as an on-campus candidate" do
@@ -84,7 +84,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "You've signed up"
+    expect(page).to have_text "you're signed up"
   end
 
   scenario "Full journey as an existing candidate" do
@@ -138,7 +138,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "You've signed up"
+    expect(page).to have_text "you're signed up"
   end
 
   scenario "Full journey as an existing candidate that resends the verification code" do
@@ -259,7 +259,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "You've signed up"
+    expect(page).to have_text "you're signed up"
   end
 
   scenario "Invalid magic link tokens" do

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -45,7 +45,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_title("You've signed up | Get Into Teaching")
-    expect(page).to have_text "you're signed up"
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text("You'll receive a welcome email shortly")
   end
 
   scenario "Full journey as an on-campus candidate" do
@@ -84,7 +85,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "you're signed up"
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text("You'll receive a welcome email shortly")
   end
 
   scenario "Full journey as an existing candidate" do
@@ -138,7 +140,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "you're signed up"
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text("You'll receive a welcome email shortly")
   end
 
   scenario "Full journey as an existing candidate that resends the verification code" do
@@ -259,7 +262,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "you're signed up"
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text("You'll receive a welcome email shortly")
   end
 
   scenario "Invalid magic link tokens" do

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -46,7 +46,7 @@ describe MailingList::Wizard do
     end
 
     it { is_expected.to have_received(:valid?) }
-    it { expect(store[uuid]).to eql({}) }
+    it { expect(store[uuid]).to eql({ "first_name" => "Joe", "last_name" => "Joseph" }) }
 
     it "logs the request model (filtering sensitive attributes)" do
       filtered_json = { "email" => "[FILTERED]", "firstName" => "[FILTERED]", "lastName" => "[FILTERED]" }.to_json

--- a/spec/models/wizard/store_spec.rb
+++ b/spec/models/wizard/store_spec.rb
@@ -124,11 +124,24 @@ describe Wizard::Store do
   end
 
   describe "#purge!" do
-    before { instance.purge! }
     subject { instance.keys }
+
+    before { instance.purge! }
 
     it "will remove all keys" do
       is_expected.to have_attributes empty?: true
+    end
+  end
+
+  describe "#prune!" do
+    subject { instance.keys }
+    let(:leave) { "age" }
+
+    before { instance.prune!(leave: leave) }
+
+    it "will remove all keys that aren't marked as 'leave'" do
+      expect(instance.keys).to include(leave)
+      expect(instance.keys).not_to include(app_data.keys.excluding(leave))
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/BbakOzej/1921-welcome-guide-design-and-develop-mailing-list-completion-page

### Context

This change replaces the old mailing list completion page with a new personalised one. To do this, rather than purging the mailing list data from the session at the end of the wizard we prune it, leaving in the few bits we'll need for personalised pages we want to display (here, the completion page and welcome guide).

For now, because the welcome guide's not ready, I've left the purple boxes in when the environment is `production`. This will allow the new completion page to be deployed before the welcome guide is finalised and not leave users with a dead end.

#### Potential data risks

The `#prune!` method is a little like purge except it allows some keys (none by default) to be left in the session's `app_data` store.

For now, if a user restarts the mailing list signup, the first page will have the `first_name` and `last_name` they used on the previous run pre-filled.

Data is all stored in the session so assumed to be safe, although using a shared machine could allow people to see previous users' data. This would be the same had a user partially filled in the wizard then stopped though, so we're not really introducing a new attack vector here, but it's something to be aware of.

### Changes

- Replace mailing list completion page
- Add `#prune!` to Wizard::Store

### Preview

|  Desktop | Mobile |
| ----- | ----- |
| ![Screenshot-2021-09-27-14:12:11](https://user-images.githubusercontent.com/128088/134932331-d92f9ef8-385a-45c8-8a3a-8975d4c9f678.png) | ![Screenshot-2021-09-27-14:11:58](https://user-images.githubusercontent.com/128088/134932361-18207631-c937-4f72-8dec-fe73ba0e09b5.png) |




### Guidance to review

* is leaving things in the session a new security/PII risk?
* are the purple boxes on the completion page suitable for users who finish the wizard? Should we add a button that takes them to the homepage too?
