### PR TITLE
Use event summary as description

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -118,7 +118,7 @@ module StructuredDataHelper
       name: event.name,
       startDate: event.start_at,
       endDate: event.end_at,
-      description: strip_tags(event.description).strip,
+      description: strip_tags(event.summary).strip,
       eventAttendanceMode: event.is_online ? ONLINE_EVENT : OFFLINE_EVENT,
       eventStatus: EVENT_SCHEDULED,
       offers: {

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -300,7 +300,7 @@ describe StructuredDataHelper, type: "helper" do
         name: event.name,
         startDate: event.start_at,
         endDate: event.end_at,
-        description: strip_tags(event.description).strip,
+        description: strip_tags(event.summary).strip,
         eventStatus: described_class::EVENT_SCHEDULED,
         eventAttendanceMode: described_class::OFFLINE_EVENT,
         offers: {


### PR DESCRIPTION
The event description contains HTML however event summaries should not; they are also much shorter so are better suited to the small space available in the event search result boxes. I've left the code to strip any HTML in place as it won't hurt in case someone does add some into that field in the future.

