### PR TITLE
Make welcome guide use path instead of query

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -44,7 +44,7 @@ module WelcomeHelper
   end
 
   def degree_stage_based_encouragement
-    # degree stage:         final year , second year
+    # degree stage:          final year , second year
     if degree_status_id.in?([222_750_001, 222_750_002])
       "Especially as you get closer to graduating"
     else

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -82,7 +82,7 @@ module MailingList
     end
 
     def welcome_guide_variant(degree_status_id: nil, preferred_teaching_subject_id: nil)
-      %w[/welcome email].tap { |path|
+      %w[/email].tap { |path|
         if preferred_teaching_subject_id
           path << ["subject", TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id).downcase]
         end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -74,12 +74,23 @@ module MailingList
 
       return export unless show_welcome_guide
 
-      export.tap do |h|
-        h[:welcome_guide_variant] = export_data.slice(
-          "degree_status_id",
-          "preferred_teaching_subject_id",
-        ).to_query
-      end
+      wg_params = export_data
+        .slice("degree_status_id", "preferred_teaching_subject_id")
+        .symbolize_keys
+
+      export.tap { |h| h[:welcome_guide_variant] = welcome_guide_variant(**wg_params) }
+    end
+
+    def welcome_guide_variant(degree_status_id: nil, preferred_teaching_subject_id: nil)
+      %w[/welcome email].tap { |path|
+        if preferred_teaching_subject_id
+          path << ["subject", TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id).downcase]
+        end
+
+        if degree_status_id
+          path << ["degree-status", OptionSet.lookup_by_value(:degree_status, degree_status_id).downcase]
+        end
+      }.join("/")
     end
   end
 end

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -32,6 +32,14 @@ class OptionSet
       lookup_const(category).fetch_values(*keys)
     end
 
+    def lookup_by_value(category, value)
+      lookup_const(category).invert.fetch(value)
+    end
+
+    def lookup_by_values(category, *values)
+      lookup_const(category).invert.fetch_values(*values)
+    end
+
     def lookup_const(category)
       const = const_get(category.to_s.pluralize.upcase)
       const.transform_keys { |k| k.parameterize(separator: "_").to_sym }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,12 +49,18 @@ Rails.application.routes.draw do
   end
 
   get "/funding-your-training", to: "pages#funding_your_training", as: :funding_your_training
-  get "/welcome", to: "pages#welcome", as: :welcome_guide
-  get "/welcome/my-journey-into-teaching", to: "pages#welcome_my_journey_into_teaching", as: :welcome_my_journey_into_teaching
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/tta-service", to: "pages#tta_service", as: :tta_service
   get "/tta", to: "pages#tta_service", as: nil
