### PR TITLE
Hide provider website URL for TTT/QT events

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -30,7 +30,7 @@
   <h2>Venue information</h2>
   <p><%= @event.building.venue %>, <%= event_address(@event) %>.</p>
   <p><%= link_to("Open in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %></p>
-  <% if @event.provider_website_url %>
+  <% if display_event_provider_info?(@event) && @event.provider_website_url %>
     <p><%= link_to("Visit venue website", @event.provider_website_url, { target: "blank" }) %><i class="icon"></i></p>
   <% end %>
   <p><%= event_location_map(@event) %></p>

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -152,7 +152,7 @@ describe EventsController, type: :request do
         it { is_expected.to match(/#{event.building.address_line2}/) }
         it { is_expected.to match(/#{event.building.address_postcode}/) }
         it { is_expected.to match(/iframe.+src="#{event.video_url}"/) }
-        it { is_expected.to include(event.provider_website_url) }
+        it { is_expected.not_to include(event.provider_website_url) }
         it { is_expected.not_to include("Provider information") }
         it { is_expected.to include(event.building.image_url) }
 
@@ -160,6 +160,7 @@ describe EventsController, type: :request do
           let(:event) { build(:event_api, :online_event, :with_provider_info, readable_id: event_readable_id) }
 
           it { is_expected.to include("Provider information") }
+          it { is_expected.to include(event.provider_website_url) }
           it { is_expected.to include(event.provider_target_audience) }
           it { is_expected.to include(event.provider_organiser) }
           it { is_expected.to match(/mailto:#{event.provider_contact_email}/) }


### PR DESCRIPTION
### Trello card

[Trello-2684](https://trello.com/c/hC1qqyGs/2684-events-provider-website-being-erroneously-displayed-for-ttt-events)

### Context

We didn't used to populate the provider website URL for TTT/QT events, however since we are serving structured data we have asked the events team to fill it in for all event types. We still want to hide the provider information for TTT/QT events on our website though.

### Changes proposed in this pull request

- Hide provider website URL for TTT/QT events

### Guidance to review

