### PR TITLE
Refactor event status logic into new model

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -27,7 +27,7 @@ private
   end
 
   def redirect_closed_events
-    event_is_closed = @event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]
+    event_is_closed = EventStatus.new(@event).closed?
     candidate_is_walk_in = wizard_store[:is_walk_in]
 
     if event_is_closed && !candidate_is_walk_in

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -31,7 +31,7 @@ class EventsController < ApplicationController
     breadcrumb "events.search", :events_path
 
     @event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
-    render_not_found && return unless viewable_event?(@event)
+    render_not_found && return unless EventStatus.new(@event).viewable?
 
     @page_title = @event.name
     @front_matter = { "description" => @event.summary }
@@ -55,14 +55,6 @@ protected
   end
 
 private
-
-  def viewable_event?(event)
-    not_pending = event.status_id != pending_event_status_id
-    in_future = event.start_at.to_date >= Time.zone.now.utc.to_date
-    online_q_a = EventType.new(event).online_qa_event?
-
-    not_pending && (in_future || online_q_a)
-  end
 
   def render_not_found
     @fullwidth = true
@@ -107,9 +99,5 @@ private
 
     (params[Events::Search.model_name.param_key] || defaults)
       .permit(:type, :distance, :postcode, :month)
-  end
-
-  def pending_event_status_id
-    GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -25,20 +25,8 @@ module EventsHelper
     end
   end
 
-  def event_status_open?(event)
-    event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
-  end
-
-  def event_status_pending?(event)
-    event.status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
-  end
-
   def can_sign_up_online?(event)
-    event.web_feed_id && event_status_open?(event) && !is_event_type?(event, "School or University event")
-  end
-
-  def is_event_type?(event, type_name)
-    event.type_id == EventType.lookup_by_name(type_name)
+    event.web_feed_id && EventStatus.new(event).open? && !EventType.new(event).provider_event?
   end
 
   def embed_event_video_url(video_url)

--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -128,7 +128,7 @@ module StructuredDataHelper
         "@type": "Offer",
         price: 0,
         priceCurrency: "GBP",
-        availability: event_status_open?(event) ? IN_STOCK : SOLD_OUT,
+        availability: EventStatus.new(event).open? ? IN_STOCK : SOLD_OUT,
       },
     }.merge(building_data, provider_data, image_data)
 

--- a/app/models/event_status.rb
+++ b/app/models/event_status.rb
@@ -1,0 +1,65 @@
+class EventStatus
+  ALL =
+    {
+      "Open" => 222_750_000,
+      "Closed" => 222_750_001,
+      "Pending" => 222_750_003,
+    }.freeze
+
+  attr_accessor :event
+
+  delegate(
+    :pending_id,
+    :closed_id,
+    :open_id,
+    to: :class,
+  )
+
+  class << self
+    def pending_id
+      ALL["Pending"]
+    end
+
+    def closed_id
+      ALL["Closed"]
+    end
+
+    def open_id
+      ALL["Open"]
+    end
+  end
+
+  def initialize(event)
+    @event = event
+  end
+
+  def closed?
+    event.status_id == closed_id
+  end
+
+  def pending?
+    event.status_id == pending_id
+  end
+
+  def open?
+    event.status_id == open_id
+  end
+
+  def viewable?
+    online_q_a = EventType.new(event).online_qa_event?
+
+    !pending? && (future_dated? || online_q_a)
+  end
+
+  def accepts_online_registration?
+    type_ids = [EventType.question_time_event_id, EventType.train_to_teach_event_id]
+
+    event.type_id.in?(type_ids) && future_dated? && open?
+  end
+
+private
+
+  def future_dated?
+    event.start_at.to_date >= Time.zone.now.utc.to_date
+  end
+end

--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -10,7 +10,7 @@ module Internal
     attribute :readable_id, :string
     attribute :status_id,
               :integer,
-              default: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+              default: EventStatus.pending_id
     attribute :type_id,
               :integer,
               default: EventType.school_or_university_event_id

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -76,7 +76,7 @@ module TeachingEvents
     end
 
     def allow_registration?
