### PR TITLE
Update mailing list sign up postcode step

### DIFF
--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -2,14 +2,26 @@ module MailingList
   module Steps
     class Postcode < ::DFEWizard::Step
       attribute :address_postcode
+      attribute :send_event_emails, :boolean
+
+      validates :send_event_emails, inclusion: { in: [true, false] }
       validates :address_postcode, postcode: true
+      validates :address_postcode, presence: true, if: -> { send_event_emails }
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
 
-      def optional?
-        true
+      def export
+        super.tap do |hash|
+          hash["address_postcode"] = postcode_in_crm unless send_event_emails
+        end
+      end
+
+    private
+
+      def postcode_in_crm
+        @store.preexisting(:address_postcode)
       end
     end
   end

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -2,7 +2,6 @@
 <html lang="en" class="govuk-template">
   <% content_for :head do %>
     <%= csrf_meta_tags %>
-    <%= javascript_pack_tag 'govuk/error_summary', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 
   <%= render "sections/head" %>
@@ -18,5 +17,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -2,7 +2,6 @@
 <html lang="en" class="govuk-template">
   <% content_for :head do %>
     <%= csrf_meta_tags %>
-    <%= javascript_pack_tag 'govuk/error_summary', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 
   <%= render "sections/head" %>
@@ -26,5 +25,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -2,7 +2,6 @@
 <html lang="en" class="govuk-template">
   <% content_for :head do %>
     <%= csrf_meta_tags %>
-    <%= javascript_pack_tag 'govuk/error_summary', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 
   <%= render "sections/head" %>
@@ -23,5 +22,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -1,9 +1,14 @@
+<h1>Would you like to hear about teacher training events?</h1>
+
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { tag: 'h1', size: "xl", text: t('helpers.label.mailing_list_steps_postcode.address_postcode') } do %>
-
 <p>
-  Stay up to date about events in your area.
+  We'll let you know via email about upcoming teacher training events near you
 </p>
 
+<%= f.govuk_radio_buttons_fieldset(:send_event_emails, legend: nil) do %>
+  <%= f.govuk_radio_button :send_event_emails, "true", link_errors: true do %>
+    <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { text: t('helpers.label.mailing_list_steps_postcode.address_postcode') } %>
+  <% end %>
+  <%= f.govuk_radio_button :send_event_emails, "false" %>
 <% end %>

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -1,4 +1,4 @@
-<h1>Would you like to hear about teacher training events?</h1>
+<h1>Would you like to hear about teacher training events in your area?</h1>
 
 <%= f.govuk_error_summary %>
 
@@ -8,7 +8,7 @@
 
 <%= f.govuk_radio_buttons_fieldset(:send_event_emails, legend: nil) do %>
   <%= f.govuk_radio_button :send_event_emails, "true", link_errors: true do %>
-    <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { text: t('helpers.label.mailing_list_steps_postcode.address_postcode') } %>
+    <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { text: t('helpers.label.mailing_list_steps_postcode.address_postcode') }, width: 10 %>
   <% end %>
   <%= f.govuk_radio_button :send_event_emails, "false" %>
 <% end %>

--- a/app/webpacker/packs/govuk/error_summary.js
+++ b/app/webpacker/packs/govuk/error_summary.js
@@ -1,5 +1,0 @@
-import { ErrorSummary } from 'govuk-frontend'
-
-// Find first error summary module to enhance.
-var $errorSummary = document.querySelector('[data-module="govuk-error-summary"]');
-new ErrorSummary($errorSummary).init();

--- a/app/webpacker/packs/govuk/frontend.js
+++ b/app/webpacker/packs/govuk/frontend.js
@@ -1,0 +1,10 @@
+import { ErrorSummary, Radios } from 'govuk-frontend'
+
+// Find first error summary module to enhance.
+var $errorSummary = document.querySelector('[data-module="govuk-error-summary"]');
+new ErrorSummary($errorSummary).init();
+
+var $radios = [...document.querySelectorAll('[data-module="govuk-radios"]')];
+$radios.forEach(($radio) => {
+  new Radios($radio).init();
+});

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -399,6 +399,8 @@ en:
             address_postcode:
               blank: Enter your postcode
               invalid: Enter a valid postcode
+            send_event_emails:
+              inclusion: Select if you would like to hear about teacher training events
         mailing_list/steps/privacy_policy:
           attributes:
             accept_privacy_policy:
@@ -516,7 +518,10 @@ en:
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
-        address_postcode: Your postcode (optional)
+        address_postcode: Your postcode
+        send_event_emails_options:
+          "true": "Yes"
+          "false": "No"
 
       search:
         search: Search for ...

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -31,8 +31,9 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "events in your area"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    expect(page).to have_text "Would you like to hear about teacher training events?"
+    choose "Yes"
+    fill_in "Your postcode", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -72,8 +73,9 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "events in your area"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    expect(page).to have_text "Would you like to hear about teacher training events?"
+    choose "Yes"
+    fill_in "Your postcode", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -131,6 +133,10 @@ RSpec.feature "Mailing list wizard", type: :feature do
       "Which subject do you want to teach?",
       selected: TeachingSubject.lookup_by_uuid(response.preferred_teaching_subject_id),
     )
