### PR TITLE
Focus on the Zendesk widget when it loads

### DIFF
--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -50,10 +50,12 @@ export default class extends Controller {
     this.appendZendeskScript();
     this.waitForZendesk(() => {
       window.$zopim.livechat.window.show();
-
-      setTimeout(() => {
-        this.buttonTarget.querySelector('span').innerHTML = originalText;
-      }, 500); // Small delay to account for the chat box animating in.
+      this.waitForWidget(() => {
+        setTimeout(() => {
+          document.getElementById('webWidget').focus();
+          this.buttonTarget.querySelector('span').innerHTML = originalText;
+        }, 500); // Small delay to account for the chat box animating in.
+      });
     });
   }
 
@@ -77,6 +79,15 @@ export default class extends Controller {
     script.src =
       'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
     document.body.appendChild(script);
+  }
+
+  waitForWidget(callback) {
+    const interval = setInterval(() => {
+      if (document.getElementById('webWidget')) {
+        clearInterval(interval);
+        callback();
+      }
+    }, 100);
   }
 
   waitForZendesk(callback) {

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -8,14 +8,19 @@ describe('TalkToUsController', () => {
 
   const setBody = (zendeskEnabled, offlineText = null) => {
     document.body.innerHTML = `
-      <span data-controller="talk-to-us" data-talk-to-us-zendesk-enabled-value="${zendeskEnabled}">
-        <a
-          href="#"
-          data-action="click->talk-to-us#startChat"
-          data-talk-to-us-target="button"
-        ><span>Chat Online</span></a>
-        ${offlineText ? `<p data-talk-to-us-target="offlineText">${offlineText}</p>` : ''}
-      </span>
+      <div>
+        <span data-controller="talk-to-us" data-talk-to-us-zendesk-enabled-value="${zendeskEnabled}">
+          <a
+            href="#"
+            data-action="click->talk-to-us#startChat"
+            data-talk-to-us-target="button"
+          ><span>Chat Online</span></a>
+          ${offlineText ? `<p data-talk-to-us-target="offlineText">${offlineText}</p>` : ''}
+        </span>
+        <div> // Represents the Zendesk modal
+          <iframe id="webWidget"></iframe>
+        </div>
+      </div>
     `;
   }
 
@@ -68,13 +73,16 @@ describe('TalkToUsController', () => {
 
     it('appends the Zendesk snippet, opens the chat window and shows a loading message when clicking the button', () => {
       const button = document.querySelector('a');
+      expect(document.activeElement.id).not.toEqual("webWidget");
       button.click();
       expect(document.querySelector('#ze-snippet')).not.toBeNull();
       expect(getButtonText()).toEqual("Starting chat...");
       jest.runOnlyPendingTimers(); // Timer for script loading,
+      jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
       jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
       expect(chatShowSpy).toHaveBeenCalled();
       expect(getButtonText()).toEqual("Chat Online");
+      expect(document.activeElement.id).toEqual("webWidget");
     });
 
     describe('when clicking the chat button twice', () => {
@@ -83,6 +91,7 @@ describe('TalkToUsController', () => {
         button.click();
         expect(button.textContent).toEqual("Starting chat...");
         jest.runOnlyPendingTimers(); // Timer for script loading,
+        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
         expect(chatShowSpy).toHaveBeenCalled();
         expect(button.textContent).toEqual("Chat Online");


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/IBHfmk2u)

### Context
Currently, when the widget loads, the focus is still in the footer, so the user has to tab all the way through it until focus gets trapped in the widget.

### Changes proposed in this pull request
- Add another looped timer to wait until the widget is loaded, then focus on it.

### Guidance to review
The extra loop was needed to wait for the widget on first load. To simulate: 1. Empty cache and hard reload in the browser. 2. Visit a new page. 3. click the start chat button. Without the additional loop,  the `webWidget` wasn't fully loaded at the time it was trying to focus.

I explored await/async to neaten things up, but it is difficult to test asynchronous code with the way we test the Stimulus.js controllers