### PR TITLE
Updating contact details and organisation name

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -141,7 +141,7 @@ provider_groups:
       name: Clare Hunton
       telephone: '0208 5203142'
       email: training@henrymaynard.waltham.sch.uk
-    - header: Jewish Teacher Training Partnership
+    - header: London School of Jewish Studies
       link: https://www.lsjs.ac.uk/
       name: Galia Segal
       telephone: 020 8203 6427
@@ -334,8 +334,8 @@ provider_groups:
       email: m.l.jacobs@reading.ac.uk
     - header: University of Sussex
       link: https://www.sussex.ac.uk/
-      name: Janet Steadman
-      email: l.harknett@sussex.ac.uk
+      name: Mike Lambert
+      email: mike.lambert@sussex.ac.uk
     - header: University of Winchester
       link: https://www.winchester.ac.uk/pages/home.aspx
       name: Keith Smith

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -141,7 +141,7 @@ provider_groups:
       name: Clare Hunton
       telephone: '0208 5203142'
       email: training@henrymaynard.waltham.sch.uk
-    - header: London School of Jewish Studies
+    - header: London School of Jewish Studies (LSJS)
       link: https://www.lsjs.ac.uk/
       name: Galia Segal
       telephone: 020 8203 6427


### PR DESCRIPTION
Updated contact details for University of Sussex and changed the organisation name from Jewish Teacher Training Partnership to London School of Jewish Studies.

### Trello card

### Context Updating details for organisations as per their email requests

### Changes proposed in this pull request

### Guidance to review

