### PR TITLE
Enable new GTM container in non-prod environments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,4 @@
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudapps.digital/"
 PREVIEW_PAGES=1
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
-GTM_ID=GTM-KF4ZCTS
+GTM_ID=GTM-WSDJ5TZ

--- a/.env.preprod
+++ b/.env.preprod
@@ -11,4 +11,4 @@ TTA_SERVICE_URL="https://get-teacher-training-adviser-service-test.london.clouda
 SKIP_REQ_LIMITS=true
 FAIL2BAN=3
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
-GTM_ID=GTM-KF4ZCTS
+GTM_ID=GTM-WSDJ5TZ

--- a/.env.rolling
+++ b/.env.rolling
@@ -3,4 +3,4 @@ TTA_SERVICE_URL="https://get-teacher-training-adviser-service-dev.london.cloudap
 BAM_ID=1
 SKIP_REQ_LIMITS=true
 GOOGLE_OPTIMIZE_ID=OPT-K8LFCTM
-GTM_ID=GTM-KF4ZCTS
+GTM_ID=GTM-WSDJ5TZ

--- a/.env.userresearch
+++ b/.env.userresearch
@@ -5,4 +5,4 @@
 GOOGLE_TAG_MANAGER_ID=GTM-TCZDM7V
 HOTJAR_ID=1871524
 TTA_SERVICE_URL="https://get-teacher-training-adviser-service-ur.london.cloudapps.digital/"
-GTM_ID=GTM-KF4ZCTS
+GTM_ID=GTM-WSDJ5TZ

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   config.x.structured_data.event = true
   config.x.structured_data.how_to = true
 
-  config.x.legacy_tracking_pixels = true
+  config.x.legacy_tracking_pixels = false
 
   config.x.covid_banner = false
 end

--- a/config/environments/pagespeed.rb
+++ b/config/environments/pagespeed.rb
@@ -5,6 +5,4 @@ Rails.application.configure do
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
-
-  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -16,6 +16,4 @@ Rails.application.configure do
     "https://get-into-teaching-api-test.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
-
-  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -7,6 +7,4 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
-
-  config.x.legacy_tracking_pixels = true
 end

--- a/config/environments/userresearch.rb
+++ b/config/environments/userresearch.rb
@@ -8,7 +8,5 @@ Rails.application.configure do
   config.x.static_pages.disable_caching = true
   config.x.utm_codes = true
 
-  config.x.legacy_tracking_pixels = true
-
   Rack::Attack.enabled = false
 end


### PR DESCRIPTION
The non-prod environments have their own GTM container now, so we can switch from the legacy tracking method.

Also changes the non-prod GTM ID as I created it in the wrong account 🙄 