### PR TITLE
Disable new GTM container in non-prod environments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,5 @@
 # Add public visible environment variables here for the Developemnt environment
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 PREVIEW_PAGES=1
-GTM_ID=GTM-5ZQLL9K
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
 

--- a/.env.rolling
+++ b/.env.rolling
@@ -2,6 +2,5 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 BAM_ID=1
 SKIP_REQ_LIMITS=true
-GTM_ID=GTM-5ZQLL9K
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   config.x.structured_data.event = true
   config.x.structured_data.how_to = true
 
-  config.x.legacy_tracking_pixels = false
+  config.x.legacy_tracking_pixels = true
 
   config.x.covid_banner = false
 end

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -16,6 +16,4 @@ Rails.application.configure do
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
-
-  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -7,6 +7,4 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
-
-  config.x.legacy_tracking_pixels = false
 end


### PR DESCRIPTION
Disables everywhere ahead of switch to prod (to avoid non-prod traffic going to the prod analytics instance when I flip it in GTM)