### PR TITLE
Try out using an event type model

### DIFF
--- a/app/components/events/event_box_component.rb
+++ b/app/components/events/event_box_component.rb
@@ -71,7 +71,7 @@ module Events
     end
 
     def is_online_event_category?
-      type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+      type == EventType.online_event_id
     end
   end
 end

--- a/app/components/teaching_events/event_component.html.erb
+++ b/app/components/teaching_events/event_component.html.erb
@@ -76,7 +76,7 @@
         <% end %>
       </div>
 
-      <% unless school_and_university? %>
+      <% unless provider_event? %>
         <div class="event__bottom-bar--right">
           <%= image_pack_tag "media/images/dfelogo-black.svg", class: "dfelogo", alt: "This is an official Department for Education event" %>
         </div>

--- a/app/components/teaching_events/event_component.rb
+++ b/app/components/teaching_events/event_component.rb
@@ -15,12 +15,10 @@ module TeachingEvents
       super
     end
 
+    delegate :provider_event?, to: :type
+
     def train_to_teach?
       type.train_to_teach_or_question_time_event?
-    end
-
-    def school_and_university?
-      type.school_or_university_event?
     end
 
     def online?
@@ -52,7 +50,7 @@ module TeachingEvents
         "event",
         "event--train-to-teach" => train_to_teach?,
         "event--regular" => !train_to_teach?,
-        "event--training-provider" => school_and_university?,
+        "event--training-provider" => provider_event?,
       )
     end
   end

--- a/app/components/teaching_events/event_component.rb
+++ b/app/components/teaching_events/event_component.rb
@@ -5,7 +5,7 @@ module TeachingEvents
     def initialize(event:)
       @event     = event
       @title     = event.name
-      @type      = event.type_id
+      @type      = EventType.new(event)
       @online    = event.is_online
       @in_person = event.building.present?
       @start_at  = event.start_at
@@ -16,11 +16,11 @@ module TeachingEvents
     end
 
     def train_to_teach?
-      type.in?(GetIntoTeachingApiClient::Constants::EVENT_TYPES.values_at("Train to Teach event", "Question Time"))
+      type.train_to_teach_or_question_time_event?
     end
 
     def school_and_university?
-      type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+      type.school_or_university_event?
     end
 
     def online?
@@ -32,7 +32,7 @@ module TeachingEvents
     end
 
     def event_type
-      helpers.event_type_name(type)
+      helpers.event_type_name(type.type_id)
     end
 
     def location

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -59,7 +59,7 @@ private
   def viewable_event?(event)
     not_pending = event.status_id != pending_event_status_id
     in_future = event.start_at.to_date >= Time.zone.now.utc.to_date
-    online_q_a = EventType.new(event).online_event?
+    online_q_a = EventType.new(event).online_qa_event?
 
     not_pending && (in_future || online_q_a)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -59,7 +59,7 @@ private
   def viewable_event?(event)
     not_pending = event.status_id != pending_event_status_id
     in_future = event.start_at.to_date >= Time.zone.now.utc.to_date
-    online_q_a = event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+    online_q_a = EventType.new(event).online_event?
 
     not_pending && (in_future || online_q_a)
   end

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -148,8 +148,8 @@ module Internal
 
     def event_types
       {
-        provider: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-        online: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"],
+        provider: EventType.school_or_university_event_id,
+        online: EventType.online_event_id,
       }
         .with_indifferent_access
         .freeze

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -6,7 +6,7 @@ class TeachingEventsController < ApplicationController
   FEATURED_EVENT_COUNT = 2 # 2 featured events max on the first page
   EVENT_COUNT = 15 # 15 regular ones per page
 
