### PR TITLE
Refactor teaching subjects into new model

### DIFF
--- a/app/helpers/welcome_content_helper.rb
+++ b/app/helpers/welcome_content_helper.rb
@@ -152,20 +152,22 @@ module WelcomeContentHelper
 private
 
   def mappings(id)
+    key = TeachingSubject.key_with_uuid(id)
+
     {
-      "a42655a1-2afa-e811-a981-000d3a276620" => MATHS,
-      "942655a1-2afa-e811-a981-000d3a276620" => ENGLISH,
+      maths: MATHS,
+      english: ENGLISH,
 
-      "802655a1-2afa-e811-a981-000d3a276620" => SCIENCES,  # biology
-      "842655a1-2afa-e811-a981-000d3a276620" => SCIENCES,  # chemistry
-      "ac2655a1-2afa-e811-a981-000d3a276620" => SCIENCES,  # physics
-      "ae2655a1-2afa-e811-a981-000d3a276620" => SCIENCES,  # physics with maths
-      "982655a1-2afa-e811-a981-000d3a276620" => SCIENCES,  # general science
+      biology: SCIENCES,
+      chemistry: SCIENCES,
+      physics: SCIENCES,
+      physics_with_maths: SCIENCES,
+      general_science: SCIENCES,
 
-      "962655a1-2afa-e811-a981-000d3a276620" => MFL,       # french
-      "9c2655a1-2afa-e811-a981-000d3a276620" => MFL,       # german
-      "b82655a1-2afa-e811-a981-000d3a276620" => MFL,       # spanish
-      "a22655a1-2afa-e811-a981-000d3a276620" => MFL,       # languages (other)
-    }.fetch(id) { GENERIC }
+      french: MFL,
+      german: MFL,
+      spanish: MFL,
+      languages_other: MFL,
+    }.fetch(key) { GENERIC }
   end
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -64,16 +64,13 @@ private
   # return the subject name from its uuid, downcasing all except
   # proper nouns
   def retrieve_subject(uuid, leave_capitalised:)
-    subject = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.invert[uuid]
+    subject = TeachingSubject.lookup_by_uuid(uuid)
 
     return if subject.blank?
 
-    return subject if leave_capitalised || uuid.in?([
-      "942655a1-2afa-e811-a981-000d3a276620", # English
-      "962655a1-2afa-e811-a981-000d3a276620", # French
-      "9c2655a1-2afa-e811-a981-000d3a276620", # German
-      "b82655a1-2afa-e811-a981-000d3a276620", # Spanish
-    ])
+    proper_nouns = TeachingSubject.lookup_by_keys(:english, :french, :german, :spanish)
+
+    return subject if leave_capitalised || uuid.in?(proper_nouns)
 
     subject.downcase
   end

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -50,7 +50,7 @@ module Events
       def teaching_subject_options
         @teaching_subject_options ||=
           GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
-            GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
+            TeachingSubject.ignore?(type.id)
           end
       end
 

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -18,7 +18,7 @@ module MailingList
 
       def query_teaching_subjects
         GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
-          GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS.values.include?(type.id)
+          TeachingSubject.ignore?(type.id)
         end
       end
     end

