### PR TITLE
Simplify the mailing list logic on completion

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,6 +1,8 @@
 <% @hide_page_helpful_question = true %>
 
-<% if Rails.env.test? || Rails.env.production? || !show_welcome_guide? %>
+<% if show_welcome_guide? && !Rails.env.production? %>
+  <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
+<% else %>
 
   <section class="text-content">
     <h2 class="green">You've signed up</h2>
@@ -68,9 +70,6 @@
       <%= link_to "Find an event", events_path, class: "button button--white button--unpadded" %>
     <% end %>
   </div>
-
-<% else %>
-  <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% end %>
 
 <% if Rails.application.config.x.legacy_tracking_pixels %>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -90,6 +90,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
   end
 
   scenario "Full journey as an existing candidate" do
+    first_name = "Joey"
+
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token)
 
@@ -105,7 +107,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     visit mailing_list_steps_path
 
     expect(page).to have_text "Get personalised guidance to your inbox"
-    fill_in_name_step
+    fill_in_name_step(first_name: first_name)
     click_on "Next step"
 
     expect(page).to have_text "Verify your email address"
@@ -140,8 +142,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     check "Yes"
     click_on "Complete sign up"
 
-    expect(page).to have_text "You've signed up"
-    expect(page).to have_text("You'll receive a welcome email shortly")
+    expect(page).to have_text "#{first_name}, you're signed up"
+    expect(page).to have_text("We'll send your first email shortly")
   end
 
   scenario "Full journey as an existing candidate that resends the verification code" do
@@ -263,7 +265,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_text "You've signed up"
-    expect(page).to have_text("You'll receive a welcome email shortly")
+    expect(page).to have_text("We'll send your first email shortly")
   end
 
   scenario "Invalid magic link tokens" do


### PR DESCRIPTION
Now we're going ahead with the WG update the specs so they expect the WG content where the conditions are matched. Also flip the `if` statement so it reads more easily; now we're showing it everywhere except prod.
