### PR TITLE
Teaching events visual tweaks

### DIFF
--- a/app/components/teaching_events/event_component.rb
+++ b/app/components/teaching_events/event_component.rb
@@ -28,7 +28,7 @@ module TeachingEvents
     end
 
     def in_person?
-      @in_person
+      @in_person && !online?
     end
 
     def event_type

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -21,7 +21,7 @@ module TeachingEventsHelper
   # override:
   # * Online event               => Online forum
   # * School or University event => Training provider
-  def event_type_name(id, overrides: { "Online forum" => 222_750_008, "Training provider" => 222_750_009 })
+  def event_type_name(id, overrides: { "DfE Online Q&A" => 222_750_008, "Training provider" => 222_750_009 })
     GetIntoTeachingApiClient::Constants::EVENT_TYPES
       .merge(overrides)
       .invert[id]

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -13,8 +13,14 @@
     </div>
 
     <% if @featured_events.blank? && @events.blank? %>
-      <div role="alert">
-        No events were found.
+      <div class="teaching-events__none" role="alert">
+        <div class="teaching-events__none--message">
+          <h3>
+            No events found.
+          </h3>
+
+          <a class="button" href="/mailinglist/signup">Sign up to be notified about events in your area</a>
+        </div>
       </div>
     <% else %>
       <div class="teaching-events__listing">

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,8 +18,8 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "Train to Teach" } %>
-      <%= f.govuk_check_box :type, "222_750_008", label: { text: "Online forum" } %>
+      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "DfE Train to Teach" } %>
+      <%= f.govuk_check_box :type, "222_750_008", label: { text: "DfE Online Q&A" } %>
       <%= f.govuk_check_box :type, "222_750_009", label: { text: "Training provider" } %>
     <% end %>
   </div>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -1,4 +1,5 @@
 <%= govuk_form_for(@event_search, method: :get, url: "/teaching-events") do |f| %>
+  <h2>Filters</h2>
 
   <div class="events__filter--group">
     <%= f.govuk_text_field(:postcode, label: { text: "Postcode" }, form_group: { classes: 'reduce-bottom-margin' }) %>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -1,22 +1,22 @@
 <%= govuk_form_for(@event_search, method: :get, url: "/teaching-events") do |f| %>
   <h2>Filters</h2>
 
-  <div class="events__filter--group">
+  <div class="teaching-events__filter--group">
     <%= f.govuk_text_field(:postcode, label: { text: "Postcode" }, form_group: { classes: 'reduce-bottom-margin' }) %>
   </div>
 
-  <div class="events__filter--group">
+  <div class="teaching-events__filter--group">
     <%= f.govuk_select(:distance, options_for_select(TeachingEvents::Search::DISTANCES, selected: @event_search.distance), label: { text: "Search area" }) %>
   </div>
 
-  <div class="events__filter--group">
+  <div class="teaching-events__filter--group with-top-border">
     <%= f.govuk_check_boxes_fieldset(:online, legend: nil) do %>
       <%= f.govuk_check_box :online, "true", label: { text: "Online" } %>
       <%= f.govuk_check_box :online, "false", label: { text: "In person" } %>
     <% end %>
   </div>
 
-  <div class="events__filter--group">
+  <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
       <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "Train to Teach" } %>
       <%= f.govuk_check_box :type, "222_750_008", label: { text: "Online forum" } %>
@@ -24,7 +24,7 @@
     <% end %>
   </div>
 
-  <div class="events__filter--group">
+  <div class="teaching-events__filter--group">
     <%= tag.button("Update results", class: "button") %>
   </div>
 <% end %>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -23,6 +23,12 @@
   </header>
 
   <section class="event-info">
+    <% if @event.message %>
+      <div class="event-alert">
+        <%= tag.p(@event.message) %>
+      </div>
+    <% end %>
+
     <h2>What to expect from this event</h2>
 
     <div class="event-summary">

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -36,6 +36,7 @@
 
   <%= render(partial: "teaching_events/show/event-attributes") %>
   <%= render(partial: "teaching_events/show/venue-information") if @event.building.present? %>
+  <%= render(partial: "teaching_events/show/attending-training-providers") %>
   <%= render(partial: "teaching_events/show/scribble") if @event.scribble_id.present? %>
   <%= render(partial: "teaching_events/show/what-theyre-saying") %>
 </div>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -28,10 +28,10 @@
     <div class="event-summary">
       <% if is_a_train_to_teach_event?(@event) %>
         <%= render(partial: 'teaching_events/show/train-to-teach-event-summary') %>