--- a/app/models/teaching_subject.rb
+++ b/app/models/teaching_subject.rb
@@ -1,0 +1,58 @@
+class TeachingSubject
+  # Not a complete list.
+  ALL =
+    {
+      "Art and design" => "7e2655a1-2afa-e811-a981-000d3a276620",
+      "Biology" => "802655a1-2afa-e811-a981-000d3a276620",
+      "Chemistry" => "842655a1-2afa-e811-a981-000d3a276620",
+      "English" => "942655a1-2afa-e811-a981-000d3a276620",
+      "French" => "962655a1-2afa-e811-a981-000d3a276620",
+      "General science" => "982655a1-2afa-e811-a981-000d3a276620",
+      "German" => "9c2655a1-2afa-e811-a981-000d3a276620",
+      "Languages (other)" => "a22655a1-2afa-e811-a981-000d3a276620",
+      "Maths" => "a42655a1-2afa-e811-a981-000d3a276620",
+      "Physics with maths" => "ae2655a1-2afa-e811-a981-000d3a276620",
+      "Physics" => "ac2655a1-2afa-e811-a981-000d3a276620",
+      "Spanish" => "b82655a1-2afa-e811-a981-000d3a276620",
+    }.freeze
+
+  IGNORED =
+    {
+      "Other" => "bc2655a1-2afa-e811-a981-000d3a276620",
+      "No Preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
+    }.freeze
+
+  class << self
+    def lookup_by_key(key)
+      keyed_subjects.fetch(key)
+    end
+
+    def lookup_by_keys(*keys)
+      keyed_subjects.fetch_values(*keys)
+    end
+
+    def lookup_by_uuid(uuid)
+      ALL.invert[uuid]
+    end
+
+    def key_with_uuid(uuid)
+      keyed_subjects.invert[uuid]
+    end
+
+    def all_uuids
+      ALL.values
+    end
+
+    def all_subjects
+      ALL.keys
+    end
+
+    def ignore?(uuid)
+      IGNORED.value?(uuid)
+    end
+
+    def keyed_subjects
+      @keyed_subjects ||= ALL.transform_keys { |key| key.parameterize(separator: "_").to_sym }
+    end
+  end
+end

--- a/lib/extensions/get_into_teaching_api_client/constants.rb
+++ b/lib/extensions/get_into_teaching_api_client/constants.rb
@@ -24,28 +24,5 @@ module GetIntoTeachingApiClient
         "I’m fairly sure and exploring my options" => 222_750_002,
         "I’m very sure and think I’ll apply" => 222_750_003,
       }.freeze
-
-    # This is not a complete list.
-    TEACHING_SUBJECTS =
-      {
-        "Art and design" => "7e2655a1-2afa-e811-a981-000d3a276620",
-        "Biology" => "802655a1-2afa-e811-a981-000d3a276620",
-        "Chemistry" => "842655a1-2afa-e811-a981-000d3a276620",
-        "English" => "942655a1-2afa-e811-a981-000d3a276620",
-        "French" => "962655a1-2afa-e811-a981-000d3a276620",
-        "General science" => "982655a1-2afa-e811-a981-000d3a276620",
-        "German" => "9c2655a1-2afa-e811-a981-000d3a276620",
-        "Languages (other)" => "a22655a1-2afa-e811-a981-000d3a276620",
-        "Maths" => "a42655a1-2afa-e811-a981-000d3a276620",
-        "Physics with maths" => "ae2655a1-2afa-e811-a981-000d3a276620",
-        "Physics" => "ac2655a1-2afa-e811-a981-000d3a276620",
-        "Spanish" => "b82655a1-2afa-e811-a981-000d3a276620",
-      }.freeze
-
-    IGNORED_PREFERRED_TEACHING_SUBJECTS =
-      {
-        "Other" => "bc2655a1-2afa-e811-a981-000d3a276620",
-        "No Preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
-      }.freeze
   end
 end

--- a/spec/factories/mailing_list/subject_factory.rb
+++ b/spec/factories/mailing_list/subject_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :mailing_list_subject, class: "MailingList::Steps::Subject" do
-    preferred_teaching_subject_id { GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS["Physics"] }
+    preferred_teaching_subject_id { TeachingSubject.fetch(:physics) }
   end
 end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -396,7 +396,7 @@ RSpec.feature "Event wizard", type: :feature do
       degree_status_id: 222_750_000,
       consideration_journey_stage_id: 222_750_000,
       address_postcode: "TE57 1NG",