-  FEATURED_EVENT_TYPES = GetIntoTeachingApiClient::Constants::EVENT_TYPES.values_at(
+  FEATURED_EVENT_TYPES = EventType.lookup_by_names(
     "Train to Teach event",
     "Question Time",
   ).freeze

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -38,7 +38,7 @@ module EventsHelper
   end
 
   def is_event_type?(event, type_name)
-    event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES[type_name]
+    event.type_id == EventType.lookup_by_name(type_name)
   end
 
   def embed_event_video_url(video_url)
@@ -128,10 +128,10 @@ module EventsHelper
   end
 
   def ttt_event_type_id
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+    EventType.train_to_teach_event_id
   end
 
   def qt_event_type_id
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+    EventType.question_time_event_id
   end
 end

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -1,6 +1,6 @@
 module TeachingEventsHelper
   def is_a_train_to_teach_event?(event)
-    event.type_id.in?(GetIntoTeachingApiClient::Constants::EVENT_TYPES.values_at("Train to Teach event", "Question Time"))
+    event.type_id.in?(EventType.lookup_by_names("Train to Teach event", "Question Time"))
   end
 
   def event_list_id(name)
@@ -15,7 +15,7 @@ module TeachingEventsHelper
   end
 
   def is_event_type?(event, type_name)
-    event.type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES[type_name]
+    event.type_id == EventType.lookup_by_name(type_name)
   end
 
   # override:

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -7,7 +7,7 @@ class EventType
     :school_or_university_event_id,
     :train_to_teach_event_id,
     :question_time_event_id,
-    to: :class
+    to: :class,
   )
 
   class << self
@@ -50,7 +50,7 @@ class EventType
   end
 
   def type
-    self.lookup_by_id(type_id)
+    lookup_by_id(type_id)
   end
 
   # this name might be confusing...

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -32,7 +32,7 @@ class EventType
     end
 
     def lookup_by_names(*names)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.values_at(*names)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.fetch_values(*names)
     end
 
     def lookup_by_id(id)
@@ -40,7 +40,7 @@ class EventType
     end
 
     def lookup_by_ids(*ids)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.values_at(*ids)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.fetch_values(*ids)
     end
   end
 

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,0 +1,76 @@
+class EventType
+  attr_accessor :type_id
+
+  delegate(
+    :lookup_by_id,
+    :online_event_id,
+    :school_or_university_event_id,
+    :train_to_teach_event_id,
+    :question_time_event_id,
+    to: :class
+  )
+
+  class << self
+    def school_or_university_event_id
+      lookup_by_name("School or University event")
+    end
+
+    def train_to_teach_event_id
+      lookup_by_name("Train to Teach event")
+    end
+
+    def online_event_id
+      lookup_by_name("Online event")
+    end
+
+    def question_time_event_id
+      lookup_by_name("Question Time")
+    end
+
+    def lookup_by_name(name)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.fetch(name)
+    end
+
+    def lookup_by_names(*names)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.values_at(*names)
+    end
+
+    def lookup_by_id(id)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.fetch(id)
+    end
+
+    def lookup_by_ids(*ids)
+      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.values_at(*ids)
+    end
+  end
+
+  def initialize(event)
+    @event   = event
+    @type_id = event.type_id
+  end
+
+  def type
+    self.lookup_by_id(type_id)
+  end
+
+  # this name might be confusing...
+  def online_event?
+    type_id == online_event_id
+  end
+
+  def school_or_university_event?
+    type_id == school_or_university_event_id
+  end
+
+  def question_time_event?
+    type_id == question_time_event_id
+  end
+
+  def train_to_teach_event?
+    type_id == train_to_teach_event_id
+  end
+
+  def train_to_teach_or_question_time_event?
+    type_id.in?([train_to_teach_event_id, question_time_event_id])
+  end
+end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -53,12 +53,11 @@ class EventType
     lookup_by_id(type_id)
   end
 
-  # this name might be confusing...
-  def online_event?
+  def online_qa_event?
     type_id == online_event_id
   end
 
-  def school_or_university_event?
+  def provider_event?
     type_id == school_or_university_event_id
   end
 

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -80,8 +80,8 @@ module Events
       type_ids = [type]
 
       # We combine Question Time events with Train to Teach events
-      if type == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-        type_ids << GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+      if type == EventType.train_to_teach_event_id
+        type_ids << EventType.question_time_event_id
       end
 
       type_ids.compact.presence

