### PR TITLE
Add new GTM container

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 # Add public visible environment variables here for the Developemnt environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 PREVIEW_PAGES=1
+GTM_ID=GTM-5ZQLL9K

--- a/.env.rolling
+++ b/.env.rolling
@@ -2,3 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 BAM_ID=1
 SKIP_REQ_LIMITS=true
+GTM_ID=GTM-5ZQLL9K

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -6,6 +6,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new do |c| %>
       <% c.hero(@front_matter) do %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>
@@ -63,8 +64,8 @@
             <%= render(partial) %>
           <% end %>
 
-          <% @front_matter.key?("accordion") && @front_matter.dig("accordion").tap do |accordion_fm| %>
-            <%= render Content::AccordionComponent.new(numbered: accordion_fm.dig("numbered"), active_step: accordion_fm.dig("active_step")) do |accordion| %>
+          <% @front_matter.key?("accordion") && @front_matter["accordion"].tap do |accordion_fm| %>
+            <%= render Content::AccordionComponent.new(numbered: accordion_fm["numbered"], active_step: accordion_fm["active_step"]) do |accordion| %>
               <% accordion.content_before_accordion(
                 partial: accordion_fm.dig("content_before_accordion", "partial"),
                 call_to_action: accordion_fm.dig("content_before_accordion", "cta")

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -6,6 +6,7 @@
 
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/registration_attractive.html.erb
+++ b/app/views/layouts/registration_attractive.html.erb
@@ -6,6 +6,7 @@
 
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>
@@ -23,7 +24,7 @@
 
           <%= yield %>
 
-          <% @front_matter.key?("steps") && @front_matter.dig("steps").tap do |steps_fm| %>
+          <% @front_matter.key?("steps") && @front_matter["steps"].tap do |steps_fm| %>
 
             <div class="steps">
               <% steps_fm.each.with_index(1) do |(title, contents), i| %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+      <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
       <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
         <%= c.hero(@front_matter) %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -2,6 +2,8 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>
@@ -12,7 +14,7 @@
           <%= yield %>
 
           <div class="cards stories">
-            <%= render Cards::RendererComponent.with_collection(@front_matter.dig("stories")) %>
+            <%= render Cards::RendererComponent.with_collection(@front_matter["stories"]) %>
           </div>
         </section>
       </section>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -2,6 +2,8 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+      <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+
       <%= render HeaderComponent.new %>
 
       <main id="main-content">

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/sections/_gtm.html.erb
+++ b/app/views/sections/_gtm.html.erb
@@ -1,0 +1,18 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer',<%= raw ENV["GTM_ID"].to_json %>);</script>
+<!-- End Google Tag Manager -->
+
+<!-- Turbolinks Page Views -->
+<script>
+document.addEventListener('turbolinks:load', () => {
+  dataLayer.push({
+    'event': 'pageview',
+    'virtualUrl': window.location.pathname
+  });
+})
+</script>
+<!-- End Turbolinks Page Views -->

--- a/app/views/sections/_gtm_fallback.html.erb
+++ b/app/views/sections/_gtm_fallback.html.erb
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= ENV["GTM_ID"] %>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -2,6 +2,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
 
+  <%= render(partial: "sections/gtm") unless Rails.application.config.x.legacy_tracking_pixels %>
   <%= csrf_meta_tags unless @cacheable_static_page %>
   <%= csp_meta_tag %>
   <%#= canonical_tag %>

--- a/spec/requests/gtm_spec.rb
+++ b/spec/requests/gtm_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "Google Tag Manager", type: :request do
+  include_context "with wizard data"
+
+  let(:event) { build(:event_api) }
+  let(:layout_paths) do
+    [
+      "/cookies",
+      "/my-story-into-teaching",
+      "/my-story-into-teaching/career-changers/financiers-future-in-maths",
+      "/my-story-into-teaching/internaltional-career-changers",
+      "/steps-to-become-a-teacher",
+      "/three-things-to-help-you-get-into-teaching",
+      "/ways_to_train",
+      "/welcome",
+      blog_path("choosing-the-right-teacher-training-course-provider"),
+      blog_index_path,
+      event_path(event.readable_id),
+      event_step_path(event.readable_id, :personal_details),
+      events_path,
+      new_mailing_list_signup_path,
+      root_path,
+    ]
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:get_teaching_event).with(event.readable_id) { event }
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:search_teaching_events_grouped_by_type).and_return([])
+    allow(Rails.application.config.x).to receive(:legacy_tracking_pixels) { legacy_tracking_pixels }
+  end
+
+  context "when legacy tracking pixels are disabled" do
+    let(:legacy_tracking_pixels) { false }
+
+    it "has the GTM and fallback scripts" do
+      layout_paths.each do |layout_path|
+        get layout_path
+        expect(response.body).to include("https://www.googletagmanager.com/gtm.js"), "#{layout_path} does not include GTM"
+        expect(response.body).to include("https://www.googletagmanager.com/ns.html"), "#{layout_path} does not include GTM fallback"
+      end
+    end
+  end
+
+  context "when legacy tracking pixels are enabled" do
+    let(:legacy_tracking_pixels) { true }
+
+    it "does not have the GTM and fallback scripts" do
+      layout_paths.each do |layout_path|
+        get layout_path
+        expect(response.body).not_to include("https://www.googletagmanager.com/gtm.js"), "#{layout_path} does not include GTM"
+        expect(response.body).not_to include("https://www.googletagmanager.com/ns.html"), "#{layout_path} does not include GTM fallback"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-2481](https://trello.com/c/LLysk4GJ/2481-cookies-review-consent-mechanism-cookie-categories)

### Context

We are going to migrate all of our tracking/analytics into a new GTM container so that we can switch from the old one to the new one without any downtime.

Add the new container to the dev/rolling environments so we can test it locally and in the review apps.

### Changes proposed in this pull request

- Add new GTM container

### Guidance to review

Enabled only in rolling/local dev for now.
