### PR TITLE
Use formatted_event_description helper

### DIFF
--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -6,7 +6,7 @@
   </div>
 <% end %>
 
-<%= tag.div(safe_html_format(@event.description)) %>
+<%= tag.div(formatted_event_description(@event.description)) %>
 
 <% if @event.video_url %>
   <div class="teaching-event__video youtube-video-container">


### PR DESCRIPTION
This makes the new template match the behaviour of the old one more closely. Some events with Word-style formatting behaved a bit differently in the test environment.
