### PR TITLE
Fix image processing not working for cached pages

### DIFF
--- a/app/controllers/concerns/static_page_cache.rb
+++ b/app/controllers/concerns/static_page_cache.rb
@@ -5,9 +5,11 @@ module StaticPageCache
     def cache_actions(*actions)
       # This appears to be the only way to get `caches_page` to
       # run before the image/link processing that happens in ActionController.
-      skip_after_action :process_images, :process_links
+      skip_after_action :process_images
+      skip_after_action :process_links
       caches_page *actions
-      after_action :process_images, :process_links
+      after_action :process_images
+      after_action :process_links
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2624](https://trello.com/c/ACqZyeCE/2624-fix-next-gen-image-formats-not-serving)

### Context

The image pre-processing had stopped working after updating to the new caching strategy; this fixes it.

### Changes proposed in this pull request

- Fix skip/after-action hooks

I thought these could be chained in the same declaration but seemingly not!

### Guidance to review

<img width="1095" alt="Screenshot 2021-11-03 at 11 02 02" src="https://user-images.githubusercontent.com/29867726/140049181-29fd7503-141a-4c92-a156-68d8560e501a.png">

