### PR TITLE
Various tweaks to teaching events pages

### DIFF
--- a/app/components/teaching_events/event_component.html.erb
+++ b/app/components/teaching_events/event_component.html.erb
@@ -31,9 +31,9 @@
     </div>
 
     <div class="event__meta">
-      <%= image_pack_tag "media/images/content/welcome-guide/jack-rowing-crop-face.jpg" %>
+      <%= image_pack_tag("media/images/content/event-signup/birmingham-event-2.jpg", class: "event-image", alt: "A popular train to teach event in a hall with stalls and banners" ) %>
 
-      <%= image_pack_tag "media/images/dfelogo-black.svg", class: "dfelogo", alt: "This is an official Department for Education event" %>
+      <%= image_pack_tag("media/images/dfelogo-black.svg", class: "dfelogo", alt: "This is an official Department for Education event") %>
     </div>
 
   <% else %>

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -41,10 +41,6 @@ module EventsHelper
     event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES[type_name]
   end
 
-  def event_type_name(id)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[id]
-  end
-
   def embed_event_video_url(video_url)
     video_url&.sub("watch?v=", "embed/")
   end

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -18,7 +18,12 @@ module TeachingEventsHelper
     event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES[type_name]
   end
 
-  def event_type_name(id)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[id]
+  # override:
+  # * Online event               => Online forum
+  # * School or University event => Training provider
+  def event_type_name(id, overrides: { "Online forum" => 222_750_008, "Training provider" => 222_750_009 })
+    GetIntoTeachingApiClient::Constants::EVENT_TYPES
+      .merge(overrides)
+      .invert[id]
   end
 end

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -19,7 +19,7 @@
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
       <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "Train to Teach" } %>
       <%= f.govuk_check_box :type, "222_750_008", label: { text: "Online forum" } %>
-      <%= f.govuk_check_box :type, "222_750_009", label: { text: "School and university" } %>
+      <%= f.govuk_check_box :type, "222_750_009", label: { text: "Training provider" } %>
     <% end %>
   </div>
 

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -17,7 +17,7 @@
 
   <div class="events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "Train to teach" } %>
+      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "Train to Teach" } %>
       <%= f.govuk_check_box :type, "222_750_008", label: { text: "Online forum" } %>
       <%= f.govuk_check_box :type, "222_750_009", label: { text: "School and university" } %>
     <% end %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -259,16 +259,20 @@
 
       &--left {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
+        flex-wrap: wrap;
         flex: 1 0 60%;
+        align-content: center;
+        gap: .5em 2em;
       }
 
       &--right{
         display: flex;
         flex-direction: column;
         justify-items: center;
-        padding: 1em;
+        padding: .2em 1em;
         flex: 0 1 40%;
+        text-align: right;
       }
     }
 
@@ -345,7 +349,7 @@
         &__location {
           @include font-size(xsmall);
 
-          padding: 1em 1em 1em 3.5rem;
+          padding: 1em 1em 1em 2.5rem;
         }
 
         &__setting {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -230,7 +230,10 @@
       &--left {
         @include font-size(xsmall);
         flex: 1 1 30%;
-        padding: .2em 1em;
+        padding: .2em 1em .2em 3em;
+        background: url(../images/icon-calendar.svg) no-repeat left center;
+        background-size: 2em;
+        background-position: .5em;
       }
 
       &--right {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -212,15 +212,11 @@
       }
 
       .dfelogo {
-        max-height: 6em;
-
-        @include mq($from: tablet) {
-          width: 60%;
-        }
+        max-height: 3em;
       }
 
       @include mq($from: tablet) {
-        picture {
+        .event-image {
           align-self: auto;
         }
       }
@@ -280,7 +276,7 @@
       padding: 2em 1em;
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
+      gap: 2em;
     }
 
     &--train-to-teach {
@@ -330,7 +326,17 @@
         }
       }
 
