### PR TITLE
Fix broken links in funding widget

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -58,12 +58,12 @@
           <div>
             <h3>Next steps</h3>
             <div>
-              Find out more about <a href="#bursaries-and-scholarships">bursaries and scholarships</a>, including T&Cs.<br>
+              Find out more about <a href="#bursaries-and-scholarships">bursaries and scholarships</a>, including terms and conditions.<br>
               Explore <a href="/ways-to-train">ways to train</a>.
             </div>
           </div>
         <% end %>
-        <p>You may be able to get extra support <a href="#extra-financial-support-for-students-with-disabilities">if you're disabled</a>, <a href="#extra-financial-support-for-parents-and-carers">if you're a parent or carer</a>. You may still be eligible for funding <a href="#applying-for-funding-if-you-come-from-outside-england">if you're an international candidate</a>.</p>
+        <p>You may be able to get extra support <a href="#if-youre-disabled">if you're disabled</a>, <a href="#if-youre-a-parent-or-carer">if you're a parent or carer</a>. You may still be eligible for funding <a href="#if-you-come-from-outside-england">if you're an international candidate</a>.</p>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/Odqjb1Of

### Context
Three of the links in the funding widget don't work and need replacing - they are anchor links to content further down the page.

In addition, 'T&Cs' should be 'terms and conditions' for readability.

