### PR TITLE
Disable BetterHtml on Rails error pages

### DIFF
--- a/config/initializers/better_html.rb
+++ b/config/initializers/better_html.rb
@@ -1,1 +1,5 @@
 BetterHtml.config = BetterHtml::Config.new(YAML.safe_load(File.read(Rails.root.join(".better-html.yml"))))
+
+BetterHtml.configure do |config|
+  config.template_exclusion_filter = Proc.new { |filename| !filename.start_with?(Rails.root.to_s) }
+end


### PR DESCRIPTION
It prevents the web console from being rendered and just shows the default uninformative error screen.

More info here: https://github.com/Shopify/better-html/issues/50
