### PR TITLE
Enable Sentry for client-side errors in production

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,8 +92,6 @@ module ApplicationHelper
   end
 
   def sentry_dsn
-    return nil if Rails.env.production?
-
     Sentry.configuration.dsn&.to_s
   end
 end

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -12,10 +12,11 @@
     <%= javascript_pack_tag 'fake_browser_time', 'data-turbolinks-track': 'reload', id: "fake-browser-time" %>
   <% end %>
   <%= google_optimize_script %>
+  <%= javascript_pack_tag 'sentry', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env } %>
   <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
   <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env }, async: true %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,14 +1,3 @@
-import * as Sentry from "@sentry/browser";
-
-const sentryConfig = document.querySelector("[data-sentry-dsn]")?.dataset;
-
-if (sentryConfig) {
-  Sentry.init({
-    dsn: sentryConfig.sentryDsn,
-    environment: sentryConfig.sentryEnvironment,
-  });
-}
-
 import '@stimulus/polyfills';
 import "core-js/stable";
 import "regenerator-runtime/runtime";

--- a/app/webpacker/packs/sentry.js
+++ b/app/webpacker/packs/sentry.js
@@ -1,0 +1,10 @@
+import * as Sentry from "@sentry/browser";
+
+const sentryConfig = document.querySelector("[data-sentry-dsn]")?.dataset;
+
+if (sentryConfig) {
+  Sentry.init({
+    dsn: sentryConfig.sentryDsn,
+    environment: sentryConfig.sentryEnvironment,
+  });
+}

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -217,12 +217,6 @@ describe ApplicationHelper do
       before { allow(Sentry.configuration).to receive(:dsn).and_return("1234") }
 
       it { is_expected.to eq("1234") }
-
-      context "when production" do
-        before { allow(Rails).to receive(:env) { "production".inquiry } }
-
-        it { is_expected.to be_nil }
-      end
     end
   end
 end

--- a/spec/requests/sentry_js_spec.rb
+++ b/spec/requests/sentry_js_spec.rb
@@ -14,11 +14,5 @@ describe "Sentry JS", type: :request do
 
     it { is_expected.to include(%(data-sentry-dsn="1234")) }
     it { is_expected.to include(%(data-sentry-environment="test")) }
-
-    context "when production" do
-      before { allow(Rails).to receive(:env) { "production".inquiry } }
-
-      it { is_expected.not_to include("data-sentry-dsn") }
-    end
   end
 end


### PR DESCRIPTION
This appears to be working fine in staging, so enabling in production.
