### PR TITLE
Ensure partial URL can't have leading or trailing hyphens or underscores

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -29,7 +29,7 @@ module Internal
     attribute :venue_type, default: VENUE_TYPES[:none]
 
     validates :name, presence: true, allow_blank: false, length: { maximum: 300 }
-    validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }, format: { with: /\A[\w-]+\Z/ }
+    validates :readable_id, presence: true, allow_blank: false, length: { maximum: 300 }, format: { with: /\A[^_\W][\w-]+[^_\W]\Z/ }
     validates :summary, presence: true, allow_blank: false, length: { maximum: 1000 }
     validates :description, presence: true, allow_blank: false, length: { maximum: 2000 }
     validates :is_online, inclusion: { in: [true, false] }, if: -> { provider_event? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,7 +464,7 @@ en:
               blank: Enter a name
             readable_id:
               blank: Enter a partial URL
-              invalid: Partial URL can only contain alphanumeric characters, hyphens, and underscores
+              invalid: Partial URL can only contain alphanumeric characters, hyphens, and underscores. Must begin and end with an alphanumeric character.
             summary:
               blank: Enter a summary
             description:

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -27,9 +27,14 @@ describe Internal::Event do
     end
 
     describe "#readable_id" do
-      it { is_expected.to allow_value("test_event-url").for :readable_id }
-      it { is_expected.not_to allow_values("test@event", "test?event", "test:event", "test(event)", nil).for :readable_id }
       it { is_expected.to validate_length_of(:readable_id).is_at_most(300) }
+      it { is_expected.to allow_value("test_event-url").for :readable_id }
+
+      it do
+        is_expected.not_to allow_values(
+          "test@event", "test?event", "test:event", "test(event)", "_test", "test_", "-test", "test-", nil
+        ).for :readable_id
+      end
     end
 
     describe "#summary" do


### PR DESCRIPTION
### Context
The API validates that event partial URLs can't have leading or trailing hyphens or underscores. Match that here so that we can provide a better error message.

### Changes proposed in this pull request
- Update the event partial URL regex to include leading and trailing hyphens and underscores.