### PR TITLE
Disable GZip compression for certain assets

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,8 +4,13 @@ require_relative 'config/environment'
 
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
+require_relative 'lib/rack/deflater_with_exclusions'
 
-use Rack::Deflater
+EXTENSIONS_TO_EXCLUDE = %w(.jpg .jpeg .png .gif .pdf).freeze
+
+use Rack::DeflaterWithExclusions, exclude: proc { |env|
+  File.extname(env["PATH_INFO"]).in?(EXTENSIONS_TO_EXCLUDE)
+}
 use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 

--- a/lib/rack/deflater_with_exclusions.rb
+++ b/lib/rack/deflater_with_exclusions.rb
@@ -1,0 +1,17 @@
+module Rack
+  class DeflaterWithExclusions < Deflater
+    def initialize(app, options = {})
+      @app = app
+
+      @exclude = options[:exclude]
+    end
+
+    def call(env)
+      if @exclude && @exclude.call(env)
+        @app.call(env)
+      else
+        super(env)
+      end
+    end
+  end
+end

--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature "link checks", :onschedule do
       # comparing to hash instead of checking .empty? so the failures dump
       # the difference in the hashes
       expect(failures).to eql({})
-
     end
   end
 

--- a/spec/lib/rack/deflater_with_exclusions_spec.rb
+++ b/spec/lib/rack/deflater_with_exclusions_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+require_relative "../../../lib/rack/deflater_with_exclusions"
+
+describe Rack::DeflaterWithExclusions do
+  let(:app) { ->(_env) { [200, { "Content-Type" => "text/plain" }, %w[OK]] } }
+  let(:instance) do
+    described_class.new(
+      app,
+      exclude: proc { |_env|
+        exclude
+      },
+    )
+  end
+
+  describe "#call" do
+    let(:env) { {} }
+
+    subject(:call) { instance.call(env) }
+
+    context "when not excluded" do
+      let(:exclude) { false }
+
+      it "calls parent" do
+        expect_any_instance_of(Rack::Deflater).to receive(:call)
+        call
+      end
+    end
+
+    context "when excluded" do
+      let(:exclude) { true }
+
+      it "does not call parent, instead calls on app" do
+        expect_any_instance_of(Rack::Deflater).not_to receive(:call)
+        expect(app).to receive(:call)
+        call
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-2635](https://trello.com/c/kObYlPsJ/2635-disable-gzip-compression-for-images)

### Context

We currently GZip compress all assets, however its recommended that you don't GZip images and other binary files as they are usually already compressed and running them through GZip leads to slightly larger files (and wasted processing).

Subclass `Rack::Deflater` so that we can exclude certain requests.

### Changes proposed in this pull request

- Disable GZip compression for certain assets

### Guidance to review

Tested locally and it seems to correctly prevent gzipping binary assets whilst still compressing HTML pages, etc:

```
❯ curl -Is -H "Accept-Encoding: gzip" "http://0.0.0.0:3000/packs/v1/media/images/content/hero-images/0012-cb6435a02b879e8df922882afba620a8.jpg" | grep "Content-Encoding"

❯ curl -Is -H "Accept-Encoding: gzip" "http://0.0.0.0:3000/" | grep "Content-Encoding"
Content-Encoding: gzip
```
