### PR TITLE
Add ability to easily exclude a content page from sitemap/index

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -44,19 +44,6 @@ class PagesController < ApplicationController
     render_page(params[:page])
   end
 
-  # TEMP: routes to try an A/B test in production
-  def temp_test_a
-    response.headers["X-Robots-Tag"] = "noindex"
-
-    render_page("steps-to-become-a-teacher")
-  end
-
-  def temp_test_b
-    response.headers["X-Robots-Tag"] = "noindex"
-
-    render_page("ways-to-train")
-  end
-
   # Avoid caching by rendering these pages manually:
 
   def funding_your_training
@@ -105,6 +92,8 @@ private
     (@page.ancestors.reverse + [@page]).each do |page|
       breadcrumb page.title, page.path if @page.title.present?
     end
+
+    response.headers["X-Robots-Tag"] = "noindex" if @page.noindex
 
     render template: @page.template, layout: page_layout
   end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -23,6 +23,8 @@ private
     Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         published_pages.each do |path, metadata|
+          next if metadata[:noindex]
+
           xml.url do
             xml.loc(request.base_url + page_location(path))
             xml.lastmod(metadata.fetch(:date) { DEFAULT_LASTMOD })

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -7,7 +7,7 @@ module Pages
 
     attr_reader :path, :frontmatter
 
-    delegate :title, :image, to: :frontmatter
+    delegate :title, :image, :noindex, to: :frontmatter
 
     class << self
       def find(path)

--- a/app/views/content/test/a.md
+++ b/app/views/content/test/a.md
@@ -1,0 +1,6 @@
+---
+title: Test A
+noindex: true
+---
+
+Variant A (test)

--- a/app/views/content/test/b.md
+++ b/app/views/content/test/b.md
@@ -1,0 +1,6 @@
+---
+title: Test B
+noindex: true
+---
+
+Variant B (test)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,8 +48,6 @@ Rails.application.routes.draw do
     get "/open_events", to: "events#open_events"
   end
 
-  get "/test/a", to: "pages#temp_test_a"
-  get "/test/b", to: "pages#temp_test_b"
   get "/funding-your-training", to: "pages#funding_your_training", as: :funding_your_training
   get "/welcome", to: "pages#welcome", as: :welcome_guide
   get "/welcome/my-journey-into-teaching", to: "pages#welcome_my_journey_into_teaching", as: :welcome_my_journey_into_teaching

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
   include_context "with stubbed types api"
 
   let(:other_paths) { %w[/ /blog /search /tta-service /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }
-  let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}] }
+  let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}, %r{/test}] }
 
   before do
     # we don't care about the contents of the events pages here, just

--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature "link checks", :onschedule do
       # comparing to hash instead of checking .empty? so the failures dump
       # the difference in the hashes
       expect(failures).to eql({})
-
     end
   end
 

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -19,6 +19,14 @@ describe PagesController, type: :request do
       it { is_expected.to have_http_status(:success) }
     end
 
+    context "when the page is noindexed" do
+      before { get "/test/a" }
+
+      subject { response.headers["X-Robots-Tag"] }
+
+      it { is_expected.to eq("noindex") }
+    end
+
     context "with invalid page" do
       subject { response }
 


### PR DESCRIPTION
### Trello card

[Trello-2617](https://trello.com/c/ERCqXqVM/2617-enable-pages-to-be-excluded-from-the-sitemap)

### Context

When we are running A/B tests we will need to de-index any variants that we don't want to let Google know about.

### Changes proposed in this pull request

- Add ability to easily exclude a content page from sitemap/index

Provide simple mechanism to exclude a page from the sitemap and serve a noindex header; include `noindex: true` in the frontmatter.

Refactor our existing test A/B pages to use the new mechanism.

### Guidance to review

