### PR TITLE
Enable Google Optimize in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 # Add public environment variables here for the Production environment
 TTA_SERVICE_URL="https://adviser-getintoteaching.education.gov.uk/"
 FAIL2BAN=5
-#GOOGLE_OPTIMIZE_ID=OPT-W7F6P8Q
+GOOGLE_OPTIMIZE_ID=OPT-W7F6P8Q
 GTM_ID=GTM-5ZQLL9K


### PR DESCRIPTION
As we are putting an A/B test live on the events page we need to enable this in the production environment.