-      preferred_teaching_subject_id: "7e2655a1-2afa-e811-a981-000d3a276620",
+      preferred_teaching_subject_id: TeachingSubject.lookup_by_key(:art_and_design),
     }
   end
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
       receive(:create_candidate_access_token)
 
     response = GetIntoTeachingApiClient::MailingListAddMember.new(
-      preferredTeachingSubjectId: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS["Maths"],
+      preferredTeachingSubjectId: TeachingSubject.lookup_by_key(:maths),
       considerationJourneyStageId: GetIntoTeachingApiClient::Constants::CONSIDERATION_JOURNEY_STAGES["I’m very sure and think I’ll apply"],
       degreeStatusId: GetIntoTeachingApiClient::Constants::DEGREE_STATUS_OPTIONS["Final year"],
       addressPostcode: "TE57 1NG",
@@ -129,7 +129,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "Which subject do you want to teach"
     expect(page).to have_select(
       "Which subject do you want to teach?",
-      selected: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.key(response.preferred_teaching_subject_id),
+      selected: TeachingSubject.lookup_by_uuid(response.preferred_teaching_subject_id),
     )
     click_on "Next step"
 

--- a/spec/helpers/welcome_content_helper_spec.rb
+++ b/spec/helpers/welcome_content_helper_spec.rb
@@ -3,20 +3,25 @@ require "rails_helper"
 RSpec.describe WelcomeContentHelper, type: :helper do
   describe "#subject_specific_story_data" do
     {
-      "a42655a1-2afa-e811-a981-000d3a276620" => "Dimitra", # meths
-      "942655a1-2afa-e811-a981-000d3a276620" => "Laura",   # english
-      "802655a1-2afa-e811-a981-000d3a276620" => "Holly",   # science
-      "962655a1-2afa-e811-a981-000d3a276620" => "Tom",     # mfl
-      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" => "Abigail", # generic
-    }.each do |input, output|
+      maths: "Dimitra",
+      english: "Laura",
+      biology: "Holly",
+      french: "Tom",
+    }.each do |key, name|
       specify "returns the right content for each subject category" do
-        expect(subject_specific_story_data(input).fetch(:name)).to eql(output)
+        uuid = TeachingSubject.lookup_by_key(key)
+        expect(subject_specific_story_data(uuid).fetch(:name)).to eql(name)
       end
+    end
+
+    specify "returns the generic content when the subject is not recognised" do
+      uuid = "00000000-0000-0000-0000-000000000000"
+      expect(subject_specific_story_data(uuid).fetch(:name)).to eql("Abigail")
     end
   end
 
   describe "#subject_category" do
-    let(:id) { "942655a1-2afa-e811-a981-000d3a276620" }
+    let(:id) { TeachingSubject.lookup_by_key(:english) }
 
     specify "returns the subject's category in lower case" do
       expect(subject_category(id)).to eql("english")
@@ -31,12 +36,14 @@ RSpec.describe WelcomeContentHelper, type: :helper do
 
   describe "#subject_specific_video_path" do
     specify "returns the given path for the matching subject" do
-      expect(subject_specific_video_path("ac2655a1-2afa-e811-a981-000d3a276620")).to eql("/videos/welcome-guide-science.webm")
+      physics_uuid = TeachingSubject.lookup_by_key(:physics)
+      expect(subject_specific_video_path(physics_uuid)).to eql("/videos/welcome-guide-science.webm")
     end
 
     context "when the path is overridden" do
       specify "returns the given path for the matching subject" do
-        expect(subject_specific_video_path("962655a1-2afa-e811-a981-000d3a276620", prefix: "/blockbusters/")).to eql("/blockbusters/welcome-guide-mfl.webm")
+        french_uuid = TeachingSubject.lookup_by_key(:french)
+        expect(subject_specific_video_path(french_uuid, prefix: "/blockbusters/")).to eql("/blockbusters/welcome-guide-mfl.webm")
       end
     end
   end

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe WelcomeHelper, type: :helper do
-  let(:physics_uuid) { "ac2655a1-2afa-e811-a981-000d3a276620" }
+  let(:physics_uuid) { TeachingSubject.lookup_by_key(:physics) }
 
   shared_context "with first name" do
     before { allow(session).to receive(:dig).with("mailinglist", "first_name") { name } }
@@ -80,7 +80,7 @@ RSpec.describe WelcomeHelper, type: :helper do
     context "when set by query param and stored in the welcome_guide session store" do
       include_context "with preferred teaching subject set in welcome_guide"
 
-      let(:subject_id) { "842655a1-2afa-e811-a981-000d3a276620" }
+      let(:subject_id) { TeachingSubject.lookup_by_key(:chemistry) }
 
       specify "returns the correct subject" do
         expect(subject).to eql("chemistry")
