### PR TITLE
Remove underline styles for non-link text

### DIFF
--- a/app/views/content/welcome/andrews-story/_header.html.erb
+++ b/app/views/content/welcome/andrews-story/_header.html.erb
@@ -16,7 +16,7 @@
 
     <div class="caption caption-l">
       <div class="blue no-wrap blend">
-        <em>lessons to life</em>.
+        lessons to life.
       </div>
     </div>
 

--- a/app/views/content/welcome/jacks-story/_header.html.erb
+++ b/app/views/content/welcome/jacks-story/_header.html.erb
@@ -16,7 +16,7 @@
 
     <div class="caption caption-l">
       <div class="blue no-wrap blend">
-        <em>lessons to life</em>.
+        lessons to life.
       </div>
     </div>
 

--- a/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
+++ b/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
@@ -39,9 +39,9 @@
       <h2>
         <span class="pink nowrap">
           <% if welcome_guide_subject.present? %>
-            Teaching <span class="underline"><%= welcome_guide_subject %></span>
+            Teaching <%= welcome_guide_subject %>
           <% else %>
-            <span class="underline">Teaching </span>
+            Teaching
           <% end %>
         </span>
 

--- a/app/views/content/welcome/landing/_welcome-to-teaching.html.erb
+++ b/app/views/content/welcome/landing/_welcome-to-teaching.html.erb
@@ -24,7 +24,7 @@
         Welcome to
       </span>
 
-      <span class="purple"><span class="underline">Teaching</span>.</span>
+      <span class="purple">Teaching.</span>
     </h1>
   </div>
 

--- a/app/views/content/welcome/my-journey-into-teaching/_header.html.erb
+++ b/app/views/content/welcome/my-journey-into-teaching/_header.html.erb
@@ -19,7 +19,7 @@
 
     <div class="caption caption-l">
       <div class="yellow no-wrap blend">
-        into <em>teaching</em>.
+        into teaching.
       </div>
     </div>
 

--- a/app/views/content/welcome/my-journey-into-teaching/_three-things-youll-never-hear-me-say.html.erb
+++ b/app/views/content/welcome/my-journey-into-teaching/_three-things-youll-never-hear-me-say.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="caption blend">
         <span class="purple">
-          <em>never</em> hear me say.
+          never hear me say.
         </span>
       </div>
     </h2>

--- a/app/views/content/welcome/yvonnes-story/_header.html.erb
+++ b/app/views/content/welcome/yvonnes-story/_header.html.erb
@@ -16,7 +16,7 @@
 
     <div class="caption caption-l">
       <div class="blue no-wrap blend">
-        <em>lessons to life</em>.
+        lessons to life.
       </div>
     </div>
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -151,8 +151,6 @@
       align-self: center;
       padding: 0 1em;
       @include font-size(medium);
-      text-decoration: underline;
-      text-underline-offset: .2em;
       line-height: 1.3em;
       text-decoration-thickness: .12em;
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -165,12 +165,27 @@ $mobile-cutoff: 800px;
       > span {
         @include font-size("large");
 
+        // user a border bottom to simulate a underline that
+        // looks like the branding. It's not perfect as the line
+        // extends beyond the edges of the text by a few px
+        border-bottom: 3px solid $black;
+
+        // proper underline styles - switch to this when (if) we
+        // start using a standard font. while we're relying on
+        // user-installed default sans fonts we run the risk
+        // of descenders breaking up the line
+        //
+        // text-decoration: underline;
+        // text-underline-offset: .3em;
+        // text-decoration-thickness: .1em;
+
         &:after {
           content: ".";
         }
 
         @include mq($from: tablet) {
           @include font-size("xxlarge");
+          border-bottom: 6px solid $black;
         }
       }
     }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -164,7 +164,6 @@ $mobile-cutoff: 800px;
 
       > span {
         @include font-size("large");
-        border-bottom: 3px solid $black;
 
         &:after {
           content: ".";
@@ -172,7 +171,6 @@ $mobile-cutoff: 800px;
 
         @include mq($from: tablet) {
           @include font-size("xxlarge");
-          border-bottom: 5px solid $black;
         }
       }
     }

