### PR TITLE
Fix error caused by bad postcodes and no distance

### DIFF
--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -19,7 +19,9 @@ module TeachingEvents
     attribute :postcode, :string
     attribute :distance, :integer
 
-    validates :postcode, presence: true, postcode: { allow_blank: true, accept_partial_postcode: true }, if: :distance
+    validates :postcode, postcode: { allow_blank: true, accept_partial_postcode: true }
+    validates :postcode, presence: true, if: -> { distance.present? }
+
     validates :distance, inclusion: { in: DISTANCES.values }, allow_nil: true
 
     before_validation { self.distance = nil if distance.blank? }

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -37,6 +37,13 @@ describe TeachingEvents::Search do
       context "when distance isn't set" do
         it { is_expected.to allow_value(nil).for(:postcode) }
       end
+
+      context "when distance isn't set but postcode is" do
+        subject { described_class.new(distance: nil) }
+
+        it { is_expected.not_to allow_values("M", "Manchester", "M1-2WD").for(:postcode) }
+        it { is_expected.to allow_value(nil, "").for(:postcode) }
+      end
     end
 
     describe "distance" do


### PR DESCRIPTION
Previously the postcode validation was only fired when distance was present; this meant that an error could be triggered by entering an invalid postcode and setting the distance to 'Nationwide'

This changes the behaviour so it checks the postcode validity when the postcode is valid regardless of distance
