### PR TITLE
Swap phone number links

### DIFF
--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -15,7 +15,7 @@
               <% end %>
               <div>
                 <p>Call us</p>
-                <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+                <p class="telephone">0800 389 2500</p>
               </div>
             </div>
           </div>

--- a/app/components/service_unavailable_component.html.erb
+++ b/app/components/service_unavailable_component.html.erb
@@ -1,3 +1,2 @@
 <h1>Sorry, it's not possible to sign up online right now</h1>
-<p>Call us on
-  <a href="tel:08003892500" class="telephone-number" aria-label="Telephone">0800 389 2500</a> to sign up.</p>
+<p>Call us on 0800 389 2500 to sign up.</p>

--- a/app/views/content/funding-your-training.md
+++ b/app/views/content/funding-your-training.md
@@ -35,8 +35,7 @@
       arguments:
         text: |-
           If you're unsure about whether you qualify for a bursary or
-          scholarship you can chat to us, or call us on
-          <a href="tel:08003892500">0800 389 2500</a>.
+          scholarship you can chat to us, or call us on 0800 389 2500.
     get-school-experience:
       name: simple
       arguments:

--- a/app/views/content/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/train-to-teach-in-england-as-an-international-student.md
@@ -84,7 +84,7 @@ To teach children aged 3 to 11, you also need the equivalent of a GCSE (grade 4)
 
 If your qualifications come from a non-UK institution, your teacher training provider may want to see a ‘[statement of comparability](https://enic.org.uk/Qualifications/SOC/Default.aspx)’ showing their equivalence to UK qualifications.
 
-Call us on [0800 389 2500](tel://08003892500) for:
+Call us on 0800 389 2500 for:
 
 * guidance on the UK equivalents of your qualifications
 * a free statement of comparability from UK ENIC once you’ve submitted your application, if your provider asks for this

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -17,7 +17,7 @@
       <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
       <div>
         <small>or call us now:</small>
-        <a class="telephone" href="tel:08003892500" aria-label="Telephone">0800 389 2500</a>
+        <p class="telephone">0800 389 2500</p>
       </div>
     </div>
 

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -42,6 +42,7 @@
       font-weight: bold;
       text-decoration: none;
       color: $black;
+      margin: 0;
     }
   }
 

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -80,17 +80,6 @@ a {
   }
 }
 
-.telephone-number {
-  @include font;
-  color: $blue;
-  text-decoration: underline;
-  font-weight: bold;
-}
-
-.telephone-number:hover {
-  text-decoration: none;
-}
-
 .strong {
   font-weight: bold;
 }


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/FJ6nGXWx)

### Context
Telephone number links have been flagged as inaccessible due to how they are read by screen readers.

[The GOV.UK Design System suggests that phone numbers should not be links at all. Most devices automatically detect phone numbers if they support phone calls.](https://design-system.service.gov.uk/patterns/telephone-numbers/#do-not-display-telephone-numbers-as-links-on-devices-that-cannot-make-calls)

### Changes proposed in this pull request
- Replace telephone number links with text only

### Guidance to review
See replacements below (some look the same):

| Before      | After |
| ----------- | ----------- |
|   ![image](https://user-images.githubusercontent.com/47089130/137121833-78fe8238-9175-4f69-a296-b84f16952992.png)  |  ![image](https://user-images.githubusercontent.com/47089130/137121953-6471042d-a007-4123-a7a9-2bbba2f004ed.png)  |
|  ![image](https://user-images.githubusercontent.com/47089130/137122195-4e0e282c-e90f-4c26-ab98-b3886f222396.png) | ![image](https://user-images.githubusercontent.com/47089130/137122337-a127970d-f2eb-4d27-a799-d30791f9eaf9.png)  |  
![image](https://user-images.githubusercontent.com/47089130/137124879-8cf3a177-91a2-4149-bfec-c95232504bff.png)  | ![image](https://user-images.githubusercontent.com/47089130/137125003-62dbbf31-b992-4072-8820-906f03371343.png)  |  
![image](https://user-images.githubusercontent.com/47089130/137125136-28a2b14e-762f-4064-8ead-92724b899bb5.png) | ![image](https://user-images.githubusercontent.com/47089130/137125154-0c813cba-a495-4959-a8c0-993020fb08c8.png)  |  
![image](https://user-images.githubusercontent.com/47089130/137127831-436bf561-a67d-4cb1-932f-24d460b667bb.png) | ![image](https://user-images.githubusercontent.com/47089130/137127879-c31a141d-88bc-4d1c-b715-7e816561335b.png)  |