-      .event__meta { flex-basis: 40%; }
+      .event__meta {
+        flex-basis: 40%;
+
+        .event-image {
+          object-position: center;
+
+          @include mq($from: tablet) {
+            max-height: 8em;
+          }
+        }
+      }
     }
 
     &--regular {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -184,7 +184,7 @@
     margin: 0;
     position: relative;
     background: white;
-    border: 2px solid $grey;
+    border: 2px solid darken($grey, 10%);
     padding: 0;
 
     &__info {

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("School or University event")
 
-      check "School and university"
+      check "Training provider"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
@@ -171,7 +171,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expected_type_ids = event_types.values_at("Train to Teach event", "Question Time", "School or University event")
 
       check "Train to Teach"
-      check "School and university"
+      check "Training provider"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("Train to Teach event", "Question Time")
 
-      check "Train to teach"
+      check "Train to Teach"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
@@ -170,7 +170,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("Train to Teach event", "Question Time", "School or University event")
 
-      check "Train to teach"
+      check "Train to Teach"
       check "School and university"
       click_on "Update results"
 

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -86,8 +86,8 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "each event should be listed with the appropriate details" do
       expect(page).to have_css(".event.event--train-to-teach", count: 2)
 
-      expect(page).to have_css(".event .event__info__type", text: "Online event")
-      expect(page).to have_css(".event .event__info__type", text: "School or University event")
+      expect(page).to have_css(".event .event__info__type", text: "Online forum")
+      expect(page).to have_css(".event .event__info__type", text: "Training provider")
 
       events.each do |event|
         expect(page).to have_link(event.name, href: teaching_event_path(event.readable_id))

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -134,19 +134,6 @@ describe EventsHelper, type: "helper" do
     end
   end
 
-  describe "#event_type_name" do
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES.each do |name, id|
-      describe %(when the id is #{id}) do
-        let(:name) { name }
-        let(:id) { id }
-
-        specify %(the returned name is '#{name}') do
-          expect(event_type_name(id)).to eql(name)
-        end
-      end
-    end
-  end
-
   describe "#event_type_color" do
     it "returns purple for train to teach events" do
       type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -74,11 +74,29 @@ describe TeachingEventsHelper, type: "helper" do
 
   describe "#event_type_name" do
     specify "returns the event name given a valid id" do
-      expect(event_type_name(222_750_008)).to eql("Online event")
+      expect(event_type_name(222_750_007)).to eql("Question Time")
     end
 
     specify "returns nil when given an invalid id" do
       expect(event_type_name(987_654_321)).to be nil
+    end
+
+    context "when overriding values" do
+      let(:custom_event) { "Bingo night" }
+
+      specify "returns online forum instead of online event by default" do
+        expect(GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[222_750_008]).to eql("Online event")
+        expect(event_type_name(222_750_008)).to eql("Online forum")
+      end
+
+      specify "returns training provider instead of school or uni event by default" do
+        expect(GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[222_750_009]).to eql("School or University event")
+        expect(event_type_name(222_750_009)).to eql("Training provider")
+      end
+
+      specify "allows the arbitrary overriding of event types" do
+        expect(event_type_name(123, overrides: { custom_event => 123 })).to eql(custom_event)
+      end
     end
   end
 


### PR DESCRIPTION
Various visual tweaks to the teaching events pages:


* Add calendar icon to regular event times
* Allow override of event names for Online Forum
* Remove duplicated helper method event_type_name
* Use Training provider label in the filter
* Darken the event box border a touch
* Arrange the event bottom bar horizontally
* Make the DFE logo smaller and event cards shorter
* Fix capitalisation on Train to Teach in the filter

![Screenshot from 2021-11-17 12-56-55](https://user-images.githubusercontent.com/128088/142204872-8f747a2e-f5ed-4fbf-9358-6aa2f2d2f667.png)


![Screenshot from 2021-11-17 12-57-23](https://user-images.githubusercontent.com/128088/142204936-954148da-d2d3-4133-9460-27ea3c1efb6a.png)
![Screenshot from 2021-11-17 12-57-44](https://user-images.githubusercontent.com/128088/142204977-f3c2ed4a-d619-403a-b28f-3c34c6ce8d89.png)
