### PR TITLE
Teaching event item display tweaks

### DIFF
--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -61,12 +61,20 @@ module TeachingEvents
       end
     end
 
+    def allow_registration?
+      open? && type_id.in?([qt_event_type_id, ttt_event_type_id])
+    end
+
     def show_provider_information?
       !type_id.in?([qt_event_type_id, ttt_event_type_id])
     end
 
     def show_venue_information?
       !@event.is_virtual && @event.building.present?
+    end
+
+    def open?
+      (start_at >= Time.zone.now && status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"])
     end
 
   private

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -26,6 +26,7 @@ module TeachingEvents
       :start_at,
       :type_id,
       :status_id,
+      :video_url,
       to: :event,
     )
 

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -25,6 +25,7 @@ module TeachingEvents
       :scribble_id,
       :start_at,
       :type_id,
+      :status_id,
       to: :event,
     )
 

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -53,7 +53,20 @@ module TeachingEvents
       when "Train to Teach event", "Question Time"
         "So useful! I got answers to questions I didn't know I had yet and I'm so inspired and excited."
 
-      # FIXME: the alternatives quotes might be added later
+      when "Online event"
+        nil
+      when "School or University event"
+        nil
+      end
+    end
+
+    def image
+      case event_type
+      when "Train to Teach event", "Question Time"
+        [
+          "media/images/content/event-signup/birmingham-event-1.jpg",
+          { alt: "A bustling Train to Teach event taking place in a church, busy with stalls and visitors" },
+        ]
       when "Online event"
         nil
       when "School or University event"

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -12,7 +12,7 @@ module TeachingEvents
       :end_at,
       :is_in_person,
       :is_online,
-      :is_online,
+      :is_virtual,
       :message,
       :name,
       :provider_contact_email,

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -64,6 +64,10 @@ module TeachingEvents
       !type_id.in?([qt_event_type_id, ttt_event_type_id])
     end
 
+    def show_venue_information?
+      !@event.is_virtual && @event.building.present?
+    end
+
   private
 
     def ttt_event_type_id

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -11,9 +11,7 @@
       <%= render(partial: 'teaching_events/show/register-button') if is_a_train_to_teach_event?(@event) %>
     </div>
 
-    <div class="image">
-      <%= image_pack_tag("media/images/content/hero-images/0017.jpg", alt: "A photograph of the venue", class: "event-info__venue_img") %>
-    </div>
+    <%= render(partial: 'teaching_events/show/event-image') %>
 
     <div class="triangle yellow">
       <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -27,7 +27,7 @@
       <%= render(partial: "teaching_events/show/event-summary") %>
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
       <%= render(partial: "teaching_events/show/scribble") if @event.scribble_id.present? %>
-      <%= render(partial: "teaching_events/show/how-to-attend") if is_a_train_to_teach_event?(@event) %>
+      <%= render(partial: "teaching_events/show/how-to-attend") if @event.allow_registration? %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
     </article>
 

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -32,7 +32,7 @@
     </article>
 
     <aside>
-      <%= render(partial: "teaching_events/show/venue-information") if @event.building.present? %>
+      <%= render(partial: "teaching_events/show/venue-information") if @event.show_venue_information? %>
     </aside>
   </div>
 

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -8,16 +8,11 @@
     <div class="event-details">
       <%= render(partial: 'teaching_events/show/date-and-time') %>
       <%= render(partial: 'teaching_events/show/location-and-setting') %>
-      <%= render(partial: 'teaching_events/show/register-button') if is_a_train_to_teach_event?(@event) %>
+      <%= render(partial: 'teaching_events/show/register-button') if @event.allow_registration? %>
     </div>
 
     <%= render(partial: 'teaching_events/show/event-image') %>
-
-    <div class="triangle yellow">
-      <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">
-        <polygon points="0,100 0,0 100,0" />
-      </svg>
-    </div>
+    <%= render(partial: 'teaching_events/show/triangle') %>
   </header>
 
   <div class="container teaching-event__info">

--- a/app/views/teaching_events/show/_event-image.html.erb
+++ b/app/views/teaching_events/show/_event-image.html.erb
@@ -1,0 +1,3 @@
+<div class="image">
+  <%= image_pack_tag("media/images/content/event-signup/birmingham-event-1.jpg", alt: "A bustling Train to Teach event in action") %>
+</div>

--- a/app/views/teaching_events/show/_event-image.html.erb
+++ b/app/views/teaching_events/show/_event-image.html.erb
@@ -1,7 +1,8 @@
 <% image_args = @event.image %>
 
-<% if image_args %>
-  <div class="image">
+<%# keep an empty image div here when there's no image args to keep grid positions %>
+<div class="image">
+  <% if image_args %>
     <%= image_pack_tag(*image_args) %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/teaching_events/show/_event-image.html.erb
+++ b/app/views/teaching_events/show/_event-image.html.erb
@@ -1,3 +1,7 @@
-<div class="image">
-  <%= image_pack_tag("media/images/content/event-signup/birmingham-event-1.jpg", alt: "A bustling Train to Teach event in action") %>
-</div>
+<% image_args = @event.image %>
+
+<% if image_args %>
+  <div class="image">
+    <%= image_pack_tag(*image_args) %>
+  </div>
+<% end %>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -7,3 +7,9 @@
 <% end %>
 
 <%= tag.div(safe_html_format(@event.description)) %>
