### PR TITLE
Display email fallback in place of chat when JS is disabled

### DIFF
--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -11,7 +11,7 @@
               <div class="live-chat">
                 <p class="js-enabled-title">Live chat</p>
                 <p class="js-disabled-title">Email us</p>
-                <%= helpers.chat_link("Chat online", classes: "button", fallback_text: nil, fallback_email: "getintoteaching@education.gov.uk", offline_text: "Chat closed") %>
+                <%= helpers.chat_link("Chat online", classes: "button", fallback_text: nil, fallback_email: "getintoteaching.getintoteaching@education.gov.uk", offline_text: "Chat closed") %>
               </div>
               <% end %>
               <div>

--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -9,8 +9,9 @@
             <div class="options">
               <% unless helpers.privacy_page?(request.path) %>
               <div class="live-chat">
-                <p>Live chat</p>
-                <%= helpers.chat_link("Chat online", classes: "button", fallback_text: nil, offline_text: "Chat closed") %>
+                <p class="js-enabled-title">Live chat</p>
+                <p class="js-disabled-title">Email us</p>
+                <%= helpers.chat_link("Chat online", classes: "button", fallback_text: nil, fallback_email: "getintoteaching@education.gov.uk", offline_text: "Chat closed") %>
               </div>
               <% end %>
               <div>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,11 +103,19 @@ module ApplicationHelper
     link_to text, path, **options
   end
 
