### PR TITLE
Clear cookies on all domains when opting-out

### DIFF
--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -81,8 +81,9 @@ export default class CookiePreferences {
 
   clearNonEssentialCookies() {
     Object.keys(Cookies.get()).forEach((key) => {
-      if (!CookiePreferences.functionalCookies.includes(key))
-        Cookies.remove(key);
+      if (!CookiePreferences.functionalCookies.includes(key)) {
+        this.cookieDomains.forEach((domain) => Cookies.remove(key, { domain }));
+      }
     });
   }
 
@@ -101,6 +102,13 @@ export default class CookiePreferences {
     newSettings[category] = boolValue;
 
     this.all = newSettings;
+  }
+
+  get cookieDomains() {
+    const subdomain = window.location.hostname;
+    const parent = subdomain.replace(/(.*?)\./, '');
+
+    return [subdomain, `.${subdomain}`, parent, `.${parent}`];
   }
 
   get allowedCategories() {

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -105,10 +105,10 @@ export default class CookiePreferences {
   }
 
   get cookieDomains() {
-    const subdomain = window.location.hostname;
-    const parent = subdomain.replace(/(.*?)\./, '');
+    const hostname = window.location.hostname;
+    const rootDomain = hostname.replace(/(.*?)\./, '');
 
-    return [subdomain, `.${subdomain}`, parent, `.${parent}`];
+    return [hostname, `.${hostname}`, rootDomain, `.${rootDomain}`];
   }
 
   get allowedCategories() {


### PR DESCRIPTION
### Trello card

[Trello-2721](https://trello.com/c/L49IRIQ1/2721-update-ga-to-drop-on-the-getintoteaching-subdomain-instead-of-educationgovuk)

### Context

Currently our various tracking pixels/analytics drop cookies on a variety of domains:

```
getintoteaching.education.gov.uk
.getintoteaching.education.gov.uk
education.gov.uk
.education.gov.uk
```

Calling `Cookies.get()` will return all accessible cookies from the above domains, however a call to `Cookies.remove()` must specify the correct domain. By default it uses `getintoteaching.education.gov.uk`, which is the default domain it
sets cookies on, however 3rd parties use all of the above. To make this more robust we iterate over all possible domains (the subdomain and parent domain with/without a leading dot) and attempt to remove the different keys (there's no error/penalty if a matching cookie is not found). The cookies API provides no way to obtain the domain of a cookie key, unfortunately.

### Changes proposed in this pull request

- Clear cookies on all domains when opting-out

### Guidance to review

I can't find a way of testing this as we can't mock out the hostname JS thinks we're using.