-      <% else %>
-        <%= render(partial: 'teaching_events/show/event-summary') %>
       <% end %>
     </div>
+
+    <%= render(partial: 'teaching_events/show/event-summary') %>
   </section>
 
   <%= render(partial: "teaching_events/show/event-attributes") %>

--- a/app/views/teaching_events/show/_attending-training-providers.html.erb
+++ b/app/views/teaching_events/show/_attending-training-providers.html.erb
@@ -1,0 +1,7 @@
+<% if @event.providers_list %>
+  <section class="attending-providers">
+    <h3>Providers attending this event:</h3>
+
+    <%= safe_html_format(@event.providers_list) %>
+  </section>
+<% end %>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -1,5 +1,3 @@
 <div class="about-event">
-  <%= tag.p(@event.summary, class: "leading") %>
-
   <%= tag.div(safe_html_format(@event.description)) %>
 </div>

--- a/app/views/teaching_events/show/_location-and-setting.html.erb
+++ b/app/views/teaching_events/show/_location-and-setting.html.erb
@@ -1,5 +1,5 @@
 <div class="location-and-setting">
-  <% if @event.building.present? %>
+  <% if @event.building.present? && !@event.is_online %>
     <%= @event.building.venue %>,
     <%= @event.building.address_postcode %>
   <% end %>

--- a/app/views/teaching_events/show/_location-and-setting.html.erb
+++ b/app/views/teaching_events/show/_location-and-setting.html.erb
@@ -1,6 +1,6 @@
 <div class="location-and-setting">
   <% if @event.building.present? %>
-    <%= @event.building.venue %>
+    <%= @event.building.venue %>,
     <%= @event.building.address_postcode %>
   <% end %>
 

--- a/app/views/teaching_events/show/_register-button.html.erb
+++ b/app/views/teaching_events/show/_register-button.html.erb
@@ -1,5 +1,5 @@
 <div class="register">
-  <%= link_to event_steps_path(@event.readable_id), class: %w[button button--black-chevron] do %>
+  <%= link_to event_steps_path(@event.readable_id), class: %w[button] do %>
     Register for this event
   <% end %>
 </div>

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -7,7 +7,9 @@
       <%= @event.building.address_postcode %>
     </p>
   </div>
-  <div class="venue-image">
-    <%= image_pack_tag "media/images/content/blog/seminar-room.jpg", alt: "A seminar with people sitting around a large table looking at a whiteboard" %>
-  </div>
+  <% if @event.building.image_url %>
+    <div class="venue-image">
+      <%= image_tag(@event.building.image_url, alt: @event.building.venue) %>
+    </div>
+  <% end %>
 </section>

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -3,10 +3,11 @@
     <h3>Venue information</h3>
 
     <p>
-      <%= @event.building.venue %>
-      <%= @event.building.address_postcode %>
+      <%= @event.building.venue %>,
+      <%= event_address(@event) %>
     </p>
   </div>
+
   <% if @event.building.image_url %>
     <div class="venue-image">
       <%= image_tag(@event.building.image_url, alt: @event.building.venue) %>

--- a/app/views/teaching_events/show/_what-theyre-saying.html.erb
+++ b/app/views/teaching_events/show/_what-theyre-saying.html.erb
@@ -1,6 +1,6 @@
 <% quote ||= "So useful! I got answers to questions I didn't know I had yet and I'm so inspired and excited." %>
 
-<section class="what-theyre-saying">
+<div class="what-theyre-saying">
   <div class="triangle yellow">
     <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">
       <polygon points="0,100 100,0 100,100" />
@@ -12,4 +12,4 @@
   <figure>
     <blockquote><%= quote %></blockquote>
   </figure>
-</section>
+</div>

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -60,10 +60,6 @@ a {
     @include chevron($color: $black);
   }
 
