### PR TITLE
Urgent call copy updates 2021-12-22

### DIFF
--- a/app/views/content/urgent-call-for-qualified-teachers.md
+++ b/app/views/content/urgent-call-for-qualified-teachers.md
@@ -1,7 +1,7 @@
 ---
 title: Get back into the classroom and teach supply
 heading: Urgent call for qualified teachers
-subheading: Be part of the national effort to support face-to-face education in schools and colleges in the New Year
+subheading: Be part of the national effort to support face-to-face education in schools and colleges
 description: |-
   Find supply teaching agencies and help shape a life. Answer the urgent call
   for qualified teachers to support children and young people.
@@ -2956,7 +2956,7 @@ agencies:
 Are you a qualified teacher not currently working in the sector?
 We are asking for your help to support your teaching colleagues and the nation's children and young people through this difficult time.
 
-Covid continues to impact schools and colleges in England. We want to make sure that as many supply staff as possible are available in the new year.
+Covid continues to impact schools and colleges in England. We want to make sure that as many supply staff as possible are available.
 
 ## Who can help?
 

--- a/app/views/content/urgent-call-for-qualified-teachers/_faq.html.erb
+++ b/app/views/content/urgent-call-for-qualified-teachers/_faq.html.erb
@@ -173,11 +173,13 @@
 
   <div>
     <p>
-      As of 13 December 2021, 89% of all adults and children over 12 years old in
-      England have received at least one dose of a vaccine, 81.1% have received a
-      second dose and 40.8% have received a booster (or third dose). Vaccines
-      remain an effective measure against COVID-19 and we encourage everyone to
-      <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/book-coronavirus-vaccination/">take up the offer of a vaccine and booster where possible</a>.
+      As of 20 December 2021, 89.5% of all adults and children over 12 years old in
+      England have received at least one dose of a vaccine, 81.7% have received a
+      second dose and 51.9% have received a booster (or third
+      dose). Vaccines remain an effective measure against COVID-19 and we
+      encourage everyone to
+      <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/book-coronavirus-vaccination/">take
+        up the offer of a vaccine and booster where possible</a>.
     </p>
 
     <p>

--- a/app/views/content/urgent-call-for-qualified-teachers/_list.html.erb
+++ b/app/views/content/urgent-call-for-qualified-teachers/_list.html.erb
@@ -1,4 +1,4 @@
-<h3 id="find-an-agency">Find an agency</h3>
+<h3 id="find-an-agency">Find an agency in England</h3>
 
 <ul class="agencies-toc">
   <% @front_matter["agencies"].each_key do |region| %>


### PR DESCRIPTION
- Remove 'in the new year' text from urgent call copy
- Update some stats in FAQ answer
- Add 'in England' to 'Find an agency' heading
