### PR TITLE
Add autocomplete attribute to text input fields

### DIFF
--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -21,7 +21,7 @@
 
               <%= tag.div(class: input_field_classes(:postcode), data: { "conditional-field-target": "showhide" }) do %>
                 <%= f.label :postcode, "Postcode" %>
-                <%= f.text_field :postcode %>
+                <%= f.text_field :postcode, autocomplete: "postal-code" %>
               <% end %>
 
               <%= tag.div(class: input_field_classes(:month)) do %>

--- a/app/views/callbacks/steps/_personal_details.html.erb
+++ b/app/views/callbacks/steps/_personal_details.html.erb
@@ -6,6 +6,6 @@
 
 <p>This is a free service.</p>
 
-<%= f.govuk_text_field :first_name %>
-<%= f.govuk_text_field :last_name %>
-<%= f.govuk_email_field :email %>
+<%= f.govuk_text_field :first_name, autocomplete: "given-name" %>
+<%= f.govuk_text_field :last_name, autocomplete: "family-name" %>
+<%= f.govuk_email_field :email, autocomplete: "email" %>

--- a/app/views/event_steps/_contact_details.html.erb
+++ b/app/views/event_steps/_contact_details.html.erb
@@ -1,1 +1,1 @@
-<%= f.govuk_text_field :address_telephone, label: { tag: 'h1', size: 'm' }, width: 20 %>
+<%= f.govuk_text_field :address_telephone, autocomplete: "tel", label: { tag: 'h1', size: 'm' }, width: 20 %>

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_text_field :first_name %>
-<%= f.govuk_text_field :last_name %>
-<%= f.govuk_email_field :email %>
+<%= f.govuk_text_field :first_name, autocomplete: "given-name" %>
+<%= f.govuk_text_field :last_name, autocomplete: "family-name" %>
+<%= f.govuk_email_field :email, autocomplete: "email" %>
 <%= f.hidden_field :is_walk_in, value: f.object.is_walk_in? %>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -12,7 +12,7 @@
       :value,
       options: { prompt: true } %>
 
-<%= f.govuk_text_field :address_postcode unless f.object.hide_postcode_field? %>
+<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code" unless f.object.hide_postcode_field? %>
 
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
     f.object.teaching_subject_options,

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -13,7 +13,7 @@
 
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :first_name, width: 'two-thirds' %>
-<%= f.govuk_text_field :last_name, width: 'two-thirds' %>
-<%= f.govuk_email_field :email, width: 'two-thirds' %>
+<%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
+<%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
+<%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>
 <%= f.hidden_field :channel_id, value: params[:channel] %>

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :address_postcode, label: { tag: 'h1', size: "xl", text: t('helpers.label.mailing_list_steps_postcode.address_postcode') } do %>
+<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { tag: 'h1', size: "xl", text: t('helpers.label.mailing_list_steps_postcode.address_postcode') } do %>
 
 <p>
   Stay up to date about events in your area.

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -3,6 +3,7 @@
 <%= govuk_form_for Search.new, url: search_path, method: :get do |f| %>
   <%= f.govuk_text_field :search,
         width: "two-thirds",
+        autocomplete: "on",
         label: { text: "Enter your search term" },
         placeholder: "Enter your search term" %>
 

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -2,7 +2,7 @@
   <h2>Filters</h2>
 
   <div class="teaching-events__filter--group">
-    <%= f.govuk_text_field(:postcode, label: { text: "Postcode" }, form_group: { classes: 'reduce-bottom-margin' }) %>
+    <%= f.govuk_text_field(:postcode, autocomplete: "postal-code", label: { text: "Postcode" }, form_group: { classes: 'reduce-bottom-margin' }) %>
   </div>
 
   <div class="teaching-events__filter--group">

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -5,5 +5,6 @@
 %>
 
 <%= f.govuk_text_field :timed_one_time_password,
+autocomplete: "off",
 label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', email: email) },
 hint: { text: safe_html_format(hint_text) } %>


### PR DESCRIPTION
### Trello card

[Trello-2751](https://trello.com/c/e1rgnH7J/2751-accessibility-issue-identify-the-purpose-of-fields-programmatically)

### Context

Silktide has thrown up a warning around our text input fields not being accessible due to lacking `autocomplete` attributes. Chrome does a decent job in my experience of inferring it from the input names, but it doesn't hurt to be explicit.

Add `autocomplete` attributes to all text input fields. Disable autocomplete for the verification code field and use `on` when a specific value doesn't make sense (i.e. for the search input).

### Changes proposed in this pull request

- Add autocomplete attribute to text input fields

### Guidance to review

