### PR TITLE
Switch noindex to meta tag method

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -22,6 +22,10 @@
   <%= search_structured_data if current_page?(root_path) %>
   <%= how_to_structured_data(@page) if @page.present? && @front_matter.key?("how_to") %>
 
+  <% if @front_matter&.dig("noindex") %>
+    <%= meta_tag(key: "robots", value: "noindex") %>
+  <% end %>
+
   <% if @front_matter && @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>
     <%= meta_tag(key: 'description', value: @front_matter['description'], opengraph: true) %>

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -22,9 +22,9 @@ describe PagesController, type: :request do
     context "when the page is noindexed" do
       before { get "/test/a" }
 
-      subject { response.headers["X-Robots-Tag"] }
+      subject { response.body }
 
-      it { is_expected.to eq("noindex") }
+      it { is_expected.to include(%(<meta name="robots" content="noindex">)) }
     end
 
     context "with invalid page" do


### PR DESCRIPTION
### Trello card

[Trello-2683](https://trello.com/c/rS8Bpyfc/2683-check-noindex-behaviour)

### Context

We were preventing search engines from indexing a web page by returning a `X-Robots-Tag` header. This works for the first request that hits Rails, but if the page is then served by the static page cache middleware the header is no longer present.

Instead, we can add a `meta` tag to the page, which will then be part of the static page cache and return on every request.

### Changes proposed in this pull request

- Switch noindex to meta tag method

### Guidance to review

