### PR TITLE
Only enable structured data for TTT/QT events

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -111,6 +111,8 @@ module StructuredDataHelper
   end
 
   def event_structured_data(event)
+    return unless event.type_id.in?([qt_event_type_id, ttt_event_type_id])
+
     building_data = event_building_data(event)
     provider_data = event_provider_data(event)
 

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -294,6 +294,20 @@ describe StructuredDataHelper, type: "helper" do
       expect(script_tag).to be_nil
     end
 
+    it "returns nil when not a TTT/QT event" do
+      event = build(:event_api, :school_or_university_event)
+      expect(event_structured_data(event)).to be_nil
+
+      event = build(:event_api, :online_event)
+      expect(event_structured_data(event)).to be_nil
+
+      event = build(:event_api, :train_to_teach_event)
+      expect(event_structured_data(event)).not_to be_nil
+
+      event = build(:event_api, :question_time_event)
+      expect(event_structured_data(event)).not_to be_nil
+    end
+
     it "includes event information" do
       expect(data).to include({
         "@type": "Event",


### PR DESCRIPTION
### Trello card

[Trello-2623](https://trello.com/c/ICt3mFnJ/2623-only-serve-event-structured-data-for-ttt-events)

### Context

We only want to serve structured data for Train to Teach and Question Time event types, not any of the others.v

### Changes proposed in this pull request

- Only enable structured data for TTT/QT events

### Guidance to review

