### PR TITLE
November 2021 package updates part deux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ group :development, :test do
   # Testing framework
   gem "rspec-rails", "~> 5.0.2"
   # Adds support for Capybara system testing and selenium driver
-  gem "capybara", "~> 3.35", ">= 3.35.3"
+  gem "capybara", "~> 3.36"
   gem "factory_bot_rails", ">= 6.1.0"
   gem "parallel_split_test"
   gem "rspec-sonarqube-formatter", "~> 1.5", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "faraday_middleware"
 
 gem "dotenv-rails", ">= 2.7.6"
 
-gem "govuk_design_system_formbuilder", ">= 2.7.3"
+gem "govuk_design_system_formbuilder", ">= 2.7.5"
 
 gem "loaf", ">= 0.10.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem "redis"
 
 gem "kaminari", "~> 1.2", ">= 1.2.1"
-gem "view_component", "~> 2.40.0"
+gem "view_component", "~> 2.42.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "view_component", "~> 2.42.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 
-gem "actionpack-page_caching"
+gem "actionpack-page_caching", ">= 1.2.4"
 
 # Fix CVE errors
 gem "delegate", ">= 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,9 @@ GEM
     byebug (11.1.3)
     canonical-rails (0.2.12)
       rails (>= 4.1, < 6.2)
-    capybara (3.35.3)
+    capybara (3.36.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
@@ -505,7 +506,7 @@ DEPENDENCIES
   brakeman (~> 5.1.2)
   byebug
   canonical-rails (>= 0.2.12)
-  capybara (~> 3.35, >= 3.35.3)
+  capybara (~> 3.36)
   delegate (>= 0.2.0)
   dfe_wizard!
   dotenv-rails (>= 2.7.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,7 +467,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (1.7.0)
     victor (0.3.3)
-    view_component (2.40.0)
+    view_component (2.42.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.1.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   text
   tzinfo-data
   victor
-  view_component (~> 2.40.0)
+  view_component (~> 2.42.0)
   web-console (>= 4.1.0)
   webmock (>= 3.14.0)
   webpacker (>= 5.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
-    govuk_design_system_formbuilder (2.7.4)
+    govuk_design_system_formbuilder (2.7.5)
       actionview (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
@@ -520,7 +520,7 @@ DEPENDENCIES
   geometry!
   get_into_teaching_api_client_faraday!
   google-api-client (>= 0.53.0)
-  govuk_design_system_formbuilder (>= 2.7.3)
+  govuk_design_system_formbuilder (>= 2.7.5)
   kaminari (~> 1.2, >= 1.2.1)
   kramdown (>= 2.3.1)
   listen (~> 3.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.5.1)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,7 +498,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-cloudfront (>= 1.1.0)
-  actionpack-page_caching
+  actionpack-page_caching (>= 1.2.4)
   addressable (~> 2.8.0)
   amazing_print
   better_html


### PR DESCRIPTION
### Context

More updates, not sure why Dependabot waits for one batch before prepping another 😩

### Changes proposed in this pull request

- Update govuk form builder to 2.7.5
- Update capybara to 3.36.0
- Update puma to 5.5.2
- Update view component to 2.42.0
- Ensure actionpack-page_caching is at least 1.2.4

Closes #1934,#1938,#1939,#1940,#1941
