### PR TITLE
Rework the enter verification code step

### DIFF
--- a/app/views/callbacks/steps/_authenticate.html.erb
+++ b/app/views/callbacks/steps/_authenticate.html.erb
@@ -1,5 +1,5 @@
-<h1>Verify your email address</h1>
+<%= tag.h1("You're already registered with us") %>
 
 <p>Before you can book a callback, you need to verify your email address.</p>
 
-<%= render "wizard/steps/authenticate", f: f, email: callbacks_session["email"], resend_verification_path: resend_verification_callbacks_steps_path %>
+<%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_callbacks_steps_path %>

--- a/app/views/callbacks/steps/_form.html.erb
+++ b/app/views/callbacks/steps/_form.html.erb
@@ -12,5 +12,9 @@
       <% button_text = safe_html_format(wizard.last_step? ? "Book your callback <span></span>" : "Next step <span></span>") %>
       <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
+
+    <% if content_for?(:form_help) %>
+      <div class="form-help"><%= yield(:form_help) %></div>
+    <% end %>
   <% end %>
 </section>

--- a/app/views/event_steps/_authenticate.html.erb
+++ b/app/views/event_steps/_authenticate.html.erb
@@ -1,6 +1,6 @@
-<%= tag.h1("Verify your email address") %>
+<%= tag.h1("You're already registered with us") %>
 
-<%= render "wizard/steps/authenticate", f: f, email: event_session["email"], resend_verification_path: resend_verification_event_steps_path %>
+<%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_event_steps_path %>
 
 <% if event_session["is_walk_in"] %>
 <p>If you cannot access your verification code, you can still <%= link_to("continue without verifying your identity", event_step_path(params[:event_id], :authenticate, { skip_verification: true })) %>.</p>

--- a/app/views/event_steps/_form.html.erb
+++ b/app/views/event_steps/_form.html.erb
@@ -13,6 +13,10 @@
         <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next step <span></span>") %>
         <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
       <% end %>
+
+      <% if content_for?(:form_help) %>
+        <div class="form-help"><%= yield(:form_help) %></div>
+      <% end %>
     <% end %>
 
     <div class="event-info">

--- a/app/views/mailing_list/steps/_already_subscribed.html.erb
+++ b/app/views/mailing_list/steps/_already_subscribed.html.erb
@@ -1,4 +1,4 @@
-<h1>You’ve already signed up</h1>
+<h1>You've already signed up</h1>
 
 <p>
 The email address <%= mailing_list_session["email"] %> is already signed up to receive emails.

--- a/app/views/mailing_list/steps/_authenticate.html.erb
+++ b/app/views/mailing_list/steps/_authenticate.html.erb
@@ -1,3 +1,3 @@
-<h1>Verify your email address</h1>
+<%= tag.h1("You're already registered with us") %>
 
-<%= render "wizard/steps/authenticate", f: f, email: mailing_list_session["email"], resend_verification_path: resend_verification_mailing_list_steps_path %>
+<%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_mailing_list_steps_path %>

--- a/app/views/mailing_list/steps/_form.html.erb
+++ b/app/views/mailing_list/steps/_form.html.erb
@@ -12,5 +12,9 @@
       <% button_text = safe_html_format(wizard.last_step? ? "Complete sign up <span></span>" : "Next step <span></span>") %>
       <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
     <% end %>
+
+    <% if content_for?(:form_help) %>
+      <div class="form-help"><%= yield(:form_help) %></div>
+    <% end %>
   <% end %>
 </section>

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,10 +1,15 @@
 <%
-  hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text",
-    link: link_to(t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.link"), resend_verification_path))
+  hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text")
   hint_text += "<br><b>#{t('helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent')}</b>" if params[:verification_resent]
 %>
 
 <%= f.govuk_text_field :timed_one_time_password,
 autocomplete: "off",
-label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', email: email) },
+label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password'), class: "govuk-hint" },
 hint: { text: safe_html_format(hint_text) } %>
+
+<% content_for(:form_help) do %>
+  <p>The code expires in 15 minutes.</p>
+  <p>Check your spam or junk folder if you cannot find the email.</p>
+  <p><%= link_to("Send another code to verify my details.", resend_verification_path) %></p>
+<% end %>

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -17,6 +17,10 @@
     }
   }
 