+    click_on "Next step"
+
+    expect(page).to have_text "Would you like to hear about teacher training events?"
+    choose "Yes"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -256,8 +262,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "events in your area"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    expect(page).to have_text "Would you like to hear about teacher training events?"
+    choose "No"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events?"
+    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
     choose "Yes"
     fill_in "Your postcode", with: "TE57 1NG"
     click_on "Next step"
@@ -73,7 +73,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events?"
+    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
     choose "Yes"
     fill_in "Your postcode", with: "TE57 1NG"
     click_on "Next step"
@@ -135,7 +135,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     )
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events?"
+    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
     choose "Yes"
     click_on "Next step"
 
@@ -262,7 +262,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events?"
+    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
     choose "No"
     click_on "Next step"
 

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -7,7 +7,6 @@ describe MailingList::Steps::Postcode do
   it_behaves_like "a with wizard step"
 
   it { is_expected.to respond_to :address_postcode }
-  it { expect(subject).to be_optional }
 
   describe "validations for address_postcode" do
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
@@ -16,6 +15,33 @@ describe MailingList::Steps::Postcode do
     it { is_expected.to allow_value("").for :address_postcode }
     it { is_expected.not_to allow_value("random").for(:address_postcode).with_message(msg) }
     it { is_expected.not_to allow_value("TE57 ING").for(:address_postcode).with_message(msg) }
+
+    context "when send_event_emails is true" do
+      before { subject.send_event_emails = true }
+
+      it { is_expected.not_to allow_value(nil).for(:address_postcode) }
+    end
+  end
+
+  describe "validations for send_event_emails" do
+    it { is_expected.not_to allow_value(nil).for(:send_event_emails) }
+    it { is_expected.to validate_inclusion_of(:send_event_emails).in_array([true, false]) }
+  end
+
+  describe "#export" do
+    subject { instance.export["address_postcode"] }
+
+    let(:backingstore) { { "send_event_emails" => true, "address_postcode" => "app-postcode" } }
+    let(:crm_backingstore) { {} }
+
+    it { is_expected.to eq("app-postcode") }
+
+    context "when the postcode exists in the CRM and they select 'No'" do
+      let(:backingstore) { { "send_event_emails" => false } }
+      let(:crm_backingstore) { { "address_postcode" => "crm-postcode" } }
+
+      it { is_expected.to eq("crm-postcode") }
+    end
   end
 
   describe "data cleaning for the postcode" do


### PR DESCRIPTION
> :warning: I'll need to update the frontend tests after this ships to account for the new step structure.

### Trello card

[Trello-2732](https://trello.com/c/eMl4jPKM/2732-improve-copy-in-mailing-list-funnel-to-encourage-people-to-give-their-postcode?filter=member:rossoliver15)

### Context

The mailing list currently gives users an option to enter their postcode, however the number of users opting to do this could be better. In an attempt to improve the uptake in this option we are making the copy and form clearer.

### Changes proposed in this pull request

- Add send_event_emails attribute to postcode step

We want to show a yes/no toggle on the postcode step, so we only show the text input when the user selects 'yes'.

Add necessary attribute to populate the form with.

Change postcode presence to be conditional based on if they select 'yes'.

- Pull in radio functionality from govuk-frontend

Pull in the radio button functionality from govuk-frontend in addition to the error summaries. We only do s will allow the toggle to show field JS to work. We only pull this into the registration pages; update the filename to be more generic.

Move JS to pull in after the footer instead of the head tag; previously if you submitted the form, went back (via Turbolinks page change) and toggled the radio it would not show the field as the JS was not re-initialising.

- Update postcode step to include radio buttons

Include yes/no radio buttons; when 'yes' is selected we show the postcode field.

### Guidance to review

|  Postcode Step |  Enter Postcode State |  Select Radio Error | Enter Postcode Error  |
|---|---|---|---|
|  <img width="1130" alt="Screenshot 2022-01-12 at 10 17 29" src="https://user-images.githubusercontent.com/29867726/149121571-37957626-15f8-47ac-8f46-63fbe17dfe46.png"> |  <img width="1130" alt="Screenshot 2022-01-12 at 10 17 48" src="https://user-images.githubusercontent.com/29867726/149121635-01865865-d311-421e-b350-3c40ce254a68.png">  |  <img width="1130" alt="Screenshot 2022-01-12 at 10 20 50" src="https://user-images.githubusercontent.com/29867726/149122061-81a1e6e2-0302-4750-a599-6345fbce1a3f.png">  |  <img width="1130" alt="Screenshot 2022-01-12 at 10 21 07" src="https://user-images.githubusercontent.com/29867726/149122127-dc96a42e-2ff5-4b8d-bffa-5db335e30095.png">  | 

