### PR TITLE
Fix broken link checker failing on assets

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -80,8 +80,10 @@ test:
   <<: *default
   compile: false
 
-  # Compile test packs to a separate directory
-  public_output_path: packs-test
+  # Compile test packs to a separate directory, note the
+  # version must match production for the external link checker
+  # to work!
+  public_output_path: packs-test/v1
 
 production:
   <<: *default

--- a/spec/components/calls_to_action/attachment_component_spec.rb
+++ b/spec/components/calls_to_action/attachment_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CallsToAction::AttachmentComponent, type: :component do
 
   context "with the basic arguments" do
     specify "includes a link to the attachment" do
-      is_expected.to have_css(%(a[href*="packs-test/media/documents/ICT_skills_audit_returners"]))
+      is_expected.to have_css(%(a[href*="packs-test/v1/media/documents/ICT_skills_audit_returners"]))
     end
 
     specify "includes the text in the link" do

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
     end
 
     specify "the image is present" do
-      expect(page.find(".call-to-action__image")["style"]).to include("packs-test/media/images/dfelogo")
+      expect(page.find(".call-to-action__image")["style"]).to include("packs-test/v1/media/images/dfelogo")
     end
   end
 end

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -24,7 +24,7 @@ describe CardComponent, type: "component" do
 
   specify "includes a link wrapping the story image" do
     is_expected.to have_link(href: card["link"]) do |anchor|
-      expect(anchor).to have_css(%(img[src*="packs-test/media/images/dfelogo"]))
+      expect(anchor).to have_css(%(img[src*="packs-test/v1/media/images/dfelogo"]))
     end
   end
 
@@ -93,7 +93,7 @@ describe CardComponent, type: "component" do
 
     specify "the image links to the video instead of the card" do
       is_expected.to have_link(href: card["video"]) do |anchor|
-        expect(anchor).to have_css(%(img[src*="packs-test/media/images/dfelogo"]))
+        expect(anchor).to have_css(%(img[src*="packs-test/v1/media/images/dfelogo"]))
       end
     end
 

--- a/spec/components/cards/featured_story_component_spec.rb
+++ b/spec/components/cards/featured_story_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Cards::FeaturedStoryComponent, type: :component do
   it { is_expected.to have_css ".card.card--no-border" }
   it { is_expected.to have_css ".card header", text: "Teacher's story" }
 
-  it { is_expected.to have_css 'img[src*="packs-test/media/images/dfelogo"][alt="A photograph of a teacher"]' }
+  it { is_expected.to have_css 'img[src*="packs-test/v1/media/images/dfelogo"][alt="A photograph of a teacher"]' }
   it { is_expected.to have_content "Page title" }
 
   it "includes the footer link" do

--- a/spec/components/cards/story_component_spec.rb
+++ b/spec/components/cards/story_component_spec.rb
@@ -28,7 +28,7 @@ describe Cards::StoryComponent, type: "component" do
   it { is_expected.to have_css ".card" }
   it { is_expected.to have_css ".card.card--no-border" }
   it { is_expected.not_to have_css ".card header" }
-  it { is_expected.to have_css(%(img[src*="packs-test/media/images/dfelogo"])) }
+  it { is_expected.to have_css(%(img[src*="packs-test/v1/media/images/dfelogo"])) }
   it { is_expected.to have_content story["snippet"] }
 
   specify "includes the name in a link" do

--- a/spec/components/content/image_component_spec.rb
+++ b/spec/components/content/image_component_spec.rb
@@ -8,7 +8,7 @@ describe Content::ImageComponent, type: "component" do
   before { render_inline(described_class.new(**example_args)) }
 
   specify "image has the right path" do
