### PR TITLE
Fix page caching on funding your training page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,10 +33,9 @@ private
     process_images
     process_links
 
-    # TODO: turn back on once the funding widget is fixed.
-    # if perform_caching? && action_name.to_sym.in?(static_page_actions)
-    #   cache_page(nil, nil, Zlib::BEST_COMPRESSION)
-    # end
+    if perform_caching? && action_name.to_sym.in?(static_page_actions)
+      cache_page(nil, nil, Zlib::BEST_COMPRESSION)
+    end
   end
 
   def raise_not_found

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -39,22 +39,18 @@ class PagesController < ApplicationController
   end
 
   def show
-    @page = ::Pages::Page.find content_template
+    render_page(params[:page])
+  end
 
-    (@page.ancestors.reverse + [@page]).each do |page|
-      breadcrumb page.title, page.path if @page.title.present?
-    end
+  def funding_your_training
+    @funding_widget =
+      if params[:funding_widget].blank?
+        FundingWidget.new
+      else
+        FundingWidget.new(funding_widget_params).tap(&:valid?)
+      end
 
-    if @page.path.match?(/funding-your-training/)
-      @funding_widget =
-        if params[:funding_widget].blank?
-          FundingWidget.new
-        else
-          FundingWidget.new(funding_widget_params).tap(&:valid?)
-        end
-    end
-
-    render template: @page.template, layout: page_layout
+    render_page("funding-your-training")
   end
 
   def tta_service
@@ -76,6 +72,16 @@ protected
 
 private
 
+  def render_page(path)
+    @page = ::Pages::Page.find content_template(path)
+
+    (@page.ancestors.reverse + [@page]).each do |page|
+      breadcrumb page.title, page.path if @page.title.present?
+    end
+
+    render template: @page.template, layout: page_layout
+  end
+
   def funding_widget_params
     params.require(:funding_widget).permit(:subject)
   end
@@ -87,12 +93,12 @@ private
     "layouts/content"
   end
 
-  def content_template
-    "/#{filtered_page_template}"
+  def content_template(path)
+    "/#{filtered_page_template(path)}"
   end
 
-  def filtered_page_template(page_param = :page)
-    params[page_param].to_s.tap do |page|
+  def filtered_page_template(path)
+    path.to_s.tap do |page|
       raise InvalidTemplateName if page !~ PAGE_TEMPLATE_FILTER
     end
   end

--- a/app/views/content/funding-your-training/_funding-widget.html.erb
+++ b/app/views/content/funding-your-training/_funding-widget.html.erb
@@ -1,6 +1,6 @@
 <section id="funding-widget">
   <%= render FundingWidgetComponent.new(
     @funding_widget,
-    page_path(anchor: 'funding-widget'))
+    page_path("funding-your-training", anchor: 'funding-widget'))
   %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     get "/open_events", to: "events#open_events"
   end
 
+  get "/funding-your-training", to: "pages#funding_your_training", as: :funding_your_training
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/tta-service", to: "pages#tta_service", as: :tta_service

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -59,12 +59,9 @@ describe PagesController, type: :request do
   end
 
   describe "#filtered_page_template" do
-    subject { controller.send :filtered_page_template }
+    subject { controller.send(:filtered_page_template, template) }
 
     let(:controller) { described_class.new }
-    let(:params) { { page: template } }
-
-    before { allow(controller).to receive(:params).and_return params }
 
     context "with valid page template" do
       let(:template) { "hello" }
@@ -100,14 +97,6 @@ describe PagesController, type: :request do
       let(:template) { "stories/my-top-10" }
 
       it { is_expected.to eql "stories/my-top-10" }
-    end
-
-    context "with custom page value" do
-      subject { controller.send :filtered_page_template, :story }
-
-      let(:params) { { story: "hello" } }
-
-      it { is_expected.to eql "hello" }
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2629](https://trello.com/c/2TaMA1rF/2629-revisit-new-caching-method)

### Context

When the new caching behaviour was turned on in production we noticed the funding your training page was not responding correctly. This is because we use query string parameters to determine the state of the form on load, so we can't use the static page cache here.

### Changes proposed in this pull request

- Re-enable static page cache

This was disabled due to a bug with the funding your training page/widget - re-enabling as we're fixing the issue.

- Exclude /funding-your-training from static page cache

Route `/funding-your-training` to its own controller action so that it doesn't get cached. This page doesn't work with the static page cache due to its use of query string parameters to construct the form in a given state on page load.

### Guidance to review

Have I missed any other pages that have forms/use query strings/may not work with the static page cache?