### PR TITLE
Enable new GTM container in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -7,3 +7,4 @@ HOTJAR_ID=1871524
 TTA_SERVICE_URL="https://adviser-getintoteaching.education.gov.uk/"
 FAIL2BAN=5
 GOOGLE_OPTIMIZE_ID=OPT-W7F6P8Q
+GTM_ID=GTM-5ZQLL9K

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,10 @@ module ApplicationHelper
     end
   end
 
+  def new_gtm_enabled?
+    ENV["GTM_ID"].present? && !Rails.application.config.x.legacy_tracking_pixels
+  end
+
   def gtm_consent_body_tag(attributes = {}, &block)
     attributes[:data] ||= {}
     attributes[:data][:controller] ||= ""

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>
     <% end %>

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -6,7 +6,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new do |c| %>
       <% c.hero(@front_matter) do %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -7,7 +7,7 @@
 
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -7,7 +7,7 @@
 
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -7,7 +7,7 @@
 
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-      <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+      <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
       <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
         <%= c.hero(@front_matter) %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
     <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-      <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+      <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
       <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/teaching_event.html.erb
+++ b/app/views/layouts/teaching_event.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content" }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: false) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content" }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new(breadcrumbs: false) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
-    <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
+    <%= render(partial: "sections/gtm_fallback") if new_gtm_enabled? %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -12,7 +12,7 @@
     <%= javascript_pack_tag 'fake_browser_time', 'data-turbolinks-track': 'reload', id: "fake-browser-time" %>
   <% end %>
   <%= google_optimize_script %>
-  <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true unless Rails.application.config.x.legacy_tracking_pixels %>
+  <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if new_gtm_enabled? %>
   <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>

--- a/config/environments/pagespeed.rb
+++ b/config/environments/pagespeed.rb
@@ -5,4 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
+
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -16,4 +16,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
+
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,7 +140,7 @@ Rails.application.configure do
   config.x.structured_data.event = true
   config.x.structured_data.how_to = false
 
-  config.x.legacy_tracking_pixels = true
+  config.x.legacy_tracking_pixels = false
 
   config.x.covid_banner = false
 

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -7,4 +7,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
+
+  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -8,5 +8,7 @@ Rails.application.configure do
   config.x.static_pages.disable_caching = true
   config.x.utm_codes = true
 
+  config.x.legacy_tracking_pixels = true
+
   Rack::Attack.enabled = false
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -127,6 +127,27 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#new_gtm_enabled?" do
+    it "returns true when GTM_ID is present and legacy_tracking_pixels is false" do
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return("ABC-123")
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false)
+
+      expect(helper).to be_new_gtm_enabled
+    end
+
+    it "returns false when GTM_ID is blank or legacy_tracking_pixels is true" do
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return("ABC-123")
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(true)
+
+      expect(helper).not_to be_new_gtm_enabled
+
+      allow(ENV).to receive(:[]).with("GTM_ID").and_return(nil)
+      allow(Rails.application.config.x).to receive(:legacy_tracking_pixels).and_return(false)
+
+      expect(helper).not_to be_new_gtm_enabled
+    end
+  end
+
   describe "#internal_referer" do
     before { helper.request = instance_double("ActionDispatch::Request") }
 

--- a/spec/requests/gtm_spec.rb
+++ b/spec/requests/gtm_spec.rb
@@ -18,7 +18,10 @@ describe "Google Tag Manager", type: :request do
       blog_index_path,
       event_path(event.readable_id),
       event_step_path(event.readable_id, :personal_details),
+      event_step_path(event.readable_id, :further_details),
       events_path,
+      teaching_events_path,
+      teaching_event_path(event.readable_id),
       root_path,
     ]
   end
@@ -39,6 +42,21 @@ describe "Google Tag Manager", type: :request do
         get layout_path
         expect(response.body).to include("data-gtm-id=\"123-ABC\""), "#{layout_path} does not include GTM"
         expect(response.body).to include("https://www.googletagmanager.com/ns.html"), "#{layout_path} does not include GTM fallback"
+      end
+    end
+
+    context "when the GTM_ID is not set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("GTM_ID").and_return(nil)
+      end
+
+      it "does not have the GTM and fallback scripts" do
+        layout_paths.each do |layout_path|
+          get layout_path
+          expect(response.body).not_to include("data-gtm-id"), "#{layout_path} does not include GTM"
+          expect(response.body).not_to include("https://www.googletagmanager.com/ns.html"), "#{layout_path} does not include GTM fallback"
+        end
       end
     end
   end


### PR DESCRIPTION
> :warning: Update GA ID in GTM to prod before merging this

Switch to using the new GTM container in production. Switches non-prod environments back to the legacy tracking method so we don't pollute the prod GA account with traffic from non-prod environments.