### PR TITLE
Avoid nil reference error when summary is not set

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -118,7 +118,7 @@ module StructuredDataHelper
       name: event.name,
       startDate: event.start_at,
       endDate: event.end_at,
-      description: strip_tags(event.summary).strip,
+      description: strip_tags(event.summary)&.strip,
       eventAttendanceMode: event.is_online ? ONLINE_EVENT : OFFLINE_EVENT,
       eventStatus: EVENT_SCHEDULED,
       offers: {

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -315,6 +315,12 @@ describe StructuredDataHelper, type: "helper" do
       expect(data).not_to have_key(:location)
     end
 
+    context "when event summary is nil" do
+      let(:event) { build(:event_api, summary: nil) }
+
+      it { is_expected.to include({ description: nil }) }
+    end
+
     context "when the event is online" do
       let(:event) { build(:event_api, :online) }
 


### PR DESCRIPTION
If the summary is `nil` it was throwing an exception trying to call `strip` - this avoids that.