### PR TITLE
Update acronym for PGCE

### DIFF
--- a/config/frontmatter.yml
+++ b/config/frontmatter.yml
@@ -13,7 +13,7 @@ acronyms:
   NPQ: National Professional Qualification
   SKE: subject knowledge enhancement
   PGDE: Postgraduate Diploma in Education
-  PGCE: Postgraduate Certificate of Education
+  PGCE: Postgraduate Certificate in Education
   BEd: Bachelor of Education degree
   BA: Bachelor of Arts
   BSc: Bachelor of Science


### PR DESCRIPTION
### Trello card
https://trello.com/c/nRM9srwZ

### Context
Update to definition of PGCE to be `Postgraduate Certificate in Education` rather than `Postgraduate Certificate of Education` to be consistent with Find
