### PR TITLE
Use different 1x1 transparent GIF

### DIFF
--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -1,6 +1,6 @@
 class LazyLoadImages
   # Used as a placeholder to prevent invalid HTML.
-  TINY_GIF = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=".freeze
+  TINY_GIF = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==".freeze
 
   def initialize(page)
     @page = page


### PR DESCRIPTION
We found Safari was not correctly rendering the previous 1x1 pixel placeholder GIF; it must have been incorrectly encoded. The resulting broken image was causing an x-overflow of images respective to their parent bounds. This version appears to work.