@@ -89,29 +89,27 @@ RSpec.describe WelcomeHelper, type: :helper do
 
     context "when stored in the mailinglist session store" do
       context "when the subject name is a common noun" do
-        GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.slice("Art and design", "Biology", "Chemistry", "General science", "Languages (other)", "Maths", "Physics with maths", "Physics")
-          .each do |subject_name, subject_id|
-            describe "#{subject_name} is lowercased" do
-              let(:subject_id) { subject_id }
+        %i[art_and_design biology chemistry general_science languages_other maths physics_with_maths physics].each do |subject_key|
+          describe "#{subject_key} is lowercased" do
+            let(:subject_id) { TeachingSubject.lookup_by_key(subject_key) }
 
-              include_context "with preferred teaching subject set in welcome_guide"
+            include_context "with preferred teaching subject set in welcome_guide"
 
-              it { is_expected.to eql(subject_name.downcase) }
-            end
+            it { is_expected.to eql(TeachingSubject.lookup_by_uuid(subject_id).downcase) }
           end
+        end
       end
 
       context "when the subject name is a proper noun" do
-        GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.slice("English", "German", "Spanish", "French")
-          .each do |subject_name, subject_id|
-            describe "#{subject_name} is not lowercased" do
-              let(:subject_id) { subject_id }
+        %i[english german spanish french].each do |subject_key|
+          describe "#{subject_key} is not lowercased" do
+            let(:subject_id) { TeachingSubject.lookup_by_key(subject_key) }
 
-              include_context "with preferred teaching subject set in welcome_guide"
+            include_context "with preferred teaching subject set in welcome_guide"
 
-              it { is_expected.to eql(subject_name) }
-            end
+            it { is_expected.to eql(TeachingSubject.lookup_by_uuid(subject_id)) }
           end
+        end
       end
     end
 
@@ -171,7 +169,7 @@ RSpec.describe WelcomeHelper, type: :helper do
     subject { welcome_guide_subject }
 
     context "when the subject id is in the welcome_guide session store" do
-      let(:subject_id) { GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS["Languages (other)"] }
+      let(:subject_id) { TeachingSubject.lookup_by_key(:languages_other) }
 
       include_context "with preferred teaching subject set in welcome_guide"
 
@@ -181,7 +179,7 @@ RSpec.describe WelcomeHelper, type: :helper do
     end
 
     context "when the subject id is in the mailinglist session store" do
-      let(:subject_id) { GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS["German"] }
+      let(:subject_id) { TeachingSubject.lookup_by_key(:german) }
 
       include_context "with preferred teaching subject set in welcome_guide and mailinglist"
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -103,9 +103,7 @@ describe Events::Steps::PersonalisedUpdates do
     subject { instance.teaching_subject_options }
 
     let(:teaching_subject_types) do
-      subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
-        GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
-      )
+      subjects = TeachingSubject::ALL.merge(TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
     end
 
@@ -114,7 +112,7 @@ describe Events::Steps::PersonalisedUpdates do
         receive(:get_teaching_subjects).and_return(teaching_subject_types)
     end
 
-    it { expect(subject.map(&:id)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
-    it { expect(subject.map(&:value)).to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.keys) }
+    it { expect(subject.map(&:id)).to eq(TeachingSubject.all_uuids) }
+    it { expect(subject.map(&:value)).to eq(TeachingSubject.all_subjects) }
   end
 end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -31,7 +31,7 @@ describe Healthcheck do
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
-        body: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map { |k, v| { id: v, value: k } }.to_json
+        body: TeachingSubject::ALL.map { |k, v| { id: v, value: k } }.to_json
   end
 
   include_examples "reading git shas", "app_sha", "/etc/get-into-teaching-app-sha"

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -8,9 +8,7 @@ describe MailingList::Steps::Subject do
   end
 
   let(:teaching_subject_types) do
-    GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
-      GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k })
-    end
+    TeachingSubject::ALL.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
   end
 
   it_behaves_like "a with wizard step"
