### PR TITLE
Update event type references to use EventType model

### DIFF
--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -77,7 +77,7 @@ private
   end
 
   def has_archive?(type)
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES_WITH_ARCHIVE.values.include?(type.id)
+    EventType.has_archive?(type.id)
   end
 
   # filtering is like searching but limited to a single event type. A custom

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,7 +2,7 @@ module EventsHelper
   include TextFormattingHelper
 
   def show_events_teaching_logo(index, type_id)
-    index.zero? && type_id != GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"]
+    index.zero? && type_id != EventType.school_or_university_event_id
   end
 
   def format_event_date(event, stacked: true)

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -22,8 +22,6 @@ module TeachingEventsHelper
   # * Online event               => Online forum
   # * School or University event => Training provider
   def event_type_name(id, overrides: { "DfE Online Q&A" => 222_750_008, "Training provider" => 222_750_009 })
-    GetIntoTeachingApiClient::Constants::EVENT_TYPES
-      .merge(overrides)
-      .invert[id]
+    EventType::ALL.merge(overrides).invert[id]
   end
 end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,4 +1,17 @@
 class EventType
+  ALL =
+    {
+      "Train to Teach event" => 222_750_001,
+      "Question Time" => 222_750_007,
+      "Online event" => 222_750_008,
+      "School or University event" => 222_750_009,
+    }.freeze
+
+  WITH_ARCHIVE =
+    {
+      "Online event" => 222_750_008,
+    }.freeze
+
   attr_accessor :type_id
 
   delegate(
@@ -28,19 +41,27 @@ class EventType
     end
 
     def lookup_by_name(name)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.fetch(name)
+      ALL.fetch(name)
     end
 
     def lookup_by_names(*names)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.fetch_values(*names)
+      ALL.fetch_values(*names)
     end
 
     def lookup_by_id(id)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.fetch(id)
+      ALL.invert.fetch(id)
     end
 
     def lookup_by_ids(*ids)
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert.fetch_values(*ids)
+      ALL.invert.fetch_values(*ids)
+    end
+
+    def has_archive?(id)
+      WITH_ARCHIVE.values.include?(id)
+    end
+
+    def all_ids
+      ALL.values
     end
   end
 

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -35,7 +35,7 @@ module Events
       def available_event_types
         # We can't search for Question Time events explicitly. Instead, they
         # are returned as Train to Teach events.
-        @available_event_types ||= GetIntoTeachingApiClient::Constants::EVENT_TYPES
+        @available_event_types ||= EventType::ALL
           .except("Question Time")
           .map do |key, value|
             GetIntoTeachingApiClient::PickListItem.new(id: value, value: key)

--- a/app/presenters/events/group_presenter.rb
+++ b/app/presenters/events/group_presenter.rb
@@ -46,14 +46,14 @@ module Events
     end
 
     def page_param_name(type_id)
-      category_name = event_types.key(type_id)
+      category_name = EventType.lookup_by_id(type_id)
       "#{category_name.parameterize(separator: '_')}_page"
     end
 
   private
 
     def merge_question_time_events(events_by_type)
-      types = [event_types["Train to Teach event"], event_types["Question Time"]]
+      types = [EventType.train_to_teach_event_id, EventType.question_time_event_id]
 
       combined_events = events_by_type
         .select { |e| types.include?(e.type_id) }
@@ -63,7 +63,7 @@ module Events
       return events_by_type if combined_events.blank?
 
       combined_events_type = GetIntoTeachingApiClient::TeachingEventsByType.new(
-        typeId: event_types["Train to Teach event"],
+        typeId: EventType.train_to_teach_event_id,
         teachingEvents: combined_events,
       )
 
@@ -84,11 +84,7 @@ module Events
     end
 
     def event_type_ids
-      event_types.except("Question Time").values
-    end
-
-    def event_types
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES
+      EventType.all_ids - [EventType.question_time_event_id]
     end
   end
 end

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -46,7 +46,7 @@ module TeachingEvents
     end
 
     def event_type
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES.invert[type_id]
+      EventType.lookup_by_id(type_id)
     end
 
     def quote
@@ -76,11 +76,11 @@ module TeachingEvents
     end
 
     def allow_registration?
-      open? && type_id.in?([qt_event_type_id, ttt_event_type_id])
+      open? && type_id.in?([EventType.question_time_event_id, EventType.train_to_teach_event_id])
     end
 
     def show_provider_information?
-      !type_id.in?([qt_event_type_id, ttt_event_type_id])
+      !type_id.in?([EventType.question_time_event_id, EventType.train_to_teach_event_id])
     end
 
     def show_venue_information?
@@ -89,16 +89,6 @@ module TeachingEvents
 
     def open?
       (start_at >= Time.zone.now && status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"])
-    end
-
-  private
-
-    def ttt_event_type_id
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"]
-    end
-
-    def qt_event_type_id
-      GetIntoTeachingApiClient::Constants::EVENT_TYPES["Question Time"]
     end
   end
 end

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -1,18 +1,5 @@
 module GetIntoTeachingApiClient
   module Constants
-    EVENT_TYPES =
-      {
-        "Train to Teach event" => 222_750_001,
-        "Question Time" => 222_750_007,
-        "Online event" => 222_750_008,
-        "School or University event" => 222_750_009,
-      }.freeze
-
-    EVENT_TYPES_WITH_ARCHIVE =
-      {
-        "Online event" => 222_750_008,
-      }.freeze
-
     # This is not a complete list.
     EVENT_STATUS =
       {

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Internal section", type: :feature do
           name: "Pending provider event",
           readable_id: "Readable_id",
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["School or University event"])
+          type_id: EventType.school_or_university_event_id)
   end
   let(:pending_online_event) do
     build(:event_api,
@@ -17,7 +17,7 @@ RSpec.feature "Internal section", type: :feature do
           name: "Pending online event",
           readable_id: "Readable_id",
           status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
-          type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"])
+          type_id: EventType.online_event_id)
   end
   let(:provider_events_by_type) { group_events_by_type([pending_provider_event]) }
   let(:online_events_by_type) { group_events_by_type([pending_online_event]) }

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -103,7 +103,6 @@ RSpec.feature "Searching for teaching events", type: :feature do
   describe "searching for events" do
     let(:events_by_type) { group_events_by_type(events) }
     let(:fake_api) { instance_double(GetIntoTeachingApiClient::TeachingEventsApi, search_teaching_events_grouped_by_type: []) }
-    let(:event_types) { GetIntoTeachingApiClient::Constants::EVENT_TYPES }
 
     before do
       allow(GetIntoTeachingApiClient::TeachingEventsApi).to receive(:new).and_return(fake_api)
@@ -140,7 +139,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for train to teach events" do
       visit teaching_events_path
 
-      expected_type_ids = event_types.values_at("Train to Teach event", "Question Time")
+      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time")
 
       check "DfE Train to Teach"
       click_on "Update results"
@@ -151,7 +150,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for online forum events" do
       visit teaching_events_path
 
-      expected_type_ids = event_types.values_at("Online event")
+      expected_type_ids = [EventType.online_event_id]
 
       check "DfE Online Q&A"
       click_on "Update results"
@@ -162,7 +161,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for school or university events" do
       visit teaching_events_path
 
-      expected_type_ids = event_types.values_at("School or University event")
+      expected_type_ids = [EventType.school_or_university_event_id]
 
       check "Training provider"
       click_on "Update results"
@@ -173,7 +172,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for online and train to teach events" do
       visit teaching_events_path
 
-      expected_type_ids = event_types.values_at("Train to Teach event", "Question Time", "School or University event")
+      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time", "School or University event")
 
       check "DfE Train to Teach"
       check "Training provider"

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -258,7 +258,7 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#show_see_all_events_button?" do
-    let(:type_id) { GetIntoTeachingApiClient::Constants::EVENT_TYPES["Train to Teach event"] }
+    let(:type_id) { EventType.train_to_teach_event_id }
 
     context "when checking for TTT event type id" do
       it "returns false when events is empty" do

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -101,12 +101,10 @@ describe TeachingEventsHelper, type: "helper" do
   end
 
   describe "#is_a_train_to_teach_event?" do
-    let(:event_types) { GetIntoTeachingApiClient::Constants::EVENT_TYPES }
-
-    let(:ttt_event) { OpenStruct.new(type_id: event_types["Train to Teach event"]) }
-    let(:qt_event) { OpenStruct.new(type_id: event_types["Question Time"]) }
-    let(:online_event) { OpenStruct.new(type_id: event_types["Online event"]) }
-    let(:school_or_university_event) { OpenStruct.new(type_id: event_types["School or University event"]) }
+    let(:ttt_event) { OpenStruct.new(type_id: EventType.train_to_teach_event_id) }
+    let(:qt_event) { OpenStruct.new(type_id: EventType.question_time_event_id) }
+    let(:online_event) { OpenStruct.new(type_id: EventType.online_event_id) }
+    let(:school_or_university_event) { OpenStruct.new(type_id: EventType.school_or_university_event_id) }
 
     specify "returns true when the event is either Train to Teach or Question Time" do
       expect(is_a_train_to_teach_event?(ttt_event)).to be true

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -2,6 +2,24 @@ require "rails_helper"
 
 describe EventType do
   describe "class_methods" do
+    describe ".has_archive" do
+      specify "returns true if the event type has an archive" do
+        expect(described_class).to have_archive(222_750_008)
+      end
+
+      specify "returns false if the event type does not have an archive" do
+        expect(described_class).not_to have_archive(222_750_001)
+        expect(described_class).not_to have_archive(222_750_007)
+        expect(described_class).not_to have_archive(222_750_009)
+      end
+    end
+
+    describe ".all_ids" do
+      subject { described_class.all_ids }
+
+      it { is_expected.to eq([222_750_001, 222_750_007, 222_750_008, 222_750_009]) }
+    end
+
     describe ".school_or_university_event_id" do
       subject { described_class.school_or_university_event_id }
 

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -26,7 +26,7 @@ describe Events::Search do
   describe ".available_event_type_ids" do
     subject { described_class.new.available_event_type_ids }
 
-    it { is_expected.to eql GetIntoTeachingApiClient::Constants::EVENT_TYPES.except("Question Time").values }
+    it { is_expected.to eq(EventType.all_ids - [EventType.question_time_event_id]) }
   end
 
   describe "#future?" do

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -23,8 +23,12 @@ describe Events::GroupPresenter do
       ])
     end
 
