### PR TITLE
Update Access-Control-Allow-Origin header for test

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -1,6 +1,15 @@
 # Just use the production settings
 require File.expand_path("production.rb", __dir__)
 
+# We have multiple domains that serve the test instance of the app:
+#
+# get-into-teaching-app-test.london.cloudapps.digital
+# staging-getintoteaching.education.gov.uk
+#
+# We can only set one domain in this header, which means fonts don't work
+# on the other. To get around this we need to use a wildcard in test.
+config.public_file_server.headers["Access-Control-Allow-Origin"] = "*"
+
 Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \


### PR DESCRIPTION
### Trello card

[Trello-2645](https://trello.com/c/zx8jCZ45/2645-fix-icons-on-test-environment)

### Context

We have multiple domains that point to our test instance of the app; the Access-Control-Allow-Origin header restricts requests to our assets from certain domains, however we can only specify a single domain in this header which means fonts aren't loaded on the other test domain.

A way around this is to change it to a wildcard that accepts all requests; it should be no less secure given we have basic auth on the test instance anyway.

The only other solution would require a reverse proxy such as NGINX that would let us set the header dynamically if it comes from a list of supported domains, but we don't have that infrastructure at present.

### Changes proposed in this pull request

- Update Access-Control-Allow-Origin header for test

### Guidance to review

I'm not sure why this is only effecting the fonts; other assets work fine 🤷‍♂️ 