### PR TITLE
Add links to events for international returners

### DIFF
--- a/app/views/content/international-returners.md
+++ b/app/views/content/international-returners.md
@@ -53,14 +53,14 @@ keywords:
   - teachers standards
   - standards
   - chartered college of teaching
- right_column:
+right_column:
   ctas:
-  - title: Take the next step
-    text: |
-      Get support to take the next step at an event.
-    link_text: "Attend an event"
-    link_target: "/events"
-    icon: "icon-calendar"
+    - title: Take the next step
+      text: |
+        Get support to take the next step at an event.
+      link_text: "Attend an event"
+      link_target: "/events"
+      icon: "icon-calendar"
 ---
 
 Are you a UK-trained teacher and UK citizen currently working abroad? Our


### PR DESCRIPTION
### Trello card
https://trello.com/c/14pEK7TQ

### Context
The international returners team have requested links be added to promote their events.

### Changes proposed in this pull request

- Right column CTA added
- Link added in first text section


