### PR TITLE
Switch to RSpec's progress formatter in CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         run: |-
           docker run -t --rm -e RAILS_ENV=test \
             ${{ needs.build.outputs.DOCKER_IMAGE }} \
-            rspec --format documentation spec/features/content_pages_spec.rb
+            rspec --format progress spec/features/content_pages_spec.rb
 
       - name: Slack Notification
         if: failure()
@@ -206,7 +206,7 @@ jobs:
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage:/app/coverage -e RAILS_ENV=test ${{needs.build.outputs.DOCKER_IMAGE}} \
-            bundle exec parallel_split_test spec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format documentation
+            bundle exec parallel_split_test spec --format RspecSonarqubeFormatter --out /app/out/test-report.xml --format progress
 
       - name: Fixup report file paths
         run: sudo sed -i "s?\"/app/?\"${PWD}/?" coverage/coverage.json

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker run -t --rm -e RAILS_ENV=test \
             ${{ env.DOCKER_REPOSITORY }}:master \
-            rspec --format documentation -t onschedule spec/features/external_links_spec.rb
+            rspec --format progress -t onschedule spec/features/external_links_spec.rb
 
       - name: Slack Notification
         if: failure()


### PR DESCRIPTION
We have a lot of tests and when something fails finding it in the log on GitHub actions is a bit of a pain. The progress formatter should relieve this.
