### PR TITLE
Track cookie opt-in success rate

### DIFF
--- a/app/controllers/client_metrics_controller.rb
+++ b/app/controllers/client_metrics_controller.rb
@@ -1,0 +1,11 @@
+class ClientMetricsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    metric_json = JSON.parse(request.body.read)
+
+    ActiveSupport::Notifications.instrument("app.client_metric", metric_json)
+
+    head :ok
+  end
+end

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -29,16 +29,18 @@ export default class extends Controller {
   save(event) {
     event.preventDefault();
 
-    for (const categoryFieldset of this.categoryTargets) {
-      const category = categoryFieldset.getAttribute('data-category');
-      const field = categoryFieldset.querySelector(
-        'input[type="radio"]:checked'
-      );
+    const categories = this.categoryTargets.reduce((acc, fieldset) => {
+      const category = fieldset.getAttribute('data-category');
+      const field = fieldset.querySelector('input[type="radio"]:checked');
 
       if (field) {
-        this.cookiePreferences.setCategory(category, field.value);
+        return { ...acc, [category]: field.value };
+      } else {
+        return acc;
       }
-    }
+    }, {});
+
+    this.cookiePreferences.setCategories(categories);
 
     this.data.set('save-state', 'saving');
     window.setTimeout(this.finishSave.bind(this), 600);

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -100,25 +100,30 @@ export default class CookiePreferences {
     });
   }
 
