### PR TITLE
Add feature flag to disable existing tracking/analytics

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -65,7 +65,7 @@
   </div>
 </footer>
 
-<% if lid_pixel_event %>
+<% if lid_pixel_event && Rails.application.config.x.legacy_tracking_pixels %>
   <%= tag.span(data: { "controller" => "lid", "lid-action" => "track", "lid-event" => lid_pixel_event }) %>
 <% end %>
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 module ApplicationHelper
   def analytics_body_tag(attributes = {}, &block)
+    return tag.body(**attributes, &block) unless Rails.application.config.x.legacy_tracking_pixels
+
     attributes = attributes.symbolize_keys
 
     analytics = {

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -35,6 +35,7 @@
     ]
   ) %>
 
+  <% if Rails.application.config.x.legacy_tracking_pixels %>
   <span data-controller="pinterest"
         data-pinterest-action="track"
         data-pinterest-event="custom"></span>
@@ -46,6 +47,7 @@
   <span data-controller="facebook"
         data-pinterest-action="track"
         data-pinterest-event="Event_Registrations"></span>
+  <% end %>
 </section>
 
 <div class="blocks">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -44,4 +44,6 @@
   </p>
 </section>
 
+<% if Rails.application.config.x.legacy_tracking_pixels %>
 <span data-controller="lid" data-lid-action="track" data-lid-event="Events"></span>
+<% end %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -73,6 +73,7 @@
   <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% end %>
 
+<% if Rails.application.config.x.legacy_tracking_pixels %>
 <span data-controller="pinterest"
       data-pinterest-action="track"
       data-pinterest-event="lead"
@@ -89,3 +90,4 @@
 <span data-controller="bam" data-bam-action="track"></span>
 
 <span data-controller="lid" data-lid-action="track" data-lid-event="MailingList"></span>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
   config.x.structured_data.how_to = true
 
   config.x.zendesk_chat = true
+
+  config.x.legacy_tracking_pixels = false
 end

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -10,4 +10,6 @@ Rails.application.configure do
   config.view_component.show_previews = true
 
   config.x.zendesk_chat = true
+
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -138,4 +138,6 @@ Rails.application.configure do
   config.x.structured_data.how_to = false
 
   config.x.zendesk_chat = true
+
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -10,4 +10,6 @@ Rails.application.configure do
   config.view_component.show_previews = true
 
   config.x.zendesk_chat = true
+
+  config.x.legacy_tracking_pixels = false
 end

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -1,8 +1,14 @@
 require "rails_helper"
 
 describe FooterComponent, type: "component" do
-  subject! { render_inline(described_class.new) }
+  subject(:render) { render_inline(described_class.new) }
 
+  before do
+    allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(legacy_tracking_pixels)
+    render
+  end
+
+  let(:legacy_tracking_pixels) { true }
   let(:feedback_selector) { ".feedback-bar" }
   let(:talk_to_us_selector) { ".talk-to-us" }
   let(:mailing_list_selector) { ".mailing-list-bar" }
@@ -56,12 +62,20 @@ describe FooterComponent, type: "component" do
   end
 
   context "when a lid_pixel_event is supplied" do
-    subject! { render_inline(described_class.new(lid_pixel_event: event)) }
+    subject(:render) { render_inline(described_class.new(lid_pixel_event: event)) }
 
     let(:event) { "Success" }
 
     specify "renders the right analytics element" do
       expect(rendered_component).to include_analytics("lid", { action: "track", event: event })
+    end
+
+    context "when legacy tracking is disabled" do
+      let(:legacy_tracking_pixels) { false }
+
+      specify "does not render the analytics element" do
+        expect(rendered_component).not_to include_analytics("lid", { action: "track", event: event })
+      end
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,6 +16,7 @@ describe ApplicationHelper do
     let(:twitter_id) { id }
 
     before do
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(true)
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("GOOGLE_TAG_MANAGER_ID").and_return gtm_id
       allow(ENV).to receive(:[]).with("GOOGLE_ANALYTICS_ID").and_return ga_id
@@ -110,6 +111,16 @@ describe ApplicationHelper do
       subject { analytics_body_tag(class: "homepage") { tag.hr } }
 
       it { is_expected.to have_css "body[data-controller~=gtm]" }
+      it { is_expected.to have_css "body.homepage" }
+    end
+
+    context "when legacy tracking is disabled" do
+      subject { analytics_body_tag(data: { timefmt: "24" }, class: "homepage") { tag.hr } }
+
+      before { allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false) }
+
+      it { is_expected.not_to have_css "body[data-controller~=gtm]" }
+      it { is_expected.to have_css "body[data-timefmt=24]" }
       it { is_expected.to have_css "body.homepage" }
     end
   end

--- a/spec/requests/lid_tracking_pixels_spec.rb
+++ b/spec/requests/lid_tracking_pixels_spec.rb
@@ -1,12 +1,15 @@
 require "rails_helper"
 
 describe "LID tracking pixels", type: :request do
-  subject { response.body }
+  subject do
+    get path
+    response.body
+  end
 
   before do
+    allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(true)
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events_grouped_by_type).and_return([])
-    get path
   end
 
   context "when visiting /events" do
@@ -31,5 +34,33 @@ describe "LID tracking pixels", type: :request do
     let(:path) { "/steps-to-become-a-teacher" }
 
     it { is_expected.to include_analytics("lid", { action: "track", event: "Steps" }) }
+  end
+
+  context "when legacy tracking is disabled" do
+    before { allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false) }
+
+    context "when visiting /events" do
+      let(:path) { events_path }
+
+      it { is_expected.not_to include_analytics("lid", { action: "track", event: "Events" }) }
+    end
+
+    context "when visiting /mailinglist/signup/completed" do
+      let(:path) { completed_mailing_list_steps_path }
+
+      it { is_expected.not_to include_analytics("lid", { action: "track", event: "MailingList" }) }
+    end
+
+    context "when visiting a content page" do
+      let(:path) { "/tracked-page" }
+
+      it { is_expected.not_to include_analytics("lid", { action: "track", event: "EventName" }) }
+    end
+
+    context "when visiting /steps-to-become-a-teacher" do
+      let(:path) { "/steps-to-become-a-teacher" }
+
+      it { is_expected.not_to include_analytics("lid", { action: "track", event: "Steps" }) }
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2481](https://trello.com/c/LLysk4GJ/2481-cookies-review-consent-mechanism-cookie-categories)

### Context

We are migrating all of our tracking/analytics to a new GTM container. In order make the switch cleanly we need a way of turning off all our existing (to be legacy) analytics and turning on our new analytics in one go.

Add feature flag to control turning off all our existing analytics and tracking pixels. When the new GTM container is pulled in we will do so conditionally based on the same feature flag, so that only one or the other is ever running at once.

### Changes proposed in this pull request

- Add feature flag to disable existing tracking/analytics

### Guidance to review

The legacy (i.e. current) tracking and analytics will only be enabled in production and preprod while we are developing out the new GTM container/cookie setup (which is enabled in development/rolling).