### PR TITLE
Fix the scribble signup display

### DIFF
--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -37,6 +37,6 @@
 
   <%= render(partial: "teaching_events/show/event-attributes") %>
   <%= render(partial: "teaching_events/show/venue-information") if @event.building.present? %>
-  <%= render(partial: "teaching_evetns/show/scribble") if @event.scribble_id.present? %>
+  <%= render(partial: "teaching_events/show/scribble") if @event.scribble_id.present? %>
   <%= render(partial: "teaching_events/show/what-theyre-saying") %>
 </div>

--- a/app/views/teaching_events/show/_scribble.html.erb
+++ b/app/views/teaching_events/show/_scribble.html.erb
@@ -1,3 +1,3 @@
 <section class="scribble">
-  <div data-controller="scribble" data-scribble-id="<%= @event.scribble_id %>"></div>
+  <%= tag.div(data: { "controller" => "scribble", "scribble-id" => @event.scribble_id }) %>
 </section>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -605,6 +605,11 @@
     }
   }
 
+  .scribble {
+    max-width: 65rem;
+    margin: 2em auto;
+  }
+
   .venue-information {
     max-width: 65rem;
     margin: auto;


### PR DESCRIPTION
### Context

The page is 404ing in the test env due to a typo in the partial name

### Changes proposed in this pull request

Fix the typo and add some better styling to the scribble event box.

### Guidance to review

There's now an online event accessible from the test so it should be visible and look fine when viewed. Thanks @jkempster34 for helping get this set up!

![Screenshot from 2021-11-15 16-28-04](https://user-images.githubusercontent.com/128088/141818105-6b9e8269-0c19-4854-bdb9-50c3bf597845.png)
