### PR TITLE
Fix accessibility issues with autocomplete input

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -7,7 +7,7 @@
     </li>
 
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search], data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }) do %>
-      <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden]) %>
+      <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden], data: { "searchbox-target": "label" }) %>
       <%= tag.div(data: { "searchbox-target" => "searchbar" }) %>
       <span class="fas fa-search"></span>
     <% end %>

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -4,13 +4,14 @@ import Redacter from '../javascript/redacter';
 
 export default class extends Controller {
   static openedClass = 'searchbox--opened';
-  static targets = ['searchbar'];
+  static targets = ['searchbar', 'label'];
   static values = { searchInputId: String };
 
   searchQuery = null;
 
   connect() {
     this.setupAccessibleAutocomplete();
+    this.fixLabelAccessibility();
 
     this.mobileMenuHandler = this.hide.bind(this);
     document.addEventListener('navigation:menu', this.mobileMenuHandler);
@@ -79,6 +80,16 @@ export default class extends Controller {
         suggestion: this.formatResults.bind(this),
       },
     });
+  }
+
+  fixLabelAccessibility() {
+    // We see a warning on Silktide that the input has no label.
+    // To fix this we're going to try adding an aria-label to the
+    // auto-complete input and also co-locate the label next to the
+    // input. One or both of these may not be necessary, but we won't
+    // know until the next Silktide report.
+    this.input.ariaLabel = this.labelTarget.textContent;
+    this.input.parentNode.insertBefore(this.labelTarget, this.input);
   }
 
   searchParams(query) {
@@ -177,5 +188,9 @@ export default class extends Controller {
     const showingSearchEvent = new CustomEvent('navigation:search');
 
     document.dispatchEvent(showingSearchEvent);
+  }
+
+  get input() {
+    return this.searchbarTarget.querySelector('input');
   }
 }

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -8,6 +8,7 @@ describe('SearchboxController', () => {
         Toggle
       </a>
 
+      <label for="searchbox__input" data-searchbox-target="label">Search</label>
       <div data-searchbox-target="searchbar">
       </div>
     </div>
@@ -23,6 +24,17 @@ describe('SearchboxController', () => {
       const autocompletes = document.querySelectorAll('.autocomplete__wrapper');
 
       expect(autocompletes.length).toBe(1);
+    });
+
+    it('adds an aria-label attribute to the input', () => {
+      const input = document.querySelector('input');
+      expect(input.ariaLabel).toEqual('Search');
+    });
+
+    it('co-locates the label with the autocomplete input', () => {
+      const label = document.querySelector('label');
+      const input = document.querySelector('input');
+      expect(label.nextSibling).toEqual(input);
     });
   });
 


### PR DESCRIPTION
### Trello card

[Trello-2506](https://trello.com/c/Wtt0YC5h/2506-take-a-closer-look-at-search-accessibility)

### Context

We see a warning on Silktide that the input has no label. To fix this we're going to try adding an aria-label to the
auto-complete input and also co-locate the label next to the input. One or both of these may not be necessary, but we
won't know until the next Silktide report.

### Changes proposed in this pull request

- Fix accessibility issues with autocomplete input

### Guidance to review

<img width="820" alt="Screenshot 2021-12-08 at 14 46 01" src="https://user-images.githubusercontent.com/29867726/145228426-16b253d7-a80e-42d0-9905-9558858b977b.png">