--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -13,7 +13,7 @@ module Internal
               default: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
     attribute :type_id,
               :integer,
-              default: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+              default: EventType.school_or_university_event_id
     attribute :name, :string
     attribute :summary, :string
     attribute :description, :string
@@ -114,11 +114,11 @@ module Internal
     end
 
     def provider_event?
-      type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+      type_id == EventType.school_or_university_event_id
     end
 
     def online_event?
-      type_id == GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+      type_id == EventType.online_event_id
     end
 
   private

--- a/spec/components/events/type_description_component_spec.rb
+++ b/spec/components/events/type_description_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Events::TypeDescriptionComponent, type: "component" do
   subject! { render_inline(described_class.new(type)) }
 
-  let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+  let(:type) { EventType.online_event_id }
 
   it "has a containing div" do
     expect(page).to have_css("div.type-description")

--- a/spec/components/teaching_events/event_component_spec.rb
+++ b/spec/components/teaching_events/event_component_spec.rb
@@ -26,17 +26,17 @@ describe TeachingEvents::EventComponent, type: "component" do
       end
     end
 
-    describe "#school_and_university?" do
+    describe "#provider_event?" do
       context "when the event is a school and university event" do
         let(:event) { build(:event_api, :school_or_university_event) }
 
-        it { expect(subject.school_and_university?).to be(true) }
+        it { expect(subject.provider_event?).to be(true) }
       end
 
       context "when the event is a train to teach event" do
         let(:event) { build(:event_api) }
 
-        it { expect(subject.school_and_university?).to be(false) }
+        it { expect(subject.provider_event?).to be(false) }
       end
     end
 

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :event_api, class: "GetIntoTeachingApiClient::TeachingEvent" do
     id { SecureRandom.uuid }
     sequence(:readable_id, &:to_s)
-    type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    type_id { EventType.train_to_teach_event_id }
     web_feed_id { "123" }
     status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"] }
     sequence(:name) { |i| "Become a Teacher #{i}" }
@@ -32,11 +32,11 @@ FactoryBot.define do
     end
 
     trait :train_to_teach_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+      type_id { EventType.train_to_teach_event_id }
     end
 
     trait :question_time_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"] }
+      type_id { EventType.question_time_event_id }
     end
 
     trait :virtual do
@@ -52,11 +52,11 @@ FactoryBot.define do
 
     trait :online_event do
       online
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+      type_id { EventType.online_event_id }
     end
 
     trait :school_or_university_event do
