### PR TITLE
Improve resizing behaviour in the footer

### DIFF
--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -95,13 +95,24 @@ footer.site-footer {
 
     &__logo-container {
       flex: 33% 0 0;
+      flex-direction: column;
 
       display: flex;
       align-content: center;
 
-      // gap: 3em;
       picture + picture {
-        margin-left: 3em;
+        margin-top: 1em;
+      }
+
+
+      @include mq($from: tablet) {
+        // gap: 3em;
+        picture + picture {
+          margin-top: 0;
+          margin-left: 3em;
+        }
+
+        flex-direction: row;
       }
     }
 


### PR DESCRIPTION
Now it will be a column on mobile and a row on tablet/desktop. This stops it from pushing the page out wider than it needs to be.

| Before | After |
| ------ | ------- |
| ![Screenshot from 2021-11-09 16-17-12](https://user-images.githubusercontent.com/128088/140962340-947c49f8-98ee-46f4-9efc-b32cab224777.png) | ![Screenshot from 2021-11-09 16-15-05](https://user-images.githubusercontent.com/128088/140962233-845cb9db-16bf-4050-99e0-d1c1eab46f72.png) |
