### PR TITLE
Remove automated event closed message

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,12 +7,6 @@
 
   <p class="event-info__date"><%= format_event_date(@event, stacked: false) %></p>
 
-  <% unless event_status_open?(@event) || event_status_pending?(@event) %>
-    <div class="content-alert content-alert--fullwidth">
-      <p>This event is now closed. Search <%= link_to("here", events_path) %> for our other events.</p>
-    </div>
-  <% end %>
-
   <% if @event.message %>
     <div class="content-alert content-alert--fullwidth">
       <p><%= @event.message %></p>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -187,7 +187,6 @@ describe EventsController, type: :request do
           let(:event) { build(:event_api, :closed, web_feed_id: "123", readable_id: event_readable_id) }
 
           it { is_expected.not_to match(/How to attend/) }
-          it { is_expected.to match(/This event is now closed/) }
         end
 
         context "when the event has a scribble_id" do


### PR DESCRIPTION
### Trello card

[Trello-2493](https://trello.com/c/uZ2jJ38y/2493-events-remove-automated-this-event-is-closed-banner-message)

### Context

We currently display an automated message on events that are 'closed'. Instead, the events team want to use the existing `message` attribute to display a message when the event is closed. We already render this when its filled on the event page, so we simply need to remove the automated message.

### Changes proposed in this pull request

- Remove automated event closed message

### Guidance to review

