### PR TITLE
Refactor global hidden style

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -18,7 +18,7 @@
               <% end %>
             </div>
           <% end %>
-          <div class="actions hidden">
+          <div class="actions hidden-when-js-enabled">
             <%= f.button 'See funding', type: 'submit', class: 'button' %>
           </div>
         <% end %>

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -34,10 +34,6 @@ $grey-very-light: #f3f2f1;
     margin-bottom: 30px;
   }
 
-  .hidden {
-    display: none;
-  }
-
   &.open_events {
     background-color: $grey-very-light;
     max-width: none;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -37,8 +37,16 @@ main,
   width: 1px;
 }
 
-.js-enabled .hidden {
-  display: none;
+.js-enabled {
+  .hidden-when-js-enabled {
+    display: none;
+  }
+}
+
+.hidden {
+  // We use important! to ensure any component-level
+  // display values (such as flex) are still hidden.
+  display: none !important;
 }
 
 // new layouts, intended to remove the reliance on float and instead use semantic markup and flexbox:
@@ -55,7 +63,7 @@ main {
   }
 
   &--no-bottom-margin {
-    bottom-margin: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -109,9 +109,6 @@ a {
 iframe#launcher {
   display: none;
 }
-.chat-button.hidden {
-  display: none;
-}
 
 .chat-button-offline {
   display: none;

--- a/app/webpacker/styles/page-helpful.scss
+++ b/app/webpacker/styles/page-helpful.scss
@@ -24,9 +24,5 @@
     &:hover {
       text-decoration: none;
     }
-
-    &.hidden {
-      display: none;
-    }
   }
 }


### PR DESCRIPTION
### Trello card

[Trello-2644](https://trello.com/c/eiXVZiU3/2644-clean-up-hidden-classes)

### Context

There was a global `.hidden` class that was only applied when JS is enabled; this is confusing and a pain to override, as you often want the element to be hidden regardless of JS status when applying a `hidden` class.

Rename `.hidden` to `.hidden-when-js-enabled` and create a new `.hidden` class that will always hide an element when applied. It's decorated with `important!` so that custom components that have, for example, `display: flex` will still be
hidden when the class is applied.

Fix typo in style attribute that should be `margin-bottom`, not `bottom-margin`.

### Changes proposed in this pull request

- Refactor global hidden style

### Guidance to review

