### PR TITLE
Make image_meta_tags use asset_pack_url internally

### DIFF
--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -7,10 +7,10 @@ module MetadataHelper
     tag.meta(name: prepend_opengraph(key, opengraph), content: value)
   end
 
-  def image_meta_tags(base_url:, image_path:, alt:, opengraph: true)
+  def image_meta_tags(image_path:, alt:, opengraph: true)
     return if image_path.blank?
 
-    image_url = "#{base_url}#{asset_pack_path(image_path)}"
+    image_url = asset_pack_url(image_path)
 
     safe_join([
       meta_tag(key: "image", value: image_url, opengraph: opengraph),

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -37,7 +37,6 @@
   <%= meta_tag(key: 'locale', value: "en_GB", opengraph: true) %>
   <%= meta_tag(key: "facebook-domain-verification", value: "h1r6sd9bvqql7fyzy5jmdoniuw1rtf") %>
   <%= image_meta_tags(
-    base_url: request.base_url,
     image_path: @front_matter["image"] || @front_matter["meta_image"],
     alt: "Photograph of teaching taking place in a classroom"
   ) %>

--- a/spec/helpers/metadata_helper_spec.rb
+++ b/spec/helpers/metadata_helper_spec.rb
@@ -24,15 +24,15 @@ describe MetadataHelper, type: "helper" do
 
   describe "#image_meta_tags" do
     it "returns nil when not given an image_path" do
-      expect(image_meta_tags(base_url: "https://example.com", image_path: "", alt: "")).to be_nil
+      expect(image_meta_tags(image_path: "", alt: "")).to be_nil
     end
 
     it "returns image/alt meta tags when given an image_path" do
-      tags = image_meta_tags(base_url: "https://example.com", image_path: "media/images/content/hero-images/0012.jpg", alt: "An image")
+      tags = image_meta_tags(image_path: "media/images/content/hero-images/0012.jpg", alt: "An image")
 
       expect(tags).to include(
         <<~HTML.chomp,
-          <meta name="og:image" content="https://example.com/packs-test/v1/media/images/content/hero-images/0012-cb6435a02b879e8df922882afba620a8.jpg">
+          <meta name="og:image" content="/packs-test/v1/media/images/content/hero-images/0012-cb6435a02b879e8df922882afba620a8.jpg">
         HTML
       )
 
@@ -41,6 +41,16 @@ describe MetadataHelper, type: "helper" do
           <meta name="og:image:alt" content="An image">
         HTML
       )
+    end
+
+    it "uses asset_pack_url internally" do
+      fake_host = "https://fake.com/123"
+
+      allow_any_instance_of(described_class).to receive(:asset_pack_url) { fake_host }
+
+      tags = image_meta_tags(image_path: "media/images/content/hero-images/0012.jpg", alt: "An image")
+
+      expect(tags).to match(fake_host)
     end
   end
 end


### PR DESCRIPTION
Now we use a different host for the app and assets this method doubles up the domain. Using asset_pack_url should resolve it.

Testing proved tricky, was unable to override the `#asset_path` on a per-test basis, so remove the domain from the existing test and add a new one to ensure we're using `#asset_pack_url` from within `#image_meta_tags`.

@ethaxross - if there's a better way of testing this please let me know, couldn't get it to play ball by stubbing `#asset_pack_url`