-    it "sorts event types according to GetIntoTeachingApiClient::Constants::EVENT_TYPES" do
-      expect(type_ids).to eq(GetIntoTeachingApiClient::Constants::EVENT_TYPES.except("Question Time").values)
+    it "sorts event types" do
+      expect(type_ids).to eq([
+        EventType.train_to_teach_event_id,
+        EventType.online_event_id,
+        EventType.school_or_university_event_id,
+      ])
     end
 
     context "when there are no events for a type" do
@@ -106,7 +110,7 @@ describe Events::GroupPresenter do
     end
 
     it "defaults to 9 events per page" do
-      pages_by_type = GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.product([nil]).to_h
+      pages_by_type = EventType.all_ids.product([nil]).to_h
       paginated_events_by_type = subject.paginated_events_by_type(pages_by_type)
 
       expect(paginated_events_by_type).to include(

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -234,8 +234,7 @@ describe EventsController, type: :request do
           it { expect(response.body).to include("Unfortunately, that event has already happened.") }
         end
 
-        event_types_with_archive = GetIntoTeachingApiClient::Constants::EVENT_TYPES_WITH_ARCHIVE
-        event_types_with_archive.each do |type, id|
+        EventType::WITH_ARCHIVE.each do |type, id|
           context "when the event is a past #{type} type" do
             let(:event) { build(:event_api, type_id: id, start_at: Time.zone.now.utc - 1.day) }
 
@@ -244,7 +243,7 @@ describe EventsController, type: :request do
           end
         end
 
-        GetIntoTeachingApiClient::Constants::EVENT_TYPES.except(*event_types_with_archive.keys).each do |type, id|
+        EventType::ALL.except(*EventType::WITH_ARCHIVE.keys).each do |type, id|
           context "when the event is a past #{type} type" do
             let(:event) { build(:event_api, type_id: id, start_at: Time.zone.now.utc - 1.day) }
 

--- a/spec/requests/find_an_event_near_you_spec.rb
+++ b/spec/requests/find_an_event_near_you_spec.rb
@@ -45,7 +45,7 @@ describe "Find an event near you", type: :request do
 
     context "when there are events of different types" do
       let(:events) do
-        GetIntoTeachingApiClient::Constants::EVENT_TYPES.values.map do |type_id|
+        EventType.all_ids.map do |type_id|
           build(:event_api, start_at: Time.zone.now, type_id: type_id)
         end
       end

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -410,7 +410,7 @@ describe Internal::EventsController, type: :request do
         let(:params) do
           attributes_for :internal_event,
                          :online_event,
-                         type_id: GetIntoTeachingApiClient::Constants::EVENT_TYPES["Online event"]
+                         type_id: EventType.online_event_id
         end
         let(:expected_request_body) do
           build(:event_api,

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -25,7 +25,7 @@ shared_context "with stubbed types api" do
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
-        body: GetIntoTeachingApiClient::Constants::EVENT_TYPES.map { |k, v| { id: v, value: k } }.to_json
+        body: EventType::ALL.map { |k, v| { id: v, value: k } }.to_json
 
     stub_request(:get, "#{git_api_endpoint}/api/lookup_items/teaching_subjects")
       .to_return \


### PR DESCRIPTION
### Trello card

[Trello-2703](https://trello.com/c/jHOXJGrE/2703-clean-up-use-of-constants-file)

### Context

Remove the event type constants from `GetIntoTeachingApiClient::Constants`, updating references to use the new `EventType` model.

Add `all_ids` and `has_archive?` convenience methods to `EventType`.

### Changes proposed in this pull request

- Update event type references to use `EventType` model

### Guidance to review

