### PR TITLE
Fix broken postgrad teacher training link

### DIFF
--- a/app/views/content/blog/how-to-apply-for-teacher-training.md
+++ b/app/views/content/blog/how-to-apply-for-teacher-training.md
@@ -54,7 +54,7 @@ Our free events are the perfect opportunity to find out more about teacher train
 
 ### 1. Find teacher training courses
 
-Use the Department for Education’s ‘[find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/)’ to search for courses in England. You’ll be able to search by location, training provider and subject. When you apply, you have three choices for teacher training providers. It’s a good idea to select three choices; the more flexible you are, the more likely it is that you’ll secure a place.
+Use the Department for Education’s [find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/) service to search for courses in England. You’ll be able to search by location, training provider and subject. When you apply, you have three choices for teacher training providers. It’s a good idea to select three choices; the more flexible you are, the more likely it is that you’ll secure a place.
 
 ### 2. Write your personal statement
 

--- a/app/views/content/blog/how-to-apply-for-teacher-training.md
+++ b/app/views/content/blog/how-to-apply-for-teacher-training.md
@@ -54,7 +54,7 @@ Our free events are the perfect opportunity to find out more about teacher train
 
 ### 1. Find teacher training courses
 
-Use the Department for Education’s ‘[find postgraduate teacher training courses](https://find-postgraduate-teacher-training.education.gov.uk/)’ to search for courses in England. You’ll be able to search by location, training provider and subject. When you apply, you have three choices for teacher training providers. It’s a good idea to select three choices; the more flexible you are, the more likely it is that you’ll secure a place.
+Use the Department for Education’s ‘[find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/)’ to search for courses in England. You’ll be able to search by location, training provider and subject. When you apply, you have three choices for teacher training providers. It’s a good idea to select three choices; the more flexible you are, the more likely it is that you’ll secure a place.
 
 ### 2. Write your personal statement
 

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -53,6 +53,7 @@ module LinkChecker
       tommyflowersscitt.co.uk
       www.nett.org.uk
       www.2schools.org
+      www.iop.org
     ].freeze
 
     def initialize(page, body)


### PR DESCRIPTION
The postgraduate teacher training service has changed domain; there used to be a redirect in place but that was recently removed so we need to point directly to the new service.

The IOP domain does not have a valid SSL certificate at the moment, so ignoring.