### PR TITLE
Change email listings text to mailto links

### DIFF
--- a/app/views/content/urgent-call-for-qualified-teachers/_faq.html.erb
+++ b/app/views/content/urgent-call-for-qualified-teachers/_faq.html.erb
@@ -271,7 +271,7 @@
 
     <p>
       For additional queries on supply teaching in Wales, please contact the Welsh
-      Government at SMED2Consultations@gov.wales
+      Government at <%= mail_to("SMED2Consultations@gov.wales") %>
     </p>
 
     <h3>Scotland</h3>

--- a/app/views/content/urgent-call-for-qualified-teachers/_list.html.erb
+++ b/app/views/content/urgent-call-for-qualified-teachers/_list.html.erb
@@ -43,7 +43,7 @@
 
           <div>
             <dt>Email:</dt>
-            <%= tag.dd(a["email"]) %>
+            <%= tag.dd(mail_to(a["email"])) %>
           </div>
 
           <div>


### PR DESCRIPTION
Adding this PR as an optional one - it introduces [some usability problems on desktop](https://adamsilver.io/blog/the-trouble-with-mailto-email-links-and-what-to-do-instead/) but it's a widely used pattern so people are likely to understand its shortfalls already.
