### PR TITLE
Trim white space before rendering Markdown placeholders

### DIFF
--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -61,9 +61,8 @@ module TemplateHandlers
       # use $1 rather than a block argument here because gsub assigns the
       # entire placeholder to the arg (including dollar symbols) but we only
       # want what's inside the capture group
-
       parsed.content.gsub(COMPONENT_PLACEHOLDER_REGEX) do
-        safe_join([cta_component($1), component("quote", $1), image($1)].compact)
+        safe_join([cta_component($1), component("quote", $1), image($1)].compact).strip
       end
     end
     # rubocop:enable Style/PerlBackrefs

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -1,5 +1,13 @@
 require "rails_helper"
 
+module CallsToAction
+  class WithWhiteSpaceComponent < ViewComponent::Base
+    def call
+      "  text  "
+    end
+  end
+end
+
 describe TemplateHandlers::Markdown, type: :view do
   subject { rendered }
 
@@ -225,6 +233,24 @@ describe TemplateHandlers::Markdown, type: :view do
 
     specify "unregistered calls to action should be omitted" do
       expect(rendered).not_to have_content(/one-that-does-not-exist/)
+    end
+
+    context "when the rich content has surrounding white space" do
+      let(:front_matter_with_calls_to_action) do
+        {
+          "title": "Page with rich content (calls to action)",
+          "calls_to_action" => {
+            "big-warning" => "with_white_space",
+            "small-warning" => "with_white_space",
+          },
+        }
+      end
+
+      it "strips the white space" do
+        rendered_component = CallsToAction::WithWhiteSpaceComponent.new.call
+        expect(rendered).to include(rendered_component.strip)
+        expect(rendered).not_to include(rendered_component)
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

N/A I noticed it while investigating [Trello-2512](https://trello.com/c/S4jAhQGb/2512-table-column-scopes)

### Context

Some of the view components are wrapped in a conditional whereby the HTML content is then indented in the template file, for example:

```
<% if something %>
  <p>text</p>
<% end %>
```

Most of the time when this is injected into Markdown its absolutely fine, however if it happens to be injected immediately after a bullet list the leading spaces result in the component itself being included in the final `<li></li>` content. For example:

```
* one
* two
$component$
```

Results in:

```
<ul>
  <li>one</li>
  <li>two</li>
  <li>[component-html]</li>
</ul>
```

To prevent this, we need to trim the leading white space prior to rendering  components so that they are never treated as a list item.

### Changes proposed in this pull request

- Trim white space before rendering Markdown placeholders

### Guidance to review

The reason this happens is because a leading space after a bullet list results in the content also being indented:

```
* one
* two

  three
```

Renders out as:

* one
* two

  three


Where as what we want is:

```
* one 
* two

three
```

Which becomes:

* one
* two

three

| Before      | After |
| ----------- | ----------- |
| <img width="862" alt="Screenshot 2021-11-26 at 15 44 22" src="https://user-images.githubusercontent.com/29867726/143604846-8228180f-a0e8-4407-8cca-e63b8c5d161f.png">      | <img width="875" alt="Screenshot 2021-11-26 at 15 44 03" src="https://user-images.githubusercontent.com/29867726/143604805-8761425a-f2dd-4486-ab68-8e029a9cd71a.png">       |




