### PR TITLE
More blue links

### DIFF
--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -37,8 +37,7 @@
       You can see <%= past_category_name(@type.id).downcase %>, including
       all questions and answers,
       <%= link_to "on this page",
-                  archive_event_category_path(pluralised_category_name(@type.id).parameterize),
-                  class: "dark-link" %>
+                  archive_event_category_path(pluralised_category_name(@type.id).parameterize) %>
     </p>
   </section>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -36,7 +36,7 @@
 <section class="content-cta">
   <h3>Do you have a teaching event?</h3>
   <p>
-    If you'd like to advertise your teaching event in this listing, <a class="dark-link" href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
+    If you'd like to advertise your teaching event in this listing, <a href="https://form.education.gov.uk/service/Provider-event-details---Get-into-Teaching-website"
       title="Submit your event details on GOV.UK"
       target="_blank"
       rel="noopener norefferer">

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -4,6 +4,10 @@
   margin-bottom: 2em;
   display: flex;
 
+  a {
+    color: $blue-very-dark;
+  }
+
   @include mq($until: tablet) {
     flex-direction: column;
   }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -5,7 +5,7 @@
   display: flex;
 
   a {
-    color: $blue-very-dark;
+    @include dark-link;
   }
 
   @include mq($until: tablet) {

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -12,6 +12,10 @@
     color: $black;
   }
 
+  a {
+    color: $blue-very-dark;
+  }
+
   p:first-child {
     margin-top: 0;
   }

--- a/app/webpacker/styles/components/content-cta.scss
+++ b/app/webpacker/styles/components/content-cta.scss
@@ -13,7 +13,7 @@
   }
 
   a {
-    color: $blue-very-dark;
+    @include dark-link;
   }
 
   p:first-child {

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -8,7 +8,7 @@
   margin: 1em auto;
 
   a {
-    color: $blue-very-dark;
+    @include dark-link
   }
 
   h3,

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -7,6 +7,10 @@
   padding: 1em;
   margin: 1em auto;
 
+  a {
+    color: $blue-very-dark;
+  }
+
   h3,
   &__description {
     margin: .2em auto 1em;
@@ -14,6 +18,10 @@
 
   .group__cards {
     @include cards-grid;
+
+    a {
+      color: $blue-dark;
+    }
 
     .group__card {
       box-sizing: border-box;

--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -57,6 +57,12 @@
     padding: .2em 2em;
   }
 
+  &__text {
+    a {
+      @include dark-link;
+    }
+  }
+
   &__buttons {
     display: flex;
     flex-wrap: wrap;

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -97,7 +97,7 @@ a {
 }
 
 // passes accessibility contrast check on grey background
-.dark-link {
+@mixin dark-link {
   color: $blue-very-dark;
 }
 


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/mn8w3HG5)

### Context
Silktide is reporting some links that do not pass their accessibility checks (blue link on grey background). It doesn't give a full list of occurrences because we don't pay, but I have been through each area with a $grey background and think I have got them all

### Changes proposed in this pull request
Found some more failing links 👇 
![dark-links](https://user-images.githubusercontent.com/47089130/135829520-c7e4a9e8-3d5c-4529-8025-e8cd9b991edf.png)