### PR TITLE
Fix broken link errors

### DIFF
--- a/app/views/content/test.md
+++ b/app/views/content/test.md
@@ -1,0 +1,6 @@
+---
+title: Test Index
+noindex: true
+---
+
+Test index


### PR DESCRIPTION
The `/test/a` and `/test/b` pages get breadcrumbs that point back to `/test`, but that page does not exist so it gets picked up on the broken link checker. I've added a `/test` index page to resolve this (also excluded from the sitemap/indexing).