@@ -31,12 +29,10 @@ describe MailingList::Steps::Subject do
     subject { instance.teaching_subject_ids }
 
     let(:teaching_subject_types) do
-      subjects = GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.merge(
-        GetIntoTeachingApiClient::Constants::IGNORED_PREFERRED_TEACHING_SUBJECTS,
-      )
+      subjects = TeachingSubject::ALL.merge(TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
     end
 
-    it { is_expected.to eq(GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.values) }
+    it { is_expected.to eq(TeachingSubject.all_uuids) }
   end
 end

--- a/spec/models/teaching_subject_spec.rb
+++ b/spec/models/teaching_subject_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe TeachingSubject do
+  describe "class_methods" do
+    describe ".lookup_by_key" do
+      it { expect(described_class.lookup_by_key(:physics)).to eq("ac2655a1-2afa-e811-a981-000d3a276620") }
+      it { expect(described_class.lookup_by_key(:languages_other)).to eq("a22655a1-2afa-e811-a981-000d3a276620") }
+      it { expect { described_class.lookup_by_key(:unknown) }.to raise_error(KeyError) }
+    end
+
+    describe ".lookup_by_keys" do
+      it "returns uuids for matching subjects" do
+        expect(described_class.lookup_by_keys(:physics, :languages_other)).to \
+          eq(%w[ac2655a1-2afa-e811-a981-000d3a276620 a22655a1-2afa-e811-a981-000d3a276620])
+      end
+
+      it { expect { described_class.lookup_by_keys(:physics, :unknown) }.to raise_error(KeyError) }
+    end
+
+    describe ".lookup_by_uuid" do
+      it { expect(described_class.lookup_by_uuid("ac2655a1-2afa-e811-a981-000d3a276620")).to eq("Physics") }
+      it { expect(described_class.lookup_by_uuid("a22655a1-2afa-e811-a981-000d3a276620")).to eq("Languages (other)") }
+      it { expect(described_class.lookup_by_uuid("00000000-0000-0000-0000-000000000000")).to be_nil }
+    end
+
+    describe ".keyed_subjects" do
+      subject(:keyed_subjects) { described_class.keyed_subjects }
+
+      it { is_expected.to include({ physics: "ac2655a1-2afa-e811-a981-000d3a276620" }) }
+      it { is_expected.to include({ languages_other: "a22655a1-2afa-e811-a981-000d3a276620" }) }
+      it { expect(keyed_subjects.count).to eq(described_class::ALL.count) }
+    end
+
+    describe ".key_with_uuid" do
+      it { expect(described_class.key_with_uuid("ac2655a1-2afa-e811-a981-000d3a276620")).to eq(:physics) }
+      it { expect(described_class.key_with_uuid("a22655a1-2afa-e811-a981-000d3a276620")).to eq(:languages_other) }
+      it { expect(described_class.key_with_uuid("00000000-0000-0000-0000-000000000000")).to be_nil }
+    end
+
+    describe ".all_uuids" do
+      subject { described_class.all_uuids }
+
+      it { is_expected.to eq(described_class::ALL.values) }
+    end
+
+    describe ".all_subjects" do
+      subject { described_class.all_subjects }
+
+      it { is_expected.to eq(described_class::ALL.keys) }
+    end
+
+    describe ".ignore?" do
+      it { expect(described_class).to be_ignore(described_class::IGNORED.values.sample) }
+      it { expect(described_class).not_to be_ignore(described_class.all_uuids.sample) }
+    end
+  end
+end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -47,7 +47,7 @@ describe PagesController, type: :request do
 
     let(:params) do
       {
-        "preferred_teaching_subject_id" => "802655a1-2afa-e811-a981-000d3a276620",
+        "preferred_teaching_subject_id" => TeachingSubject.lookup_by_key(:biology),
         "degree_status_id" => "222_750_003",
         "a_key_that_shouldnt_be_accepted" => "abc123",
       }

--- a/spec/requests/welcome_guide_spec.rb
+++ b/spec/requests/welcome_guide_spec.rb
@@ -2,32 +2,33 @@ require "rails_helper"
 
 describe "Welcome guide landing page", type: :request do
   {
-    "a42655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    maths: OpenStruct.new(
       subject: "Maths",
       name: "Dimitra",
       quote_headline: "The highs are immeasurable",
       quote_body: "Gaming, sport, travelling",
     ),
-    "942655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    english: OpenStruct.new(
       subject: "English",
       name: "Laura",
       quote_headline: "From delving into literature",
       quote_body: "Those moments when kids suddenly get it",
     ),
