### PR TITLE
Fix Google Optimize redirect experiments

### DIFF
--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -30,6 +30,19 @@ export default class CookiePreferences {
     );
   }
 
+  static get cookieDomains() {
+    const hostname = window.location.hostname;
+    const rootDomain = hostname.replace(/(.*?)\./, '');
+
+    return [hostname, `.${hostname}`, rootDomain, `.${rootDomain}`];
+  }
+
+  static clearCookie(key) {
+    CookiePreferences.cookieDomains.forEach((domain) =>
+      Cookies.remove(key, { domain })
+    );
+  }
+
   readCookie() {
     const cookie = Cookies.get(CookiePreferences.cookieName);
     if (typeof cookie === 'undefined' || !cookie) {
@@ -82,7 +95,7 @@ export default class CookiePreferences {
   clearNonEssentialCookies() {
     Object.keys(Cookies.get()).forEach((key) => {
       if (!CookiePreferences.functionalCookies.includes(key)) {
-        this.cookieDomains.forEach((domain) => Cookies.remove(key, { domain }));
+        CookiePreferences.clearCookie(key);
       }
     });
   }
@@ -102,13 +115,6 @@ export default class CookiePreferences {
     newSettings[category] = boolValue;
 
     this.all = newSettings;
-  }
-
-  get cookieDomains() {
-    const hostname = window.location.hostname;
-    const rootDomain = hostname.replace(/(.*?)\./, '');
-
-    return [hostname, `.${hostname}`, rootDomain, `.${rootDomain}`];
   }
 
   get allowedCategories() {

--- a/app/webpacker/javascript/google_optimize.js
+++ b/app/webpacker/javascript/google_optimize.js
@@ -9,6 +9,8 @@ export default class GoogleOptimize {
   }
 
   init() {
+    this.applyRedirectExperimentFix();
+
     if (this.canExperiment()) {
       this.initGoogleOptimize();
     }
@@ -40,6 +42,17 @@ export default class GoogleOptimize {
       'turbolinks:before-visit',
       this.turbolinksBeforeVisitHandler
     );
+  }
+
+  applyRedirectExperimentFix() {
+    // Google Optimize drops a cookie for 5 seconds that prevents it redirecting
+    // again. This is designed to avoid redirect loops, however it means if a user
+    // navigates to a redirect experiment twice in quick succession they don't get
+    // redirected the second time (and can end up seeing the control instead of the
+    // variant). Manually removing this cookie prevents that happening, but will
+    // leave us vulnerable to redirect loops if we don't set up experiments correctly;
+    // as we run few experiments this seems like the lesser of two evils.
+    CookiePreferences.clearCookie('_gaexp_rc');
   }
 
   initGoogleOptimize() {

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -334,4 +334,26 @@ describe('CookiePreferences', () => {
       });
     });
   });
+
+  describe('clearCookie', () => {
+    it('clears the cookie from all domains', () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new URL('https://getintoteaching.education.gov.uk/'),
+      });
+
+      const spy = jest.spyOn(Cookies, 'remove');
+
+      CookiePreferences.clearCookie('key');
+
+      expect(spy).toHaveBeenCalledWith('key', {
+        domain: 'getintoteaching.education.gov.uk',
+      });
+      expect(spy).toHaveBeenCalledWith('key', {
+        domain: '.getintoteaching.education.gov.uk',
+      });
+      expect(spy).toHaveBeenCalledWith('key', { domain: 'education.gov.uk' });
+      expect(spy).toHaveBeenCalledWith('key', { domain: '.education.gov.uk' });
+    });
+  });
 });

--- a/spec/javascript/google_optimize_spec.js
+++ b/spec/javascript/google_optimize_spec.js
@@ -30,7 +30,7 @@ describe('Google Optimize', () => {
   const mockWindowLocation = () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { reload: jest.fn() },
+      value: { hostname: 'localhost', reload: jest.fn() },
     });
   };
 
@@ -42,11 +42,16 @@ describe('Google Optimize', () => {
     document.dispatchEvent(event);
   };
 
+  const setGoogleOptimizeRedirectLoopCookie = () => {
+    Cookies.set('_gaexp_rc', '1');
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
     clearCookies();
     setupHtml();
     mockWindowLocation();
+    setGoogleOptimizeRedirectLoopCookie();
   });
 
   afterEach(() => {
@@ -61,6 +66,10 @@ describe('Google Optimize', () => {
   describe('when cookies have not yet been accepted', () => {
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
+
+      it('clears the _gaexp_rc cookie', () => {
+        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
+      });
 
       it('blurs the cookie acceptance background to obscure the content', () => {
         expect(
@@ -91,6 +100,10 @@ describe('Google Optimize', () => {
 
     describe('when not on an experiment path', () => {
       beforeEach(() => run('/no-experiment'));
+
+      it('clears the _gaexp_rc cookie', () => {
+        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
+      });
 
       it('does not blur the cookie acceptance background', () => {
         expect(
@@ -132,6 +145,10 @@ describe('Google Optimize', () => {
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
 
+      it('clears the _gaexp_rc cookie', () => {
+        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
+      });
+
       it('does not blur the cookie acceptance background', () => {
         expect(
           document.querySelector('.cookie-acceptance .dialog__background')
@@ -160,6 +177,10 @@ describe('Google Optimize', () => {
 
     describe('when not on an experiment path', () => {
       beforeEach(() => run('/no-experiment'));
+
+      it('clears the _gaexp_rc cookie', () => {
+        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
+      });
 
       it('does not append the Google Optimize script to the head', () => {
         expect(
@@ -202,6 +223,10 @@ describe('Google Optimize', () => {
 
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
+
+      it('clears the _gaexp_rc cookie', () => {
+        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
+      });
 
       it('does not blur the cookie acceptance background', () => {
         expect(


### PR DESCRIPTION
### Trello card

[Trello-2685](https://trello.com/c/sNHiFAcU/2685-setup-a-b-test-for-events-in-our-test-environment)

### Context

Google Optimize will drop a cookie for 5 seconds after performing a redirect; if that cookie is present it will not perform another redirect. The idea is that this prevents redirect loops happening if you incorrectly configure an experiment. The issue with it is that it means a user can be redirected to a variant, then click the link again and end up seeing the control if they do it quickly.

It doesn't feel great manually clearing this, but we're unlikely to be running lots of experiments (which is where a redirect loop becomes likely) and this ensures that users always see the correct variant every time.

### Changes proposed in this pull request

- Fix Google Optimize redirect experiments

### Guidance to review

Also adds test coverage to the cookie clearance logic added in an earlier PR.