### PR TITLE
Clear cookies when opting out of a category

### DIFF
--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -11,6 +11,12 @@ export default class CookiePreferences {
     marketing: true,
   };
 
+  static functionalCookies = [
+    'git-cookie-preferences-v1',
+    '_dfe_session',
+    'GiTBetaBannerCovid',
+  ];
+
   settings = null;
   cookieSet = false;
 
@@ -73,12 +79,25 @@ export default class CookiePreferences {
     this.emitEvent(newlyAllowed);
   }
 
+  clearNonEssentialCookies() {
+    Object.keys(Cookies.get()).forEach((key) => {
+      if (!CookiePreferences.functionalCookies.includes(key))
+        Cookies.remove(key);
+    });
+  }
+
   setCategory(category, value) {
     const strValue = value.toString();
     const boolValue =
       strValue === '1' || strValue === 'true' || strValue === 'yes';
 
     const newSettings = Object.assign({}, this.settings);
+    const optingOut = newSettings[category] === true && !boolValue;
+
+    if (optingOut) {
+      this.clearNonEssentialCookies();
+    }
+
     newSettings[category] = boolValue;
 
     this.all = newSettings;

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -148,7 +148,7 @@ describe('CookiePreferences', () => {
       });
     });
 
-    describe('assigning functational to false', () => {
+    describe('assigning functional to false', () => {
       beforeEach(() => {
         prefs.setCategory('functional', false);
       });
@@ -299,6 +299,24 @@ describe('CookiePreferences', () => {
 
       it('emits event', () => {
         expect(newCategoriesEvent).toEqual([]);
+      });
+    });
+
+    describe('opting out of a category', () => {
+      beforeEach(() => {
+        prefs.setCategory('marketing', true);
+      });
+
+      it('retains essential cookies and clears non-essential cookies', () => {
+        Cookies.set('non-essential', 'not essential');
+
+        const essentialCookieKey = CookiePreferences.functionalCookies[2];
+        Cookies.set(essentialCookieKey, 'essential');
+
+        prefs.setCategory('marketing', false);
+
+        expect(Cookies.get('non-essential')).toBeUndefined();
+        expect(Cookies.get(essentialCookieKey)).toEqual('essential');
       });
     });
 


### PR DESCRIPTION
### Trello card

[Trello-2481](https://trello.com/c/LLysk4GJ/2481-cookies-review-consent-mechanism-cookie-categories)

### Context

When a user opts-out of a cookie category we want to remove the cookies associated with activity they have opted-out of. As its not easy to map the cookies back to the particular categories we will instead blow away all the non-essential cookies (they will then be treated as a new user tracking-wise, but we don't expect a lot of people are doing this in general so its likely not a big deal).

### Changes proposed in this pull request

- Clear non-essential cookies when opting-out

### Guidance to review

Opt-in to cookies, then opt out of either marketing or non-functional and you should see all cookies are cleared apart from a couple of essential ones.
