### PR TITLE
Ensure @front_matter is always declared

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   before_action :set_api_client_request_id
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
+  before_action :declare_frontmatter
 
   after_action :post_processing
 
@@ -28,6 +29,12 @@ protected
   end
 
 private
+
+  def declare_frontmatter
+    # Not all pages have frontmatter, but ensuring it
+    # is declared everywhere simplifies its use throughout.
+    @front_matter ||= {}
+  end
 
   def post_processing
     process_images

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -22,11 +22,11 @@
   <%= search_structured_data if current_page?(root_path) %>
   <%= how_to_structured_data(@page) if @page.present? && @front_matter.key?("how_to") %>
 
-  <% if @front_matter&.dig("noindex") %>
+  <% if @front_matter["noindex"] %>
     <%= meta_tag(key: "robots", value: "noindex") %>
   <% end %>
 
-  <% if @front_matter && @front_matter['description'] %>
+  <% if @front_matter['description'] %>
     <%= meta_tag(key: 'description', value: @front_matter['description']) %>
     <%= meta_tag(key: 'description', value: @front_matter['description'], opengraph: true) %>
   <% end %>
@@ -38,7 +38,7 @@
   <%= meta_tag(key: "facebook-domain-verification", value: "h1r6sd9bvqql7fyzy5jmdoniuw1rtf") %>
   <%= image_meta_tags(
     base_url: request.base_url,
-    image_path: @front_matter&.dig("image"),
+    image_path: @front_matter["image"],
     alt: "Photograph of teaching taking place in a classroom"
   ) %>
 </head>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -98,6 +98,7 @@ module Rack
 
     html = ApplicationController.render(
       template: "errors/too_many_requests",
+      assigns: { front_matter: {} },
     )
 
     [429, { "Content-Type" => "text/html" }, [html]]


### PR DESCRIPTION
### Trello card

[Trello-2702](https://trello.com/c/Xw9I0rwi/2702-declare-frontmatter-everywhere)

### Context

Most but not all pages have associated frontmatter; to avoid `nil` checks we can ensure a `@front_matter` hash is declared in a `before_action` for all use cases.

### Changes proposed in this pull request

- Ensure @front_matter is always declared

### Guidance to review

