### PR TITLE
Add a new page with information about TTT events

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -39,6 +39,10 @@ class TeachingEventsController < ApplicationController
     render layout: "teaching_event"
   end
 
+  def about_ttt_events
+    breadcrumb "Teaching events", "/teaching-events"
+  end
+
 private
 
   def search_params

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -45,6 +45,10 @@ class TeachingEventsController < ApplicationController
 
 private
 
+  def static_page_actions
+    %i[about_ttt_events]
+  end
+
   def search_params
     params.permit(teaching_events_search: [:postcode, :distance, { online: [], type: [] }])[:teaching_events_search]
   end

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -8,7 +8,7 @@
       <span>Train to Teach event?</span>
     </h1>
 
-    <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg" %>
+    <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg", alt: "A popular train to teach event in a hall with stalls and banners" %>
   </header>
 
 

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -4,13 +4,13 @@
 <div class="about-ttt-events">
   <header>
     <h1>
-      <span>What is a</span><br/>
+      <span>What is a</span>
+      <br>
       <span>Train to Teach event?</span>
     </h1>
 
     <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg", alt: "A popular train to teach event in a hall with stalls and banners" %>
   </header>
-
 
   <article>
     <p>
@@ -46,10 +46,5 @@
     </ul>
   </article>
 
-  <%= render(
-      partial: "teaching_events/show/what-theyre-saying",
-      locals: {
-        quote: "It was exactly what I needed to give me guidance on the next steps to be taken"
-      }
-    ) %>
+  <%= render(partial: "teaching_events/show/what-theyre-saying", locals: { quote: "It was exactly what I needed to give me guidance on the next steps to be taken" }) %>
 </div>

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -1,0 +1,55 @@
+<% @page_title = "About train to teach events" %>
+<%= render Header::BreadcrumbComponent.new %>
+
+<div class="about-ttt-events">
+  <header>
+    <h1>
+      <span>What is a</span><br/>
+      <span>Train to Teach event?</span>
+    </h1>
+
+    <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg" %>
+  </header>
+
+
+  <article>
+    <p>
+      Train to Teach events are designed to give you an insight into what it’s
+      like to be a teacher, as well as the practical information you need to get
+      onto a teacher training course.
+    </p>
+
+    <p>
+      Events are run by the Department for Education and are impartial. We do
+      invite local training providers along to give you an idea of what they
+      offer, but our goal is to answer your questions and give you the confidence
+      to take your next step.
+    </p>
+
+    <p>
+      To attend, you need to register. Spaces are limited, so the sooner you sign
+      up, the better.
+    </p>
+
+    <p>
+      <a href="/teaching-events" class="button">Register for a Train to Teach event</a>
+    </p>
+
+    <h2>What to expect on the day:</h2>
+
+    <p>Events last a few hours. In that time, you’ll have a chance to:</p>
+
+    <ul>
+      <li>put your questions to expert advisers, teachers and training providers</li>
+      <li>chat with current teachers and find out what a career in teaching is really like</li>
+      <li>listen to a step-by-step guide on how to get into teaching, the application process and funding your training</li>
+    </ul>
+  </article>
+
+  <%= render(
+      partial: "teaching_events/show/what-theyre-saying",
+      locals: {
+        quote: "It was exactly what I needed to give me guidance on the next steps to be taken"
+      }
+    ) %>
+</div>

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -32,7 +32,7 @@
     </p>
 
     <p>
-      <a href="/teaching-events" class="button">Register for a Train to Teach event</a>
+    <%= link_to("Register for a Train to Teach event", teaching_events_path("teaching_events_search[type][]" => "222_750_001,222_750_007"), class: "button") %>
     </p>
 
     <h2>What to expect on the day:</h2>

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -46,5 +46,5 @@
     </ul>
   </article>
 
