### PR TITLE
Remove ViewComponent's engine loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ require "action_view/railtie"
 # require "action_cable/engine"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
-require "view_component/engine"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
It's no longer needed and adds warning messages to test output

https://github.com/github/view_component/pull/1162
