### PR TITLE
Disable welcome_guide_variant field in production

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,5 +1,7 @@
 module WelcomeHelper
   def show_welcome_guide?(degree_status = degree_status_id, consideration_journey_stage = consideration_journey_stage_id)
+    return false if Rails.env.production?
+
     gradudate_or_postgraduate = retrieve_degree_status_ids("Graduate or postgraduate")
     allowed_graduate_consideration_stages = retrieve_consideration_journey_stage_ids(
       "It’s just an idea",

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -1,6 +1,6 @@
 <% @hide_page_helpful_question = true %>
 
-<% if show_welcome_guide? && !Rails.env.production? %>
+<% if show_welcome_guide? %>
   <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% else %>
 

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe WelcomeHelper, type: :helper do
       let(:final_year) { GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["Final year"] }
 
       it { expect(show_welcome_guide?(final_year)).to be true }
+
+      context "when production" do
+        before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+        it { expect(show_welcome_guide?(final_year)).to be false }
+      end
     end
 
     context "when degree_status is 'graduate or postgraduate'" do


### PR DESCRIPTION
The welcome guide is not currently shown to users in production and we want to mirror this behaviour for the new `welcome_guide_variant` field on sign up by not populating it.

As both places use the same helper It makes sense to move the logic into there and then we only have one place to change in order to enable it in production.