### PR TITLE
Add descriptions for event types in a details box

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,6 +5,24 @@
     <p>
       All events listed here are designed to help you get into teacher training. They are all free to attend.
     </p>
+
+    <details>
+      <summary>What are the event types?</summary>
+
+      <dl>
+        <dt>DfE Train to Teach events</dt>
+
+        <dl>Watch presentations, hear from teachers and speak to advisers one-to-one.</dl>
+
+        <dt>DfE Online Q&amp;As</dt>
+
+        <dl>Get answers to your specific questions from an online panel.</dl>
+
+        <dt>Training provider events</dt>
+
+        <dl>Find out about local courses and how to apply; hosted by teacher training providers.</dl>
+      </dl>
+    </details>
   </header>
 
   <div class="teaching-events__container">

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -45,7 +45,7 @@
       padding: 0 1rem;
 
       summary {
-        color: $blue;
+        color: $blue-dark;
         text-decoration: underline;
       }
 

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -40,6 +40,23 @@
     p {
       padding: 0 1rem;
     }
+
+    details {
+      padding: 0 1rem;
+
+      summary {
+        color: $blue;
+        text-decoration: underline;
+      }
+
+      dl {
+        dt { font-weight: bold; }
+
+        dl + dt {
+          margin-top: 1em;
+        }
+      }
+    }
   }
 
   @include mq($from: desktop) {


### PR DESCRIPTION
### Trello card

https://trello.com/c/bb8rAGQr/2663-events-build-event-type-explanation-popup-and-ttt-page

### Context and changes

This is an alternative to the proposed modal popup. It has some usability advantages:

* no accessibility concerns (ie, how do we announce to screen readers that an information modal has occupied the screen?)
* no need for a non-JS fallback
* no additional code/tests to maintain

Disadvantages:

* isn't as fancy looking


https://user-images.githubusercontent.com/128088/142866806-584468ff-97bd-4bd4-b467-6c7721757722.mp4

