### PR TITLE
Add app_instance label to all metrics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ TTA_SERVICE_URL=http://tta-service.test
 PREVIEW_PAGES=1
 VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"
 GTM_ID=123-ABC
+CF_INSTANCE_INDEX=app-instance

--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -1,7 +1,6 @@
 ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   payload = event.payload.symbolize_keys.reject { |_, v| v.nil? }
-
   prometheus = Prometheus::Client.registry
 
   labels = { path: nil, method: nil, status: nil }

--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -5,6 +5,7 @@ module Prometheus
         app: Rails.application.config.x.vcap_app["application_name"],
         organisation: Rails.application.config.x.vcap_app["organization_name"],
         space: Rails.application.config.x.vcap_app["space_name"],
+        app_instance: ENV["CF_INSTANCE_INDEX"],
       }
     end
 

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -107,6 +107,7 @@ describe Prometheus::Metrics do
       app: "app-name",
       organisation: "org-name",
       space: "space-name",
+      app_instance: "app-instance",
     }
   end
 end


### PR DESCRIPTION
The metrics are not correctly aggregating due to multiple instances sending the same metric/labels. We need another label to differentiate between metrics so that Prometheus correctly aggregates them.

A change made to Prometheus also requires this label or it ends up stuck in a loop and forever incrementing the counter.
