### PR TITLE
Prevent external link icon appearing on links to internal assets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,10 @@ private
 
       next if classes && (classes & classes_to_suppress).any?
 
-      if anchor[:href].include?("//")
+      external_link = anchor[:href].include?("//")
+      externally_hosted_internal_asset = ENV["APP_ASSETS_URL"].present? && anchor[:href].start_with?(ENV["APP_ASSETS_URL"])
+
+      if external_link && !externally_hosted_internal_asset
         anchor.add_child(helpers.image_pack_tag("media/images/icon-external.svg", class: "external-link-icon", alt: ""))
       end
     end

--- a/spec/requests/external_links_image_spec.rb
+++ b/spec/requests/external_links_image_spec.rb
@@ -2,20 +2,36 @@ require "rails_helper"
 
 describe "External link images", type: :request do
   excluded_classes = %w[button]
-  subject { response.body }
 
-  before { get "/ways-to-train" }
+  subject(:markdown_links) do
+    get path
+    doc = Nokogiri::HTML.parse(response.body)
+    doc.css(".markdown a")
+  end
 
   context "when external link and not #{excluded_classes.join(' ')}" do
     it "adds an external link icon" do
-      doc = Nokogiri::HTML.parse(response.body)
-      markdown_links = doc.css(".markdown a")
       markdown_links.each do |anchor|
         classes = anchor.attr("class")&.split
         if anchor[:href].include?("//") && !classes&.difference(excluded_classes)
           expect(anchor.children.at("img").to_html).to include('class="external-link-icon')
           expect(anchor.children.at("img").to_html).to include('alt=""')
         end
+      end
+    end
+  end
+
+  context "when a link to an internal asset hosted on an external domain" do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("APP_ASSETS_URL").and_return("https://external-asset.domain")
+    end
+
+    let(:path) { "/test" }
+
+    it "does not add an external link icon" do
+      markdown_links.each do |anchor|
+        expect(anchor.children.at("img")).to be_nil
       end
     end
   end

--- a/spec/support/views/content/test.md
+++ b/spec/support/views/content/test.md
@@ -1,3 +1,5 @@
 ---
 title: "Test Page"
 ---
+
+[link to interanl asset hosted on a different domain](https://external-asset.domain/image.png)


### PR DESCRIPTION
### Trello card

[Trello-2643](https://trello.com/c/lN13BuX4/2643-blue-external-icon-shouldnt-be-on-pdf-download-button)

### Context

In the test/prod environments our internal assets are hosted on an different domain, which is then treated as external by our code that adds the external icon to links.

Ensure externally hosted 'internal' assets are not treated as external by the link checker.

### Changes proposed in this pull request

- Prevent external link icon appearing on links to internal assets

### Guidance to review

I thought I had fixed this a while ago, but it turns out we are doing this logic in multiple places; the `LinkController` (JS) and `ApplicationController` (Ruby). I've created another ticket to consolidate these two approaches: https://trello.com/c/MUYUEYgC/2671-consolidate-how-we-add-external-link-icons