### PR TITLE
Retry failed external link checks

### DIFF
--- a/spec/features/external_links_spec.rb
+++ b/spec/features/external_links_spec.rb
@@ -3,24 +3,14 @@ require "rails_helper"
 RSpec.feature "link checks", :onschedule do
   describe "all pages (external)" do
     specify "all linked-to pages exist" do
-      results = LinkChecker::Results.new
-
-      PageLister.content_urls.each do |current_page|
-        visit(current_page)
-        checker = LinkChecker::External.new(current_page, page.body)
-
-        WebMock.enable_net_connect!
-        checker.check_links(results)
-        WebMock.disable_net_connect!
-      end
-
-      failures = results.reject do |_page, response|
-        (200..299).include? response[:status]
-      end
+      # Check external links multiple times
+      failures_per_run = 3.times.collect { check_external_links }
+      # Persistent failures are those that failed on every run
+      persistent_failures = failures_per_run.map(&:keys).reduce(&:intersection)
 
       # comparing to hash instead of checking .empty? so the failures dump
       # the difference in the hashes
-      expect(failures).to eql({})
+      expect(failures_per_run.first.slice(*persistent_failures)).to eql({})
     end
   end
 
@@ -45,6 +35,23 @@ RSpec.feature "link checks", :onschedule do
       # comparing to hash instead of checking .empty? so the failures dump
       # the difference in the hashes
       expect(failures).to eql({})
+    end
+  end
+
+  def check_external_links
+    results = LinkChecker::Results.new
+
+    PageLister.content_urls.shuffle.each do |current_page|
+      visit(current_page)
+      checker = LinkChecker::External.new(current_page, page.body)
+
+      WebMock.enable_net_connect!
+      checker.check_links(results)
+      WebMock.disable_net_connect!
+    end
+
+    results.reject do |_page, response|
+      (200..299).include? response[:status]
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2733](https://trello.com/c/Gda476AL/2733-investigate-internal-link-checker-failures)

### Context

We are seeing flakiness in the external link checker where it reports a broken link and when we check it manually straight after, or perform a re-run, the link check passes. To try and limit the impact of 'blips' with external websites we can retry the external links multiple times. The order is also shuffled which may help weed out flakiness.

### Changes proposed in this pull request

- Retry failed external link checks

### Guidance to review

I thought about putting the retry logic within the `LinkChecker` class, but it would be difficult to work in a delay that way and the natural delay we get in doing it this way (given each run takes several minutes) will hopefully help make it more robust.