### PR TITLE
Update AO providers for Teaching London

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -170,7 +170,7 @@ provider_groups:
       telephone: '0208 2404326'
       email: ao@stmarys.ac.uk
     - header: 'Teaching London: LDBS SCITT'
-      link: https://teachinglondon.org
+      # link: https://teachinglondon.org
       name: Saskia Rossi
       telephone: 0207 932 1126
       email: admin@teachinglondon.org


### PR DESCRIPTION
### Context
Removal of link that has been serving a 503 error for a couple of days (the SCITT has been contacted by the Accreditation team).

