### PR TITLE
Add canonical links on teaching events pages

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for(:head) do %>
+  <%= tag.link(rel: "canonical", href: events_url) %>
+<% end %>
+
 <section class="teaching-events">
   <header>
     <h1>Get Into Teaching events</h1>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -1,3 +1,7 @@
+<%= content_for(:head) do %>
+  <%= tag.link(rel: "canonical", href: event_url(@event.readable_id)) %>
+<% end %>
+
 <div class="teaching-event">
   <header class="yellow">
     <div class="breadcrumbs-and-heading">


### PR DESCRIPTION
### Trello card

[Trello-2685](https://trello.com/c/sNHiFAcU/2685-setup-a-b-test-for-events-in-our-test-environment)

### Context

As these pages are going to be tested alongside the current event pages we should have canonical link tags that point back to the originals (which should avoid SEO issues).

### Changes proposed in this pull request

- Add canonical links on teaching events pages

### Guidance to review