-  setCategory(category, value) {
-    const strValue = value.toString();
-    const boolValue =
-      strValue === '1' || strValue === 'true' || strValue === 'yes';
+  setCategories(categories) {
+    for (const [key, value] of Object.entries(categories)) {
+      categories[key] = this.boolValue(value);
+    }
 
-    const newSettings = Object.assign({}, this.settings);
-    const optingOut = newSettings[category] === true && !boolValue;
+    const newSettings = { ...this.settings, ...categories };
+    const optingOut = Object.keys(categories).some((category) => {
+      return !categories[category] && this.settings[category];
+    });
 
     if (optingOut) {
       this.clearNonEssentialCookies();
     }
-
-    newSettings[category] = boolValue;
 
     this.all = newSettings;
   }
 
   get allowedCategories() {
     return this.categories.filter((category) => this.allowed(category));
+  }
+
+  boolValue(value) {
+    const strValue = value.toString();
+    return strValue === '1' || strValue === 'true' || strValue === 'yes';
   }
 
   emitEvent(newCategories) {

--- a/app/webpacker/javascript/cookie_preferences.js
+++ b/app/webpacker/javascript/cookie_preferences.js
@@ -90,6 +90,7 @@ export default class CookiePreferences {
     );
 
     this.emitEvent(newlyAllowed);
+    this.sendMetric();
   }
 
   clearNonEssentialCookies() {
@@ -124,6 +125,21 @@ export default class CookiePreferences {
   boolValue(value) {
     const strValue = value.toString();
     return strValue === '1' || strValue === 'true' || strValue === 'yes';
+  }
+
+  sendMetric() {
+    const xhr = new XMLHttpRequest();
+    const data = JSON.stringify({
+      key: 'app_client_cookie_consent_total',
+      labels: {
+        non_functional: this.allowed('non-functional'),
+        marketing: this.allowed('marketing'),
+      },
+    });
+
+    xhr.open('POST', '/client_metrics', true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send(data);
   }
 
   emitEvent(newCategories) {

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,6 +15,11 @@ module Rack
       req.ip if req.path == "/csp_reports"
     end
 
+    # Throttle /client_metrics requests by IP (5rpm)
+    throttle("client_metrics req/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if req.path == "/client_metrics"
+    end
+
     unless ENV["SKIP_REQ_LIMITS"].to_s.in? %w[true yes 1]
       # Throttle requests that issue a verification code by IP (5rpm)
       throttle("issue_verification_code req/ip", limit: 5, period: 1.minute) do |req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
   get "/cookie-policy", to: redirect("/cookies")
 
   resource :csp_reports, only: %i[create]
+  resource :client_metrics, only: %i[create]
 
   resources :blog, controller: "blog", only: %i[index show] do
     collection do

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -79,5 +79,12 @@ module Prometheus
       labels: %i[strategy path] + preset_labels.keys,
       preset_labels: preset_labels,
     )
+
+    prometheus.counter(
+      :app_client_cookie_consent_total,
+      docstring: "A counter of cookie consent",
+      labels: %i[non_functional marketing] + preset_labels.keys,
+      preset_labels: preset_labels,
+    )
   end
 end

--- a/spec/javascript/cookie_preferences_spec.js
+++ b/spec/javascript/cookie_preferences_spec.js
@@ -77,6 +77,30 @@ describe('CookiePreferences', () => {
       });
     });
 
+    describe('#setCategories', () => {
+      it('casts values to boolean', () => {
+        prefs.setCategories({
+          marketing: 'yes',
+          test: 1,
+          other: 'true',
+        });
+
+        expect(prefs.allowed('marketing')).toBe(true);
+        expect(prefs.allowed('test')).toBe(true);
+        expect(prefs.allowed('other')).toBe(true);
+
+        prefs.setCategories({
+          marketing: 'no',
+          test: 0,
+          other: 'false',
+        });
+
+        expect(prefs.allowed('marketing')).toBe(false);
+        expect(prefs.allowed('test')).toBe(false);
+        expect(prefs.allowed('other')).toBe(false);
+      });
+    });
+
     describe('assigning #all', () => {
       beforeEach(() => {
         prefs.all = { required: false, features: true };
@@ -112,7 +136,7 @@ describe('CookiePreferences', () => {
 
     describe('assigning existing category', () => {
       beforeEach(() => {
-        prefs.setCategory('marketing', true);
+        prefs.setCategories({ marketing: true });
       });
 
       it('updates allowed value', () => {
@@ -150,7 +174,7 @@ describe('CookiePreferences', () => {
 
     describe('assigning functional to false', () => {
       beforeEach(() => {
-        prefs.setCategory('functional', false);
+        prefs.setCategories({ functional: false });
       });
 
       it('leaves the value as true', () => {
@@ -168,7 +192,7 @@ describe('CookiePreferences', () => {
 
     describe('assigning new category', () => {
       beforeEach(() => {
-        prefs.setCategory('features', true);
+        prefs.setCategories({ features: true });
       });
 
       it('updates allowed value', () => {
@@ -282,7 +306,7 @@ describe('CookiePreferences', () => {
 
     describe('assigning new category', () => {
       beforeEach(() => {
-        prefs.setCategory('functional', true);
+        prefs.setCategories({ functional: true });
       });
 
       it('updates allowed value', () => {
@@ -304,7 +328,7 @@ describe('CookiePreferences', () => {
 
     describe('opting out of a category', () => {
       beforeEach(() => {
-        prefs.setCategory('marketing', true);
+        prefs.setCategories({ marketing: true });
       });
 
       it('retains essential cookies and clears non-essential cookies', () => {
@@ -313,7 +337,7 @@ describe('CookiePreferences', () => {
         const essentialCookieKey = CookiePreferences.functionalCookies[2];
         Cookies.set(essentialCookieKey, 'essential');
 
-        prefs.setCategory('marketing', false);
+        prefs.setCategories({ marketing: false });
 
         expect(Cookies.get('non-essential')).toBeUndefined();
         expect(Cookies.get(essentialCookieKey)).toEqual('essential');

--- a/spec/javascript/google_optimize_spec.js
+++ b/spec/javascript/google_optimize_spec.js
@@ -89,10 +89,9 @@ describe('Google Optimize', () => {
 
       describe('when cookies are accepted', () => {
         it('reloads the page', () => {
-          new CookiePreferences().setCategory(
-            GoogleOptimize.cookieCategory,
-            true
-          );
+          new CookiePreferences().setCategories({
+            [GoogleOptimize.cookieCategory]: true,
+          });
           expect(window.location.reload).toHaveBeenCalled();
         });
       });
@@ -127,10 +126,9 @@ describe('Google Optimize', () => {
 
       describe('when cookies are accepted', () => {
         it('does not reload the page', () => {
-          new CookiePreferences().setCategory(
-            GoogleOptimize.cookieCategory,
-            true
-          );
+          new CookiePreferences().setCategories({
+            [GoogleOptimize.cookieCategory]: true,
+          });
           expect(window.location.reload).not.toHaveBeenCalled();
         });
       });
@@ -139,7 +137,7 @@ describe('Google Optimize', () => {
 
   describe('when cookies have already been accepted', () => {
     beforeEach(() => {
-      new CookiePreferences().setCategory('non-functional', true);
+      new CookiePreferences().setCategories({ 'non-functional': true });
     });
 
     describe('when on an experiment path', () => {
@@ -218,7 +216,7 @@ describe('Google Optimize', () => {
 
   describe('when cookies have been accepted but the category was not opted-in to', () => {
     beforeEach(() => {
-      new CookiePreferences().setCategory('marketing', true);
+      new CookiePreferences().setCategories({ marketing: true });
     });
 
     describe('when on an experiment path', () => {

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -83,7 +83,7 @@ describe('Google Tag Manager', () => {
 
     describe('when cookies are accepted', () => {
       it('updates GTM of all cookie preferences', () => {
-        new CookiePreferences().setCategory('marketing', true);
+        new CookiePreferences().setCategories({ marketing: true });
         expect(window.gtag).toHaveBeenCalledWith('consent', 'update', {
           analytics_storage: 'denied',
           ad_storage: 'granted',
@@ -94,7 +94,7 @@ describe('Google Tag Manager', () => {
 
   describe('when cookies have already been accepted', () => {
     beforeEach(() => {
-      new CookiePreferences().setCategory('non-functional', true);
+      new CookiePreferences().setCategories({ 'non-functional': true });
       mockGtag();
       run();
     });

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -93,6 +93,15 @@ describe Prometheus::Metrics do
     it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
+  describe "app_client_cookie_consent_total" do
+    subject { registry.get(:app_client_cookie_consent_total) }
+
+    it { is_expected.not_to be_nil }
+    it { is_expected.to have_attributes(docstring: "A counter of cookie consent") }
+    it { expect { subject.get(labels: %i[non_functional marketing]) }.not_to raise_error }
+    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
+  end
+
   def expected_preset_labels
     {
       app: "app-name",

--- a/spec/requests/client_metrics_spec.rb
+++ b/spec/requests/client_metrics_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Client metrics", type: :request do
+  subject { response }
+
+  let(:params) { { "key" => "app_client_cookie_consent_total", "labels" => { "non_functional" => true, "marketing" => false } } }
+  let(:events) { [] }
+
+  before do
+    record_client_metric_events
+    post client_metrics_path, params: params.to_json
+  end
+
+  it { is_expected.to have_http_status(:success) }
+  it { expect(self).to have_recorded_metric(params) }
+
+  def has_recorded_metric?(metric = nil)
+    events.any? { |event| event.payload == metric }
+  end
+
+private
+
+  def record_client_metric_events
+    ActiveSupport::Notifications.subscribe("app.client_metric") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+end

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -81,4 +81,35 @@ describe "Instrumentation", type: :request do
         }).once
     end
   end
+
+  describe "app.client_metrics" do
+    let(:params) do
+      {
+        key: "app_client_cookie_consent_total",
+        labels: {
+          non_functional: true,
+          marketing: false,
+        },
+      }
+    end
+
+    it "increments the client metric" do
+      metric = registry.get(:app_client_cookie_consent_total)
+      expect(metric).to receive(:increment).with(labels:
+        {
+          non_functional: true,
+          marketing: false,
+        }).once
+      post client_metrics_path, params: params.to_json
+    end
+
+    context "when attempting to increment a non-client app metric" do
+      before { params[:key] = "app_metric" }
+
+      it "raises an error" do
+        expect { post client_metrics_path, params: params.to_json }.to \
+          raise_error(ArgumentError, "attempted to increment non-client metric")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-2640](https://trello.com/c/PMZfAK9g/2640-create-grafana-dashboard-for-cookie-opt-ins-opt-outs)

### Context

We want to be able to track some metrics that trigger from the client-side. As all our metrics go via Prometheus we will need to send the information to Rails from the client in order to track it.

### Changes proposed in this pull request

- Add ability to track client-side metrics

Add `ClientMetricsController` to accept incoming client metric information from Javascript.

Add `app_client_cookie_consent_total` metric as the first client-side metric to track the opt-in success rate.

- Update interface to accept setting multiple categories

We want to be able to emit an event when cookies change; currently we use a `setCategory` method that is called multiple times, so the `CookiePreference` class doesn't know when all the cookies have finished changing. By changing this to `setCategories` we encourage callers to set all cookie categories in one go and can emit an event thereafter.

- Send metric when opt-in status changes

When a user updates their opt-in status we want to increment a metric so that we can track the success rate of opting-in to cookies.

When a user changes their cookie preferences (either manually or via 'allow all') emit a `app_client_cookie_consent_total` metric with the respective labels.

### Guidance to review

In an ideal world we would want to track opt-in rate per user, so that if a user opts-out but subsequently opts-in we have their latest status reflected in the metric. Given we are tracking even if they don't accept cookies we have to make sure its completely anonymous, so the best we can do is track the various opt-in/out events to give a decent indication of what portion of users are allowing the different cookie categories.