-      open? && type_id.in?([EventType.question_time_event_id, EventType.train_to_teach_event_id])
+      EventStatus.new(@event).accepts_online_registration?
     end
 
     def show_provider_information?
@@ -85,10 +85,6 @@ module TeachingEvents
 
     def show_venue_information?
       !@event.is_virtual && @event.building.present?
-    end
-
-    def open?
-      (start_at >= Time.zone.now && status_id == GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"])
     end
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -63,7 +63,7 @@
   <br>
   <% end %>
 
-  <% if event_status_open?(@event) || event_status_pending?(@event) %>
+  <% unless EventStatus.new(@event).closed? %>
     <% if can_sign_up_online?(@event) %>
       <h2>How to attend</h2>
       <% if @event.is_online %>

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -1,14 +1,6 @@
 module GetIntoTeachingApiClient
   module Constants
     # This is not a complete list.
-    EVENT_STATUS =
-      {
-        "Open" => 222_750_000,
-        "Closed" => 222_750_001,
-        "Pending" => 222_750_003,
-      }.freeze
-
-    # This is not a complete list.
     CANDIDATE_MAILING_LIST_SUBSCRIPTION_CHANNELS =
       {
         "GITIS - On Campus - Careers Services activity" => 222_750_037,

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:readable_id, &:to_s)
     type_id { EventType.train_to_teach_event_id }
     web_feed_id { "123" }
-    status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"] }
+    status_id { EventStatus.open_id }
     sequence(:name) { |i| "Become a Teacher #{i}" }
     sequence(:description) { |i| "<b>Become a Teacher #{i} event description</b>" }
     sequence(:summary) { |i| "Become a Teacher #{i} event summary" }
@@ -17,7 +17,7 @@ FactoryBot.define do
     building { build :event_building_api }
 
     trait :closed do
-      status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"] }
+      status_id { EventStatus.closed_id }
     end
 
     trait :past do
@@ -68,7 +68,7 @@ FactoryBot.define do
     end
 
     trait :pending do
-      status_id { GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"] }
+      status_id { EventStatus.pending_id }
     end
 
     trait :without_train_to_teach_fields do

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Event wizard", type: :feature do
   end
 
   scenario "Full journey as a walk-in candidate (closed event)" do
-    event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"]
+    event.status_id = EventStatus.closed_id
 
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Internal section", type: :feature do
           :with_provider_info,
           name: "Pending provider event",
           readable_id: "Readable_id",
-          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
+          status_id: EventStatus.pending_id,
           type_id: EventType.school_or_university_event_id)
   end
   let(:pending_online_event) do
@@ -16,7 +16,7 @@ RSpec.feature "Internal section", type: :feature do
           :with_provider_info,
           name: "Pending online event",
           readable_id: "Readable_id",
-          status_id: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"],
+          status_id: EventStatus.pending_id,
           type_id: EventType.online_event_id)
   end
   let(:provider_events_by_type) { group_events_by_type([pending_provider_event]) }

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -78,27 +78,11 @@ describe EventsHelper, type: "helper" do
     it { is_expected.to match(/alt="Map showing #{event.name}"/) }
   end
 
-  describe "#event_status_open?" do
-    it "returns true for events that have a status of open" do
-      event = GetIntoTeachingApiClient::TeachingEvent.new(
-        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
-      )
-      expect(event_status_open?(event)).to be_truthy
-    end
-
-    it "returns false for closed events" do
-      event = GetIntoTeachingApiClient::TeachingEvent.new(
-        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"],
-      )
-      expect(event_status_open?(event)).to be_falsy
-    end
-  end
-
   describe "#can_sign_up_online?" do
     it "returns true for events with a web_feed_id that are not closed" do
       event = GetIntoTeachingApiClient::TeachingEvent.new(
         webFeedId: "abc-123",
-        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
+        statusId: EventStatus.open_id,
       )
       expect(can_sign_up_online?(event)).to be_truthy
     end
@@ -106,7 +90,7 @@ describe EventsHelper, type: "helper" do
     it "returns false for events without a web_feed_id" do
       event = GetIntoTeachingApiClient::TeachingEvent.new(
         webFeedId: nil,
-        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"],
+        statusId: EventStatus.open_id,
       )
       expect(can_sign_up_online?(event)).to be_falsy
     end
