### PR TITLE
Make sure dark blue colour is stored in a constant

### DIFF
--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -37,7 +37,8 @@
       You can see <%= past_category_name(@type.id).downcase %>, including
       all questions and answers,
       <%= link_to "on this page",
-                  archive_event_category_path(pluralised_category_name(@type.id).parameterize) %>
+                  archive_event_category_path(pluralised_category_name(@type.id).parameterize),
+                  class: "dark-link" %>
     </p>
   </section>
 <% end %>

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -24,4 +24,4 @@ $red: #d4351c;
 
 // NOT PART OF THE OFFICIAL COLOUR SCHEME
 $dark-cyan: #008b8b; // used for tags
-$blue-very-dark: #0062A3; // passes accessibility contrast check on $grey
+$blue-very-dark: #0062a3; // passes accessibility contrast check on $grey

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -98,7 +98,7 @@ a {
 
 // passes accessibility contrast check on grey background
 .dark-link {
-  color: #005487;
+  color: $blue-very-dark;
 }
 
 // Default Zendesk chat button (hidden as we use our own).


### PR DESCRIPTION
### Trello

[Trello](https://trello.com/c/mn8w3HG5)

### Changes

- Make sure dark blue colour is stored in a constant - Previously, when testing colours that would pass accessibility contract checks, I had accidentally left in two dark blue colours. The colour stored in `$blue-very-dark` passes all contrast checks here: https://webaim.org/resources/linkcontrastchecker/?fcolor=0B0C0C&bcolor=F0F0F0&lcolor=0062A3
- Apply dark link colour to past events box - This isn't passing the Silktide contrast check currently.  Apply the colour used previously for the cookies popup and advertise your teaching event links.