### PR TITLE
No index event sign up page

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -7,6 +7,7 @@ class EventStepsController < ApplicationController
   include DFEWizard::Controller
   self.wizard_class = Events::Wizard
 
+  before_action :noindex
   before_action :redirect_closed_events, only: %i[show update]
   before_action :set_step_page_title, only: [:show]
   before_action :set_completed_page_title, only: [:completed]
@@ -20,6 +21,10 @@ protected
   end
 
 private
+
+  def noindex
+    @noindex = true
+  end
 
   def redirect_closed_events
     event_is_closed = @event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -93,8 +93,6 @@ private
       breadcrumb page.title, page.path if @page.title.present?
     end
 
-    response.headers["X-Robots-Tag"] = "noindex" if @page.noindex
-
     render template: @page.template, layout: page_layout
   end
 

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -7,7 +7,7 @@ module Pages
 
     attr_reader :path, :frontmatter
 
-    delegate :title, :image, :noindex, to: :frontmatter
+    delegate :title, :image, to: :frontmatter
 
     class << self
       def find(path)

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -22,7 +22,7 @@
   <%= search_structured_data if current_page?(root_path) %>
   <%= how_to_structured_data(@page) if @page.present? && @front_matter.key?("how_to") %>
 
-  <% if @front_matter["noindex"] %>
+  <% if @front_matter["noindex"] || @noindex %>
     <%= meta_tag(key: "robots", value: "noindex") %>
   <% end %>
 

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -37,6 +37,7 @@ describe EventStepsController, type: :request do
     before { get step_path }
 
     it { is_expected.to have_http_status :success }
+    it { expect(response.body).to include(%(<meta name="robots" content="noindex">)) }
 
     context "when the event is closed" do
       let(:event) { build :event_api, :closed, readable_id: readable_event_id }


### PR DESCRIPTION
### Trello card

[Trello-2763](https://trello.com/c/mz5aAzEr/2763-resolve-google-search-console-coverage-issue-for-apply-pages)

### Context

We don't want users to land directly on this page; instead they should go through the view event page.

Google Search Console also shows a redirect error here, as we redirect back to the event page if the event is closed -- if the event also happens to be in the past we will then return a 404 and I think Google has an issue with redirecting to a 404 page.

### Changes proposed in this pull request

- No index event sign up page

Remove header method of no-indexing a page given that we specify this in the HTML now (this should have been removed already but I must have missed it -- noindex via header doesn't work all the time because of our static page cache).

### Guidance to review

As part of this I looked at the sitemap and I'm wondering if we would benefit from explicitly surfacing our individual event pages in there (as we don't currently)?