### PR TITLE
Don't display provider information for TTT/QT events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -53,6 +53,10 @@ module EventsHelper
     end
   end
 
+  def display_event_provider_info?(event)
+    !event.type_id.in?([qt_event_type_id, ttt_event_type_id])
+  end
+
   def event_has_provider_info?(event)
     event.provider_website_url ||
       event.provider_target_audience ||
@@ -125,6 +129,10 @@ module EventsHelper
 
   def ttt_event_type_id
     GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+  end
+
+  def qt_event_type_id
+    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
   end
 
   def event_list_id(name)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -39,7 +39,7 @@
   <% end %>
   <% end %>
 
-  <% if event_has_provider_info?(@event) %>
+  <% if display_event_provider_info?(@event) && event_has_provider_info?(@event) %>
     <h2>Provider information</h2>
     <% if @event.provider_website_url %>
       <p><strong>Event website</strong><br><%= link_to(@event.provider_website_url, @event.provider_website_url, { target: "blank" }) %><em class="icon"></em></p>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -170,6 +170,22 @@ describe EventsHelper, type: "helper" do
     end
   end
 
+  describe "#display_event_provider_info?" do
+    it "returns false if train to teach or question time" do
+      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+      expect(display_event_provider_info?(event)).to be(false)
+      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+      expect(display_event_provider_info?(event)).to be(false)
+    end
+
+    it "returns true if not train to teach or question time" do
+      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+      expect(display_event_provider_info?(event)).to be(true)
+      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University event"]
+      expect(display_event_provider_info?(event)).to be(true)
+    end
+  end
+
   describe "#event_has_provider_info?" do
     it "returns true if the event has provider information" do
       event = build(:event_api, :with_provider_info)

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -153,10 +153,17 @@ describe EventsController, type: :request do
         it { is_expected.to match(/#{event.building.address_postcode}/) }
         it { is_expected.to match(/iframe.+src="#{event.video_url}"/) }
         it { is_expected.to include(event.provider_website_url) }
-        it { is_expected.to include(event.provider_target_audience) }
-        it { is_expected.to include(event.provider_organiser) }
-        it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }
+        it { is_expected.not_to include("Provider information") }
         it { is_expected.to include(event.building.image_url) }
+
+        context "when the type is not TTT or QT" do
+          let(:event) { build(:event_api, :online_event, :with_provider_info, readable_id: event_readable_id) }
+
+          it { is_expected.to include("Provider information") }
+          it { is_expected.to include(event.provider_target_audience) }
+          it { is_expected.to include(event.provider_organiser) }
+          it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }
+        end
 
         context "when the event can be registered for online" do
           let(:event) { build(:event_api, web_feed_id: "123", readable_id: event_readable_id) }


### PR DESCRIPTION
### Trello card

[Trello-2589](https://trello.com/c/Zo5VaC7Y/2589-events-suppress-provider-information-for-train-to-teach-events-to-facilitate-structured-data)

### Context

We currently don't populate provider information in the CRM for Train to Teach or Question Time events, however we _do_ want to start displaying this information in the Google Structured Data for events. As we are going to start populating the fields we need to add another conditional that hides that information from the event details page in the website.

### Changes proposed in this pull request

- Don't display provider information for TTT/QT events

### Guidance to review

