### PR TITLE
Fix tab behaviour with cookie dialog

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -4,7 +4,7 @@
     <div class="dialog__content">
       <div class="logo-wrapper">
         <div class="logo">
-          <a href="/" class="logo__image">
+          <a tabindex="-1" href="/" class="logo__image">
             <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "180x62", data: { "lazy-disable": true } %>
           </a>
         </div>
@@ -13,7 +13,7 @@
       <div class="dialog__text">
 
         <p>
-          We use <a id="cookies-info" href="/cookies" class="dark-link" data-cookie-acceptance-target="info">cookies</a> to collect information about how you use this website.
+          We use <a tabindex="-1" id="cookies-info" href="/cookies" class="dark-link" data-cookie-acceptance-target="info">cookies</a> to collect information about how you use this website.
           We use this information to make the website work as well as possible, and improve this website.
           We also share some of this information with our social media, advertising and analytics partners.
         </p>
@@ -25,10 +25,10 @@
           The id is `biscuits-agrees` instead of `cookies-agree`
           to prevent ad blockers from removing the button.
         -->
-        <a tabindex="1" href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
+        <a tabindex="-1" href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
           <span>Accept all cookies</span>
         </a>
-        <a class="button button--secondary" href="/cookie_preference" data-cookie-acceptance-target="disagree" id="cookies-disagree">
+        <a tabindex="-1" class="button button--secondary" href="/cookie_preference" data-cookie-acceptance-target="disagree" id="cookies-disagree">
           <span>Set cookie preferences</span>
         </a>
       </div>

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -19,60 +19,90 @@ export default class extends Controller {
 
   accept(event) {
     event.preventDefault();
-    this.overlayTarget.classList.remove('visible');
 
     const cookiePrefs = new CookiePreferences();
     cookiePrefs.allowAll();
+
+    this.overlayTarget.classList.remove('visible');
+    this.stopInterceptingTabKeydown();
+    this.resetFocus();
   }
 
   showDialog() {
     this.overlayTarget.classList.add('visible');
+    this.startInterceptingTabKeydown();
+  }
 
+  resetFocus() {
+    // focus then blur on the first link to prevent
+    // the next element being tabbed to after accepting
+    // being in the footer (which is where the cookie acceptance
+    // HTML is placed)
+    document.querySelector('a').focus();
+    document.querySelector('a').blur();
+  }
+
+  startInterceptingTabKeydown() {
+    // by default these have a -1 tab index which
+    // prevents the keydown event triggering on tab
+    this.agreeTarget.tabIndex = 1;
+    this.infoTarget.tabIndex = 2;
+    this.disagreeTarget.tabIndex = 3;
+
+    this.keydownHandler = this.handleKeydown.bind(this);
+    this.agreeTarget.addEventListener('keydown', this.keydownHandler);
+    this.infoTarget.addEventListener('keydown', this.keydownHandler);
+    this.disagreeTarget.addEventListener('keydown', this.keydownHandler);
+  }
+
+  stopInterceptingTabKeydown() {
+    this.agreeTarget.removeEventListener('keydown', this.keydownHandler);
+    this.infoTarget.removeEventListener('keydown', this.keydownHandler);
+    this.disagreeTarget.removeEventListener('keydown', this.keydownHandler);
+
+    // revert to -1 to ensure tabbing ignores these elements
+    this.agreeTarget.tabIndex = -1;
+    this.infoTarget.tabIndex = -1;
+    this.disagreeTarget.tabIndex = -1;
+  }
+
+  // agree button is focussed on the first tab
+  // cookies (link) on the second
+  // disagree button on the third
+  // back to agree on the fourth, and so on
+  handleKeydown(e) {
     const tabKey = 9;
-    const agreeButtonID = 'biscuits-agree';
-    const disagreeButtonID = 'cookies-disagree';
-    const infoLinkID = 'cookies-info';
 
-    // agree button is focussed on the first tab
-    // cookies (link) on the second
-    // disagree button on the third
-    // back to agree on the fourth, and so on
+    if (e.keyCode === tabKey) {
+      e.preventDefault();
+      e.shiftKey ? this.focusOnPrevious(e) : this.focusOnNext(e);
+    }
+  }
 
-    this.agreeTarget.addEventListener('keydown', function (e) {
-      if (e.keyCode === tabKey) {
-        e.preventDefault();
+  focusOnNext(e) {
+    switch (e.target) {
+      case this.agreeTarget:
+        this.infoTarget.focus();
+        break;
+      case this.infoTarget:
+        this.disagreeTarget.focus();
+        break;
+      default:
+        this.agreeTarget.focus();
+    }
+  }
 
-        if (e.shiftKey) {
-          document.getElementById(disagreeButtonID).focus();
-        } else {
-          document.getElementById(infoLinkID).focus();
-        }
-      }
-    });
-
-    this.infoTarget.addEventListener('keydown', function (e) {
-      if (e.keyCode === tabKey) {
-        e.preventDefault();
-
-        if (e.shiftKey) {
-          document.getElementById(agreeButtonID).focus();
-        } else {
-          document.getElementById(disagreeButtonID).focus();
-        }
-      }
-    });
-
-    this.disagreeTarget.addEventListener('keydown', function (e) {
-      if (e.keyCode === tabKey) {
-        e.preventDefault();
-
-        if (e.shiftKey) {
-          document.getElementById(infoLinkID).focus();
-        } else {
-          document.getElementById(agreeButtonID).focus();
-        }
-      }
-    });
+  focusOnPrevious(e) {
+    switch (e.target) {
+      case this.agreeTarget:
+        this.disagreeTarget.focus();
+        break;
+      case this.disagreeTarget:
+        this.infoTarget.focus();
+        break;
+      default:
+        this.agreeTarget.focus();
+    }
   }
 
   isPrivacyPage() {

--- a/spec/components/footer/cookie_acceptance_component_spec.rb
+++ b/spec/components/footer/cookie_acceptance_component_spec.rb
@@ -5,6 +5,11 @@ describe Footer::CookieAcceptanceComponent, type: "component" do
 
   let(:cookie_acceptance_selector) { ".cookie-acceptance" }
 
+  specify "all anchor links are excluded from tab sequence" do
+    subject
+    expect(page.all("a").map { |e| e[:tabindex] }).to all(eq("-1"))
+  end
+
   specify "renders the cookie acceptance component" do
     subject
     expect(page).to have_css(cookie_acceptance_selector)

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -3,19 +3,23 @@ import { Application } from 'stimulus';
 import CookieAcceptanceController from 'cookie-acceptance_controller.js';
 
 describe('CookieAcceptanceController', () => {
+  let acceptButton;
+  let infoButton;
+  let disagreeButton;
+
   document.body.innerHTML = `<div data-controller="cookie-acceptance">
         <div id="overlay" class="cookie-acceptance" data-cookie-acceptance-target="overlay">
-            <a class="cookies-info" href="#" data-cookie-acceptance-target="info">some-link</a>
+            <a tabindex="-1" class="cookies-info" href="#" data-cookie-acceptance-target="info">some-link</a>
             <div class="cookie-acceptance__background"></div>
             <div class="cookie-acceptance__dialog">
                 <div class="cookie-acceptance__dialog__header">
                     Header
                 </div>
                 BODY
-                <a href="#" id="biscuits-agree" data-cookie-acceptance-target="agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
+                <a tabindex="-1" href="#" id="biscuits-agree" data-cookie-acceptance-target="agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
                     Yes, I agree. Continue to the new <span>website</span>
                 </a>
-                <a class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-cookie-acceptance-target="disagree" id="cookies-disagree">
+                <a tabindex="-1" class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-cookie-acceptance-target="disagree" id="cookies-disagree">
                   No, I want to go to the current website <i class="fas fa-chevron-right"></i>
                 </a>
             </div>
@@ -29,6 +33,10 @@ describe('CookieAcceptanceController', () => {
 
   beforeEach(() => {
     Cookies.remove('git-cookie-preferences-v1');
+
+    acceptButton = document.getElementById('biscuits-agree');
+    infoButton = document.querySelector('.cookies-info');
+    disagreeButton = document.getElementById('cookies-disagree');
   });
 
   describe('when the cookie is set', () => {
@@ -54,23 +62,64 @@ describe('CookieAcceptanceController', () => {
       const overlay = document.getElementById('overlay');
       expect(overlay.classList.contains('visible')).toBe(true);
     });
-  });
 
-  describe('clicking the accept button', () => {
-    beforeEach(() => {
-      initApp();
+    it('updates the tab indexes', () => {
+      expect(acceptButton.tabIndex).toEqual(1)
+      expect(infoButton.tabIndex).toEqual(2)
+      expect(disagreeButton.tabIndex).toEqual(3)
+    })
 
-      const acceptanceButton = document.getElementById('biscuits-agree');
-      acceptanceButton.click();
+    describe('tabbing behaviour', () => {
+      describe('when the accept button has focus', () => {
+        it('tabs to the info link and from the disagree button', () => {
+          acceptButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
+          expect(infoButton).toEqual(document.activeElement);
+
+          acceptButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
+          expect(disagreeButton).toEqual(document.activeElement);
+        })
+      });
+
+      describe('when the info link has focus', () => {
+        it('tabs to the disagree button and from the agree button', () => {
+          infoButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
+          expect(disagreeButton).toEqual(document.activeElement);
+
+          infoButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
+          expect(acceptButton).toEqual(document.activeElement);
+        })
+      });
+
+      describe('when the disagree link has focus', () => {
+        it('tabs to the accept button and from the info button', () => {
+          disagreeButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
+          expect(acceptButton).toEqual(document.activeElement);
+
+          disagreeButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
+          expect(infoButton).toEqual(document.activeElement);
+        })
+      });
     });
 
-    it('sets the cookie', () => {
-      expect(Cookies.get('git-cookie-preferences-v1')).not.toBe(false);
-    });
+    describe('clicking the accept button', () => {
+      beforeEach(() => {
+        acceptButton.click();
+      });
 
-    it('hides the dialog', () => {
-      const overlay = document.getElementById('overlay');
-      expect(overlay.classList.contains('visible')).toBe(false);
+      it('sets the cookie', () => {
+        expect(Cookies.get('git-cookie-preferences-v1')).not.toBe(false);
+      });
+
+      it('hides the dialog', () => {
+        const overlay = document.getElementById('overlay');
+        expect(overlay.classList.contains('visible')).toBe(false);
+      });
+
+      it('removes elements from the tab sequencing', () => {
+        expect(acceptButton.tabIndex).toEqual(-1)
+        expect(infoButton.tabIndex).toEqual(-1)
+        expect(disagreeButton.tabIndex).toEqual(-1)
+      });
     });
   });
 });


### PR DESCRIPTION
### Trello card

[Trello-2591](https://trello.com/c/2j0mev5k/2591-accessibility-stop-keyboard-focus-from-landing-on-cookie-modal-on-every-page)

### Context

The cookie dialog being within the page but hidden causes some issues with tabbing behaviour on the page. When tabbing down the page it enters the hidden cookie dialog elements before proceeding to the footer. In addition, after accepting cookies the tabbing sequence remains within the dialog and the rest of the page can't be tabbed through.

### Changes proposed in this pull request

- Fix tab behaviour with cookie dialog

To fix this, the `tabindex` of the cookie dialog elements are initially set to `-1`, which causes the browser to skip over them during regular tabbing.

When the cookie dialog opens we set the `tabindex` of elements to ensure the first tab goes to the accept button. We listen for `keydown` events to ensure the tab sequence goes through the dialog elements only whilst it is open.

When the dialog is closed we remove the `keydown` listeners to revert tabbing back to the main page and focus/blur on the first anchor link to ensure the tab sequence starts at the top of the page instead of the footer (which is where the cookie acceptance HTML is located).

Lastly, we set the `tabindex` of the cookie dialog elements back to `-1` so they are skipped over on any subsequent tabbing.

### Guidance to review

To review this you can check that tabbing works correctly in the cookie dialog (forwards and backwards). Then check tabbing operates over the main page on accepting cookies and no longer hits the cookie elements both after accepting cookies and on subsequent page loads.
