### PR TITLE
Job to stop merges when label applied

### DIFF
--- a/.github/workflows/stop_merges.yml
+++ b/.github/workflows/stop_merges.yml
@@ -1,0 +1,14 @@
+name: Prevent Merges
+
+on:
+  pull_request:
+    types: [ unlabeled, labeled, opened, synchronize , reopened]
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'Do Not Merge' )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Raise an Error
+        run: exit 1


### PR DESCRIPTION
A simple Github job that prevents merges when the **Do Not Merge** label is added to a PR.