-    "802655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    biology: OpenStruct.new(
       subject: "Biology",
       name: "Holly",
       quote_headline: "Plants, planets, protons",
       quote_body: "I value the way science teaches a clear thought process",
     ),
-    "962655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    french: OpenStruct.new(
       subject: "French",
       name: "Tom",
       quote_headline: "From delving into different cultures to discussing new ways of thinking",
       quote_body: "I get to travel still and can keep up with my languages",
     ),
-  }.each do |subject_id, metadata|
+  }.each do |subject_key, metadata|
     specify "shows #{metadata.subject || 'non'}-specific content" do
+      subject_id = TeachingSubject.lookup_by_key(subject_key)
       get("/welcome?preferred_teaching_subject_id=#{subject_id}")
 
       expect(response.body).to match(%r{teaching <mark>#{metadata.subject}.</mark>}i)
@@ -38,36 +39,34 @@ describe "Welcome guide landing page", type: :request do
   end
 
   {
-    # "Maths",
-    "a42655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    maths: OpenStruct.new(
       name: "Dimitra",
       shoutout_name: "Alison Conner",
       shoutout_text: "When I doubted myself, she believed in me",
       story_text: "I've always found it fascinating learning how maths shapes the world",
     ),
-    # "English",
-    "942655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    english: OpenStruct.new(
       name: "Laura",
       shoutout_name: "Ms Colley",
       shoutout_text: "She left such a strong imprint on me",
       story_text: "Going to uni wasn't the norm where I'm from",
     ),
-    # Sciences
-    "802655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    biology: OpenStruct.new(
       name: "Holly",
       shoutout_name: "Mr Eaves",
       shoutout_text: "he would never give up",
       story_text: "I really enjoyed the coaching aspect of the degree",
     ),
-    "962655a1-2afa-e811-a981-000d3a276620" => OpenStruct.new(
+    french: OpenStruct.new(
       subject: "French",
       name: "Tom",
       shoutout_name: "Ms Langley and Ms Meredith",
       shoutout_text: "I was totally in awe of my GCSE and A Level Spanish teachers",
       story_text: "Some of my friends were going into office jobs",
     ),
-  }.each do |subject_id, metadata|
+  }.each do |subject_key, metadata|
     specify "shows #{metadata.subject || 'non'}-specific case study content" do
+      subject_id = TeachingSubject.lookup_by_key(subject_key)
       get("/welcome/my-journey-into-teaching?preferred_teaching_subject_id=#{subject_id}")
 
       expect(response.body).to match(metadata.name)

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -31,7 +31,7 @@ shared_context "with stubbed types api" do
       .to_return \
         status: 200,
         headers: { "Content-type" => "application/json" },
-        body: GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map { |k, v| { id: v, value: k } }.to_json
+        body: TeachingSubject::ALL.map { |k, v| { id: v, value: k } }.to_json
   end
 end
 

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -38,7 +38,7 @@ shared_context "with wizard data" do
   end
 
   let(:teaching_subject_types) do
-    GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS.map do |k, v|
+    TeachingSubject::ALL.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-2704](https://trello.com/c/bO8W7Dn9/2704-clean-up-welcome-guide-references-to-subject-uuids)

### Context

Refactor teaching subjects into new model Remove the `GetIntoTeachingApiClient::Constants::TEACHING_SUBJECTS` and
`IGNORED_PREFERRED_TEACHING_SUBJECTS` constants, shifting the logic into an `TeachingSubject` class.

Remove all references to hard-coded UUIDs with calls to the `TeachingSubject` class.

### Changes proposed in this pull request

- Refactor teaching subjects into new model

### Guidance to review

Along the same lines as the `EventType` and `EventStatus` models.
