### PR TITLE
Same link text going to multiple destinations

### DIFF
--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -39,7 +39,7 @@ We've also made the service text as simple as possible to understand.
 
 For advice on making your device easier to use if you have a disability visit [AbilityNet](https://mcmw.abilitynet.org.uk/).
 
-You can also find advice on GOV.UK at [Accessibility](https://www.gov.uk/help/accessibility).
+You can also find [accessibility advice on GOV.UK](https://www.gov.uk/help/accessibility).
 
 ## Service accessibility
 

--- a/app/views/content/get-school-experience.md
+++ b/app/views/content/get-school-experience.md
@@ -52,7 +52,7 @@ During your experience, you’ll get to do things like:
 
 ## Find school experience
 
-Use our [Get school experience service](https://schoolexperience.education.gov.uk/) to search for and request experience in England.
+Use our [Get school experience](https://schoolexperience.education.gov.uk/) service to search for and request experience in England.
 
 If you cannot find what you’re looking for, you can call a school directly. You can [find schools near you](https://get-information-schools.service.gov.uk/) and ask who to talk to about getting school experience. They may ask you to have a DBS check before attending.
 

--- a/app/views/content/research.md
+++ b/app/views/content/research.md
@@ -8,7 +8,7 @@ calls_to_action:
   bringit-report:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read the Bring it report summary
       file_path: media/documents/bringit-report.pdf
       file_type: PDF
       file_size: 258KB
@@ -16,7 +16,7 @@ calls_to_action:
   breakthrough-moments:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read the Breakthrough moments report summary
       file_path: media/documents/breakthrough-moments.pdf
       file_type: PDF
       file_size: 274KB
@@ -24,7 +24,7 @@ calls_to_action:
   my-favourite-subject:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read the My favourite subject report summary
       file_path: media/documents/my-favourite-subject.pdf
       file_type: PDF
       file_size: 266KB
@@ -32,7 +32,7 @@ calls_to_action:
   exploring-career-aspirations-in-the-wake-of-2020:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read the Decade dilemmas report summary
       file_path: media/documents/exploring-career-aspirations-in-the-wake-of-2020.pdf
       file_type: PDF
       file_size: 754KB
@@ -40,7 +40,7 @@ calls_to_action:
   it-takes-you-to-teach:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the career aspirations and what it takes to teach survey
       file_path: media/documents/it-takes-you-to-teach.pdf
       file_type: PDF
       file_size: 764KB
@@ -48,7 +48,7 @@ calls_to_action:
   thank-a-teacher:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the appreciation for teachers survey
       file_path: media/documents/thank-a-teacher.pdf
       file_type: PDF
       file_size: 754KB
@@ -56,7 +56,7 @@ calls_to_action:
   millenial-career-crossroads:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read the Millennial Career Crossroads report summary
       file_path: media/documents/millenial-career-crossroads.pdf
       file_type: PDF
       file_size: 752KB
@@ -64,7 +64,7 @@ calls_to_action:
   career-conundrum:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the career change conundrum survey
       file_path: media/documents/career-conundrum.pdf
       file_type: PDF
       file_size: 460KB
@@ -72,7 +72,7 @@ calls_to_action:
   career-change-research:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the switching careers survey
       file_path: media/documents/career-change-research.pdf
       file_type: PDF
       file_size: 450KB
@@ -80,7 +80,7 @@ calls_to_action:
   perceptions-of-influence:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the perceptions of influence survey
       file_path: media/documents/perceptions-of-influence.pdf
       file_type: PDF
       file_size: 450KB
@@ -88,7 +88,7 @@ calls_to_action:
   career-survey-summary:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the careers survey
       file_path: media/documents/career-survey-summary.pdf
       file_type: PDF
       file_size: 424KB
@@ -97,7 +97,7 @@ calls_to_action:
   soft-messaging:
     name: attachment
     arguments:
-      text: Read the summary of findings
+      text: Read a summary of the soft messaging survey
       file_path: media/documents/soft-messaging.pdf
       file_type: PDF
       file_size: 459KB 

--- a/app/views/content/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/train-to-teach-in-england-as-an-international-student.md
@@ -187,7 +187,7 @@ Alternatively, you may be eligible for a different type of visa which allows you
 
 ## 6. Plan your move to the UK
 
-The [UK Council for International Student Affairs](https://www.ukcisa.org.uk/Information--Advice) delivers independent advice about all aspects of the international student experience, including immigration, finding a place to live and opening a bank account. Their [Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
+The [UK Council for International Student Affairs delivers independent advice](https://www.ukcisa.org.uk/Information--Advice) about all aspects of the international student experience, including immigration, finding a place to live and opening a bank account. Their [Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
 
 Your teacher training provider may also be able to help you plan your move to the UK  – contact them directly to ask.
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/A1JXUPQh

### Context
Silktide has highlighted an issue whereby the same link text is used for multiple links on a page that point to different destinations. This makes it difficult for people using screen readers to know which link is which.

In addition, we also have one instance where different link text is used to point to the same page, which again is not good from an accessibility perspective.

