### PR TITLE
Minor bug fix for external link checker

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -119,7 +119,7 @@ module LinkChecker
     IGNORE_PREFIX = %r{^/welcome}.freeze
 
     def initialize(page, body, adjust_packs_path: [])
-      super
+      super(page, body)
 
       @page = page
       @document = Nokogiri.parse(body)


### PR DESCRIPTION
The call to `super` raises an error due to not having the `adjust_packs_path` attribute.
