### PR TITLE
Allow pages to be easily excluded static page cache

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,7 @@ class PagesController < ApplicationController
   ].freeze
 
   PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}.freeze
+  DYNAMIC_PAGE_PATHS = [].freeze
 
   rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
 
@@ -67,7 +68,9 @@ class PagesController < ApplicationController
 protected
 
   def static_page_actions
-    %i[show cookies privacy_policy]
+    %i[cookies privacy_policy].tap do |actions|
+      actions << :show unless DYNAMIC_PAGE_PATHS.include?(request.path)
+    end
   end
 
 private


### PR DESCRIPTION
### Trello card

[Trello-2642](https://trello.com/c/mIknuOTy/2642-add-a-simple-way-to-omit-pages-from-caching)

### Context

Some pages are not suitable for caching (usually due to the use of query parameters/forms). We need a way to easily exclude these from the default static page caching behaviour on the `show` action.

### Changes proposed in this pull request

- Allow pages to be easily excluded from static page cache

Add `DYNAMIC_PAGE_PATHS` which will be excluded from the static page cache.

### Guidance to review

There's no way we can test this unfortunately due to caching being disabled in the test env by default 😞 I have manually tested however by adding a route to `DYNAMIC_PAGES` and checking it it doesn't get cached in the preview environment.