-  &--black-chevron {
-    @include chevron($color: $black);
-  }
-
   &--nowrap {
     white-space: nowrap;
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -67,6 +67,17 @@ $slightly-darker-grey: darken($grey, 10%);
     h2 {
       @include font-size(medium);
     }
+
+    &--group {
+      p {
+        @include reset;
+      }
+    }
+
+    &--group.with-top-border {
+      border-top: 1px solid $slightly-darker-grey;
+      padding-top: 2rem;
+    }
   }
 
   &__listing {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -436,14 +436,8 @@ $slightly-darker-grey: darken($grey, 10%);
     &.yellow {
       background: $yellow;
 
-      .register .button {
-        background: $yellow;
-        color: $black;
-
-        &:focus {
-          color: $yellow;
-          background: $black;
-        }
+      .button:focus {
+        outline: 1px solid black;
       }
     }
 
@@ -486,16 +480,6 @@ $slightly-darker-grey: darken($grey, 10%);
         display: inline-block;
         border-bottom: 1px solid black;
         padding-bottom: 1em;
-      }
-
-      .register {
-        .button {
-          outline: 1px solid black;
-
-          &:hover {
-            outline: 2px solid black;
-          }
-        }
       }
     }
 

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -532,6 +532,7 @@ $slightly-darker-grey: darken($grey, 10%);
       flex-direction: column;
       padding-block: 2em;
       gap: 3em;
+      margin-bottom: 4em;
 
       @include mq($from: tablet) {
         flex-direction: row;
@@ -546,16 +547,6 @@ $slightly-darker-grey: darken($grey, 10%);
         @include train-to-teach-event-box;
 
         flex-basis: 40%;
-      }
-
-      .about-event {
-        flex-basis: 100%;
-
-        padding: 1.5rem 1rem;
-
-        .leading {
-          font-weight: strong;
-        }
       }
 
       figure {
@@ -595,6 +586,22 @@ $slightly-darker-grey: darken($grey, 10%);
           margin-top: .6em;
           @include font-size(xsmall);
         }
+      }
+    }
+
+    .about-event {
+      flex-basis: 100%;
+      max-width: 65ch;
+      padding: 1.5rem auto;
+      margin: auto;
+
+      @include mq($from: tablet) {
+        padding: 1.5rem 1rem;
+      }
+
+      ul {
+        list-style-position: outside;
+        padding-left: 1.5em;
       }
     }
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -511,8 +511,7 @@ $slightly-darker-grey: darken($grey, 10%);
     }
   }
 
