### PR TITLE
Add noscript pictures to end of parent

### DIFF
--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -12,7 +12,7 @@ class LazyLoadImages
     doc.css("picture").each do |picture|
       next if picture.css("img[data-lazy-disable]").any?
 
-      picture.after(noscript_picture(picture, doc))
+      picture.parent.add_child(noscript_picture(picture, doc))
 
       picture.css("source").each do |source|
         source["data-srcset"] = source.attribute("srcset")


### PR DESCRIPTION
### Context and changes

There's a slight display oddity in the footer where two images that are next to each other in the markup don't have the correct spacing applied.

![Screenshot-2021-10-13-11:01:33](https://user-images.githubusercontent.com/128088/137114476-821b8c6e-7a17-4ff2-b315-20bf36701998.png)


The spacing uses the css `picture + picture`, but there's a `<noscript>` tag injected between them by the lazy loading images.

Now instead of adding the noscript right after the picture, we're adding them all at the end of the parent, so instead of:

```html
<picture> <noscript> <picture> <noscript>
```

it will be:


```html
<picture> <picture> <noscript> <noscript>
```