-    expect(rendered_component).to match(%r{src=\"/packs-test/media/images/#{image_name}-.*.svg\"})
+    expect(rendered_component).to match(%r{src=\"/packs-test/v1/media/images/#{image_name}-.*.svg\"})
   end
 
   specify "image has the right alt text" do

--- a/spec/components/stories/card_component_spec.rb
+++ b/spec/components/stories/card_component_spec.rb
@@ -21,7 +21,7 @@ describe Stories::CardComponent, type: "component" do
 
   specify "includes a link wrapping the story image" do
     is_expected.to have_link(href: story["link"]) do |anchor|
-      expect(anchor).to have_css(%(img[src*="packs-test/media/images/dfelogo"]))
+      expect(anchor).to have_css(%(img[src*="packs-test/v1/media/images/dfelogo"]))
     end
   end
 
@@ -52,7 +52,7 @@ describe Stories::CardComponent, type: "component" do
 
     specify "the image links to the video instead of the story" do
       is_expected.to have_link(href: video_story["video"]) do |anchor|
-        expect(anchor).to have_css(%(img[src*="packs-test/media/images/dfelogo"]))
+        expect(anchor).to have_css(%(img[src*="packs-test/v1/media/images/dfelogo"]))
       end
     end
 

--- a/spec/components/stories/story_component_spec.rb
+++ b/spec/components/stories/story_component_spec.rb
@@ -56,7 +56,7 @@ describe Stories::StoryComponent, type: "component" do
     end
 
     specify "the story's image is rendered" do
-      is_expected.to have_css(%(img[src*="/packs-test/media/images/content/stories/stories-karen"]))
+      is_expected.to have_css(%(img[src*="/packs-test/v1/media/images/content/stories/stories-karen"]))
     end
 
     specify "the teacher name and position are in secondary heading" do

--- a/spec/helpers/metadata_helper_spec.rb
+++ b/spec/helpers/metadata_helper_spec.rb
@@ -32,7 +32,7 @@ describe MetadataHelper, type: "helper" do
 
       expect(tags).to include(
         <<~HTML.chomp,
-          <meta name="og:image" content="https://example.com/packs-test/media/images/content/hero-images/0012-cb6435a02b879e8df922882afba620a8.jpg">
+          <meta name="og:image" content="https://example.com/packs-test/v1/media/images/content/hero-images/0012-cb6435a02b879e8df922882afba620a8.jpg">
         HTML
       )
 

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -342,9 +342,9 @@ describe StructuredDataHelper, type: "helper" do
 
       it "has the online images" do
         is_expected.to include({ image: [
-          "/packs-test/media/images/structured_data/ttt_online_1x1-bf484c635cd3e795df567d2949dcf934.jpeg",
-          "/packs-test/media/images/structured_data/ttt_online_4x3-b85e3f4f32bc44694c87fa0fac81bbe1.jpeg",
-          "/packs-test/media/images/structured_data/ttt_online_16x9-a44602bd76aaec3798f3798d711310bd.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_online_1x1-bf484c635cd3e795df567d2949dcf934.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_online_4x3-b85e3f4f32bc44694c87fa0fac81bbe1.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_online_16x9-a44602bd76aaec3798f3798d711310bd.jpeg",
         ] })
       end
     end
@@ -352,9 +352,9 @@ describe StructuredDataHelper, type: "helper" do
     context "when the event is in-person" do
       it "has the in-person images" do
         is_expected.to include({ image: [
-          "/packs-test/media/images/structured_data/ttt_in_person_1x1-7536d67c191fbc627baefc64808659a9.jpeg",
-          "/packs-test/media/images/structured_data/ttt_in_person_4x3-5c08900b1f812a977d05b21a4428eb7f.jpeg",
-          "/packs-test/media/images/structured_data/ttt_in_person_16x9-76e0739a9059dad3e151f07cfe169a75.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_in_person_1x1-7536d67c191fbc627baefc64808659a9.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_in_person_4x3-5c08900b1f812a977d05b21a4428eb7f.jpeg",
+          "/packs-test/v1/media/images/structured_data/ttt_in_person_16x9-76e0739a9059dad3e151f07cfe169a75.jpeg",
         ] })
       end
     end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -262,7 +262,7 @@ describe TemplateHandlers::Markdown, type: :view do
 
       %w[black white].each do |colour|
         expect(rendered).to have_css("img")
-        expect(rendered).to match(%r{src\=\"/packs-test/media/images/dfelogo-#{colour}-.*.svg\"})
+        expect(rendered).to match(%r{src\=\"/packs-test/v1/media/images/dfelogo-#{colour}-.*.svg\"})
         expect(rendered).to have_css(%(img[alt="#{front_matter_with_images.dig('images', colour, 'alt')}"]))
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-2672](https://trello.com/c/Jn29oHA3/2672-fix-broken-link-checker)

### Context

When the broken link checker finds a link that goes to an asset it replaces `packs-test` with `packs`, however the production assets have since been versioned to `packs/v1`, so we need to replicate this in the test environment in order to have the asset paths ultimately match.

### Changes proposed in this pull request

- Fix broken link checker failing on assets

### Guidance to review

