### PR TITLE
Return 404 for past teaching events

### DIFF
--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.feature "Finding an event", type: :feature do
   include_context "with stubbed types api"
 
+  let(:beginning_of_month) { Time.zone.today.at_beginning_of_month }
   let(:events) do
     11.times.collect do |index|
-      start_at = Time.zone.today.at_beginning_of_month + index.days
+      start_at = beginning_of_month + index.days
       build(:event_api, name: "Event #{index + 1}", start_at: start_at)
     end
   end
@@ -18,6 +19,12 @@ RSpec.feature "Finding an event", type: :feature do
       receive(:search_teaching_events_grouped_by_type) { events_by_type }
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:get_teaching_event) { event }
+  end
+
+  around do |example|
+    travel_to(beginning_of_month) do
+      example.run
+    end
   end
 
   scenario "Landing on the find an event page and searching" do


### PR DESCRIPTION
### Trello card

[Trello-2675](https://trello.com/c/d6dk89B4/2675-address-why-so-many-historic-events-are-still-on-site-and-appear-in-serps)

### Context

If a teaching event is in the past we no longer want to serve it to the user, instead returning a 404 with the custom event not found page.

The 404 response should prompt Google to deindex the page and the not found events page directs the user to search for another event.

We define "in the past" as being on the previous day, rather than a time-granular comparison; this makes it consistent with the search results so if we return an event the starts at 9am and its now 10am it will still be accessible for the remainder of the day.

The exception to this is with Online Q&A events, which have an archive so that users can still view transcripts/comments of the event after it has happened. We want to still allow users to access these events and Google to index them.

### Changes proposed in this pull request

- Return 404 for past teaching events

### Guidance to review

