### PR TITLE
Perform beta redirect before static page cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,8 @@ gem "better_html"
 
 gem "dfe_wizard", github: "DFE-Digital/dfe_wizard"
 
+gem "rack-host-redirect"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,8 +290,6 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
-      racc (~> 1.4)
     observer (0.1.1)
     os (1.1.1)
     parallel (1.20.1)
@@ -316,6 +314,8 @@ GEM
     rack (2.2.3)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
+    rack-host-redirect (1.3.0)
+      rack
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -536,6 +536,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.5)
   rack-attack
+  rack-host-redirect
   rails (~> 6.1.4.1)
   rails_semantic_logger (>= 4.6.1)
   redis

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
   config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence || \
     Rails.application.credentials.google_maps_key.presence
-  config.x.enable_beta_redirects = false
 
   config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence || \
     Rails.application.credentials.basic_auth_credentials.presence

--- a/config/environments/pagespeed.rb
+++ b/config/environments/pagespeed.rb
@@ -5,5 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
-  config.x.enable_beta_redirects = false
 end

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -5,7 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
-  config.x.enable_beta_redirects = false
 
   config.view_component.show_previews = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,7 +108,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-prod.london.cloudapps.digital/api"
   config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence || \
     Rails.application.credentials.google_maps_key.presence
-  config.x.enable_beta_redirects = true
 
   config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence || \
     Rails.application.credentials.basic_auth_credentials.presence
@@ -144,4 +143,9 @@ Rails.application.configure do
   config.x.legacy_tracking_pixels = true
 
   config.x.covid_banner = false
+
+  # Ensure beta redirect happens before static page cache.
+  config.middleware.insert_before ActionDispatch::Static, Rack::HostRedirect, {
+    "beta-getintoteaching.education.gov.uk" => "getintoteaching.education.gov.uk",
+  }
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -5,7 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
-  config.x.enable_beta_redirects = false
 
   config.view_component.show_previews = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,9 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Ensure beta redirect happens before static page cache.
+  config.middleware.insert_before ActionDispatch::Static, Rack::HostRedirect, {
+    "beta-getintoteaching.education.gov.uk" => "getintoteaching.education.gov.uk",
+  }
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -6,7 +6,6 @@ Rails.application.configure do
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
   config.x.static_pages.disable_caching = true
-  config.x.enable_beta_redirects = false
   config.x.utm_codes = true
 
   Rack::Attack.enabled = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  if Rails.configuration.x.enable_beta_redirects
-    constraints(host: "beta-getintoteaching.education.gov.uk") do
-      get "/(*path)", to: redirect(host: "getintoteaching.education.gov.uk")
-    end
-  end
-
   root to: "pages#show", page: "home"
 
   get "/robots.txt", to: "robots#show"

--- a/spec/requests/beta_redirect_spec.rb
+++ b/spec/requests/beta_redirect_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe "Redirecting beta-getintoteaching.education.gov.uk to getintoteaching.education.gov.uk", type: :request do
   before do
-    allow(Rails.configuration.x).to receive(:enable_beta_redirects).and_return(true)
     host!("beta-getintoteaching.education.gov.uk")
   end
 


### PR DESCRIPTION
### Trello card

[Trello-2654](https://trello.com/c/OMCl1OIG/2654-fix-beta-redirect-not-working)

### Context

The beta redirect currently happens as a Rails route, which used to work fine but now that the pages are statically cached the routes aren't evaluated on every request. If the page matches a static page it will be served by Rack; to re-instate the redirect we need to do so in Rack before the `ActionDispatch::Static` middleware.

### Changes proposed in this pull request

- Perform beta redirect before static page cache

### Guidance to review

Added to the test environment as well so that the existing rspec test still passes (it was passing despite not working due to the caching being disabled in the test env; not a lot we can do about that.)