-  <%= render(partial: "teaching_events/show/what-theyre-saying", locals: { quote: "It was exactly what I needed to give me guidance on the next steps to be taken" }) %>
+  <%= render(partial: "teaching_events/show/what-theyre-saying", locals: { quote: "It was exactly what I needed to give me guidance on the next steps to be taken." }) %>
 </div>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -23,6 +23,21 @@
             <h2>Upcoming Train to Teach events</h2>
 
             <ol><%= render TeachingEvents::EventComponent.with_collection(@featured_events) %></ol>
+
+            <div class="teaching-events__about-ttt-banner">
+              <div class="teaching-events__about-ttt-banner--message">
+                <p>
+                  The main event. Designed by the Department for Education to
+                  give you everything you need to get into teaching.
+                </p>
+              </div>
+
+              <div class="teaching-events__about-ttt-banner--link">
+                <a href="#">
+                  What happens at a Train to Teach event?
+                </a>
+              </div>
+            </div>
           </div>
         <% end %>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -33,9 +33,7 @@
               </div>
 
               <div class="teaching-events__about-ttt-banner--link">
-                <a href="#">
-                  What happens at a Train to Teach event?
-                </a>
+                <%= link_to("What happens at a Train to Teach event?", about_ttt_teaching_events_path) %>
               </div>
             </div>
           </div>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -33,7 +33,7 @@
               </div>
 
               <div class="teaching-events__about-ttt-banner--link">
-                <%= link_to("What happens at a Train to Teach event?", about_ttt_teaching_events_path) %>
+                <%= link_to("What happens at a Train to Teach event?", about_ttt_teaching_events_path, class: "button button--white") %>
               </div>
             </div>
           </div>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -1,5 +1,4 @@
 <div class="teaching-event">
-
   <header class="yellow">
     <div class="breadcrumbs-and-heading">
       <%= render Header::BreadcrumbComponent.new %>

--- a/app/views/teaching_events/show/_what-theyre-saying.html.erb
+++ b/app/views/teaching_events/show/_what-theyre-saying.html.erb
@@ -1,3 +1,5 @@
+<% quote ||= "So useful! I got answers to questions I didn't know I had yet and I'm so inspired and excited." %>
+
 <section class="what-theyre-saying">
   <div class="triangle yellow">
     <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">
@@ -8,9 +10,6 @@
     <h3>What they're saying</h3>
   </div>
   <figure>