-      type_id { GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"] }
+      type_id { EventType.school_or_university_event_id }
     end
 
     trait :no_event_type do

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -10,20 +10,20 @@ describe EventsHelper, type: "helper" do
 
   describe "#show_events_teaching_logo" do
     it "returns false if the index != 0" do
-      show_logo = show_events_teaching_logo(1, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"])
+      show_logo = show_events_teaching_logo(1, EventType.train_to_teach_event_id)
       expect(show_logo).to be_falsy
     end
 
     it "returns false if the type_id is School or University event" do
-      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
+      show_logo = show_events_teaching_logo(0, EventType.school_or_university_event_id)
       expect(show_logo).to be_falsy
     end
 
-    it "returns true if the index is 0 and the type_id is not chool or University event" do
-      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"])
+    it "returns true if the index is 0 and the type_id is not School or University event" do
+      show_logo = show_events_teaching_logo(0, EventType.train_to_teach_event_id)
       expect(show_logo).to be_truthy
 
-      show_logo = show_events_teaching_logo(0, GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
+      show_logo = show_events_teaching_logo(0, EventType.online_event_id)
       expect(show_logo).to be_truthy
     end
   end
@@ -123,7 +123,7 @@ describe EventsHelper, type: "helper" do
   describe "#is_event_type?" do
     let(:matching_type) { "School or University event" }
     let(:non_matching_type) { "Online event" }
-    let(:event) { build(:event_api, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[matching_type]) }
+    let(:event) { build(:event_api, type_id: EventType.lookup_by_name(matching_type)) }
 
     it "is truthy when the type matches" do
       expect(is_event_type?(event, matching_type)).to be_truthy
@@ -136,15 +136,12 @@ describe EventsHelper, type: "helper" do
 
   describe "#event_type_color" do
     it "returns purple for train to teach events" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-      expect(event_type_color(type_id)).to eq("purple")
+      expect(event_type_color(EventType.train_to_teach_event_id)).to eq("purple")
     end
 
     it "returns blue for non-train to teach events" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
-      expect(event_type_color(type_id)).to eq("blue")
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University event"]
-      expect(event_type_color(type_id)).to eq("blue")
+      expect(event_type_color(EventType.online_event_id)).to eq("blue")
+      expect(event_type_color(EventType.school_or_university_event_id)).to eq("blue")
     end
   end
 
@@ -172,16 +169,16 @@ describe EventsHelper, type: "helper" do
 
   describe "#display_event_provider_info?" do
     it "returns false if train to teach or question time" do
-      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+      event.type_id = EventType.train_to_teach_event_id
       expect(display_event_provider_info?(event)).to be(false)
-      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+      event.type_id = EventType.question_time_event_id
       expect(display_event_provider_info?(event)).to be(false)
     end
 
     it "returns true if not train to teach or question time" do
-      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+      event.type_id = EventType.online_event_id
       expect(display_event_provider_info?(event)).to be(true)
-      event.type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Schools or University event"]
+      event.type_id = EventType.school_or_university_event_id
       expect(display_event_provider_info?(event)).to be(true)
     end
   end
@@ -278,7 +275,7 @@ describe EventsHelper, type: "helper" do
     end
 
     context "when checking for any other event type ids" do
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+      let(:type_id) { EventType.online_event_id }
 
       it "returns true when events is empty" do
         events = build_list(:event_api, 2, :online_event)
@@ -296,7 +293,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#ttt_event_type_id?" do
     it "returns the TTT event id" do
-      expect(ttt_event_type_id).to eq GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
+      expect(ttt_event_type_id).to eq EventType.train_to_teach_event_id
     end
   end
 end

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -60,7 +60,7 @@ describe TeachingEventsHelper, type: "helper" do
     let(:qt) { "Question Time" }
 
     let(:ttt_event) do
-      OpenStruct.new(type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[ttt])
+      OpenStruct.new(type_id: EventType.lookup_by_name(ttt))
     end
 
     specify "returns true when there's a match" do
@@ -85,12 +85,12 @@ describe TeachingEventsHelper, type: "helper" do
       let(:custom_event) { "Bingo night" }
 
       specify "returns online forum instead of online event by default" do
-        expect(GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[222_750_008]).to eql("Online event")
+        expect(EventType.lookup_by_id(222_750_008)).to eql("Online event")
         expect(event_type_name(222_750_008)).to eql("DfE Online Q&A")
       end
 
       specify "returns training provider instead of school or uni event by default" do
-        expect(GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[222_750_009]).to eql("School or University event")
+        expect(EventType.lookup_by_id(222_750_009)).to eql("School or University event")
         expect(event_type_name(222_750_009)).to eql("Training provider")
       end
 

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+describe EventType do
+  describe "class_methods" do
+    describe ".school_or_university_event_id" do
+      subject { described_class.school_or_university_event_id }
+
+      it { is_expected.to eq(222_750_009) }
+    end
+
+    describe ".train_to_teach_event_id" do
+      subject { described_class.train_to_teach_event_id }
+
+      it { is_expected.to eq(222_750_001) }
+    end
+
+    describe ".online_event_id" do
+      subject { described_class.online_event_id }
+
+      it { is_expected.to eq(222_750_008) }
+    end
+
+    describe ".question_time_event_id" do
+      subject { described_class.question_time_event_id }
+
+      it { is_expected.to eq(222_750_007) }
+    end
+
+    describe ".lookup_by_name" do
+      specify "returns the id given the corresponding name" do
+        expect(described_class.lookup_by_name("Question Time")).to eq(222_750_007)
+      end
+
+      specify "errors when an unrecognised name is passed in" do
+        expect { described_class.lookup_by_name("Bingo night") }.to raise_error(KeyError)
+      end
+    end
+
+    describe ".lookup_by_names" do
+      specify "returns the ids given the corresponding names" do
+        expect(described_class.lookup_by_names("Question Time", "Online event")).to eq([222_750_007, 222_750_008])
+      end
+
+      specify "errors when an unrecognised name is passed in" do
+        expect { described_class.lookup_by_names("Bingo night") }.to raise_error(KeyError)
+      end
+    end
+
+    describe ".lookup_by_id" do
+      specify "returns the id given the corresponding id" do
+        expect(described_class.lookup_by_id(222_750_007)).to eq("Question Time")
+      end
+
+      specify "errors when an unrecognised id is passed in" do
+        expect { described_class.lookup_by_id(999_888_777) }.to raise_error(KeyError)
+      end
+    end
+
+    describe ".lookup_by_ids" do
+      specify "returns the ids given the corresponding class names" do
+        expect(described_class.lookup_by_ids(222_750_007, 222_750_008)).to eq(["Question Time", "Online event"])
+      end
+
+      specify "errors when an unrecognised name is passed in" do
+        expect { described_class.lookup_by_ids(999_888_777) }.to raise_error(KeyError)
+      end
+    end
+  end
+
+  subject { described_class.new(build(:event_api)) }
+
+  it { is_expected.to respond_to(:type_id) }
+
+  %i[lookup_by_id online_event_id school_or_university_event_id train_to_teach_event_id question_time_event_id]
+    .each do |delegated_method|
+      it { is_expected.to delegate_method(delegated_method).to(:class).as(delegated_method) }
+    end
+
+  describe "#online_event?" do
+    subject { described_class.new(build(:event_api, :online_event)) }
+
+    it { is_expected.to be_an_online_event }
+
+    it { is_expected.not_to be_a_school_or_university_event }
+    it { is_expected.not_to be_a_question_time_event }
+    it { is_expected.not_to be_a_train_to_teach_event }
+  end
+
+  describe "#train_to_teach_event?" do
+    subject { described_class.new(build(:event_api, :train_to_teach_event)) }
+
+    it { is_expected.to be_a_train_to_teach_event }
+
+    it { is_expected.not_to be_a_school_or_university_event }
+    it { is_expected.not_to be_a_question_time_event }
+    it { is_expected.not_to be_a_online_event }
+  end
+
+  describe "#school_or_university_event?" do
+    subject { described_class.new(build(:event_api, :school_or_university_event)) }
+
+    it { is_expected.to be_a_school_or_university_event }
+
+    it { is_expected.not_to be_a_question_time_event }
+    it { is_expected.not_to be_a_online_event }
+    it { is_expected.not_to be_a_train_to_teach_event }
+  end
+
+  describe "#question_time_event?" do
+    subject { described_class.new(build(:event_api, :question_time_event)) }
+
+    it { is_expected.to be_a_question_time_event }
+
+    it { is_expected.not_to be_a_online_event }
+    it { is_expected.not_to be_a_train_to_teach_event }
+    it { is_expected.not_to be_a_school_or_university_event }
+  end
+
+  describe "#train_to_teach_or_question_time_event?" do
+    context "when train_to_teach_event" do
+      subject { described_class.new(build(:event_api, :train_to_teach_event)) }
+
+      it { is_expected.to be_a_train_to_teach_or_question_time_event }
+    end
+
+    context "when question_time_event" do
+      subject { described_class.new(build(:event_api, :question_time_event)) }
+
+      it { is_expected.to be_a_train_to_teach_or_question_time_event }
+    end
+  end
+end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -76,12 +76,12 @@ describe EventType do
       it { is_expected.to delegate_method(delegated_method).to(:class).as(delegated_method) }
     end
 
-  describe "#online_event?" do
+  describe "#online_qa_event?" do
     subject { described_class.new(build(:event_api, :online_event)) }
 
-    it { is_expected.to be_an_online_event }
+    it { is_expected.to be_a_online_qa_event }
 
-    it { is_expected.not_to be_a_school_or_university_event }
+    it { is_expected.not_to be_a_provider_event }
     it { is_expected.not_to be_a_question_time_event }
     it { is_expected.not_to be_a_train_to_teach_event }
   end
@@ -91,18 +91,18 @@ describe EventType do
 
     it { is_expected.to be_a_train_to_teach_event }
 
-    it { is_expected.not_to be_a_school_or_university_event }
+    it { is_expected.not_to be_a_provider_event }
     it { is_expected.not_to be_a_question_time_event }
-    it { is_expected.not_to be_a_online_event }
+    it { is_expected.not_to be_a_online_qa_event }
   end
 
   describe "#school_or_university_event?" do
     subject { described_class.new(build(:event_api, :school_or_university_event)) }
 
-    it { is_expected.to be_a_school_or_university_event }
+    it { is_expected.to be_a_provider_event }
 
     it { is_expected.not_to be_a_question_time_event }
-    it { is_expected.not_to be_a_online_event }
+    it { is_expected.not_to be_a_online_qa_event }
     it { is_expected.not_to be_a_train_to_teach_event }
   end
 
@@ -111,9 +111,9 @@ describe EventType do
 
     it { is_expected.to be_a_question_time_event }
 
-    it { is_expected.not_to be_a_online_event }
+    it { is_expected.not_to be_a_online_qa_event }
     it { is_expected.not_to be_a_train_to_teach_event }
-    it { is_expected.not_to be_a_school_or_university_event }
+    it { is_expected.not_to be_a_provider_event }
   end
 
   describe "#train_to_teach_or_question_time_event?" do

--- a/spec/models/events/category_spec.rb
+++ b/spec/models/events/category_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Events::Category do
 
   let(:category_name) { "Train to Teach event" }
   let(:type_id) do
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES[category_name]
+    EventType.lookup_by_name(category_name)
   end
 
   describe "#new" do

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -83,8 +83,8 @@ describe Events::Search do
 
   describe "validations" do
     describe "event #type" do
-      it { is_expected.to allow_value(GetIntoTeachingApiClient::Constants::EVENT_TYPES["Teain to Teach event"]).for :type }
-      it { is_expected.to allow_value(GetIntoTeachingApiClient::Constants::EVENT_TYPES["Teain to Teach event"].to_s).for :type }
+      it { is_expected.to allow_value(EventType.train_to_teach_event_id).for :type }
+      it { is_expected.to allow_value(EventType.train_to_teach_event_id.to_s).for :type }
       it { is_expected.to allow_value(nil).for :type }
       it { is_expected.to allow_value("").for :type }
       it { is_expected.not_to allow_value("2").for :type }
@@ -179,8 +179,8 @@ describe Events::Search do
 
       context "when searching Train to Teach events" do
         before do
-          subject.type = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-          expected_attributes[:type_ids] << GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
+          subject.type = EventType.train_to_teach_event_id
+          expected_attributes[:type_ids] << EventType.question_time_event_id
         end
 
         it "queries Question Time and Train to Teach events" do

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -190,7 +190,7 @@ describe Internal::Event do
         name: internal_event.name,
         readable_id: internal_event.readable_id,
         status_id: internal_event.status_id,
-        type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
+        type_id: EventType.school_or_university_event_id,
         summary: internal_event.summary,
         description: internal_event.description,
         is_online: internal_event.is_online,
@@ -241,7 +241,7 @@ describe Internal::Event do
 
   describe "#type_id=" do
     context "when event is initialised with 'online' event_type" do
-      subject { described_class.new({ type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }) }
+      subject { described_class.new({ type_id: EventType.online_event_id }) }
 
       it "sets 'is_online' to true" do
         expect(subject.is_online).to be true

--- a/spec/models/pages/data_spec.rb
+++ b/spec/models/pages/data_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Pages::Data do
       let(:category) { "Train to Teach event" }
 
       it { is_expected.to be_kind_of GetIntoTeachingApiClient::TeachingEvent }
-      it { is_expected.to have_attributes type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES[category] }
+      it { is_expected.to have_attributes type_id: EventType.lookup_by_name(category) }
     end
   end
 

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -49,11 +49,10 @@ describe TeachingEvents::Search do
   end
 
   describe "#results" do
-    event_types   = GetIntoTeachingApiClient::Constants::EVENT_TYPES
-    ttt           = event_types["Train to Teach event"]
-    qt            = event_types["Question Time"]
-    online        = event_types["Online event"]
-    school_or_uni = event_types["School or University event"]
+    ttt           = EventType.train_to_teach_event_id
+    qt            = EventType.question_time_event_id
+    online        = EventType.online_event_id
+    school_or_uni = EventType.school_or_university_event_id
 
     let(:fake_api) do
       instance_double(

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -13,13 +13,13 @@ describe Events::GroupPresenter do
 
   describe "#sorted_events_by_type" do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
-    let(:online_event_type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+    let(:online_event_type_id) { EventType.online_event_id }
 
     it "returns events_by_type as an array of [type_id, events] tuples (with TTT and QT events combined)" do
       expect(subject.sorted_events_by_type).to eq([
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events + question_time_events],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"], online_events],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events],
+        [EventType.train_to_teach_event_id, train_to_teach_events + question_time_events],
+        [EventType.online_event_id, online_events],
+        [EventType.school_or_university_event_id, school_and_university_events],
       ])
     end
 
@@ -48,13 +48,11 @@ describe Events::GroupPresenter do
         let(:question_time_events) { [] }
 
         it "still contains a key for Train to Teach events" do
-          train_to_teach_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-          expect(type_ids).to include(train_to_teach_type_id)
+          expect(type_ids).to include(EventType.train_to_teach_event_id)
         end
 
         it "does not contain a key for Question Time events" do
-          question_time_type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
-          expect(type_ids).not_to include(question_time_type_id)
+          expect(type_ids).not_to include(EventType.question_time_event_id)
         end
       end
     end
@@ -65,7 +63,7 @@ describe Events::GroupPresenter do
       let(:early) { build(:event_api, :online_event, start_at: 1.week.from_now) }
       let(:middle) { build(:event_api, :online_event, start_at: 2.weeks.from_now) }
       let(:late) { build(:event_api, :online_event, start_at: 3.weeks.from_now) }
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+      let(:type_id) { EventType.online_event_id }
       let(:unsorted_events) { [middle, late, early] }
       let(:ascending) { true }
 
@@ -101,9 +99,9 @@ describe Events::GroupPresenter do
       paginated_events_by_type = subject.paginated_events_by_type(pages_by_type, 3)
 
       expect(paginated_events_by_type).to eq([
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"], train_to_teach_events[0...3]],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"], online_events[0...2]],
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events[3...6]],
+        [EventType.train_to_teach_event_id, train_to_teach_events[0...3]],
+        [EventType.online_event_id, online_events[0...2]],
+        [EventType.school_or_university_event_id, school_and_university_events[3...6]],
       ])
     end
 
@@ -112,13 +110,13 @@ describe Events::GroupPresenter do
       paginated_events_by_type = subject.paginated_events_by_type(pages_by_type)
 
       expect(paginated_events_by_type).to include(
-        [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"], school_and_university_events[0...9]],
+        [EventType.school_or_university_event_id, school_and_university_events[0...9]],
       )
     end
   end
 
   describe "#paginated_events_of_type" do
-    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:type) { EventType.train_to_teach_event_id }
     let(:page) { 2 }
     let(:per_page) { 2 }
 
@@ -144,14 +142,14 @@ describe Events::GroupPresenter do
   end
 
   describe "#sorted_events_of_type" do
-    let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+    let(:type) { EventType.online_event_id }
 
     it "returns the events of the given type" do
       expect(subject.sorted_events_of_type(type)).to eq(online_events)
     end
 
     context "when type is Train to Teach event" do
-      let(:type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+      let(:type) { EventType.train_to_teach_event_id }
 
       it "returns the Train to Teach and Question Time events" do
         expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events + question_time_events)

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -93,7 +93,7 @@ describe "View events by category", type: :request do
     let(:blank_search) { { postcode: nil, quantity_per_type: nil, radius: nil, start_after: start_after, start_before: start_before, type_ids: nil } }
 
     it "queries events for the correct category" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+      type_id = EventType.school_or_university_event_id
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(blank_search.merge(type_ids: [type_id], quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events")
@@ -108,7 +108,7 @@ describe "View events by category", type: :request do
     let(:filter) { { postcode: "TE57 1NG", quantity_per_type: nil, radius: radius, start_after: start_after, start_before: start_before, type_ids: nil } }
 
     it "queries events for the correct category" do
-      type_id = GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+      type_id = EventType.school_or_university_event_id
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_ids: [type_id], quantity_per_type: expected_limit))
       get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -59,7 +59,7 @@ describe EventsController, type: :request do
 
     context "with valid search params" do
       let(:event_type_name) { "School or University event" }
-      let(:event_type) { GetIntoTeachingApiClient::Constants::EVENT_TYPES[event_type_name] }
+      let(:event_type) { EventType.lookup_by_name(event_type_name) }
       let(:search_params) do
         attributes_for(
           :events_search,
@@ -221,7 +221,7 @@ describe EventsController, type: :request do
         end
 
         context %(when the event is a 'School or University event') do
-          let(:event) { build(:event_api, web_feed_id: nil, type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]) }
+          let(:event) { build(:event_api, web_feed_id: nil, type_id: EventType.school_or_university_event_id) }
 
           it { is_expected.to match(%r{To register for this event, follow the instructions in the event information section}) }
           it { is_expected.not_to match(%r{Sign up for this}) }

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -64,7 +64,7 @@ describe "Find an event near you", type: :request do
   end
 
   context "when searching for an event by type" do
-    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+    let(:type_id) { EventType.online_event_id }
     let(:events) { [build(:event_api, type_id: type_id)] }
 
     before do
@@ -88,7 +88,7 @@ describe "Find an event near you", type: :request do
       let(:events) { [] }
 
       context "when event type is Train to Teach" do
-        let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+        let(:type_id) { EventType.train_to_teach_event_id }
 
         it "displays a single no results message" do
           no_results_messages = response.body.scan(no_ttt_events_regex).flatten
@@ -158,7 +158,7 @@ describe "Find an event near you", type: :request do
     end
 
     context "when there are results for a subset of categories" do
-      let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"] }
+      let(:type_id) { EventType.online_event_id }
       let(:events) { [build(:event_api, type_id: type_id)] }
 
       it "displays the no results message per category" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -78,7 +78,7 @@ describe Internal::EventsController, type: :request do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
-                    type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]],
+                    type_ids: [EventType.school_or_university_event_id],
                     status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
                     start_after: Time.zone.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
@@ -92,7 +92,7 @@ describe Internal::EventsController, type: :request do
           allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
-                    type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]],
+                    type_ids: [EventType.online_event_id],
                     status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
                     start_after: Time.zone.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
@@ -659,8 +659,7 @@ describe Internal::EventsController, type: :request do
         allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
           .to receive(:search_teaching_events_grouped_by_type)
                 .with({
-                  type_ids: [GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"],
-                             GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]],
+                  type_ids: [EventType.school_or_university_event_id, EventType.online_event_id],
                   status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]],
                   start_after: Time.zone.now.utc.beginning_of_day,
                   quantity_per_type: 1_000,


### PR DESCRIPTION
### Trello card

https://trello.com/c/jHOXJGrE/2703-clean-up-use-of-constants-file

### Context

There are lots of places where the same text is repeated through the codebase, especailly the event type names. We can remove some of this duplication by creating a model with some useful methods that allow:

* the lookup of an event type given the name/id
* retrieval of ids using a method
* instantiation with an event and the ability to interrogate it

### Changes proposed in this pull request

- Add first draft of EventType model
- Switch over to using the new EventType model

### Guidance to review

Is this a good idea? Or is it just moving the pain upstream? 🙈
