### PR TITLE
Increase the events query limit

### DIFF
--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -31,7 +31,7 @@ module TeachingEvents
 
   private
 
-    def query(limit: 12)
+    def query(limit: 100)
       conditions = {
         type_ids: type_condition,
         postcode: postcode_condition,


### PR DESCRIPTION
### Trello card

https://trello.com/c/IcQx9mAE/2831-address-missing-pagination-in-new-events-design

### Context

There are more events in production than test, this limit is the number per event type (the three groups are then combined to create the list)

@ethax-ross - would it make sense to reinstate the old API functionality that returns a single list?


### Changes proposed in this pull request

Increase the number of events per event type from 12 to 100
