### PR TITLE
Remove Developers from Production Each Night

### DIFF
--- a/.github/workflows/rm-developers.yml
+++ b/.github/workflows/rm-developers.yml
@@ -1,0 +1,75 @@
+name: Check users in space developer role
+
+on:
+  workflow_dispatch:
+  schedule: # Midnight every day
+    - cron: '0 0 * * *'
+
+jobs:
+  CHECK-SPACE-USER:
+    runs-on: ubuntu-latest
+    environment:
+          Production
+          
+    steps:
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
+        id: PAAS-USERNAME
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          yaml_secret: INFRA-KEYS
+          secret: PAAS-USERNAME
+
+      - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
+        id: PAAS-PASSWORD
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          yaml_secret: INFRA-KEYS
+          secret: PAAS-PASSWORD
+
+      - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
+        id: SLACK-WEBHOOK
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          yaml_secret: INFRA-KEYS
+          secret: SLACK-WEBHOOK
+
+      - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
+        id: PAAS-USER-WHITELIST
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          yaml_secret: INFRA-KEYS
+          secret: PAAS-USER-WHITELIST
+
+      - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
+        id: PAAS-SPACE
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          yaml_secret: INFRA-KEYS
+          secret: PAAS-SPACE
+
+      - uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME: ${{ steps.PAAS-USERNAME.outputs.secret-value }}
+          CF_PASSWORD: ${{ steps.PAAS-PASSWORD.outputs.secret-value }}
+          CF_SPACE_NAME: ${{ steps.PAAS-SPACE.outputs.secret-value }}
+          CF_ORG_NAME: dfe
+          CF_API_URL:  https://api.london.cloud.service.gov.uk
+          INSTALL_CONDUIT: false
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          repository: DFE-Digital/bat-infrastructure
+          path: ./remote-checkout
+
+      - name: Run powershell script
+        run: |
+          ./remote-checkout/scripts/check-users-in-space-developer-role.ps1 \
+            -space "${{ steps.PAAS-SPACE.outputs.secret-value }}" \
+            -slack_webhook "${{ steps.SLACK-WEBHOOK.outputs.secret-value }}" \
+            -unset true \
+            -whitelist "${{ steps.PAAS-USER-WHITELIST.outputs.secret-value }}"


### PR DESCRIPTION
# Remove Developers from Production Each Night.

On the government PaaS we can assign users to a Developer role so they can make changes, this is ok for Development and Test spaces, but we should endeavour to remove users who no longer need access to Production each night.
