### PR TITLE
Change 'Teaching events' to 'Teacher training events'

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -24,7 +24,7 @@
       <span class="menu-button__text">Menu</span>
     <% end %>
   </div>
-  <%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Teaching events", "/blog" => "Blog" }) %>
+  <%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Teacher training events", "/blog" => "Blog" }) %>
 </header>
 
 <%= above_hero %>

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,10 +10,10 @@ class EventsController < ApplicationController
   MAXIMUM_EVENTS_PER_CATEGORY = 1_000
 
   def index
-    @page_title = "Find an event near you"
+    @page_title = "Teacher training events"
     @front_matter = {
       "description" => "Get your questions answered at an event.",
-      "title" => "Find an event near you",
+      "title" => "Teacher training events",
       "image" => "media/images/content/hero-images/0002.jpg",
     }
 
@@ -21,7 +21,7 @@ class EventsController < ApplicationController
   end
 
   def search
-    @page_title = "Find an event near you"
+    @page_title = "Teacher training events"
     @front_matter = { "description" => "Get your questions answered at an event." }
 
     render "index", layout: "events"

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,7 +1,7 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Have all your questions answered at an event.",
+    title: "Have all your questions answered at a teacher training event.",
     link_text: "Find events",
     link_target: "/events",
     image: "media/images/content/homepage/science-teacher.jpg")

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,7 +1,7 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Have all your questions answered at a teacher training event.",
+    title: "Have your questions answered at a teacher training event.",
     link_text: "Find events",
     link_target: "/events",
     image: "media/images/content/homepage/science-teacher.jpg")

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -119,9 +119,9 @@
   &--homepage {
     display: grid;
     margin-bottom: 0;
-    gap: .2em;
+    gap: .6em;
 
-    grid-template-rows: 1em 1fr 2fr 1fr 1em;
+    grid-template-rows: 1em 1fr 2fr .8fr 1em;
     grid-template-columns: 1.2fr .8fr;
     overflow: hidden;
 

--- a/config/locales/loaf.yml
+++ b/config/locales/loaf.yml
@@ -5,4 +5,4 @@ en:
     breadcrumbs:
       home: "Home"
       events:
-        search: "Find an event near you"
+        search: "Teacher training events"


### PR DESCRIPTION
### Trello card

https://trello.com/c/0k7s1FD7/2756-update-teaching-events-in-nav-to-be-teacher-training-events
https://trello.com/c/0y5dum5p/2757-update-text-in-events-block-on-home-page-to-refer-to-teacher-training-event

### Context

Update the text used to describe events pages on the homepage and in the nav.

### Changes proposed in this pull request

- Change events CTA on the homepage
- Replace old events name with new one

### Guidance to review