-  def chat_link(text = "Chat online", classes: nil, fallback_text: "Chat to us", offline_text: "Chat available Monday to Friday between 8:30am and 5:30pm.")
+  def chat_link(
+    text = "Chat online",
+    classes: nil,
+    fallback_text: "Chat to us",
+    fallback_email: nil,
+    offline_text: "Chat available Monday to Friday between 8:30am and 5:30pm."
+  )
+    raise ArgumentError, "Specify fallback text or email, not both" if [fallback_text, fallback_email].all?(&:present?)
+
     # Text is wrapped in a <span> so it can be easily replaced
     # without losing the > icon that gets appended by JS.
     main_link = link_to("#",
-                        class: "#{classes} chat-button #{'with-fallback' if fallback_text.present?}",
+                        class: "#{classes} chat-button #{'with-fallback' if [fallback_text, fallback_email].any?(&:present?)}",
                         data: {
                           action: "talk-to-us#startChat",
                           "talk-to-us-target": "button",
@@ -118,6 +126,7 @@ module ApplicationHelper
     ]
 
     elements << link_to(fallback_text, "#talk-to-us", class: "#{classes} chat-button-no-js") if fallback_text.present?
+    elements << mail_to(fallback_email, fallback_email, class: "chat-button-no-js") if fallback_email.present?
     elements << tag.span(offline_text, class: "chat-button-offline", data: { "talk-to-us-target": "offlineText" }) if offline_text.present?
 
     tag.span(safe_join(elements), data: {

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -9,6 +9,9 @@
   <%= tag :link, rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
+  <% if Rails.env.test? && params.key?(:fake_browser_time) %>
+    <%= javascript_pack_tag 'fake_browser_time', 'data-turbolinks-track': 'reload', id: "fake-browser-time" %>
+  <% end %>
   <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true unless Rails.application.config.x.legacy_tracking_pixels %>
   <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>

--- a/app/webpacker/packs/fake_browser_time.js
+++ b/app/webpacker/packs/fake_browser_time.js
@@ -1,0 +1,9 @@
+import sinon from 'sinon';
+
+const params = new URLSearchParams(window.location.search);
+const fakeBrowserTime = params.get('fake_browser_time');
+const time = parseInt(fakeBrowserTime, 10);
+
+if (!isNaN(time)) {
+  sinon.useFakeTimers(time);
+}

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -124,7 +124,7 @@ iframe#launcher {
 }
 
 html:not(.js-enabled) {
-  .chat-button.with-fallback, .live-chat {
+  .chat-button.with-fallback {
     display: none;
   }
 }

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -1,5 +1,7 @@
 html:not(.js-enabled) {
   .talk-to-us .content > div.contact .options > div.live-chat {
+    flex-basis: 50%;
+
     .js-enabled-title {
       display: none;
     }
@@ -44,7 +46,8 @@ html:not(.js-enabled) {
           > div {
             flex: 1 0;
 
-            &.live-chat, &.email-us {
+            &.live-chat {
+              word-break: break-all;
               border-bottom: 1px solid $purple;
               padding-bottom: $indent-amount;
               margin-bottom: $indent-amount;
@@ -100,7 +103,7 @@ html:not(.js-enabled) {
           > div {
             flex: initial;
 
-            &.live-chat, &.email-us {
+            &.live-chat {
               border: 0;
               border-right: 1px solid $purple;
               padding: 0 $indent-amount 0 0;

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -1,3 +1,15 @@
+html:not(.js-enabled) {
+  .talk-to-us .content > div.contact .options > div.live-chat {
+    .js-enabled-title {
+      display: none;
+    }
+
+    .js-disabled-title {
+      display: block;
+    }
+  }
+}
+
 .talk-to-us {
   background-color: $grey;
 
@@ -32,10 +44,14 @@
           > div {
             flex: 1 0;
 
-            &.live-chat {
+            &.live-chat, &.email-us {
               border-bottom: 1px solid $purple;
               padding-bottom: $indent-amount;
               margin-bottom: $indent-amount;
+
+              .js-disabled-title {
+                display: none
+              }
 
               span > span {
                 font-weight: bold;
@@ -84,7 +100,7 @@
           > div {
             flex: initial;
 
-            &.live-chat {
+            &.live-chat, &.email-us {
               border: 0;
               border-right: 1px solid $purple;
               padding: 0 $indent-amount 0 0;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "sass-mq": "^5.0.1",
     "serialize-javascript": "^6.0.0",
     "set-value": "^4.0.1",
+    "sinon": "^11.1.2",
     "stimulus": "^2.0.0",
     "trix": "^1.3.1",
     "turbolinks": "^5.2.0",

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Chat", type: :feature do
 
         within(".talk-to-us") do
           expect(page).to have_text("Email us")
-          expect(page).to have_link("getintoteaching@education.gov.uk")
+          expect(page).to have_link("getintoteaching.getintoteaching@education.gov.uk")
         end
       end
 
@@ -137,7 +137,7 @@ RSpec.feature "Chat", type: :feature do
 
         within(".talk-to-us") do
           expect(page).to have_text("Email us")
-          expect(page).to have_link("getintoteaching@education.gov.uk")
+          expect(page).to have_link("getintoteaching.getintoteaching@education.gov.uk")
         end
       end
 

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -1,0 +1,177 @@
+require "rails_helper"
+
+RSpec.feature "Chat", type: :feature do
+  around do |example|
+    travel_to(date.in_time_zone("London")) { example.run }
+  end
+
+  context "when Javascript is enabled", js: true do
+    context "when chat is online" do
+      let(:date) { DateTime.new(2021, 1, 1, 9) }
+
+      scenario "viewing the chat section of the talk to us component" do
+        visit_on_date root_path
+        dismiss_cookies
+
+        within(".talk-to-us") do
+          click_link("Chat online")
+          expect(page).to have_link("Starting chat...")
+        end
+      end
+
+      scenario "viewing the chat button of the steps to become a teacher page" do
+        visit_on_date "/steps-to-become-a-teacher"
+        dismiss_cookies
+
+        within("#step-2") do
+          click_link("Chat online for qualifications advice")
+          expect(page).to have_link("Starting chat...")
+        end
+      end
+
+      scenario "viewing the chat CTA of the funding your training page" do
+        visit_on_date "/funding-your-training"
+        dismiss_cookies
+
+        within(".call-to-action--chat-online") do
+          click_link("Chat online")
+          expect(page).to have_link("Starting chat...")
+        end
+      end
+
+      scenario "viewing the chat tile of the my story into teaching footer" do
+        visit_on_date "/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching"
+        dismiss_cookies
+
+        within(".feature .card:last-child") do
+          click_link("Chat online")
+          expect(page).to have_link("Starting chat...")
+        end
+      end
+    end
+
+    context "when chat is offline" do
+      let(:date) { DateTime.new(2021, 1, 1, 5) }
+
+      scenario "viewing the chat section of the talk to us component" do
+        visit_on_date root_path
+        dismiss_cookies
+
+        within(".talk-to-us") do
+          expect(page).to have_text("Chat closed")
+        end
+      end
+
+      scenario "viewing the chat button of the steps to become a teacher page" do
+        visit_on_date "/steps-to-become-a-teacher"
+        dismiss_cookies
+
+        within("#step-2") do
+          expect(page).to have_selector(:css, ".chat-button.hidden", visible: :hidden)
+        end
+      end
+
+      scenario "viewing the chat CTA of the funding your training page" do
+        visit_on_date "/funding-your-training"
+        dismiss_cookies
+
+        within(".call-to-action--chat-online") do
+          expect(page).to have_text("Chat available Monday to Friday between 8:30am and 5:30pm.")
+        end
+      end
+
+      scenario "viewing the chat tile of the my story into teaching footer" do
+        visit_on_date "/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching"
+        dismiss_cookies
+
+        within(".feature .card:last-child") do
+          expect(page).to have_selector(:css, ".chat-button.hidden", visible: :hidden)
+        end
+      end
+    end
+  end
+
+  context "when Javascript is disabled" do
+    context "when chat is online" do
+      let(:date) { DateTime.new(2021, 1, 1, 9) }
+
+      scenario "viewing the chat section of the talk to us component" do
+        visit_on_date root_path
+
+        within(".talk-to-us") do
+          expect(page).to have_text("Email us")
+          expect(page).to have_link("getintoteaching@education.gov.uk")
+        end
+      end
+
+      scenario "viewing the chat button of the steps to become a teacher page" do
+        visit_on_date "/steps-to-become-a-teacher"
+
+        within("#step-2") do
+          expect(page).to have_link("Chat to us for qualifications advice", href: "#talk-to-us")
+        end
+      end
+
+      scenario "viewing the chat CTA of the funding your training page" do
+        visit_on_date "/funding-your-training"
+
+        within(".call-to-action--chat-online") do
+          expect(page).to have_link("Chat to us", href: "#talk-to-us")
+        end
+      end
+
+      scenario "viewing the chat tile of the my story into teaching footer" do
+        visit_on_date "/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching"
+
+        within(".feature .card:last-child") do
+          expect(page).to have_link("Chat to us", href: "#talk-to-us")
+        end
+      end
+    end
+
+    context "when chat is offline" do
+      let(:date) { DateTime.new(2021, 1, 1, 7) }
+
+      scenario "viewing the chat section of the talk to us component" do
+        visit_on_date root_path
+
+        within(".talk-to-us") do
+          expect(page).to have_text("Email us")
+          expect(page).to have_link("getintoteaching@education.gov.uk")
+        end
+      end
+
+      scenario "viewing the chat button of the steps to become a teacher page" do
+        visit_on_date "/steps-to-become-a-teacher"
+
+        within("#step-2") do
+          expect(page).to have_link("Chat to us for qualifications advice", href: "#talk-to-us")
+        end
+      end
+
+      scenario "viewing the chat CTA of the funding your training page" do
+        visit_on_date "/funding-your-training"
+
+        within(".call-to-action--chat-online") do
+          expect(page).to have_link("Chat to us", href: "#talk-to-us")
+        end
+      end
+
+      scenario "viewing the chat tile of the my story into teaching footer" do
+        visit_on_date "/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching"
+
+        within(".feature .card:last-child") do
+          expect(page).to have_link("Chat to us", href: "#talk-to-us")
+        end
+      end
+    end
+  end
+
+  def dismiss_cookies
+    click_link "Accept all cookies"
+  end
+
+  def visit_on_date(path)
+    visit "#{path}?fake_browser_time=#{date.to_i * 1000}"
+  end
+end

--- a/spec/requests/fake_browser_time_spec.rb
+++ b/spec/requests/fake_browser_time_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Fake browser time", type: :request do
+  subject { Nokogiri.parse(response.body).css("#fake-browser-time") }
+
+  before do
+    allow(Rails).to receive(:env) { environment.inquiry }
+    get path
+  end
+
+  context "when running in the test environment" do
+    let(:environment) { "test" }
+
+    context "when the path has fake_browser_time in the query string" do
+      let(:path) { root_path(fake_browser_time: Time.zone.now.to_i) }
+
+      it { is_expected.to be_present }
+    end
+
+    context "when the path does not have fake_browser_time in the query string" do
+      let(:path) { root_path }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  context "when running in the production environment" do
+    let(:environment) { "production" }
+
+    context "when the path has fake_browser_time in the query string" do
+      let(:path) { root_path(fake_browser_time: Time.zone.now.to_i) }
+
+      it { is_expected.not_to be_present }
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,12 +1479,19 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
-"@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^7.0.4", "@sinonjs/fake-timers@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
+  integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 "@sinonjs/fake-timers@^8.0.1":
   version "8.0.1"
@@ -1492,6 +1499,20 @@
   integrity sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/samsam@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.0.2.tgz#a0117d823260f282c04bff5f8704bdc2ac6910bb"
+  integrity sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@stimulus/core@^2.0.0":
   version "2.0.0"
@@ -3565,6 +3586,11 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -5532,6 +5558,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -6119,6 +6150,11 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -6258,7 +6294,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.get@^4.0:
+lodash.get@^4.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -6759,6 +6795,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.0.tgz#713ef3ed138252daef20ec035ab62b7a28be645c"
+  integrity sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^7.0.4"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -7274,6 +7321,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -8867,6 +8921,18 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sinon@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-11.1.2.tgz#9e78850c747241d5c59d1614d8f9cbe8840e8674"
+  integrity sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^7.1.2"
+    "@sinonjs/samsam" "^6.0.2"
+    diff "^5.0.0"
+    nise "^5.1.0"
+    supports-color "^7.2.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -9375,7 +9441,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -9677,7 +9743,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
### Trello card

[Trello-1879](https://trello.com/c/HvPB0Jrh/1879-test-adding-age-range-to-the-mailing-sign-up-process)

### Context

When JS is disabled we need to show a fallback email address in the talk to us section and change the title to 'Email us' instead of 'Chat to us'. When out of support hours we want to hide the 'Email us' section entirely. This differs to how we handle it for JS-enabled users (we retain the heading and replace the button with 'Chat closed' text).

### Changes proposed in this pull request

- Add feature specs for chat online buttons

Add feature spec coverage for all the chat online buttons/variations. This was challenging because we need to be able to mock the current browser time from Rails for Capybara, which is in a different process. The method I used involves setting the time you want to use in the query string and then loading in a new pack that mocks out the current Javascript `Date` object. I used `sinon` for this instead of `jest` because you can't include `jest` outside of the test environment. The downside is we now have a test dependency in our non-dev JS dependencies, but its only loaded in on the test environment so it won't have a performance hit.

- Support fallback email for when JS is disabled

### Guidance to review

This is a temporary solution ahead of a wider redesign of the chat component/CTAs; the code is complex/hard to follow and not particularly elegant due to all the different ways we show a chat CTA and the variations for if chat is online/offline and JS is enabled/disabled. If the plan was to keep it as-is longer term I would have refactored the `chat_link` helper into something more maintainable... that being said, it should be robust enough as-is for now given the feature specs that surround the different uses of the chat online button/component.

<img width="651" alt="Screenshot 2021-10-21 at 07 52 30" src="https://user-images.githubusercontent.com/29867726/138226432-39656f3f-9216-4374-92be-e0d81bca63a0.png">


