### PR TITLE
Show chat as offline on weekends

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -26,8 +26,9 @@ export default class extends Controller {
     const openTime = dayjs().set('hour', 8).set('minute', 30).tz(timeZone);
     const closeTime = dayjs().set('hour', 17).set('minute', 30).tz(timeZone);
     const now = dayjs().tz(timeZone);
+    const weekend = [6, 0].includes(now.get('day'));
 
-    return now >= openTime && now <= closeTime;
+    return !weekend && now >= openTime && now <= closeTime;
   }
 
   start(e) {

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -102,10 +102,22 @@ describe('ChatController', () => {
     })
   })
 
-  describe("when the chat is offline (too late) and there is offline text", () => {
+  describe("when the chat is offline (too late)", () => {
     beforeEach(() => {
       setBody();
       setCurrentTime('2021-01-01 17:31');
+    });
+
+    it('displays the chat offline message', () => {
+      const button = document.querySelector('[data-chat-target="offline"]')
+      expect(button.classList.contains('hidden')).toBe(false)
+    })
+  })
+
+  describe("when the chat is offline (weekend)", () => {
+    beforeEach(() => {
+      setBody();
+      setCurrentTime('2021-12-18 11:00');
     });
 
     it('displays the chat offline message', () => {


### PR DESCRIPTION
### Trello card

[Trello-2779](https://trello.com/c/fblVO89g/2779-ensure-chat-button-is-unavailable-at-weekends)

### Context

We currently show the chat as offline when outside of working hours, however we aren't taking into account weekends when the chat should be offline all the time.

### Changes proposed in this pull request

- Show chat as offline on weekends

### Guidance to review

