### PR TITLE
Update clean-azure.yml

### DIFF
--- a/.github/workflows/clean-azure.yml
+++ b/.github/workflows/clean-azure.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Remove old Review Terraform Files
         run:  |
             cf target -s get-into-teaching
-            BLOBS=$(az storage blob list -o json --container-name pass-tfstate --account-name s146d01sgtfstate  | jq -r '.[] | select(.name | contains( "review-get-into-teaching-app-")) | .name' )
+            BLOBS=$(az storage blob list -o json --container-name pass-tfstate --account-key ${{secrets.ARM_ACCESS_KEY}} --account-name s146d01sgtfstate  | jq -r '.[] | select(.name | contains( "review-get-into-teaching-app-")) | .name' )
             APPS=$(cf apps | cut -d ' ' -f1 | grep 'review')
 
             for i in $(echo $BLOBS)
@@ -51,6 +51,6 @@ jobs:
                 name=$(echo $i |  cut -f1  -d '.' )
                 if ! [[ $APPS =~ (^|[[:space:]])"$name"($|[[:space:]]) ]] ; then
                      echo "....." $name
-                     az storage blob delete --container-name  pass-tfstate --account-name s146d01sgtfstate -n ${i}
+                     az storage blob delete --container-name  pass-tfstate --account-name s146d01sgtfstate --account-key ${{secrets.ARM_ACCESS_KEY}} -n ${i}
                 fi
             done


### PR DESCRIPTION
When Review apps are created a Terraform state file is created in Azure, the state file is never deleted from Azure and therefore we end up with a massive list, so each night, check what review apps are deployed and then if they are not on the system, delete the obsolete and often empty state file.