--- a/app/webpacker/styles/welcome-guide.scss
+++ b/app/webpacker/styles/welcome-guide.scss
@@ -656,6 +656,11 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
             margin-block: 1em;
           }
 
+          .q,
+          .a {
+            margin: 0;
+          }
+
           .q {
             font-weight: bold;
 
@@ -665,8 +670,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
           }
 
           .a {
-            margin: 0;
-
             figcaption,
             blockquote {
               @include reset;

--- a/app/webpacker/styles/welcome-guide.scss
+++ b/app/webpacker/styles/welcome-guide.scss
@@ -1,10 +1,5 @@
 $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
 
-@mixin underline($thickness: .15em, $padding: .05em) {
-  border-bottom: $thickness solid $black;
-  padding-bottom: $padding;
-}
-
 // here we're using the darken blend mode so when we have multi-line
 // headings the background from one line won't obscure the other. this
 // picks the darkest colour so if we have any headings with light text
@@ -186,10 +181,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
         margin: .4rem 0 0 .4em;
         font-weight: bold;
 
-        .underline {
-          @include underline;
-        }
-
         .caption {
           margin-top: 1rem;
         }
@@ -214,15 +205,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
           align-items: baseline;
 
           @include font-size(xxxlarge);
-
-          .purple {
-            padding-bottom: .5em;
-
-            &.no-wrap {
-              max-height: .8em;
-            }
-          }
-
         }
 
         @include mq($from: desktop) {
@@ -385,10 +367,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
         background-color: $pink;
         padding: 1rem;
         @include multiline-heading;
-      }
-
-      .underline {
-        @include underline($padding: 0, $thickness: .15em);
       }
 
       .text {
@@ -967,13 +945,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
         .blue {
           padding: .4rem .6rem;
           display: inline-block;
-
-          em {
-            font-style: normal;
-            text-decoration: underline;
-            text-decoration-thickness: .15em;
-            text-underline-offset: .15em;
-          }
         }
 
         .yellow {
@@ -1089,13 +1060,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
       @include font-size(xlarge);
       z-index: map-get($z-indices, "top");
       line-height: 1.3;
-
-      em {
-        text-decoration: underline;
-        text-underline-offset: .15em;
-        text-decoration-thickness: .15em;
-        font-style: normal;
-      }
     }
 
     ol {


### PR DESCRIPTION
### Trello card

https://trello.com/c/7zfSKulK/2691-remove-underlines-used-for-brand-styling-purposes

### Context

Underlining non-link text can be confusing for users who expect consistency. The Get Into Teaching brand guidelines, which are used heavily across lots of different media use underlines for headings and to emphasise words.

Unfortunately this doesn't work on the web.

### Changes proposed in this pull request

- Remove underlines from hero and homepage CTAs
- Remove any underlining from the welcome guide
- Fix alignment of Q and A section

### Guidance to review

| Before | After |
| ------- | ------- |
| ![Screenshot from 2021-12-01 15-00-21](https://user-images.githubusercontent.com/128088/144258794-0b9e2756-2d97-4d00-b009-69eca5551251.png) | ![Screenshot from 2021-12-01 14-59-53](https://user-images.githubusercontent.com/128088/144258817-34887e35-6c53-4db5-9b6d-43619fe16d8e.png) |
| ![Screenshot from 2021-12-01 15-00-28](https://user-images.githubusercontent.com/128088/144258880-48e756d7-dfc7-43af-9c96-95260edc2f6b.png) | ![Screenshot from 2021-12-01 15-00-36](https://user-images.githubusercontent.com/128088/144258895-d46d0c75-c8c9-478c-81af-4cfa57eadf08.png) |
| ![Screenshot from 2021-12-01 14-59-05](https://user-images.githubusercontent.com/128088/144258929-5f2fb64e-d6e6-4c2a-b1f9-1cdf8aea4ecb.png) | ![Screenshot from 2021-12-01 14-59-14](https://user-images.githubusercontent.com/128088/144258946-61c1e52c-6b4b-4fb9-ab3b-d07cb6d413a0.png) |
