### PR TITLE
Remove nested ul tag on related content

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -38,11 +38,9 @@
             <div class="link-block link-block--related">
               <h2 class="link-block__header">Related Content:</h2>
               <ul class="link-block__list">
-                <ul class="link-block__list">
-                  <% @front_matter["related_content"].each do |item, anchor| %>
-                    <li><%= link_to(item, anchor) %></li>
-                  <% end %>
-                </ul>
+                <% @front_matter["related_content"].each do |item, anchor| %>
+                  <li><%= link_to(item, anchor) %></li>
+                <% end %>
               </ul>
             </div>
           <% end %>


### PR DESCRIPTION
### Trello card

[Trello-1915](https://trello.com/c/bvmKdy48/1915-accessibility-ensure-lists-are-marked-up-correctly-on-ways-to-train)

### Context

We have a nested `<ul>` tag on the related content section which is not semantically valid HTML. I think its just been a typo/copy paste error as it renders fine without it; the padding changes slightly but its more even and looks better to my eye anyway.

### Changes proposed in this pull request

- Remove nested ul tag on related content

### Guidance to review

| Before      | After |
| ----------- | ----------- |
| <img width="632" alt="Screenshot 2021-09-30 at 13 01 05" src="https://user-images.githubusercontent.com/29867726/135451362-81e66993-fefa-480b-84b1-6ff1ba25b773.png">      | <img width="632" alt="Screenshot 2021-09-30 at 13 01 17" src="https://user-images.githubusercontent.com/29867726/135451384-d357d1d9-5a11-4699-91cb-74e2f653cf74.png">       |
|  <img width="1110" alt="Screenshot 2021-09-30 at 13 01 45" src="https://user-images.githubusercontent.com/29867726/135451428-0ecd0d9c-2bb0-4137-a389-a77093925b13.png">   | <img width="1110" alt="Screenshot 2021-09-30 at 13 02 07" src="https://user-images.githubusercontent.com/29867726/135451469-7d0deea2-deb4-4f1f-8362-2a1d88e60f53.png"> |





