### PR TITLE
Teaching events visual tweaks

### DIFF
--- a/app/components/teaching_events/event_component.html.erb
+++ b/app/components/teaching_events/event_component.html.erb
@@ -31,9 +31,13 @@
     </div>
 
     <div class="event__meta">
-      <%= image_pack_tag("media/images/content/event-signup/birmingham-event-2.jpg", class: "event-image", alt: "A popular train to teach event in a hall with stalls and banners" ) %>
+      <div class="event-image">
+        <%= image_pack_tag("media/images/content/event-signup/birmingham-event-2.jpg", alt: "A popular train to teach event in a hall with stalls and banners" ) %>
+      </div>
 
-      <%= image_pack_tag("media/images/dfelogo-black.svg", class: "dfelogo", alt: "This is an official Department for Education event") %>
+      <div class="dfelogo">
+        <%= image_pack_tag("media/images/dfelogo-black.svg", alt: "This is an official Department for Education event") %>
+      </div>
     </div>
 
   <% else %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -233,16 +233,22 @@ $slightly-darker-grey: darken($grey, 10%);
       &--left {
         @include font-size(xsmall);
         flex: 1 1 30%;
-        padding: .2em 1em .2em 4.3em;
-        background: url(../images/icon-calendar.svg) no-repeat left center;
-        background-size: 2em;
-        background-position: 1em;
+        padding: .4em 1em;
+
+        @include mq($from: mobile) {
+          padding: .2em 1em .2em 4.3em;
+          background: url(../images/icon-calendar.svg) no-repeat left center;
+          background-size: 2em;
+          background-position: 1em;
+        }
       }
 
       &--right {
         $adjust: 1em;
         $unskew-amount: 12deg;
         $skew-amount: -12deg;
+
+        align-self: flex-start;
 
         text-align: center;
         padding: 1.2rem;
@@ -301,37 +307,42 @@ $slightly-darker-grey: darken($grey, 10%);
       .event__info {
         flex-basis: 60%;
         padding: 0;
+        gap: 1em;
 
-        &__date-and-time,
-        &__name,
-        &__location,
-        &__setting {
-          padding-left: 3rem;
-          min-height: 2em;
-        }
+        @include mq($from: mobile) {
+          gap: 2em;
 
-        &__date-and-time {
-          background: url(../images/icon-calendar.svg) no-repeat left center;
-          background-size: 2em;
-        }
-
-        &__name {
-          min-height: 4rem;
-
-          @include mq($from: tablet) {
-            min-height: initial;
-          }
-        }
-
-        &__setting {
-          background-size: 2.4em;
-
-          &.online {
-            background: url(../images/icon-online-black.svg) no-repeat left center;
+          &__date-and-time,
+          &__name,
+          &__location,
+          &__setting {
+            padding-left: 3rem;
+            min-height: 2em;
           }
 
-          &.in-person {
-            background: url(../images/icon-building.svg) no-repeat left center;
+          &__date-and-time {
+            background: url(../images/icon-calendar.svg) no-repeat left center;
+            background-size: 2em;
+          }
+
+          &__name {
+            min-height: 4rem;
+
+            @include mq($from: tablet) {
+              min-height: initial;
+            }
+          }
+
+          &__setting {
+            background-size: 2.4em;
+
+            &.online {
+              background: url(../images/icon-online-black.svg) no-repeat left center;
+            }
+
+            &.in-person {
+              background: url(../images/icon-building.svg) no-repeat left center;
+            }
           }
         }
       }
@@ -359,24 +370,29 @@ $slightly-darker-grey: darken($grey, 10%);
         &__location {
           @include font-size(xsmall);
 
-          padding: 1em 1em 1em 2.5rem;
-        }
-
-        &__setting {
-          &.online {
-            background: url(../images/icon-online-black.svg) no-repeat left center;
-            background-size: 2em;
-          }
-
-          &.in-person {
-            background: url(../images/icon-building.svg) no-repeat left center;
-            background-size: 1.6em;
+          @include mq($from: mobile) {
+            padding: 1em 1em 1em 2.5rem;
           }
         }
 
-        &__location {
-          background: url(../images/icon-pin.svg) no-repeat left center;
-          background-size: 1.2em;
+        @include mq($from: mobile) {
+
+          &__setting {
+            &.online {
+              background: url(../images/icon-online-black.svg) no-repeat left center;
+              background-size: 2em;
+            }
+
+            &.in-person {
+              background: url(../images/icon-building.svg) no-repeat left center;
+              background-size: 1.6em;
+            }
+          }
+
+          &__location {
+            background: url(../images/icon-pin.svg) no-repeat left center;
+            background-size: 1.2em;
+          }
         }
       }
     }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -202,21 +202,23 @@ $slightly-darker-grey: darken($grey, 10%);
       gap: 1em;
       margin-bottom: 1em;
 
-      picture {
-        align-self: baseline;
+      @include mq($from: mobile) {
+        gap: 2em;
       }
 
-      img {
-        width: 100%;
-      }
+      .event-image {
+        picture {
+          img {
+            width: 100%;
+            max-height: 8em;
+            object-position: center;
+            object-fit: cover;
 
-      .dfelogo {
-        max-height: 3em;
-      }
-
-      @include mq($from: tablet) {
-        .event-image {
-          align-self: auto;
+            @include mq($from: mobile) {
+              width: 90%;
+              max-height: auto;
+            }
+          }
         }
       }
     }
@@ -252,6 +254,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
         text-align: center;
         padding: 1.2rem;
+        max-height: 3em;
 
         transform: skew($skew-amount) translate($adjust);
         padding-right: 1em + $adjust;
@@ -265,7 +268,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
     &__bottom-bar {
       background: $grey;
-      padding: .2em 1em;
+      padding: .4em 1em;
       display: flex;
 
       &--left {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -233,10 +233,10 @@ $slightly-darker-grey: darken($grey, 10%);
       &--left {
         @include font-size(xsmall);
         flex: 1 1 30%;
-        padding: .2em 1em .2em 3em;
+        padding: .2em 1em .2em 4.3em;
         background: url(../images/icon-calendar.svg) no-repeat left center;
         background-size: 2em;
-        background-position: .5em;
+        background-position: 1em;
       }
 
       &--right {
@@ -365,7 +365,7 @@ $slightly-darker-grey: darken($grey, 10%);
         &__setting {
           &.online {
             background: url(../images/icon-online-black.svg) no-repeat left center;
-            background-size: 1.4em;
+            background-size: 2em;
           }
 
           &.in-person {
@@ -376,7 +376,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
         &__location {
           background: url(../images/icon-pin.svg) no-repeat left center;
-          background-size: 1.4em;
+          background-size: 1.2em;
         }
       }
     }


### PR DESCRIPTION
### Changes proposed in this pull request

- Minor alignment tweaks to make event items line up
- Hide icons on mobile
- Improve the mobile image styling

| Before | After |
| ----- | ------ |
| ![Screenshot from 2022-01-11 16-14-41](https://user-images.githubusercontent.com/128088/148984740-d3fe7e1c-295b-4614-9eb8-896bb95dc58a.png) | ![Screenshot from 2022-01-11 16-42-43](https://user-images.githubusercontent.com/128088/148984776-92ef36d3-99ef-409f-b40c-d7249e8d4fc8.png) |
| ![Screenshot from 2022-01-11 16-43-12](https://user-images.githubusercontent.com/128088/148984853-bdb60681-4993-4fd2-8eeb-c848fa13742d.png) | ![Screenshot from 2022-01-11 16-42-57](https://user-images.githubusercontent.com/128088/148984883-04f09403-4ad2-4139-adea-96c7649550c0.png) |
| ![Screenshot from 2022-01-11 16-45-45](https://user-images.githubusercontent.com/128088/148985147-bfd500a4-674d-4040-912f-9a0535876bcc.png) | ![Screenshot from 2022-01-11 16-45-59](https://user-images.githubusercontent.com/128088/148985158-5c5a02f6-7ce3-44f1-9ea7-d5ad6f49cfeb.png) |


