### PR TITLE
Add temp routes for A/B test

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -42,6 +42,19 @@ class PagesController < ApplicationController
     render_page(params[:page])
   end
 
+  # TEMP: routes to try an A/B test in production
+  def temp_test_a
+    response.headers["X-Robots-Tag"] = "noindex"
+
+    render_page("steps-to-become-a-teacher")
+  end
+
+  def temp_test_b
+    response.headers["X-Robots-Tag"] = "noindex"
+
+    render_page("ways-to-train")
+  end
+
   def funding_your_training
     @funding_widget =
       if params[:funding_widget].blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
     get "/open_events", to: "events#open_events"
   end
 
+  get "/test/a", to: "pages#temp_test_a"
+  get "/test/b", to: "pages#temp_test_b"
   get "/funding-your-training", to: "pages#funding_your_training", as: :funding_your_training
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/cookies", to: "pages#cookies", as: :cookies


### PR DESCRIPTION
We are integrating Google Optimise and want to test the behaviour before enabling an experiment in production.

Add two test pages that are no-indexed that can be used to test in prod (they serve the existing steps/ways pages as content).