+  .form-help {
+    margin-top: $indent-amount;
+  }
+
   .registration__event {
     h2 {
       margin: .2em 0 1em;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,19 +521,6 @@ en:
       search:
         search: Search for ...
 
-      # one-page mailing list
-      mailing_list_signup:
-        first_name: First name
-        last_name: Last name
-        email: Email address
-        address_postcode: What is your postcode? (optional)
-        degree_status_id: Do you have a degree?
-        preferred_teaching_subject_id: What would you like to teach?
-        consideration_journey_stage_id: How close are you to applying for teacher training?
-        timed_one_time_password: Verification code
-        accept_privacy_policy_options:
-          1_html: I am over 16 years old and accept the <a target="_blank" href="/privacy-policy">privacy policy</a>
-
     hint:
       events_steps_contact_details:
         address_telephone: |-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,7 +481,7 @@ en:
 
     label:
       wizard_steps_authenticate:
-        timed_one_time_password: Check your email and enter the verification code sent to %{email}
+        timed_one_time_password: "To verify your details, we've sent a code to your email address."
 
       events_steps_personal_details:
         first_name: First name
@@ -540,9 +540,8 @@ en:
            We'll use this to send you a reminder and let you know about any last-minute cancellations.
       wizard_steps_authenticate:
         timed_one_time_password:
-          text: Check your junk mail folder or %{link}.
-          resent: We've sent you another email.
-          link: resend verification
+          text: "Enter your code here:"
+          resent: We've sent you another email
       events_steps_personalised_updates:
         address_postcode: |-
           We want to send you relevant information about events in your area.

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -44,8 +44,8 @@ RSpec.feature "Book a callback", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to email@address.com", with: "123456"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Choose a time for your callback"
@@ -94,16 +94,16 @@ RSpec.feature "Book a callback", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to email@address.com", with: "654321"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "654321"
     click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
-    click_link "resend verification"
-    expect(page).to have_text "We've sent you another email."
+    click_link "Send another code to verify my details."
+    expect(page).to have_text "We've sent you another email"
 
-    fill_in "Check your email and enter the verification code sent to email@address.com", with: "123456"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Choose a time for your callback"

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
+    expect(page).to have_text "To verify your details, we've sent a code to your email address."
     click_on "continue without verifying your identity"
 
     fill_in "What is your telephone number? (optional)", with: "01234567890"
@@ -185,8 +185,8 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "To verify your details, we've sent a code to your email address."
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Are you over 16 and do you agree"
@@ -242,16 +242,16 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "654321"
+    expect(page).to have_text "To verify your details, we've sent a code to your email address."
+    fill_in "To verify your details, we've sent a code to your email address.", with: "654321"
     click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
-    click_link "resend verification"
-    expect(page).to have_text "We've sent you another email."
+    click_link "Send another code to verify my details."
+    expect(page).to have_text "We've sent you another email"
 
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text("What is your telephone number? (optional)")
@@ -275,8 +275,8 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "To verify your details, we've sent a code to your email address."
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text("What is your telephone number? (optional)")
@@ -320,8 +320,8 @@ RSpec.feature "Event wizard", type: :feature do
     fill_in_personal_details_step
     click_on "Next step"
 
-    expect(page).to have_text "Check your email and enter the verification code sent to test@user.com"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "To verify your details, we've sent a code to your email address."
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text("What is your telephone number? (optional)")

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -110,8 +110,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step(first_name: first_name)
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
@@ -162,16 +162,16 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "654321"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "654321"
     click_on "Next step"
 
     expect(page).to have_text "Please enter the latest verification code"
 
-    click_link "resend verification"
-    expect(page).to have_text "We've sent you another email."
+    click_link "Send another code to verify my details."
+    expect(page).to have_text "We've sent you another email"
 
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
@@ -193,11 +193,11 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
-    expect(page).to have_text "You’ve already signed up"
+    expect(page).to have_text "You've already signed up"
     expect(page).not_to have_button("Next step")
   end
 
@@ -217,8 +217,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
     expect(page).to have_text "Do you have a degree?"
@@ -298,14 +298,14 @@ RSpec.feature "Mailing list wizard", type: :feature do
     fill_in_name_step
     click_on "Next step"
 
-    expect(page).to have_text "Verify your email address"
-    fill_in "Check your email and enter the verification code sent to test@user.com", with: "123456"
+    expect(page).to have_text "You're already registered with us"
+    fill_in "To verify your details, we've sent a code to your email address.", with: "123456"
     click_on "Next step"
 
-    expect(page).to have_text "You’ve already signed up"
+    expect(page).to have_text "You've already signed up"
     click_link("Back")
 
-    expect(page).to have_text "Verify your email address"
+    expect(page).to have_text "You're already registered with us"
     click_link("Back")
 
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \


### PR DESCRIPTION
### Trello card

[Trello-2727](https://trello.com/c/ZS2VxH2b/2727-review-whether-we-can-improve-the-authenticate-step-in-the-sign-up-funnels)

### Context

This step doesn't perform all that well and we see roughly 1/5 users drop off/don't successfully enter their verification code and progress to the next step.

In an effort to tackle this we are making the copy clearer/reworking the layout of the step. This step doesn't perform all that well and we see roughly 1/5 users drop off/don't successfully enter their verification code and progress to the next step.

### Changes proposed in this pull request

- Rework the enter verification code step

### Guidance to review

I've updated all the verification code step to match; the callback step has an extra paragraph that I've left in.

| Event      | Mailing List  | Callback |
| ----------- | ------------ | ----------- |
| <img width="775" alt="Screenshot 2021-12-17 at 15 25 12" src="https://user-images.githubusercontent.com/29867726/146567465-2e0a2bc5-9a8e-4ea7-bf37-2a1b48ed63e4.png">      |  <img width="599" alt="Screenshot 2021-12-17 at 15 25 27" src="https://user-images.githubusercontent.com/29867726/146567495-bc6844c3-d291-40e1-98c2-56cc52dd8e3f.png">     |  <img width="661" alt="Screenshot 2021-12-17 at 15 25 35" src="https://user-images.githubusercontent.com/29867726/146567520-903dbdc9-0b18-4da4-93d0-6342f349618d.png">        |


| Error State      | Resent Code State  |
| ----------- | ------------ | 
| <img width="782" alt="Screenshot 2021-12-17 at 15 26 33" src="https://user-images.githubusercontent.com/29867726/146567669-1099b41f-049d-4840-8507-69b292540ade.png">     |  <img width="774" alt="Screenshot 2021-12-17 at 15 26 46" src="https://user-images.githubusercontent.com/29867726/146567701-b67c0ce2-76aa-49fb-a1a2-484100d3384b.png">     |  