@@ -114,23 +98,9 @@ describe EventsHelper, type: "helper" do
     it "returns false for closed events" do
       event = GetIntoTeachingApiClient::TeachingEvent.new(
         webFeedId: "abc-123",
-        statusId: GetIntoTeachingApiClient::Constants::EVENT_STATUS["Closed"],
+        statusId: EventStatus.closed_id,
       )
       expect(can_sign_up_online?(event)).to be_falsy
-    end
-  end
-
-  describe "#is_event_type?" do
-    let(:matching_type) { "School or University event" }
-    let(:non_matching_type) { "Online event" }
-    let(:event) { build(:event_api, type_id: EventType.lookup_by_name(matching_type)) }
-
-    it "is truthy when the type matches" do
-      expect(is_event_type?(event, matching_type)).to be_truthy
-    end
-
-    it "is falsy when the type matches" do
-      expect(is_event_type?(event, non_matching_type)).to be_falsy
     end
   end
 

--- a/spec/models/event_status_spec.rb
+++ b/spec/models/event_status_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+describe EventStatus do
+  let(:event) { build(:event_api) }
+
+  describe "class_methods" do
+    describe ".pending_id" do
+      subject { described_class.pending_id }
+
+      it { is_expected.to eq(222_750_003) }
+    end
+
+    describe ".open_id" do
+      subject { described_class.open_id }
+
+      it { is_expected.to eq(222_750_000) }
+    end
+
+    describe ".closed_id" do
+      subject { described_class.closed_id }
+
+      it { is_expected.to eq(222_750_001) }
+    end
+  end
+
+  subject { described_class.new(event) }
+
+  it { is_expected.to respond_to(:event) }
+
+  describe "#closed?" do
+    let(:event) { build(:event_api, :closed) }
+
+    it { is_expected.to be_closed }
+    it { is_expected.not_to be_pending }
+    it { is_expected.not_to be_open }
+  end
+
+  describe "#open?" do
+    it { is_expected.to be_open }
+    it { is_expected.not_to be_closed }
+    it { is_expected.not_to be_pending }
+  end
+
+  describe "#pending?" do
+    let(:event) { build(:event_api, :pending) }
+
+    it { is_expected.to be_pending }
+    it { is_expected.not_to be_closed }
+    it { is_expected.not_to be_open }
+  end
+
+  describe "viewable?" do
+    context "when closed, future-dated, not online q&a" do
+      let(:event) { build(:event_api, :closed, :school_or_university_event) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when closed, future-dated, online q&a" do
+      let(:event) { build(:event_api, :closed, :online_event) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when closed, past, online q&a" do
+      let(:event) { build(:event_api, :closed, :online_event, :past) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when closed, past, not online q&a" do
+      let(:event) { build(:event_api, :closed, :train_to_teach_event, :past) }
+
+      it { is_expected.not_to be_viewable }
+    end
+
+    context "when pending, future-dated, online q&a" do
+      let(:event) { build(:event_api, :pending, :online_event) }
+
+      it { is_expected.not_to be_viewable }
+    end
+
+    context "when open, future-dated, online q&a" do
+      let(:event) { build(:event_api, :online_event) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when open, future-dated, not online q&a" do
+      let(:event) { build(:event_api, :train_to_teach_event) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when open, past, online q&a" do
+      let(:event) { build(:event_api, :past, :online_event) }
+
+      it { is_expected.to be_viewable }
+    end
+
+    context "when open, past, not online q&a" do
+      let(:event) { build(:event_api, :past, :school_or_university_event) }
+
+      it { is_expected.not_to be_viewable }
+    end
+  end
+
+  describe "#accepts_online_registration?" do
+    context "when QT, future-dated, open" do
+      let(:event) { build(:event_api, :question_time_event) }
+
+      it { is_expected.to be_accepts_online_registration }
+    end
+
+    context "when TTT, future-dated, open" do
+      let(:event) { build(:event_api, :train_to_teach_event) }
+
+      it { is_expected.to be_accepts_online_registration }
+    end
+
+    context "when not TTT/QT, future-dated, open" do
+      let(:event) { build(:event_api, :online_event) }
+
+      it { is_expected.not_to be_accepts_online_registration }
+    end
+
+    context "when TTT/QT, past, open" do
+      let(:event) { build(:event_api, :train_to_teach_event, :past) }
+
+      it { is_expected.not_to be_accepts_online_registration }
+    end
+
+    context "when TTT/QT, future-dated, closed" do
+      let(:event) { build(:event_api, :question_time_event, :closed) }
+
+      it { is_expected.not_to be_accepts_online_registration }
+    end
+  end
+end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -161,28 +161,6 @@ describe TeachingEvents::EventPresenter do
       end
     end
 
-    describe "#open?" do
-      subject { described_class.new(event).open? }
-
-      context "when the event's status is open and it's in the future" do
-        let(:event) { build(:event_api) }
-
-        it { is_expected.to be true }
-      end
-
-      context "when the event's status is open and it's in the past" do
-        let(:event) { build(:event_api, :past) }
-
-        it { is_expected.to be false }
-      end
-
-      context "when the event's status is closed and it's in the future" do
-        let(:event) { build(:event_api, :closed) }
-
-        it { is_expected.to be false }
-      end
-    end
-
     describe "#allow_registration?" do
       subject { described_class.new(event).allow_registration? }
 

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -79,7 +79,7 @@ describe Internal::EventsController, type: :request do
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
                     type_ids: [EventType.school_or_university_event_id],
-                    status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                    status_ids: [EventStatus.pending_id],
                     start_after: Time.zone.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
                   })
@@ -93,7 +93,7 @@ describe Internal::EventsController, type: :request do
             .to receive(:search_teaching_events_grouped_by_type)
                   .with({
                     type_ids: [EventType.online_event_id],
-                    status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]],
+                    status_ids: [EventStatus.pending_id],
                     start_after: Time.zone.now.utc.beginning_of_day,
                     quantity_per_type: 1_000,
                   })
@@ -463,7 +463,7 @@ describe Internal::EventsController, type: :request do
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
           event.tap do |event|
-            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
+            event.status_id = EventStatus.open_id
           end
         end
 
@@ -518,7 +518,7 @@ describe Internal::EventsController, type: :request do
         let(:params) { { "id": event.id } }
         let(:expected_request_body) do
           event.tap do |event|
-            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]
+            event.status_id = EventStatus.open_id
           end
         end
 
