### PR TITLE
More welcome guide content fixes

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -39,7 +39,7 @@ module WelcomeHelper
   def degree_stage_based_encouragement
     # degree stage:         final year , second year
     if degree_status_id.in?([222_750_001, 222_750_002])
-      "Especially as you get closer to graduating."
+      "Especially as you get closer to graduating"
     else
       "Now's a great time to make the move"
     end

--- a/app/views/content/welcome/landing/_did-you-know.html.erb
+++ b/app/views/content/welcome/landing/_did-you-know.html.erb
@@ -15,7 +15,7 @@
       </p>
 
       <p>
-        With a growing student population, we need maths teachers like you more
+        With a growing student population, we need teachers like you more
         than ever before.
       </p>
     </div>

--- a/app/views/content/welcome/landing/_did-you-know.html.erb
+++ b/app/views/content/welcome/landing/_did-you-know.html.erb
@@ -10,8 +10,8 @@
 
     <div class="pink">
       <p class="leading">
-          By 2025, there will be 15% more pupils in secondary schools than there
-          were in 2018.
+          By 2025, there will be 7.5% more pupils in secondary schools than there
+          were in 2020.
       </p>
 
       <p>

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -36,7 +36,7 @@
           <h3 class="stage-name">Think about funding.</h3>
           <p>
             You can get funding that you don’t have to pay back if you train to
-            teach certain subjects. Tuition fee and maintenance loans are also available
+            teach certain subjects. Tuition fee and maintenance loans are also available.
           </p>
           <a href="/funding-your-training">
             Find out about funding options

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -67,7 +67,7 @@
         <div class="number">4</div>
         <%= image_pack_tag("media/images/content/welcome-guide/paper-and-pencil.svg", alt: "") %>
         <div class="stage-info">
-          <h3 class="stage-name">Apply for your course</h3>
+          <h3 class="stage-name">Apply for your course.</h3>
           <p>
             Get tips on applying, including finding the right referees and
             writing a personal statement.

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -19,7 +19,7 @@
           <h3 class="stage-name">Get experience.</h3>
           <p>
             School experience can help you decide whether teaching is right for
-            you. Some students are able to fit this in during term breaks.
+            you.
           </p>
           <a href="/get-school-experience">
             Find out how to get school experience
@@ -36,7 +36,7 @@
           <h3 class="stage-name">Think about funding.</h3>
           <p>
             You can get funding that you don’t have to pay back if you train to
-            teach certain subjects.
+            teach certain subjects. Tuition fee and maintenance loans are also available
           </p>
           <a href="/funding-your-training">
             Find out about funding options

--- a/app/views/content/welcome/landing/_subject-specific-story.html.erb
+++ b/app/views/content/welcome/landing/_subject-specific-story.html.erb
@@ -9,7 +9,11 @@
     <br>
 
     <span class="yellow no-wrap blend">
-      teaching <%= subject_category(welcome_guide_subject_id, downcase: false) %>
+      <% if welcome_guide_subject_id %>
+        teaching <%= subject_category(welcome_guide_subject_id, downcase: false) %>.
+      <% else %>
+        teaching.
+      <% end %>
     </span>
   </h2>
 

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <div class="text">
-    <h2 class="blue">You're not the only one with questions</h2>
+    <h2 class="blue">You're not the only one with questions.</h2>
 
     <p class="blue">
       We know you’re sure to have questions - maybe even a few concerns – about


### PR DESCRIPTION
### Context and changes

- Update teaching stats and year in 'did you know?'
- Remove maths from sentence on needing more teachers
- Ensure there's a full stop after level 2 headings
- Remove extra full stop from degree encouragement
- Add full stop to 'apply for your course' heading
- Adjust text in exciting times ahead section
