### PR TITLE
Configure non-prod environments for staging GTM container

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 PREVIEW_PAGES=1
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
-
+GTM_ID=GTM-KF4ZCTS

--- a/.env.preprod
+++ b/.env.preprod
@@ -11,3 +11,4 @@ TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.clouda
 SKIP_REQ_LIMITS=true
 FAIL2BAN=3
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
+GTM_ID=GTM-KF4ZCTS

--- a/.env.rolling
+++ b/.env.rolling
@@ -3,4 +3,4 @@ TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudap
 BAM_ID=1
 SKIP_REQ_LIMITS=true
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
-
+GTM_ID=GTM-KF4ZCTS

--- a/.env.userresearch
+++ b/.env.userresearch
@@ -5,3 +5,4 @@
 GOOGLE_TAG_MANAGER_ID=GTM-TCZDM7V
 HOTJAR_ID=1871524
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-ur.london.cloudapps.digital/"
+GTM_ID=GTM-KF4ZCTS


### PR DESCRIPTION
### Trello card

[Trello-2725](https://trello.com/c/1anQfEzj/2725-setup-a-copy-gtm-container-for-test-environment)

### Context

We have a copy of the production GTM container with tracking pixels paused and setup to point to our staging GA accounts; this enables the container on non-prod environments.

### Changes proposed in this pull request

- Configure non-prod environments for staging GTM container

### Guidance to review

