### PR TITLE
Improve rendering of teaching event pagination

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -87,6 +87,7 @@
       display: flex;
       flex-wrap: wrap;
       align-items: center;
+      gap: .1em;
 
       @mixin pagination-item {
         @include font-size(medium);
@@ -97,7 +98,7 @@
 
       // kaminari selectors
       * {
-        display: block;
+        display: inline-block;
         line-height: 1;
       }
 


### PR DESCRIPTION
It's still too big and doesn't wrap as gracefully as it could, but better than before. The arrow icon might not be present in the review app, not sure why but we've had a few FontAwesome issues there.

We should (at some point) standardise these throughout the site.

![Screenshot from 2021-11-17 14-07-37](https://user-images.githubusercontent.com/128088/142215748-da13021f-8387-4fd1-8df0-9461062aea05.png)