+
+  get "/welcome", to: "pages#welcome", as: :welcome_guide
+  get "/welcome/my-journey-into-teaching", to: "pages#welcome_my_journey_into_teaching", as: :welcome_my_journey_into_teaching
+
+  # param paths for welcome guide customisation
+  get "/welcome/email/subject/:subject", to: "pages#welcome"
+  get "/welcome/email/degree-status/:degree_status", to: "pages#welcome"
+  get "/welcome/email/subject/:subject/degree-status/:degree_status", to: "pages#welcome"
 
   resource :search, only: %i[show]
   # resource :eligibility_checker,

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -42,7 +42,7 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
-    let(:variant) { "/welcome/email/subject/maths/degree-status/final_year" }
+    let(:variant) { "/email/subject/maths/degree-status/final_year" }
     let(:request) do
       GetIntoTeachingApiClient::MailingListAddMember.new({
         email: wizardstore[:email],

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -5,13 +5,14 @@ describe MailingList::Wizard do
 
   let(:uuid) { SecureRandom.uuid }
   let(:degree_status_id) { OptionSet.lookup_by_key(:degree_status, :final_year) }
+  let(:preferred_teaching_subject_id) { TeachingSubject.lookup_by_key(:maths) }
   let(:store) do
     { uuid => {
       "email" => "email@address.com",
       "first_name" => "Joe",
       "last_name" => "Joseph",
       "degree_status_id" => degree_status_id,
-      "preferred_teaching_subject_id" => "456",
+      "preferred_teaching_subject_id" => preferred_teaching_subject_id.to_s,
       "accepted_policy_id" => "789",
     } }
   end
@@ -41,7 +42,7 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
-    let(:variant) { "degree_status_id=#{degree_status_id}&preferred_teaching_subject_id=456" }
+    let(:variant) { "/welcome/email/subject/maths/degree-status/final_year" }
     let(:request) do
       GetIntoTeachingApiClient::MailingListAddMember.new({
         email: wizardstore[:email],

--- a/spec/models/option_set_spec.rb
+++ b/spec/models/option_set_spec.rb
@@ -19,6 +19,18 @@ describe OptionSet do
       it { expect(described_class.lookup_const(:consideration_journey_stage)).to eq(expected_const(described_class::CONSIDERATION_JOURNEY_STAGES)) }
       it { expect(described_class.lookup_const(:mailing_list_channel)).to eq(expected_const(described_class::MAILING_LIST_CHANNELS)) }
     end
+
+    describe ".lookup_by_value" do
+      it { expect(described_class.lookup_by_value(:degree_status, 222_750_001)).to eq(:final_year) }
+      it { expect(described_class.lookup_by_value(:mailing_list_channel, 222_750_037)).to eq(:careers_services_activity) }
+      it { expect { described_class.lookup_by_value(:degree_status, 0) }.to raise_error(KeyError) }
+    end
+
+    describe ".lookup_by_values" do
+      it { expect(described_class.lookup_by_values(:degree_status, 222_750_001, 222_750_003)).to eq(%i[final_year first_year]) }
+      it { expect(described_class.lookup_by_values(:mailing_list_channel, 222_750_037, 222_750_038)).to eq(%i[careers_services_activity students_union_media]) }
+      it { expect { described_class.lookup_by_values(:degree_status, 222_750_037, 0) }.to raise_error(KeyError) }
+    end
   end
 
   def expected_const(const)

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -48,7 +48,7 @@ describe PagesController, type: :request do
     let(:params) do
       {
         "preferred_teaching_subject_id" => TeachingSubject.lookup_by_key(:biology),
-        "degree_status_id" => "222_750_003",
+        "degree_status_id" => 222_750_003,
         "a_key_that_shouldnt_be_accepted" => "abc123",
       }
     end
@@ -57,7 +57,7 @@ describe PagesController, type: :request do
       params.map { |k, v| "#{k}=#{v}" }.join("&")
     end
 
-    before { get %(/welcome?#{joined_params}) }
+    before { get %(/welcome/email/subject/biology/degree-status/first_year) }
 
     specify "the params are saved to the session" do
       expect(session["welcome_guide"]).to eql(params.except("a_key_that_shouldnt_be_accepted"))

--- a/spec/requests/welcome_guide_spec.rb
+++ b/spec/requests/welcome_guide_spec.rb
@@ -32,8 +32,7 @@ describe "Welcome guide landing page", type: :request do
     ),
   }.each do |subject_key, metadata|
     specify "shows #{metadata.subject || 'non'}-specific content" do
-      subject_id = TeachingSubject.lookup_by_key(subject_key)
-      get("/welcome?preferred_teaching_subject_id=#{subject_id}")
+      get("/welcome/email/subject/#{subject_key}")
 
       expect(response.body).to match(%r{teaching <mark>#{metadata.subject}.</mark>}i)
       expect(response.body).to match("Read #{metadata.name}'s story")
@@ -71,8 +70,8 @@ describe "Welcome guide landing page", type: :request do
     ),
   }.each do |subject_key, metadata|
     specify "shows #{metadata.subject || 'non'}-specific case study content" do
-      subject_id = TeachingSubject.lookup_by_key(subject_key)
-      get("/welcome/my-journey-into-teaching?preferred_teaching_subject_id=#{subject_id}")
+      get("/welcome/email/subject/#{subject_key}")
+      get("/welcome/my-journey-into-teaching")
 
       expect(response.body).to match(metadata.name)
       expect(response.body).to match(metadata.shoutout_name)


### PR DESCRIPTION
### Trello card

https://trello.com/c/k6j7B40B/2806-investigate-workarounds-for-crm-welcome-guide-email-problems

### Context and changes

We ran into a problem where Dynamics' link tracking appends `?p0=` to the links it generates making the subsquent query param be ignored. Here's an example query:

```
?p0=?degree_status_id=222750001&preferred_teaching_subject_id=962655a1-2afa-e811-a981-000d3a276620
    ^
    |
    | from here is ignored
```

To combat it, this PR changes the format, we go from this:

```
/welcome?degree_status_id=222750001&preferred_teaching_subject_id=962655a1-2afa-e811-a981-000d3a276620
```

To this:

```
/welcome/email/subject/maths/degree-status/graduate
```

Two things have changed:

* we're using the path instead of the query string (see the new routes)
* we're referring to records using a slug instead of a ID or GUID. This makes it easier and gives the user a better experience

In this app we convert the string name to 'slug' by lowercasing and replacing spaces with underscores. The CRM doesn't know about them yet so ideally we'd add this data (and hard code it) in the CRM and then use that as the source.
