### PR TITLE
Fix redirect to support if you are disabled page

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -209,7 +209,7 @@ redirects:
   "/lp/email-computing": "/"
   "/register": "/"
   "/funding-and-salary/overview": "/funding-your-training"
-  "/train-to-teach-with-a-disability": "/ways-to-train"
+  "/train-to-teach-with-a-disability": "/get-support-training-to-teach-if-you-are-disabled"
   "/explore-my-options/secondary/training-options": "/ways-to-train"
   "/user/register": "/tta-service"
   "/funding-and-salary/teacher-salaries": "/salaries-and-benefits"


### PR DESCRIPTION
### Trello card
https://trello.com/c/XgEazt2Z

### Context
Apply are currently pointing to an old page called `train-to-teach-with-a-disability`. This redirects to `ways-to-train` but would be better redirecting to `get-support-training-to-teach-if-you-are-disabled`.

NB there is a separate piece of work on looking at all links from Apply > GIT (see 
https://trello.com/c/VhYWFJy3)
