### PR TITLE
not all postgrad teacher training is on gov.uk

### DIFF
--- a/app/views/content/tips-on-applying-for-teacher-training.md
+++ b/app/views/content/tips-on-applying-for-teacher-training.md
@@ -1,7 +1,7 @@
 ---
 title: Tips on applying for teacher training
 description: |-
-  Read these tips on applying for teacher training to maximise your chances of 
+  Read these tips on applying for teacher training to maximise your chances of
   being accepted on to initial teacher training, including when to apply for teaching training, how to write a good application, how to ensure you choose the right references, your personal statement and what to do if you get invited to interview.
 date: "2021-06-24"
 keywords:
@@ -51,9 +51,9 @@ You can [search for most postgraduate teacher training courses on GOV.UK](https:
 
 ## Where to apply
 
-You can use [Apply for teacher training](https://www.gov.uk/apply-for-teacher-training) to apply for any postgraduate teacher training course.
+You can use [Apply for teacher training](https://www.gov.uk/apply-for-teacher-training) to apply for postgraduate teacher training.
 
-This service has replaced the UCAS postgraduate teacher training application. 
+This service has replaced the UCAS postgraduate teacher training application.
 
 ## When to apply
 
@@ -94,7 +94,7 @@ personal statement.
 Some people do not get on the course they want because their application has
 not convinced the admissions team that they’re right for it.
 
-[Talk to an adviser for help preparing your application.](/tta-service)
+[Talk to an adviser for help preparing your application](/tta-service).
 
 ## Choose your referees
 
@@ -170,14 +170,12 @@ You can [get support preparing a personal statement from an adviser](/tta-servic
 
 ## If you’re invited to interview
 
-Interviews usually last a day and may include time spent teaching real pupils.
+Interviews usually last a day and may include time spent teaching pupils.
 
 You can [get support preparing for an interview from an adviser](/tta-service).
 
 Interviews vary from provider to provider – you’ll be given all the information
 you need when you’re invited to attend.
-
-Some providers are doing interviews online due to COVID-19 restrictions.
 
 ## If you get an offer
 


### PR DESCRIPTION
1. remove contraction about what you can apply for on gov.uk

before - it says MOST post grad training is on gov.uk but later it says you can apply for ANY postgrad teacher training on gov.uk:

![Screenshot 2021-10-12 at 13 50 39](https://user-images.githubusercontent.com/56349171/136959537-596dab1e-616b-4c69-923c-260efdf2db90.png)


after - removes the contradiction (I don't think Apply has things like Teach First so we can't say 'any') 

![Screenshot 2021-10-12 at 13 52 04](https://user-images.githubusercontent.com/56349171/136959746-f421cba1-7a1a-49a6-a2a8-b099236a1d96.png)

2. remove 'covid restrictions' as we're no longer living under restrictions 
