### PR TITLE
Prevent loss of Google Ads tracking parameters

### DIFF
--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -15,9 +15,16 @@ export default class Gtm {
 
   initWindow() {
     window.dataLayer = window.dataLayer || [];
+
+    // We use this to retain Google Ads tracking parameters in the
+    // URL of the landing page (or they are subsequently lost when
+    // Turbolinks transitions).
+    window.dataLayer.push({ originalLocation: this.originalLocation });
+
     function gtag() {
       window.dataLayer.push(arguments);
     }
+
     window.gtag = window.gtag || gtag;
   }
 
@@ -62,5 +69,10 @@ export default class Gtm {
     return new CookiePreferences().allowedCategories.includes(category)
       ? 'granted'
       : 'denied';
+  }
+
+  get originalLocation() {
+    const l = window.location;
+    return `${l.protocol}://${l.hostname}${l.pathname}${l.search}`;
   }
 }

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -23,7 +23,12 @@ describe('Google Tag Manager', () => {
   const mockWindowLocation = () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: {},
+      value: {
+        protocol: 'https',
+        hostname: 'localhost',
+        pathname: '/path',
+        search: '?utm=tag',
+      },
     });
   };
 
@@ -34,7 +39,9 @@ describe('Google Tag Manager', () => {
   });
 
   describe('initialisation', () => {
-    beforeEach(() => run());
+    beforeEach(() => {
+      run();
+    });
 
     it('defines window.dataLayer', () => {
       expect(window.gtag).toBeDefined();
@@ -42,6 +49,16 @@ describe('Google Tag Manager', () => {
 
     it('defines window.gtag', () => {
       expect(window.dataLayer).toBeDefined();
+    });
+
+    it('pushes the original location onto the dataLayer', () => {
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            originalLocation: 'https://localhost/path?utm=tag',
+          }),
+        ])
+      );
     });
 
     it('appends the GTM script', () => {


### PR DESCRIPTION
### Trello card

[Trello-2604](https://trello.com/c/Zh7Ugf48/2604-investigate-discrepancies-in-sa360-and-ga-data-for-explore-campaigns)

### Context

When a user lands on a page via a Google Ads link it will have various query parameters attached that are used to attribute the visit to an paid ad.

When GA is included on each page (not using GTM) it uses the same 'tracker object' for each page view. The tracker will use `window.location` on its first instantiation to attribute the session to a paid ad (via the query parameters).

When GA is included via GTM, however, each time the tag fires it uses a new tracker object, which looks at `document.location` and ends up attributing subsequent page views as organic (the query parameters to attribute it to the
ad are only present on the first page view).

To fix this we need to configure the tracker object manually on each page view to correctly attribute it to the paid ad. We can do this by preserving the original `document.location` in the `dataLayer` and referencing it in the tag configuration in GTM.

### Changes proposed in this pull request

- Prevent loss of Google Ads tracking parameters

### Guidance to review

A more in-depth explanation of why this happens can be found [here](https://www.simoahava.com/gtm-tips/fix-rogue-referral-problem-single-page-sites/).

I think the reason this happens on some and not all paid ads is because those that go direct to a transaction end up having separate page views from there to the completion (Turbolinks doesn't kick in on form submission POST requests). The paid ads that go to another landing page (e.g. /search) get lost because Turbolinks transitions to the event page and then the event sign up page (so the tag is firing multiple times, losing the original 'tracker object').