### PR TITLE
Remove and validate extra characters when creating event partial URL

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -29,7 +29,7 @@ module Internal
     attribute :venue_type, default: VENUE_TYPES[:none]
 
     validates :name, presence: true, allow_blank: false, length: { maximum: 300 }
-    validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }
+    validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }, format: { with: /\A[\w-]+\Z/ }
     validates :summary, presence: true, allow_blank: false, length: { maximum: 1000 }
     validates :description, presence: true, allow_blank: false, length: { maximum: 2000 }
     validates :is_online, inclusion: { in: [true, false] }, if: -> { provider_event? }

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -40,6 +40,11 @@ export default class extends Controller {
   }
 
   formatName(name) {
-    return name.trim().toLowerCase().replace(/-/g, '').split(/\s+/).join('-');
+    return name
+      .trim()
+      .toLowerCase()
+      .replace(/[^A-Za-z0-9\s]/g, '')
+      .split(/\s+/)
+      .join('-');
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,6 +464,7 @@ en:
               blank: Enter a name
             readable_id:
               blank: Enter a partial URL
+              invalid: Partial URL can only contain alphanumeric characters, hyphens, and underscores
             summary:
               blank: Enter a summary
             description:

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -69,14 +69,28 @@ describe('InternalEventsController', () => {
 
         it('removes extra hyphens', () => {
           document.getElementById('internal-event-name-field').value =
-            'event - name - with - hyphens';
+            'event - name - with-hyphens';
 
           document.getElementById('generate').click();
 
           const partialUrlFieldValue = document.getElementById(
             'internal-event-readable-id-field'
           ).value;
-          expect(partialUrlFieldValue).toBe('210515-event-name-with-hyphens');
+          expect(partialUrlFieldValue).toBe('210515-event-name-withhyphens');
+        });
+
+        it('removes characters that are not alphanumeric or whitespace', () => {
+          document.getElementById('internal-event-name-field').value =
+            'event?name:with (extra@characters)_';
+
+          document.getElementById('generate').click();
+
+          const partialUrlFieldValue = document.getElementById(
+            'internal-event-readable-id-field'
+          ).value;
+          expect(partialUrlFieldValue).toBe(
+            '210515-eventnamewith-extracharacters'
+          );
         });
       });
 

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -27,8 +27,8 @@ describe Internal::Event do
     end
 
     describe "#readable_id" do
-      it { is_expected.to allow_value("test").for :readable_id }
-      it { is_expected.not_to allow_values("", nil).for :readable_id }
+      it { is_expected.to allow_value("test_event-url").for :readable_id }
+      it { is_expected.not_to allow_values("test@event", "test?event", "test:event", "test(event)", nil).for :readable_id }
       it { is_expected.to validate_length_of(:readable_id).is_at_most(300) }
     end
 


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/G8l32WiI)

### Context
Users can generate a partial URL based on the event name and start date of an event. Currently there is only minimal validation, so we have seen event partial URLs with non-alphanumeric characters such as brackets, colons, and question marks.

### Changes proposed in this pull request
- Update the JavaScript that generates the partial URL to cut out any characters that are not alphanumeric or whitespace. 
- Update the partial URL validation so that only alphanumeric, hyphens, and underscores are allowed.

### Guidance to review
Generating the partial URL:
![image](https://user-images.githubusercontent.com/47089130/135247154-7d4e62e4-df0d-48a4-9704-39b41057548d.png)
![image](https://user-images.githubusercontent.com/47089130/135247319-b3e14e97-c492-4d2c-9c47-534866ec4893.png)

Can the JS regex be improved? is there a way to do `[^\w\s]` without underscores? [here](https://regexr.com/66hm2)