### PR TITLE
Disable Sentry for client-side errors in production

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,6 +92,8 @@ module ApplicationHelper
   end
 
   def sentry_dsn
+    return nil if Rails.env.production?
+
     Sentry.configuration.dsn&.to_s
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -217,6 +217,12 @@ describe ApplicationHelper do
       before { allow(Sentry.configuration).to receive(:dsn).and_return("1234") }
 
       it { is_expected.to eq("1234") }
+
+      context "when in production" do
+        before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+        it { is_expected.to be_nil }
+      end
     end
   end
 end


### PR DESCRIPTION
We get a steady stream of exceptions, most of which are likely due to client-specific extensions/ad blockers. Now that we have a sample from a day or so of errors to debug our GA/PPC issue we can turn this off.

We may as well leave the code in, in case we need to re-enable it in the future.