### PR TITLE
Set Asset Path

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,9 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  if ENV["APP_ASSETS_URL"].present?
+    config.action_controller.asset_host = ENV["APP_ASSETS_URL"]
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
## Description
If the environment variable APP_ASSETS_URL is set then configure the rails config.action_controller.asset_host  setting to use it. The APP_ASSETS_URL will be using different cloud front settings this will cache assets independently of the main application and thus prevent cookies and authorization headers interferring.

## Trello
[Cache Control Headers](https://trello.com/c/XuhhuxsG/1655-check-cache-control-headers-are-being-forwarded-in-cdn-route-configuration)
[404ing](https://trello.com/c/leu6mmtZ/1622-dev-action-packs-js-applicationjs-404ing)
[First Byte](https://trello.com/b/lRXllOHK/get-into-teaching-website)