-  .event-info,
-  .event-attributes {
+  section {
     max-width: 65rem;
     margin: 2em auto;
     padding-inline: 1em;

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -1,24 +1,18 @@
-@mixin train-to-teach-event-box($small: false) {
+@mixin train-to-teach-event-box {
   border: 2px solid $pink;
   padding: 2rem 1rem 1rem;
 
   &::after {
-    @include font-size(medium);
+    @include font-size(small);
     position: absolute;
     content: "Train to Teach event";
-    right: 1rem;
+    right: 5%;
     top: -1em;
     background: $pink url(../images/icon-ttt-white.svg) no-repeat left center;
     background-size: 1.2em;
     background-position: .4em;
     font-weight: bold;
     padding: .4em .4em .4em 2em;
-
-    @if $small {
-      @include mq($from: tablet) {
-        @include font-size(small);
-      }
-    }
   }
 }
 
@@ -542,7 +536,7 @@
 
       .about-ttt-event {
         position: relative;
-        @include train-to-teach-event-box($small: true);
+        @include train-to-teach-event-box;
 
         flex-basis: 40%;
       }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -1,3 +1,5 @@
+$slightly-darker-grey: darken($grey, 10%);
+
 @mixin train-to-teach-event-box {
   border: 2px solid $pink;
   padding: 2rem 1rem 1rem;
@@ -68,6 +70,9 @@
       flex-basis: 75%;
     }
 
+    @include mq($from: tablet) {
+      border-left: 1px solid $slightly-darker-grey;
+    }
   }
 
   &__pagination {
@@ -179,7 +184,7 @@
     margin: 0;
     position: relative;
     background: white;
-    border: 2px solid darken($grey, 10%);
+    border: 2px solid $slightly-darker-grey;
     padding: 0;
 
     &__info {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -539,6 +539,19 @@ $slightly-darker-grey: darken($grey, 10%);
       }
     }
 
+    .event-alert {
+      background-color: $purple;
+      color: $white;
+      max-width: 65ch;
+      padding: .5em;
+      margin: auto;
+
+      p {
+        padding: .2em 1em;
+        @include font-size(small);
+      }
+    }
+
     .event-summary {
       display: flex;
       flex-direction: column;

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -449,10 +449,14 @@ $slightly-darker-grey: darken($grey, 10%);
       flex-direction: column;
       justify-content: space-between;
 
-      .breadcrumbs > .breadcrumb > ol {
-        margin-top: 0;
-        margin-left: 0;
-        padding-left: 0;
+      .breadcrumbs {
+        margin-top: .5em;
+
+        > .breadcrumb > ol {
+          margin-top: 0;
+          margin-left: 0;
+          padding-left: 0;
+        }
       }
 
       h1 {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -90,6 +90,18 @@ $slightly-darker-grey: darken($grey, 10%);
     }
   }
 
+  &__none {
+    &--message {
+      padding: 1rem 1rem 2rem;
+      background: $grey;
+
+      h3 {
+        margin: 1em 0;
+        @include font-size(large);
+      }
+    }
+  }
+
   &__pagination {
     margin-inline: 1rem;
 

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -63,6 +63,10 @@ $slightly-darker-grey: darken($grey, 10%);
     @include mq($from: desktop) {
       flex-basis: 25%;
     }
+
+    h2 {
+      @include font-size(medium);
+    }
   }
 
   &__listing {

--- a/spec/components/teaching_events/event_component_spec.rb
+++ b/spec/components/teaching_events/event_component_spec.rb
@@ -47,10 +47,17 @@ describe TeachingEvents::EventComponent, type: "component" do
         it { expect(subject).to be_online }
       end
 
-      context "when the event has a location" do
-        let(:event) { build(:event_api) }
+      context "when the event has a location and is not online" do
+        let(:event) { build(:event_api, is_online: false) }
 
         it { expect(subject).to be_in_person }
+      end
+
+      # this is the new 'virtual', event has an address/building but nobody's invited!
+      context "when the event has a location and is online" do
+        let(:event) { build(:event_api, is_online: true) }
+
+        it { expect(subject).not_to be_in_person }
       end
 
       context "when the event has no location" do

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "each event should be listed with the appropriate details" do
       expect(page).to have_css(".event.event--train-to-teach", count: 2)
 
-      expect(page).to have_css(".event .event__info__type", text: "Online forum")
+      expect(page).to have_css(".event .event__info__type", text: "DfE Online Q&A")
       expect(page).to have_css(".event .event__info__type", text: "Training provider")
 
       events.each do |event|
@@ -137,7 +137,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("Train to Teach event", "Question Time")
 
-      check "Train to Teach"
+      check "DfE Train to Teach"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
@@ -148,7 +148,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("Online event")
 
-      check "Online forum"
+      check "DfE Online Q&A"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
@@ -170,7 +170,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expected_type_ids = event_types.values_at("Train to Teach event", "Question Time", "School or University event")
 
-      check "Train to Teach"
+      check "DfE Train to Teach"
       check "Training provider"
       click_on "Update results"
 

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -176,5 +176,16 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
     end
+
+    context "when no events are found" do
+      let(:event_count) { 0 }
+
+      scenario "a useful message is shown" do
+        visit teaching_events_path
+
+        expect(page).to have_css(".teaching-events__none", text: "No events found")
+        expect(page).to have_link("Sign up to be notified about events in your area", href: "/mailinglist/signup")
+      end
+    end
   end
 end

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -47,7 +47,6 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).not_to have_css(".register")
 
       within(".event-info") do
-        expect(page).to have_css(".about-event", text: Regexp.new(event.summary))
         expect(page).to have_css(".about-event", text: Regexp.new(Nokogiri.parse(event.description).text))
 
         expect(page).not_to have_css(".about-ttt-event")

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -86,7 +86,7 @@ describe TeachingEventsHelper, type: "helper" do
 
       specify "returns online forum instead of online event by default" do
         expect(GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[222_750_008]).to eql("Online event")
-        expect(event_type_name(222_750_008)).to eql("Online forum")
+        expect(event_type_name(222_750_008)).to eql("DfE Online Q&A")
       end
 
       specify "returns training provider instead of school or uni event by default" do


### PR DESCRIPTION
Some small tweaks on the new teaching event layouts:

* Add a vertical separator between the left and right columns
* Add horizontal separators between the filter sections
* Add heading to the filters section

![Screenshot from 2021-11-18 14-23-38](https://user-images.githubusercontent.com/128088/142433599-48b9b3dc-415b-46ec-b3af-09c865cf1c70.png)

