### PR TITLE
Make event location text line up with other text

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -304,6 +304,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
         &__date-and-time,
         &__name,
+        &__location,
         &__setting {
           padding-left: 3rem;
           min-height: 2em;


### PR DESCRIPTION
### Trello card

https://trello.com/c/dwXgoOLp/2813-add-location-icon-to-summary-card-is-on-new-events-listing-page

### Context

Originally we were going to have a (map pin) icon here on the left but the aspect ratios of the icons make it painful, we're best holding off until we have standard ones that can be used interchangeably.

### Changes proposed in this pull request

Make the location text line up with the text above and below.

| Before | After |
| ---- | ------ |
| ![Screenshot from 2022-01-07 10-43-30](https://user-images.githubusercontent.com/128088/148533012-51516392-2895-4f8d-8d06-4ef65bcec545.png) | ![Screenshot from 2022-01-07 10-43-48](https://user-images.githubusercontent.com/128088/148533024-e1215ce4-b61a-4851-a590-75b6e3616dcf.png) |


