### PR TITLE
Send welcome guide variant on ML sign up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: c448d68912ab079f0eb58a3e48c539b6f946dfea
+  revision: a57872c71b88a70084d66ff930ae3f90102998af
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.46)
+    get_into_teaching_api_client_faraday (0.1.47)
       activesupport
       faraday
       faraday-encoding
@@ -234,7 +234,7 @@ GEM
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     jwt (2.2.3)
@@ -289,6 +289,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     observer (0.1.1)
     os (1.1.1)

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -59,10 +59,28 @@ module MailingList
   private
 
     def add_member_to_mailing_list
-      request = GetIntoTeachingApiClient::MailingListAddMember.new(export_camelized_hash)
+      request = GetIntoTeachingApiClient::MailingListAddMember.new(construct_export)
       api = GetIntoTeachingApiClient::MailingListApi.new
       Rails.logger.info("MailingList::Wizard#add_mailing_list_member: #{AttributeFilter.filtered_json(request)}")
       api.add_mailing_list_member(request)
+    end
+
+    def construct_export
+      export = export_camelized_hash
+
+      show_welcome_guide = ApplicationController.helpers.show_welcome_guide?(
+        export[:degreeStatusId],
+        export[:preferredTeachingSubjectId],
+      )
+
+      return export unless show_welcome_guide
+
+      export.tap do |h|
+        h[:welcomeGuideVariant] = export_data.slice(
+          "degree_status_id",
+          "preferred_teaching_subject_id",
+        ).to_query
+      end
     end
   end
 end

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -4,11 +4,14 @@ describe MailingList::Wizard do
   subject { described_class.new wizardstore, "privacy_policy" }
 
   let(:uuid) { SecureRandom.uuid }
+  let(:degree_status_id) { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["Final year"] }
   let(:store) do
     { uuid => {
       "email" => "email@address.com",
       "first_name" => "Joe",
       "last_name" => "Joseph",
+      "degree_status_id" => degree_status_id,
+      "preferred_teaching_subject_id" => "456",
     } }
   end
   let(:wizardstore) { DFEWizard::Store.new store[uuid], {} }
@@ -37,10 +40,16 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
+    let(:variant) { "degree_status_id=#{degree_status_id}&preferred_teaching_subject_id=456" }
     let(:request) do
-      GetIntoTeachingApiClient::MailingListAddMember.new(
-        { email: "email@address.com", firstName: "Joe", lastName: "Joseph" },
-      )
+      GetIntoTeachingApiClient::MailingListAddMember.new({
+        email: wizardstore[:email],
+        firstName: wizardstore[:first_name],
+        lastName: wizardstore[:last_name],
+        degreeStatusId: degree_status_id,
+        preferredTeachingSubjectId: wizardstore[:preferred_teaching_subject_id],
+        welcomeGuideVariant: variant,
+      })
     end
 
     before do
@@ -49,16 +58,47 @@ describe MailingList::Wizard do
         receive(:add_mailing_list_member).with(request)
       allow(Rails.logger).to receive(:info)
       allow(wizardstore).to receive(:prune!).and_call_original
-      subject.complete!
     end
 
-    it { is_expected.to have_received(:valid?) }
-    it { expect(store[uuid]).to eql({ "first_name" => "Joe", "last_name" => "Joseph" }) }
-    it { expect(wizardstore).to have_received(:prune!).with({ leave: MailingList::Wizard::ATTRIBUTES_TO_LEAVE }).once }
+    it "checks the wizard is valid" do
+      subject.complete!
+      is_expected.to have_received(:valid?)
+    end
+
+    it "prunes the store, retaining certain attributes" do
+      subject.complete!
+      expect(store[uuid]).to eql({
+        "first_name" => wizardstore[:first_name],
+        "last_name" => wizardstore[:last_name],
+        "degree_status_id" => wizardstore[:degree_status_id],
+        "preferred_teaching_subject_id" => wizardstore[:preferred_teaching_subject_id],
+      })
+      expect(wizardstore).to have_received(:prune!).with({ leave: MailingList::Wizard::ATTRIBUTES_TO_LEAVE }).once
+    end
 
     it "logs the request model (filtering sensitive attributes)" do
-      filtered_json = { "email" => "[FILTERED]", "firstName" => "[FILTERED]", "lastName" => "[FILTERED]" }.to_json
+      subject.complete!
+      filtered_json = {
+        "preferredTeachingSubjectId" => request.preferred_teaching_subject_id,
+        "degreeStatusId" => request.degree_status_id,
+        "email" => "[FILTERED]",
+        "firstName" => "[FILTERED]",
+        "lastName" => "[FILTERED]",
+        "welcomeGuideVariant" => request.welcome_guide_variant,
+      }.to_json
+
       expect(Rails.logger).to have_received(:info).with("MailingList::Wizard#add_mailing_list_member: #{filtered_json}")
+    end
+
+    context "when not qualified for the welcome guide" do
+      let(:degree_status_id) { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["First year"] }
+      let(:variant) { nil }
+
+      it "does not populate the welcome_guide_variant field" do
+        allow_any_instance_of(GetIntoTeachingApiClient::MailingListApi).to \
+          receive(:add_mailing_list_member).with(request)
+        subject.complete!
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

[Trello-2661](https://trello.com/c/catUOcuk/2661-update-api-to-include-welcome-guide-query-parameters)

### Context

When a candidate signs up to the Mailing List we want to populate the `welcome_guide_variant` attribute with the query string that can be used to serve the correct version of the welcome guide in an email that will later be sent to the candidate.

We only want to populate this field if the candidate qualifies for the welcome guide, leaving it as `nil` if they don't.

### Changes proposed in this pull request

- Send welcome guide variant on ML sign up

### Guidance to review

The API/CRM only support this new field in dev at the moment, but it _shouldn't_ cause issues if its set in test/prod payloads; it'll just be ignored