### PR TITLE
Move the public file server config inside block

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -8,9 +8,9 @@ require File.expand_path("production.rb", __dir__)
 #
 # We can only set one domain in this header, which means fonts don't work
 # on the other. To get around this we need to use a wildcard in test.
-config.public_file_server.headers["Access-Control-Allow-Origin"] = "*"
-
 Rails.application.configure do
+  config.public_file_server.headers["Access-Control-Allow-Origin"] = "*"
+
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"

--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature "link checks", :onschedule do
       # comparing to hash instead of checking .empty? so the failures dump
       # the difference in the hashes
       expect(failures).to eql({})
-
     end
   end
 


### PR DESCRIPTION
It's currently causing pre-prod deploys to fail
