### PR TITLE
Enable the /teaching-events route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,11 +89,9 @@ Rails.application.routes.draw do
     end
   end
 
-  unless Rails.env.production?
-    resources "teaching_events", path: "/teaching-events", controller: "teaching_events" do
-      collection do
-        get :about_ttt_events, path: "about-ttt-events", as: "about_ttt"
-      end
+  resources "teaching_events", path: "/teaching-events", controller: "teaching_events" do
+    collection do
+      get :about_ttt_events, path: "about-ttt-events", as: "about_ttt"
     end
   end
 


### PR DESCRIPTION
This will enable the new event list and view pages. The new path, `/teaching-events`, will not be indexed just yet as it's going to be included in a round of A/B tests first.
