### PR TITLE
Disable Covid banner

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -4,6 +4,7 @@
   </div>
 </div>
 
+<% if Rails.application.config.x.covid_banner %>
 <div>
   <div class="covid" data-controller="banner" data-banner-name-value="Covid">
     <div class="limit-content-width">
@@ -12,6 +13,7 @@
     </div>
   </div>
 </div>
+<% end %>
 
 <header class="limit-content-width" data-controller="navigation">
   <%= render Header::ExtraNavigationComponent.new(classes: %w[hide-on-mobile hide-on-tablet], search_input_id: "searchbox__input--desktop") %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
   config.x.zendesk_chat = true
 
   config.x.legacy_tracking_pixels = false
+
+  config.x.covid_banner = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -142,4 +142,6 @@ Rails.application.configure do
   config.x.zendesk_chat = true
 
   config.x.legacy_tracking_pixels = true
+
+  config.x.covid_banner = false
 end

--- a/spec/requests/covid_banner_spec.rb
+++ b/spec/requests/covid_banner_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe "Covid banner", type: :request do
+  subject { response.body }
+
+  let(:covid_banner_enabled) { true }
+
+  before do
+    allow(Rails.application.config.x).to receive(:covid_banner) { covid_banner_enabled }
+    get root_path
+  end
+
+  it { is_expected.to include("data-controller=\"banner\"") }
+
+  context "when feature switched off" do
+    let(:covid_banner_enabled) { false }
+
+    it { is_expected.not_to include("data-controller=\"banner\"") }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-2478](https://trello.com/c/Dy6qh7bL/2478-review-position-of-covid-banner)

### Context

We want to turn off the Covid banner as people aren't really interacting with it and it takes up valuable space at the top of the page (it also results in cumulative layout shift due to being shown/hidden by JS).

We may want to turn the banner back on in the future, so its now behind a feature switch.

### Changes proposed in this pull request

- Disable covid banner

### Guidance to review