@@ -566,7 +566,7 @@ describe Internal::EventsController, type: :request do
         let(:event) { pending_provider_event }
         let(:expected_request_body) do
           event.tap do |event|
-            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+            event.status_id = EventStatus.pending_id
             event.building = nil
           end
         end
@@ -597,7 +597,7 @@ describe Internal::EventsController, type: :request do
         let(:params) { { "id": event.id } }
         let(:expected_request_body) do
           event.tap do |event|
-            event.status_id = GetIntoTeachingApiClient::Constants::EVENT_STATUS["Pending"]
+            event.status_id = EventStatus.pending_id
           end
         end
 
@@ -660,7 +660,7 @@ describe Internal::EventsController, type: :request do
           .to receive(:search_teaching_events_grouped_by_type)
                 .with({
                   type_ids: [EventType.school_or_university_event_id, EventType.online_event_id],
-                  status_ids: [GetIntoTeachingApiClient::Constants::EVENT_STATUS["Open"]],
+                  status_ids: [EventStatus.open_id],
                   start_after: Time.zone.now.utc.beginning_of_day,
                   quantity_per_type: 1_000,
                 })


### PR DESCRIPTION
### Trello card

[Trello-2703](https://trello.com/c/jHOXJGrE/2703-clean-up-use-of-constants-file)

### Context

Remove the `GetIntoTeachingApiClient::Constants::EVENT_STATUS` constant, shifting the logic into an `EventSatus` class.

I've also made this class responsible for determining view-ability and whether registration is open as it feels like this should be centralised and comes under the umbrella of 'status'.

### Changes proposed in this pull request

- Refactor event status logic into new model

### Guidance to review

I've kept this consistent with the `EventType` model.