### PR TITLE
Correct location path reference

### DIFF
--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -42,7 +42,7 @@ export default class Gtm {
 
   listenForHistoryChange() {
     document.addEventListener('turbolinks:load', () => {
-      window.gtag('set', 'page_path', window.location.path);
+      window.gtag('set', 'page_path', window.location.pathname);
       window.gtag('event', 'page_view');
     });
   }

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -20,7 +20,15 @@ describe('Google Tag Manager', () => {
     gtm.init();
   };
 
+  const mockWindowLocation = () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {},
+    });
+  };
+
   beforeEach(() => {
+    mockWindowLocation();
     clearCookies();
     setupHtml();
   });
@@ -51,7 +59,7 @@ describe('Google Tag Manager', () => {
     });
 
     it('updates the page_path in GTM', () => {
-      window.location.path = '/new-path';
+      window.location.pathname = '/new-path';
 
       document.dispatchEvent(new Event('turbolinks:load'));
 


### PR DESCRIPTION
I was using `window.location.path` incorrectly; it should be `window.location.pathname` to get the current path for the page view event.

