### PR TITLE
Remove legacy chat supplier and Zendesk feature flag

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -69,4 +69,4 @@
   <%= tag.span(data: { "controller" => "lid", "lid-action" => "track", "lid-event" => lid_pixel_event }) %>
 <% end %>
 
-<%= render "sections/zendesk_chat_settings" if Rails.application.config.x.zendesk_chat %>
+<%= render "sections/zendesk_chat_settings" %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,7 +131,6 @@ module ApplicationHelper
 
     tag.span(safe_join(elements), data: {
       controller: "talk-to-us",
-      "talk-to-us-zendesk-enabled-value": Rails.application.config.x.zendesk_chat,
     })
   end
 

--- a/app/webpacker/controllers/talk-to-us_controller.js
+++ b/app/webpacker/controllers/talk-to-us_controller.js
@@ -2,7 +2,6 @@ import dayjs from 'dayjs';
 import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static values = { zendeskEnabled: Boolean };
   static targets = ['button', 'offlineText'];
 
   initialize() {
@@ -37,12 +36,7 @@ export default class extends Controller {
 
   startChat(e) {
     e.preventDefault();
-
-    if (this.zendeskEnabledValue) {
-      this.showZendeskChat();
-    } else {
-      this.openKlick2ContactWindow();
-    }
+    this.showZendeskChat();
   }
 
   showZendeskChat() {
@@ -97,16 +91,6 @@ export default class extends Controller {
         callback();
       }
     }, 100);
-  }
-
-  openKlick2ContactWindow() {
-    const windowFeatures =
-      'menubar=no,location=yes,resizable=yes,scrollbars=no,status=yes,width=340,height=480';
-    window.open(
-      'https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a2&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0',
-      'Get Into Teaching: Chat online',
-      windowFeatures
-    );
   }
 
   get zendeskScriptLoaded() {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,8 +72,6 @@ Rails.application.configure do
   config.x.structured_data.event = true
   config.x.structured_data.how_to = true
 
-  config.x.zendesk_chat = true
-
   config.x.legacy_tracking_pixels = false
 
   config.x.covid_banner = false

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -9,7 +9,5 @@ Rails.application.configure do
 
   config.view_component.show_previews = true
 
-  config.x.zendesk_chat = true
-
   config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -141,8 +141,6 @@ Rails.application.configure do
   config.x.structured_data.event = false
   config.x.structured_data.how_to = false
 
-  config.x.zendesk_chat = true
-
   config.x.legacy_tracking_pixels = true
 
   config.x.covid_banner = false

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -9,7 +9,5 @@ Rails.application.configure do
 
   config.view_component.show_previews = true
 
-  config.x.zendesk_chat = true
-
   config.x.legacy_tracking_pixels = false
 end

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -81,21 +81,10 @@ describe FooterComponent, type: "component" do
 
   describe "Zendesk Chat settings snippet" do
     subject! do
-      allow(Rails.application.config.x).to receive(:zendesk_chat) { enabled }
       render_inline(described_class.new)
       page.native.inner_html
     end
 
-    context "when disabled" do
-      let(:enabled) { false }
-
-      it { is_expected.not_to include("window.zESettings") }
-    end
-
-    context "when enabled" do
-      let(:enabled) { true }
-
-      it { is_expected.to include("window.zESettings") }
-    end
+    it { is_expected.to include("window.zESettings") }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -249,8 +249,6 @@ describe ApplicationHelper do
   describe "#chat_link" do
     subject { helper.chat_link(text, classes: extra_class, fallback_text: fallback_text, fallback_email: fallback_email, offline_text: offline_text) }
 
-    before { allow(Rails.application.config.x).to receive(:zendesk_chat).and_return(true) }
-
     let(:text) { "Chat with us" }
     let(:extra_class) { "button" }
     let(:fallback_text) { "Chat to us" }
@@ -258,7 +256,6 @@ describe ApplicationHelper do
     let(:fallback_email) { nil }
 
     it { is_expected.to have_css(%(span[data-controller="talk-to-us"])) }
-    it { is_expected.to have_css(%(span[data-talk-to-us-zendesk-enabled-value="true"])) }
     it { is_expected.to have_css(%(a[data-action="talk-to-us#startChat"])) }
     it { is_expected.to have_css(%(a.chat-button.button.with-fallback span)) }
     it { is_expected.to have_link(fallback_text, href: "#talk-to-us", class: "button chat-button-no-js") }
@@ -288,12 +285,6 @@ describe ApplicationHelper do
       let(:fallback_email) { "fallback@email.com" }
 
       it { expect { is_expected }.to raise_error(ArgumentError, "Specify fallback text or email, not both") }
-    end
-
-    context "when zendesk is disabled" do
-      before { allow(Rails.application.config.x).to receive(:zendesk_chat).and_return(false) }
-
-      it { is_expected.to have_css(%(span[data-talk-to-us-zendesk-enabled-value="false"])) }
     end
   end
 end

--- a/spec/javascript/controllers/talk-to-us_controller_spec.js
+++ b/spec/javascript/controllers/talk-to-us_controller_spec.js
@@ -6,10 +6,12 @@ describe('TalkToUsController', () => {
   beforeAll(() => registerController());
   afterEach(() => jest.useRealTimers());
 
-  const setBody = (zendeskEnabled, offlineText = null) => {
+  let chatShowSpy;
+
+  const setBody = (offlineText = null) => {
     document.body.innerHTML = `
       <div>
-        <span data-controller="talk-to-us" data-talk-to-us-zendesk-enabled-value="${zendeskEnabled}">
+        <span data-controller="talk-to-us">
           <a
             href="#"
             data-action="click->talk-to-us#startChat"
@@ -37,75 +39,48 @@ describe('TalkToUsController', () => {
     return document.querySelector('a span').textContent;
   }
 
-  describe("when Zendesk Chat is disabled", () => {
-    const openSpy = jest.fn();
+  beforeEach(() => {
+    chatShowSpy = jest.fn();
+    jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy } } } }));
 
-    beforeEach(() => {
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ open: openSpy }));
-
-      setBody(false);
-      setCurrentTime('2021-01-01 10:00');
-    });
-
-    it('opens the klick2contact chat when clicking the button', () => {
-      const button = document.querySelector('a');
-      button.click();
-
-      const url =
-        'https://gov.klick2contact.com/v03/launcherV3.php?p=DfE&d=971&ch=CH&psk=chat_a2&iid=STC&srbp=0&fcl=0&r=Static&s=https://gov.klick2contact.com/v03&u=&wo=&uh=&pid=82&iif=0';
-      const target = 'Get Into Teaching: Chat online';
-      const features =
-        'menubar=no,location=yes,resizable=yes,scrollbars=no,status=yes,width=340,height=480';
-
-      expect(openSpy).toBeCalledWith(url, target, features);
-    });
+    setBody();
+    setCurrentTime('2021-01-01 10:00');
   });
 
-  describe("when Zendesk Chat is enabled", () => {
-    const chatShowSpy = jest.fn();
+  it('appends the Zendesk snippet, opens the chat window and shows a loading message when clicking the button', () => {
+    const button = document.querySelector('a');
+    expect(document.activeElement.id).not.toEqual("webWidget");
+    button.click();
+    expect(document.querySelector('#ze-snippet')).not.toBeNull();
+    expect(getButtonText()).toEqual("Starting chat...");
+    jest.runOnlyPendingTimers(); // Timer for script loading,
+    jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
+    jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
+    expect(chatShowSpy).toHaveBeenCalled();
+    expect(getButtonText()).toEqual("Chat Online");
+    expect(document.activeElement.id).toEqual("webWidget");
+  });
 
-    beforeEach(() => {
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy } } } }));
-
-      setBody(true);
-      setCurrentTime('2021-01-01 10:00');
-    });
-
-    it('appends the Zendesk snippet, opens the chat window and shows a loading message when clicking the button', () => {
+  describe('when clicking the chat button twice', () => {
+    it('only appends the Zendesk snippet once and does not show the loading message for the second click', () => {
       const button = document.querySelector('a');
-      expect(document.activeElement.id).not.toEqual("webWidget");
       button.click();
-      expect(document.querySelector('#ze-snippet')).not.toBeNull();
-      expect(getButtonText()).toEqual("Starting chat...");
+      expect(button.textContent).toEqual("Starting chat...");
       jest.runOnlyPendingTimers(); // Timer for script loading,
       jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
       jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
       expect(chatShowSpy).toHaveBeenCalled();
-      expect(getButtonText()).toEqual("Chat Online");
-      expect(document.activeElement.id).toEqual("webWidget");
-    });
-
-    describe('when clicking the chat button twice', () => {
-      it('only appends the Zendesk snippet once and does not show the loading message for the second click', () => {
-        const button = document.querySelector('a');
-        button.click();
-        expect(button.textContent).toEqual("Starting chat...");
-        jest.runOnlyPendingTimers(); // Timer for script loading,
-        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
-        jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatShowSpy).toHaveBeenCalled();
-        expect(button.textContent).toEqual("Chat Online");
-        button.click();
-        expect(button.textContent).toEqual("Chat Online");
-        expect(document.querySelectorAll('#ze-snippet').length).toEqual(1);
-      });
+      expect(button.textContent).toEqual("Chat Online");
+      button.click();
+      expect(button.textContent).toEqual("Chat Online");
+      expect(document.querySelectorAll('#ze-snippet').length).toEqual(1);
     });
   });
 
   describe("when the chat is offline (too early) and there is no offline text", () => {
     beforeEach(() => {
       registerController();
-      setBody(true);
+      setBody();
       setCurrentTime('2021-01-01 08:29');
     });
 
@@ -119,7 +94,7 @@ describe('TalkToUsController', () => {
   describe("when the chat is offline (too late) and there is offline text", () => {
     beforeEach(() => {
       registerController();
-      setBody(true, "Chat offline.");
+      setBody("Chat offline.");
       setCurrentTime('2021-01-01 17:31');
     });
 


### PR DESCRIPTION
### Trello card

[Trello-2529](https://trello.com/c/tfKoLtE0/2529-remove-klick2contact-and-zendesk-chat-feature-flag)

### Context

We have been running Zendesk Chat in production for a couple of weeks now and are confident we won't need to revert back to the old chat supplier.

### Changes proposed in this pull request

- Remove klick2contact and zendesk feature switch

Remove klick2concat chat support and the `zendesk_chat` feature switch.

### Guidance to review

