### PR TITLE
Enable Sentry for JS exceptions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,6 @@ module ApplicationHelper
   def sentry_dsn
     return nil if Rails.env.production?
 
-    Sentry.configuration.dsn&.raw_value
+    Sentry.configuration.dsn&.to_s
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,4 +90,10 @@ module ApplicationHelper
       YAML.safe_load(File.read(Rails.root.join("config/google_optimize.yml")))
         .deep_symbolize_keys
   end
+
+  def sentry_dsn
+    return nil if Rails.env.production?
+
+    Sentry.configuration.dsn&.raw_value
+  end
 end

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -15,7 +15,7 @@
   <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
   <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env }, async: true %>
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,3 +1,14 @@
+import * as Sentry from "@sentry/browser";
+
+const sentryConfig = document.querySelector("[data-sentry-dsn]")?.dataset;
+
+if (sentryConfig) {
+  Sentry.init({
+    dsn: sentryConfig.sentryDsn,
+    environment: sentryConfig.sentryEnvironment,
+  });
+}
+
 import '@stimulus/polyfills';
 import "core-js/stable";
 import "regenerator-runtime/runtime";

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -42,6 +42,7 @@ SecureHeaders::Configuration.default do |config|
   snapchat  = %w[*.snapchat.com sc-static.net]
   twitter   = %w[t.co *.twitter.com static.ads-twitter.com analytics.twitter.com]
   youtube   = %w[*.youtube.com *.youtube-nocookie.com i.ytimg.com www.youtube.com www.youtube-nocookie.com]
+  sentry    = %w[*.ingest.sentry.io]
 
   quoted_unsafe_inline = ["'unsafe-inline'"]
   quoted_unsafe_eval   = ["'unsafe-eval'"]
@@ -56,7 +57,7 @@ SecureHeaders::Configuration.default do |config|
     default_src: %w['none'],
     base_uri: ["'self'"],
     child_src: ["'self'"].concat(youtube, pinterest, snapchat, hotjar),
-    connect_src: ["'self'"].concat(pinterest, hotjar, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat),
+    connect_src: ["'self'"].concat(pinterest, hotjar, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat, sentry),
     font_src: ["'self'"].concat(govuk, data, %w[fonts.gstatic.com]),
     form_action: ["'self'"].concat(snapchat, facebook, govuk),
     frame_src: ["'self'"].concat(scribble, snapchat, facebook, youtube, hotjar, google_doubleclick, google_analytics, data, pinterest, optimize),

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@rails/webpacker": "5.4.3",
+    "@sentry/browser": "^6.16.1",
+    "@sentry/tracing": "^6.16.1",
     "@stimulus/polyfills": "^2.0.0",
     "accessible-autocomplete": "^2.0.3",
     "dayjs": "^1.10.7",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -207,4 +207,22 @@ describe ApplicationHelper do
 
     it { is_expected.to eq({ paths: ["/test/a", "/test/b", "/events", "/teaching-events"] }) }
   end
+
+  describe "#sentry_dsn" do
+    subject { sentry_dsn }
+
+    it { is_expected.to be_nil }
+
+    context "when sentry dsn exist" do
+      before { allow(Sentry.configuration).to receive(:dsn).and_return(OpenStruct.new(raw_value: "1234")) }
+
+      it { is_expected.to eq("1234") }
+
+      context "when production" do
+        before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -214,7 +214,7 @@ describe ApplicationHelper do
     it { is_expected.to be_nil }
 
     context "when sentry dsn exist" do
-      before { allow(Sentry.configuration).to receive(:dsn).and_return(OpenStruct.new(raw_value: "1234")) }
+      before { allow(Sentry.configuration).to receive(:dsn).and_return("1234") }
 
       it { is_expected.to eq("1234") }
 

--- a/spec/requests/sentry_js_spec.rb
+++ b/spec/requests/sentry_js_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe "Sentry JS", type: :request do
+  subject do
+    get root_path
+    response.body
+  end
+
+  it { is_expected.not_to include("data-sentry-dsn") }
+  it { is_expected.to include(%(data-sentry-environment="test")) }
+
+  context "when a Sentry DSN is set" do
+    before { allow(Sentry.configuration).to receive(:dsn).and_return(OpenStruct.new(raw_value: "1234")) }
+
+    it { is_expected.to include(%(data-sentry-dsn="1234")) }
+    it { is_expected.to include(%(data-sentry-environment="test")) }
+
+    context "when production" do
+      before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+      it { is_expected.not_to include("data-sentry-dsn") }
+    end
+  end
+end

--- a/spec/requests/sentry_js_spec.rb
+++ b/spec/requests/sentry_js_spec.rb
@@ -10,7 +10,7 @@ describe "Sentry JS", type: :request do
   it { is_expected.to include(%(data-sentry-environment="test")) }
 
   context "when a Sentry DSN is set" do
-    before { allow(Sentry.configuration).to receive(:dsn).and_return(OpenStruct.new(raw_value: "1234")) }
+    before { allow(Sentry.configuration).to receive(:dsn).and_return("1234") }
 
     it { is_expected.to include(%(data-sentry-dsn="1234")) }
     it { is_expected.to include(%(data-sentry-environment="test")) }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,69 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@sentry/browser@^6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.16.1.tgz#4270ab0fbd1de425e339b3e7a364feb09f470a87"
+  integrity sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==
+  dependencies:
+    "@sentry/core" "6.16.1"
+    "@sentry/types" "6.16.1"
+    "@sentry/utils" "6.16.1"
+    tslib "^1.9.3"
+
+"@sentry/core@6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.16.1.tgz#d9f7a75f641acaddf21b6aafa7a32e142f68f17c"
+  integrity sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==
+  dependencies:
+    "@sentry/hub" "6.16.1"
+    "@sentry/minimal" "6.16.1"
+    "@sentry/types" "6.16.1"
+    "@sentry/utils" "6.16.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.16.1.tgz#526e19db51f4412da8634734044c605b936a7b80"
+  integrity sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==
+  dependencies:
+    "@sentry/types" "6.16.1"
+    "@sentry/utils" "6.16.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.16.1.tgz#6a9506a92623d2ff1fc17d60989688323326772e"
+  integrity sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==
+  dependencies:
+    "@sentry/hub" "6.16.1"
+    "@sentry/types" "6.16.1"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.16.1.tgz#32fba3e07748e9a955055afd559a65996acb7d71"
+  integrity sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==
+  dependencies:
+    "@sentry/hub" "6.16.1"
+    "@sentry/minimal" "6.16.1"
+    "@sentry/types" "6.16.1"
+    "@sentry/utils" "6.16.1"
+    tslib "^1.9.3"
+
+"@sentry/types@6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.16.1.tgz#4917607115b30315757c2cf84f80bac5100b8ac0"
+  integrity sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==
+
+"@sentry/utils@6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.16.1.tgz#1b9e14c2831b6e8b816f7021b9876133bf2be008"
+  integrity sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==
+  dependencies:
+    "@sentry/types" "6.16.1"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -9726,6 +9789,11 @@ tsconfig-paths@^3.11.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
[Trello-2821](https://trello.com/c/vzTm8fCk/2821-investigate-loss-of-ppc-attribution)

We currently only capture Ruby exceptions in Sentry.

Enable capturing JS exceptions to help debug an issue with PPC attribution in production that seems very intermittent; there
may be a stray JS error happening for some users thats the cause.

The JS errors will be bundled into the same Sentry DSN as the Ruby exceptions; Sentry should let us distinguish, but if they
are too frequent we may want to look at separate projects. 

To begin with this will only run in non-production environments.