### PR TITLE
Minor style tweaks to the navigation menu

### DIFF
--- a/app/webpacker/styles/header/menu-button.scss
+++ b/app/webpacker/styles/header/menu-button.scss
@@ -14,11 +14,10 @@
     margin-right: 2em;
     margin-left: 1em;
     padding: .8em 1.4em;
-    
+
     &:hover {
 	    cursor: pointer;
 	    background: $green;
-	    
     }
 
     &.open {
@@ -36,6 +35,7 @@
   .menu-button__text {
     display: inline-block;
     margin-left: .6em;
+    color: $black;
   }
 
   .menu-button__icon {

--- a/app/webpacker/styles/header/navigation.scss
+++ b/app/webpacker/styles/header/navigation.scss
@@ -159,16 +159,16 @@ body > header nav {
         }
 
         a {
-          padding: 1em .2em 0;
-          border-bottom: 2px solid $white;
-
           &:hover {
             border-bottom: 2px solid $black;
           }
         }
 
-        div {
-	        line-height: 1.5;
+        a, div {
+          line-height: 1.2;
+          display: inline-block;
+          padding: 1em .2em 0;
+          border-bottom: 2px solid $white;
         }
       }
     }


### PR DESCRIPTION
### Trello card

[Trello-2631](https://trello.com/c/HQa4lsSi/2631-menu-item-jumps-a-few-pixels-when-you-click-it)

### Context

The active menu item on desktop/wide was a few pixels out of horizontal alignment due to an mismatched style of the active `div` with the unselected `a` elements.

On Safari iOS the menu button text is a default anchor blue; this forces it to be black (as it displays in desktop/responsive).

### Changes proposed in this pull request

- Fix active menu item alignment
- Ensure mobile menu text is black

### Guidance to review

| Before      | After |
| ----------- | ----------- |
| ![Group_2](https://user-images.githubusercontent.com/29867726/141085220-1d56cd81-48db-4b33-b984-f9cba8c42612.png)      | <img width="518" alt="Screenshot 2021-11-10 at 09 18 12" src="https://user-images.githubusercontent.com/29867726/141085294-d0f00dc4-1c5a-41d6-a8f8-3d85667ef3c0.png">       |
| <img width="352" alt="Screenshot 2021-11-10 at 09 19 09" src="https://user-images.githubusercontent.com/29867726/141085432-9d594085-83c4-470a-ad06-ffeb5cf8e1a4.png">   |  <img width="359" alt="Screenshot 2021-11-10 at 09 19 19" src="https://user-images.githubusercontent.com/29867726/141085454-316b12d1-5631-45e4-aa8a-134c6cceb23e.png"> |



