### PR TITLE
Re-introduce CSRF meta tag on internal layout

### DIFF
--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
 <% content_for :head do %>
+  <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'internal', 'data-turbolinks-track': 'reload', media: 'all' %>
   <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
 <% end %>


### PR DESCRIPTION
I did a refactoring on this when I brought in static page caching but missed adding it to the internal events layout.