+
+<% if @event.video_url %>
+  <div class="teaching-event__video youtube-video-container">
+    <%= tag.iframe(src: embed_event_video_url(@event.video_url), frameborder: "0", allowfullscreen: true, title: "Train to Teach Events: Take your next step towards teaching") %>
+  </div>
+<% end %>

--- a/app/views/teaching_events/show/_how-to-attend.html.erb
+++ b/app/views/teaching_events/show/_how-to-attend.html.erb
@@ -8,5 +8,5 @@
     to make the most of your experience at the event.
   </p>
 
-  <%= render(partial: 'teaching_events/show/register-button') if is_a_train_to_teach_event?(@event) %>
+  <%= render(partial: 'teaching_events/show/register-button') %>
 </section>

--- a/app/views/teaching_events/show/_provider-info.html.erb
+++ b/app/views/teaching_events/show/_provider-info.html.erb
@@ -5,7 +5,7 @@
     @event.provider_contact_email,
   ].any?
 %>
-  <section class="teaching-event__provider-info">
+  <section class="teaching-event__provider-information">
     <h2>Provider information</h2>
 
     <% if @event.provider_website_url %>

--- a/app/views/teaching_events/show/_triangle.html.erb
+++ b/app/views/teaching_events/show/_triangle.html.erb
@@ -1,0 +1,5 @@
+<div class="triangle yellow">
+  <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">
+    <polygon points="0,100 0,0 100,0" />
+  </svg>
+</div>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -394,7 +394,7 @@ $slightly-darker-grey: darken($grey, 10%);
     grid-template-rows: repeat(3, auto) 1em;
 
     @include mq($from: tablet) {
-      grid-template-rows: minmax(2rem, auto) 2rem minmax(2rem, auto) 2rem;
+      grid-template-rows: minmax(2rem, auto) 5rem minmax(2rem, auto) 2rem;
       grid-template-columns: minmax(5rem, auto) minmax(auto, 50rem) 10rem minmax(auto, 20rem) minmax(5rem, auto);
 
       .breadcrumbs-and-heading {
@@ -486,16 +486,24 @@ $slightly-darker-grey: darken($grey, 10%);
 
     .image {
       padding-bottom: 1rem;
+      img {
+        width: 100%;
+      }
 
       @include mq($from: tablet) {
         img {
-          max-width: 14em;
+          margin: 1em;
+          max-height: 14em;
+          object-position: center;
         }
         padding-bottom: 0;
       }
     }
 
     .triangle {
+      // slight hack, but helps ensure there's no gap between
+      // the triangle and the block above
+      margin-top: -2px;
       background-color: white;
 
       &.yellow {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -594,6 +594,10 @@ $slightly-darker-grey: darken($grey, 10%);
       @include font-size(medium);
     }
   }
+
+  &__video {
+    margin-block: 2em;
+  }
 }
 
 .teaching-events__about-ttt-banner {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -580,6 +580,12 @@ $slightly-darker-grey: darken($grey, 10%);
   &__how-to-attend {
     margin-top: 2em;
   }
+
+  &__provider-information {
+    h2 {
+      @include font-size(medium);
+    }
+  }
 }
 
 .teaching-events__about-ttt-banner {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -395,7 +395,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
     @include mq($from: tablet) {
       grid-template-rows: minmax(2rem, auto) 5rem minmax(2rem, auto) 2rem;
-      grid-template-columns: minmax(5rem, auto) minmax(auto, 50rem) 10rem minmax(auto, 20rem) minmax(5rem, auto);
+      grid-template-columns: minmax(5rem, auto) minmax(auto, 40rem) 14rem minmax(auto, 20rem) minmax(5rem, auto);
 
       .breadcrumbs-and-heading {
         grid-area: 1 / 2 / 3 / 4;

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"] }
     end
 
+    trait :past do
+      start_at { 2.weeks.ago }
+    end
+
     trait :with_provider_info do
       provider_website_url { "https://event-provider.com" }
       provider_target_audience { "Anyone interested in teaching from Sept 2021" }

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     before { visit teaching_event_path(event.readable_id) }
 
     specify "the provider info is included on the page" do
-      within(".teaching-event__provider-info") do
+      within(".teaching-event__provider-information") do
         expect(page).to have_css("h2", text: "Provider information")
 
         expect(page).to have_content("Event website")

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -45,6 +45,8 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).to have_css("h2", text: "Event information")
       expect(page).to have_css("h2", text: "Provider information")
 
+      expect(page).not_to have_link("Register for this event")
+
       if expect_venue
         expect(page).to have_css("h2", text: "Venue information")
       else

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     end
   end
 
-  shared_examples "regular teaching event" do
+  shared_examples "regular teaching event" do |expect_venue|
     scenario "the page has the right contents" do
       visit teaching_event_path(event.readable_id)
 
@@ -44,6 +44,12 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expect(page).to have_css("h2", text: "Event information")
       expect(page).to have_css("h2", text: "Provider information")
+
+      if expect_venue
+        expect(page).to have_css("h2", text: "Venue information")
+      else
+        expect(page).not_to have_css("h2", text: "Venue information")
+      end
     end
   end
 
@@ -62,13 +68,13 @@ RSpec.feature "Searching for teaching events", type: :feature do
   describe "viewing a online event" do
     let(:event) { build(:event_api, :online_event, :with_provider_info) }
 
-    include_examples "regular teaching event"
+    include_examples "regular teaching event", false
   end
 
   describe "viewing a school or university event" do
     let(:event) { build(:event_api, :school_or_university_event, :with_provider_info) }
 
-    include_examples "regular teaching event"
+    include_examples "regular teaching event", true
   end
 
   describe "provider information" do

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -129,5 +129,55 @@ describe TeachingEvents::EventPresenter do
         it { is_expected.to be true }
       end
     end
+
+    describe "#open?" do
+      subject { described_class.new(event).open? }
+
+      context "when the event's status is open and it's in the future" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the event's status is open and it's in the past" do
+        let(:event) { build(:event_api, :past) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the event's status is closed and it's in the future" do
+        let(:event) { build(:event_api, :closed) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe "#allow_registration?" do
+      subject { described_class.new(event).allow_registration? }
+
+      context "when event is a future Train to Teach event" do
+        let(:event) { build(:event_api, :train_to_teach_event) }
+
+        specify { expect(subject).to be true }
+      end
+
+      context "when event is a future Question Time event" do
+        let(:event) { build(:event_api, :question_time_event) }
+
+        specify { expect(subject).to be true }
+      end
+
+      context "when event is a past Train to Teach event" do
+        let(:event) { build(:event_api, :past, :question_time_event) }
+
+        specify { expect(subject).to be false }
+      end
+
+      context "when event is a future non-Train to Teach event" do
+        let(:event) { build(:event_api, :school_or_university_event) }
+
+        specify { expect(subject).to be false }
+      end
+    end
   end
 end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -25,6 +25,7 @@ describe TeachingEvents::EventPresenter do
       scribble_id
       start_at
       type_id
+      status_id
     ].each { |attribute| it { is_expected.to delegate_method(attribute).to(:event) } }
   end
 

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -12,7 +12,7 @@ describe TeachingEvents::EventPresenter do
       end_at
       is_in_person
       is_online
-      is_online
+      is_virtual
       message
       name
       provider_website_url

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -100,5 +100,33 @@ describe TeachingEvents::EventPresenter do
         specify { expect(subject).to be true }
       end
     end
+
+    describe "#show_venue_information?" do
+      subject { described_class.new(event).show_venue_information? }
+
+      context "when the event is virtual and has no building" do
+        let(:event) { build(:event_api, :virtual, :no_location) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the event is virtual and has a building" do
+        let(:event) { build(:event_api, :virtual) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the event not virtual and has no building" do
+        let(:event) { build(:event_api, :online, :no_location) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the event not virtual and has a building" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -74,6 +74,36 @@ describe TeachingEvents::EventPresenter do
       end
     end
 
+    describe "#image" do
+      subject { described_class.new(event).image }
+
+      context "when event is a Train to Teach event" do
+        let(:event) { build(:event_api, :train_to_teach_event) }
+
+        specify { expect(subject.first).to end_with(".jpg") }
+        specify { expect(subject.second).to have_key(:alt) }
+      end
+
+      context "when event is a Question Time event" do
+        let(:event) { build(:event_api, :question_time_event) }
+
+        specify { expect(subject.first).to end_with(".jpg") }
+        specify { expect(subject.second).to have_key(:alt) }
+      end
+
+      context "when event is a School or University event" do
+        let(:event) { build(:event_api, :school_or_university_event) }
+
+        specify { expect(subject).to be_nil }
+      end
+
+      context "when event is a Online event" do
+        let(:event) { build(:event_api, :online_event) }
+
+        specify { expect(subject).to be_nil }
+      end
+    end
+
     describe "#show_provider_information?" do
       subject { described_class.new(event).show_provider_information? }
 

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -26,6 +26,7 @@ describe TeachingEvents::EventPresenter do
       start_at
       type_id
       status_id
+      video_url
     ].each { |attribute| it { is_expected.to delegate_method(attribute).to(:event) } }
   end
 


### PR DESCRIPTION
### Context

A few more tweaks to the logic of what's displayed on the teaching event 'show' page

### Changes proposed in this pull request

- Switch duplicated delegation is_online->is_virtual
- Move venue information logic to the presenter
- Add presenter `open?` and `allow_registration methods?`
- Only show an image for TTT events
- Show a video if there's one present

| Video (desktop) | Video (mobile) |
| ------- | --------- |
| ![Screenshot from 2021-12-02 15-04-36](https://user-images.githubusercontent.com/128088/144457587-d4f03fcc-aab5-4ab8-a436-85974056cfef.png) | ![Screenshot from 2021-12-02 15-04-49](https://user-images.githubusercontent.com/128088/144457619-db75cce7-121c-4e95-8c89-0744df2e3ff8.png) |


