### PR TITLE
Add scope to table headings

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>
       <%= c.hero(@front_matter) %>

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -5,7 +5,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new do |c| %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -4,7 +4,7 @@
     <%= csrf_meta_tags %>
   <% end %>
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new do |c| %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
       <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
       <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: true) do |c| %>

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
     <%= render "sections/head" %>
-    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+    <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
       <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
       <%= render HeaderComponent.new %>

--- a/app/views/layouts/teaching_event.html.erb
+++ b/app/views/layouts/teaching_event.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content" }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: false) do |c| %>

--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content" }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content" }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new(breadcrumbs: false) do |c| %>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" class="govuk-template">
   <%= render "sections/head" %>
-  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
+  <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") unless Rails.application.config.x.legacy_tracking_pixels %>
 
     <%= render HeaderComponent.new %>

--- a/app/webpacker/controllers/table_controller.js
+++ b/app/webpacker/controllers/table_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  connect() {
+    this.addTableHeadingScopes();
+  }
+
+  addTableHeadingScopes() {
+    for (const th of this.tableHeadings) {
+      if (!th.scope && th.textContent) {
+        th.scope = 'col';
+      }
+    }
+  }
+
+  get tableHeadings() {
+    return document.querySelectorAll('.markdown table thead > tr > th');
+  }
+}

--- a/spec/javascript/controllers/table_controller_spec.js
+++ b/spec/javascript/controllers/table_controller_spec.js
@@ -1,0 +1,58 @@
+import { Application } from 'stimulus';
+import TableController from 'table_controller.js';
+
+describe('TableController', () => {
+
+  beforeAll(() => registerController());
+
+  const setBody = () => {
+    document.body.innerHTML = `
+      <div data-controller="table">
+        <div class="markdown">
+          <table>
+            <thead>
+              <tr>
+                <th class="empty-col"><!-- empty --></th>
+                <th class="col">Col 1</th>
+                <th class="col">Col 2</th>
+                <th class="col-with-scope" scope="row">Col 3</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Cell 1</td>
+                <td>Cell 2</td>
+                <td>Cell 3</td>
+                <td>Cell 4</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `;
+  }
+
+  const registerController = () => {
+    const application = Application.start();
+    application.register('table', TableController);
+  }
+
+  beforeEach(() => {
+    setBody();
+  });
+
+  it('adds a col scope to headings', () => {
+    const cols = document.querySelectorAll('.col');
+    cols.forEach(col => expect(col.scope).toEqual('col'))
+  })
+
+  it('does not add a scope to empty headings', () => {
+    const emptyCol = document.querySelector('.empty-col')
+    expect(emptyCol.scope).toBe("");
+  })
+
+  it('does not change an existing scope', () => {
+    const colWithScope = document.querySelector('.col-with-scope')
+    expect(colWithScope.scope).toEqual('row');
+  })
+});


### PR DESCRIPTION
### Trello card

[Trello-2512](https://trello.com/c/S4jAhQGb/2512-table-column-scopes)

### Context

Markdown table syntax does not support adding a `scope` attribute to table headings. Instead, we can add the `scope` attribute using a small Stimulus controller. If a table already has a scope we won't change it (which lets us write custom HTML tables that may have vertical headings and a `row` scope). If the heading has no text content we won't add a scope (which seems to be best practice).

### Changes proposed in this pull request

- Add scope to Markdown table headings

### Guidance to review

