### PR TITLE
Update AO page

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -349,11 +349,6 @@ provider_groups:
       email: a.harper@sjb.surrey.sch.uk
   South West:
     providers:
-    - header: Bath Spa University
-      link: https://www.bathspa.ac.uk/
-      name: Clare Furlonger
-      telephone: 01225 875650
-      email: assessmentonly@bathspa.ac.uk
     - header: Cornwall School Centred Initial Teacher Training (Cornwall SCITT)
       link: https://www.cornwallscitt.org/
       name: Julie Bennett

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -211,7 +211,7 @@ provider_groups:
       telephone: 01642 527675
       email: scitt@stockton.gov.uk
     - header: University of Sunderland
-      link: https://www.sunderland.ac.uk/
+      link: https://www.sunderland.ac.uk/study/short-courses-cpd/assessment-only-route-qts/
       name: Jill Wilkinson
       telephone: '0191 5153099'
       email: jill.wilkinson@sunderland.ac.uk
@@ -249,8 +249,8 @@ provider_groups:
       email: j.simmonds@chester.ac.uk
     - header: University of Cumbria
       link: https://www.cumbria.ac.uk/study/academic-departments/institute-of-education/qts-direct-assessment-only-route/
-      name: Carolyn Reade
-      email: arolyn.reade@cumbria.ac.uk
+      name: Ian Todd
+      email: qtsdirect@cumbria.ac.uk
   South East:
     providers:
     - header: Astra School Centred Initial Teacher Training / Dr Challoner's Grammar
@@ -495,7 +495,7 @@ provider_groups:
       name: Admissions Team
       telephone: +86 135 2015 3752
       email: admissions@bise.org
-    - header: TES Institute
+    - header: TES Institute (International)
       link: https://www.tes.com/institute/courses/international-assessment-only-route
       name: TI Enrolment team
       telephone: +44 (0)203 194 3000


### PR DESCRIPTION
### Trello card
https://trello.com/c/A1JXUPQh

### Context

- Change to Cumbria contact details as requested via Helpdesk

- Change to TES title for international route for accessibility purposes - to avoid having two links with the same link text going to different destinations

- Updated first University of Sunderland link to go to their AO page (same as second link) rather than university home page - for accessibility purposes, to avoid two links with same link text going to different destinations

- Additional change to remove Bath Spa



