### PR TITLE
Dependabot updates for Ocotober 2021

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "webpacker", ">= 5.4.3"
 # gem 'mini_magick', '~> 4.8'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.8.1", require: false
+gem "bootsnap", ">= 1.9.1", require: false
 
 # Manage multiple processes i.e. web server and webpack
 gem "foreman"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 6.1.4.1"
 gem "puma", "~> 5.4"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem "webpacker", ">= 5.4.2"
+gem "webpacker", ">= 5.4.3"
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,8 @@ gem "loaf", ">= 0.10.0"
 
 gem "prometheus-client"
 
-gem "sentry-rails", ">= 4.7.1"
-gem "sentry-ruby", "~> 4.7.1"
+gem "sentry-rails", ">= 4.7.3"
+gem "sentry-ruby", "~> 4.7.3"
 
 gem "skylight", "~> 5.1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    bootsnap (1.8.1)
+    bootsnap (1.9.1)
       msgpack (~> 1.0)
     brakeman (5.1.1)
     builder (3.2.4)
@@ -407,14 +407,14 @@ GEM
     semantic_logger (4.8.2)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (4.7.1)
+    sentry-rails (4.7.3)
       railties (>= 5.0)
       sentry-ruby-core (~> 4.7.0)
-    sentry-ruby (4.7.1)
+    sentry-ruby (4.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.7.1)
-    sentry-ruby-core (4.7.1)
+      sentry-ruby-core (= 4.7.3)
+    sentry-ruby-core (4.7.3)
       concurrent-ruby
       faraday
     shoulda-matchers (5.0.0)
@@ -533,8 +533,8 @@ DEPENDENCIES
   rubocop-govuk (~> 3.14.0)
   secure_headers
   selenium-webdriver (~> 3.142)
-  sentry-rails (>= 4.7.1)
-  sentry-ruby (~> 4.7.1)
+  sentry-rails (>= 4.7.3)
+  sentry-ruby (~> 4.7.3)
   shoulda-matchers
   simplecov
   skylight (~> 5.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES
   addressable (~> 2.8.0)
   amazing_print
   better_html
-  bootsnap (>= 1.8.1)
+  bootsnap (>= 1.9.1)
   brakeman (~> 5.1.1)
   byebug
   canonical-rails (>= 0.2.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (5.4.2)
+    webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -546,7 +546,7 @@ DEPENDENCIES
   view_component (~> 2.39.0)
   web-console (>= 4.1.0)
   webmock (>= 3.14.0)
-  webpacker (>= 5.4.2)
+  webpacker (>= 5.4.3)
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    secure_headers (6.3.2)
+    secure_headers (6.3.3)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)

--- a/babel.config.js
+++ b/babel.config.js
@@ -48,6 +48,12 @@ module.exports = function(api) {
         }
       ],
       [
+        "@babel/plugin-proposal-private-property-in-object",
+        {
+          "loose": true
+        }
+      ],
+      [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@rails/webpacker": "5.4.2",
+    "@rails/webpacker": "5.4.3",
     "@stimulus/polyfills": "^2.0.0",
     "accessible-autocomplete": "^2.0.3",
     "dayjs": "^1.10.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "webpack-cli": "3.3.12"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.15.0",
+    "@babel/eslint-parser": "^7.15.7",
     "@stimulus/test": "^2.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flatpickr": "^4.6.9",
     "govuk-frontend": "^3.13.1",
     "is-touch-device": "^1.0.1",
-    "js-cookie": "^3.0.0",
+    "js-cookie": "^3.0.1",
     "lazysizes": "^5.3.2",
     "rails-ujs": "^5.2.5",
     "sass-mq": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5927,10 +5927,10 @@ jest@^27.0.6:
     import-local "^3.0.2"
     jest-cli "^27.0.6"
 
-js-cookie@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.0.tgz#db1661d5459920ec95aaf186ccf74ceb4a495164"
-  integrity sha512-oUbbplKuH07/XX2YD2+Q+GMiPpnVXaRz8npE7suhBH9QEkJe2W7mQ6rwuMXHue3fpfcftQwzgyvGzIHyfCSngQ==
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,10 +1435,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@rails/webpacker@5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.4.2.tgz#efc94f7ff396529411bb02a9da964e269ff2edb0"
-  integrity sha512-35qQWK2HCHGx2TT0UH0vuo5PyXQaahB2KJeGWOVl0jDPfwbvC4yvTq3+0/lhD5uOJx2eraGLRaIN4umwFCsksw==
+"@rails/webpacker@5.4.3":
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.4.3.tgz#cfe2d8faffe7db5001bad50a1534408b4f2efb2f"
+  integrity sha512-tEM8tpUtfx6FxKwcuQ9+v6pzgqM5LeAdhT6IJ4Te3BPKFO1xrGrXugqeRuZ+gE8ASDZRTOK6yuQkapOpuX5JdA==
   dependencies:
     "@babel/core" "^7.15.0"
     "@babel/plugin-proposal-class-properties" "^7.14.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,10 +68,10 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.15.0":
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.0.tgz#b54f06e04d0e93aebcba99f89251e3bf0ee39f21"
-  integrity sha512-+gSPtjSBxOZz4Uh8Ggqu7HbfpB8cT1LwW0DnVVLZEJvzXauiD0Di3zszcBkRmfGGrLdYeHUwcflG7i3tr9kQlw==
+"@babel/eslint-parser@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.7.tgz#2dc3d0ff0ea22bb1e08d93b4eeb1149bf1c75f2d"
+  integrity sha512-yJkHyomClm6A2Xzb8pdAo4HzYMSXFn1O5zrCYvbFP0yQFvHueLedV8WiEno8yJOKStjUXzBZzJFeWQ7b3YMsqQ==
   dependencies:
     eslint-scope "^5.1.1"
     eslint-visitor-keys "^2.1.0"


### PR DESCRIPTION
### Trello card

N/A

### Context

A roundup of the batch of update PRs created by Dependabot this morning.

### Changes proposed in this pull request

- Update secure_headers to 6.3.3
- Update webpacker_to 5.4.3
- Update sentry-ruby and sentry-rails to 4.7.3
- Update bootsnap to 1.9.1
- Update @babel/eslint-parser to 7.15.7
- Update js-cookie to 3.0.1
- Update @rails/webpacker to 5.4.3
- Quieten warnings when running yarn spec

### Guidance to review

I've had a good look around and everything seems fine. I held back the one **big** update (Stimulus 3.0.0) and these all appear to be minor version bumps.