-    <blockquote>
-      So useful! I got answers to questions I didn't know I had yet and I'm so
-      inspired and excited.
-    </blockquote>
+    <blockquote><%= quote %></blockquote>
   </figure>
 </section>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -678,7 +678,7 @@
     }
 
     @include mq($from: mobile) {
-      margin: auto 1rem;
+      margin: 0 1rem;
       padding-left: 3em;
       margin-left: -2em;
       transform: skew($desktop-skew-amount);
@@ -694,10 +694,11 @@
     flex-basis: 40%;
     align-items: center;
     justify-content: center;
+    margin-block: 1em;
 
     a {
-      @include mq($from: tablet) {
-        margin-block: 1em;
+      @include mq($from: mobile) {
+        margin-block: 0;
       }
     }
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -666,10 +666,6 @@
 
     flex-basis: 60%;
 
-    p {
-      // transform: skew($unskew-amount);
-    }
-
     @include mq($until: mobile) {
       padding-top: 1em;
       margin-top: -.5em;
@@ -700,10 +696,8 @@
     justify-content: center;
 
     a {
-      margin: 2em 1em;
-
-      @include mq($from: mobile) {
-        margin: 1em;
+      @include mq($from: tablet) {
+        margin-block: 1em;
       }
     }
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -793,7 +793,7 @@
     grid-area: 1 / 2 / 2 / 3;
 
     h3 {
-      @include font-size(large);
+      @include font-size(medium);
       @include reset;
       background-color: $pink;
       color: $black;

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -719,3 +719,68 @@
     }
   }
 }
+
+.teaching-events__about-ttt-banner {
+  $desktop-unskew-amount: 12deg;
+  $desktop-skew-amount: -12deg;
+
+  $mobile-unskew-amount: 2deg;
+  $mobile-skew-amount: -2deg;
+
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  @include font-size(xsmall);
+  background: $white;
+
+  @include mq($from: mobile) {
+    flex-direction: row;
+  }
+
+  &--message {
+    background: $pink;
+
+    flex-basis: 60%;
+
+    p {
+      // transform: skew($unskew-amount);
+    }
+
+    @include mq($until: mobile) {
+      padding-top: 1em;
+      margin-top: -.5em;
+      transform: skewY($mobile-skew-amount);
+
+      p {
+        margin: .5em;
+        transform: skewY($mobile-unskew-amount);
+      }
+    }
+
+    @include mq($from: mobile) {
+      margin: auto 1rem;
+      padding-left: 3em;
+      margin-left: -2em;
+      transform: skew($desktop-skew-amount);
+
+      p {
+        transform: skew($desktop-unskew-amount);
+      }
+    }
+  }
+
+  &--link {
+    display: flex;
+    flex-basis: 40%;
+    align-items: center;
+    justify-content: center;
+
+    a {
+      margin: 2em 1em;
+
+      @include mq($from: mobile) {
+        margin: 1em;
+      }
+    }
+  }
+}

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -666,6 +666,10 @@
 
     flex-basis: 60%;
 
+    p {
+      padding-inline: 1em;
+    }
+
     @include mq($until: mobile) {
       padding-top: 1em;
       margin-top: -.5em;

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -641,83 +641,6 @@
     }
   }
 
-  .what-theyre-saying {
-    display: grid;
-    background: $yellow;
-
-    grid-template-columns: auto minmax(2em, 30em) auto;
-    grid-template-rows: 1em auto;
-
-    @include mq($from: tablet) {
-      grid-template-rows: 2em auto;
-    }
-
-    .triangle {
-      grid-area: 1 / 1 / 2 / 4;
-      background-color: white;
-      margin-bottom: -5px;
-
-      &.yellow {
-        svg {
-          fill: $yellow;
-          stroke: $yellow;
-          stroke-width: 1;
-        }
-      }
-    }
-
-    .subheading {
-      grid-area: 1 / 2 / 2 / 3;
-
-      h3 {
-        @include font-size(large);
-        @include reset;
-        background-color: $pink;
-        color: $black;
-        display: inline-block;
-        padding: .2em .5em;
-      }
-    }
-
-    figure {
-      grid-area: 2 / 2 / 3 / 3;
-      margin-bottom: 1.5em;
-
-      blockquote {
-        @include font-size(small);
-
-        font-weight: bold;
-        margin: 2em 0 1em;
-        padding: 0;
-        position: relative;
-
-        &:before,
-        &:after {
-          @include font-size(xlarge);
-          color: $pink-dark;
-        }
-
-        &:before {
-          content: open-quote;
-          position: absolute;
-          left: -.6em;
-          top: -.3em;
-        }
-
-        &:after {
-          position: absolute;
-          content: close-quote;
-          margin-left: .02em;
-          margin-top: -.1em;
-        }
-      }
-
-      figcaption {
-        margin-top: .6em;
-        @include font-size(xsmall);
-      }
-    }
-  }
 }
 
 .teaching-events__about-ttt-banner {
@@ -735,6 +658,7 @@
 
   @include mq($from: mobile) {
     flex-direction: row;
+    margin-inline: 1em;
   }
 
   &--message {
@@ -781,6 +705,144 @@
       @include mq($from: mobile) {
         margin: 1em;
       }
+    }
+  }
+}
+
+.about-ttt-events {
+  header {
+    display: grid;
+    margin: 1em 2em;
+
+    grid-template-rows: min-content 1em min-content;
+    grid-template-columns: auto;
+
+    h1 {
+      grid-area: 1 / 1 / 3 / 2;
+    }
+
+    picture {
+      transform: rotate(3deg);
+      grid-area: 2 / 1 / 4 / 2;
+      text-align: right;
+    }
+
+    @include mq($from: tablet) {
+      grid-template-rows: auto;
+      grid-template-columns: 2fr 3em 1fr;
+
+      h1 {
+        grid-area: 1 / 1 / 2 / 3;
+      }
+
+      picture {
+        grid-area: 1 / 2 / 2 / 4;
+        text-align: left;
+      }
+    }
+
+
+    h1 {
+      @include font-size(xxlarge);
+      margin: 0;
+      z-index: 100;
+
+      span {
+        background: $pink;
+      }
+    }
+
+    picture {
+      img {
+        max-height: 12em;
+      }
+    }
+  }
+
+  article {
+    max-width: 65ch;
+    margin: 2em;
+
+    .button {
+      margin-block: 2em;
+    }
+  }
+}
+
+.what-theyre-saying {
+  display: grid;
+  background: $yellow;
+
+  grid-template-columns: auto minmax(2em, 30em) auto;
+  grid-template-rows: 1em auto;
+
+  @include mq($from: tablet) {
+    grid-template-rows: 2em auto;
+  }
+
+  .triangle {
+    grid-area: 1 / 1 / 2 / 4;
+    background-color: white;
+    margin-bottom: -5px;
+
+    &.yellow {
+      svg {
+        fill: $yellow;
+        stroke: $yellow;
+        stroke-width: 1;
+      }
+    }
+  }
+
+  .subheading {
+    grid-area: 1 / 2 / 2 / 3;
+
+    h3 {
+      @include font-size(large);
+      @include reset;
+      background-color: $pink;
+      color: $black;
+      display: inline-block;
+      padding: .2em .5em;
+    }
+  }
+
+  figure {
+    grid-area: 2 / 2 / 3 / 3;
+    margin-bottom: 1.5em;
+
+    blockquote {
+      @include font-size(small);
+
+      font-weight: bold;
+      margin: 2em 0 1em;
+      padding: 0;
+      position: relative;
+
+      &:before,
+      &:after {
+        @include font-size(xlarge);
+        color: $pink-dark;
+      }
+
+      &:before {
+        content: open-quote;
+        position: absolute;
+        left: -.6em;
+        top: -.3em;
+      }
+
+      &:after {
+        position: absolute;
+        content: close-quote;
+        margin-left: .02em;
+        margin-top: -.1em;
+      }
+    }
+
+    figcaption {
+      margin-top: .6em;
+      @include font-size(xsmall);
     }
   }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,11 @@ Rails.application.routes.draw do
   end
 
   unless Rails.env.production?
-    resources "teaching_events", path: "/teaching-events", controller: "teaching_events"
+    resources "teaching_events", path: "/teaching-events", controller: "teaching_events" do
+      collection do
+        get :about_ttt_events, path: "about-ttt-events", as: "about_ttt"
+      end
+    end
   end
 
   namespace :callbacks do

--- a/spec/features/teaching_events/about_ttt_events_spec.rb
+++ b/spec/features/teaching_events/about_ttt_events_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.feature "About TTT events", type: :feature do
+  scenario "there is a link to a pre-filtered page" do
+    visit about_ttt_teaching_events_path
+    expect(page).to have_link("Register for a Train to Teach event", href: teaching_events_path("teaching_events_search[type][]" => "222_750_001,222_750_007"))
+  end
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/7LARh17h/2575-events-build-about-ttt-events-page

### Context and changes

- Add the 'about TTT events' box to event listing
- Add 'about TTT events' info page


https://user-images.githubusercontent.com/128088/142186702-85d4bae4-9df4-4abb-8a76-95ec19e2cb6f.mp4

Update from the above clip, now the link on the index page is styled like a button:

![Screenshot from 2021-11-17 10-57-51](https://user-images.githubusercontent.com/128088/142188085-e594b6d3-7888-488f-ab1b-84eb036b48ee.png)


