### PR TITLE
Fix image post-processing for hosted assets

### DIFF
--- a/app/webpacker/styles/header/covid.scss
+++ b/app/webpacker/styles/header/covid.scss
@@ -38,7 +38,7 @@ html:not(.js-enabled) {
   }
 
   &__close {
-    background: url("/packs/media/images/icon-close-4b00d0952ffd57a191ae46fdf62e895d.svg");
+    background: url("../images/icon-close.svg");
     display: block;
     width: 44px;
     height: 44px;

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,7 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Rack::Mime::MIME_TYPES.merge!({
+  ".webp" => "image/webp",
+})

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/webpacker
   source_entry_path: packs
   public_root_path: public
-  public_output_path: packs
+  public_output_path: packs/v1
   cache_path: tmp/cache/webpacker
   webpack_compile_output: true
 

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -32,13 +32,15 @@ private
   end
 
   def source(original_src, ext, doc)
-    src = "#{original_src.chomp(File.extname(original_src))}#{ext}"
+    src_uri = URI.parse(original_src)
+    base_url = src_uri.absolute ? "#{src_uri.scheme}://#{src_uri.host}" : ""
+    src_path = "#{src_uri.path.chomp(File.extname(original_src))}#{ext}"
 
-    return nil unless File.exist?("#{Rails.public_path}/#{src}")
+    return nil unless File.exist?("#{Rails.public_path}#{src_path}")
 
     Nokogiri::XML::Node.new("source", doc) do |source|
-      source["srcset"] = src
-      source["type"] = mime_type(src)
+      source["srcset"] = "#{base_url}#{src_path}"
+      source["type"] = mime_type(src_path)
     end
   end
 

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -46,13 +46,6 @@ private
 
   def mime_type(src)
     ext = File.extname(src)
-
-    case ext
-    when ".webp"
-      # Rack::Mime.mime_type is returning the wrong mime type for webp.
-      "image/webp"
-    else
-      Rack::Mime.mime_type(ext)
-    end
+    Rack::Mime.mime_type(ext)
   end
 end

--- a/lib/responsive_images.rb
+++ b/lib/responsive_images.rb
@@ -49,8 +49,16 @@ private
   end
 
   def responsive_src(src, breakpoint)
-    file = responsive_file(src, breakpoint)
-    file&.sub(Rails.public_path.to_s, "")
+    src_uri = URI.parse(src)
+
+    file = responsive_file(src_uri.path, breakpoint)
+
+    return nil if file.nil?
+
+    file_path = file.sub(Rails.public_path.to_s, "")
+    base_url = src_uri.absolute ? "#{src_uri.scheme}://#{src_uri.host}" : ""
+
+    "#{base_url}#{file_path}"
   end
 
   def responsive_file(src, breakpoint)

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -5,24 +5,26 @@ describe NextGenImages do
   describe "#html" do
     subject { instance.html }
 
-    let(:original_ext) { File.extname(original_src) }
-    let(:body) { "<img src=\"#{original_src}\">" }
+    let(:original_ext) { File.extname(original_src_path) }
+    let(:body) { %(<img src="#{original_src_url}">) }
     let(:instance) { described_class.new(body) }
+    let(:asset_host) { "" }
+    let(:original_src_url) { "#{asset_host}#{original_src_path}" }
 
     before do
       allow(File).to receive(:exist?).and_return(false)
-      allow(File).to receive(:exist?).with("#{Rails.public_path}/#{original_src}").and_return(true)
+      allow(File).to receive(:exist?).with("#{Rails.public_path}#{original_src_path}").and_return(true)
     end
 
     context "when the original image is a jpg" do
-      let(:original_src) { "path/to/image.jpg" }
+      let(:original_src_path) { "/path/to/image.jpg" }
 
       context "when there are no next-gen images" do
-        it { is_expected.to include("<picture>#{source(original_src, 'image/jpeg')}<img src=\"#{original_src}\"></picture>") }
+        it { is_expected.to include(%(picture>#{source(original_src_url, 'image/jpeg')}<img src="#{original_src_url}"></picture>)) }
       end
 
       context "when the image is already in a picture tag" do
-        let(:body) { "<picture><img src=\"#{original_src}\"></picture>" }
+        let(:body) { %(<picture><img src="#{original_src_url}"></picture>) }
 
         it { is_expected.to include(body) }
       end
@@ -30,39 +32,48 @@ describe NextGenImages do
       context "when there are next-gen images" do
         let(:next_gen_imgs) do
           {
-            "image/webp" => original_src.gsub(original_ext, ".webp"),
-            "image/jp2" => original_src.gsub(original_ext, ".jp2"),
-            "image/jpeg" => original_src,
+            "image/webp" => original_src_path.gsub(original_ext, ".webp"),
+            "image/jp2" => original_src_path.gsub(original_ext, ".jp2"),
+            "image/jpeg" => original_src_path,
           }
         end
 
         before do
           next_gen_imgs.values.each do |src|
-            allow(File).to receive(:exist?).with("#{Rails.public_path}/#{src}").and_return(true)
+            allow(File).to receive(:exist?).with("#{Rails.public_path}#{src}").and_return(true)
           end
         end
 
         it do
           sources = next_gen_imgs.map { |mime_type, src| source(src, mime_type) }.join
-          is_expected.to include("<picture>#{sources}<img src=\"#{original_src}\"></picture>")
+          is_expected.to include(%(<picture>#{sources}<img src="#{original_src_url}"></picture>))
+        end
+
+        context "when the src is absolute (assets are hosted on a different domain)" do
+          let(:asset_host) { "https://domain.com" }
+
+          it do
+            sources = next_gen_imgs.map { |mime_type, src| source(src, mime_type) }.join
+            is_expected.to include(%(<picture>#{sources}<img src="#{original_src_url}"></picture>))
+          end
         end
       end
     end
 
     context "when the original image is a png" do
-      let(:original_src) { "path/to/image.png" }
+      let(:original_src_path) { "/path/to/image.png" }
 
-      it { is_expected.to include("<picture>#{source(original_src, 'image/png')}<img src=\"#{original_src}\"></picture>") }
+      it { is_expected.to include(%(<picture>#{source(original_src_path, 'image/png')}<img src="#{original_src_url}"></picture>)) }
     end
 
     context "when the original image is an svg" do
-      let(:original_src) { "path/to/image.svg" }
+      let(:original_src_path) { "/path/to/image.svg" }
 
-      it { is_expected.to include("<picture>#{source(original_src, 'image/svg+xml')}<img src=\"#{original_src}\"></picture>") }
+      it { is_expected.to include(%(<picture>#{source(original_src_path, 'image/svg+xml')}<img src="#{original_src_url}"></picture>)) }
     end
   end
 
   def source(src, mime_type)
-    "<source srcset=\"#{src}\" type=\"#{mime_type}\"></source>"
+    %(<source srcset="#{asset_host}#{src}" type="#{mime_type}"></source>)
   end
 end

--- a/spec/lib/responsive_images_spec.rb
+++ b/spec/lib/responsive_images_spec.rb
@@ -6,7 +6,8 @@ describe ResponsiveImages do
     subject { instance.html }
 
     let(:fingerprint) { "-fingerprint1" }
-    let(:src) { "media/images/content/an-image#{fingerprint}.jpg" }
+    let(:asset_host) { "" }
+    let(:src) { "#{asset_host}/media/images/content/an-image#{fingerprint}.jpg" }
     let(:body) do
       "<picture>
         <source srcset=\"#{src}\" type=\"image/jpeg\"></source>
@@ -27,6 +28,16 @@ describe ResponsiveImages do
           is_expected.to include(
             "<source srcset=\"#{responsive_src}\" type=\"image/jpeg\" media=\"(max-width: #{max_width})\"></source>",
           )
+        end
+
+        context "when the src is absolute (assets are hosted on a different domain)" do
+          let(:asset_host) { "https://domain.com" }
+
+          it do
+            is_expected.to include(
+              "<source srcset=\"#{responsive_src}\" type=\"image/jpeg\" media=\"(max-width: #{max_width})\"></source>",
+            )
+          end
         end
       end
     end
@@ -60,11 +71,12 @@ describe ResponsiveImages do
   def setup_responsive_img(breakpoint)
     fingerprint = "1234abc"
     responsive_src = "media/images/content/an-image--#{breakpoint}-#{fingerprint}.jpg"
-    responsive_file = "#{Rails.public_path}#{responsive_src}"
-    responsive_pattern = "#{Rails.public_path}media/images/content/an-image--#{breakpoint}*.jpg"
+    public_path = Rails.public_path
+    responsive_file = "#{public_path}/#{responsive_src}"
+    responsive_pattern = "#{public_path}/media/images/content/an-image--#{breakpoint}*.jpg"
 
     allow(Dir).to receive(:glob).with(responsive_pattern) { [responsive_file] }
 
-    responsive_src
+    "#{asset_host}/#{responsive_src}"
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2624](https://trello.com/c/ACqZyeCE/2624-fix-next-gen-image-formats-not-serving)

### Context

When the app is running in the preprod/prod environment the assets are hosted on a different domain, so the various image `src` attributes contain absolute URLs instead of paths.

Update the `NextGenImages` and `ResponsiveImages` to account for `src` attributes containing either a domain or path.

Even though the assets are hosted elsewhere they remain in the docker image so the various `File` checks still work.

### Changes proposed in this pull request

- Fix image post-processing for hosted assets

- Correctly serve webp images

`Rack::Mime` doesn't support webp images out of the box; to get around this we have to tell it to use the correct content type for the extension.

Oddly, its been fine serving webp images as `text/plain` up until we added in a `Access-Control-Allow-Origin` header when we started serving assets on a different domain. A side-effect of this is that the content-type has to now be correct or the request is blocked by cross-origin read blocking (CORB). More info here:

https://www.chromium.org/Home/chromium-security/corb-for-developers

Specifically:

> For example, a response served with a “X-Content-Type-Options: nosniff” response header and an incorrect “Content-Type” response header may be blocked. This could, for example, block an actual image which is mislabeled as “Content-Type: text/html” and “nosniff.” If this occurs and interferes with a page’s behavior, we recommend informing the website and requesting that they correct the “Content-Type” header for the response.

- Flush asset cache

Updates the path prefix with a version in order to flush the assets as we now have webp images cached in the staging CloudFront with the wrong content-type (from my testing).

I can't find a better way of doing this; Webpack seems to let you define filenames explcitly but I'd have to do it for every
extension type which is awkward. Sprockets lets you specify the asset version which weighs into the digest value, however I can't find a corresponding option for Webpack and instead the easiest thing seems to be to change the pack path to include a version.

### Guidance to review

I pushed this build to our staging environment (which has hosts assets on a different domain) in order to test it as it appears in prod:

<img width="1132" alt="Screenshot 2021-11-05 at 10 01 36" src="https://user-images.githubusercontent.com/29867726/140493336-59a9360f-063f-4286-8909-05e60b292cf7.png">
