### PR TITLE
Editing salaries and benefits page for SEO

### DIFF
--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -99,11 +99,11 @@ This extra support used to last 1 year, and teachers would be called 'newly qual
 
 ## Career progression
 
-There are different ways to progress and increase your teacher salary.
+There are different ways to progress and increase your teaching salary.
 
 For example, you can move into a more senior role, or take on additional responsibilities that help your school.
 
-### Senior teacher salary
+### Senior teacher salaries
 
 If you take on extra responsibilities, like being a head of department, you can be put onto a higher teacher pay scale.
 
@@ -116,7 +116,7 @@ Annual salary ranges for senior teachers are:
 | London                        | £39,864 | £50,935  |
 | Rest of England and Wales     | £38,690 | £41,604  |
 
-### Leading practitioner salary
+### Leading practitioner salaries
 
 If you’re an established and exceptional teacher, and regularly show the highest standards of classroom teaching, you can be put onto a higher pay scale.
 
@@ -130,7 +130,7 @@ The teacher pay scales for leading practitioners are:
 | Rest of England and Wales     | £42,402 | £64,461  |
 
 
-### Headteacher salary
+### Headteacher salaries
 
 A headteacher is the most senior person in a school. They are ultimately responsible for all teachers and pupils. 
 
@@ -158,7 +158,7 @@ These payments are called ‘teaching and learning responsibility’ (TLR) payme
 | TLR 1         | £8,291 | £14,030 |
 | TLR 2         | £2,873 | £7,017  |
 
-### Unqualified teacher salary
+### Unqualified teacher salaries
 
 Many schools in England require teachers to have 'qualified teacher status' (QTS). If you do not have this, you can work
 in some schools as an unqualified teacher.

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -1,5 +1,5 @@
 ---
-title: "Teacher salaries and benefits"
+title: "Teaching salaries and benefits"
 heading: "Salaries and benefits"
 description: |-
   Teacher starting salaries are between £25,714 and £32,157, depending where you teach. Find out about teacher pay scales, pensions and benefits here.

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -1,7 +1,8 @@
 ---
-title: "Salaries and benefits"
+title: "Teacher salaries and benefits"
+heading: "Salaries and benefits"
 description: |-
-  Teacher starting salaries are between £25,714 and £32,157, depending on where you teach. Find out about teacher salaries, pensions and benefits here.
+  Teacher starting salaries are between £25,714 and £32,157, depending where you teach. Find out about teacher pay scales, pensions and benefits here.
 date: "2021-06-24"
 image: "media/images/content/hero-images/0007.jpg"
 backlink: "../../"
@@ -59,7 +60,7 @@ As a new teacher, your salary will be between £25,714 and £32,157, depending o
 
 The school you teach in will have their own pay scales for qualified teachers. Pay increases will always be linked to performance, not length of service.
 
-Annual salary ranges for qualified teachers are:
+Annual teacher pay scales for qualified teachers are:
 
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
@@ -98,13 +99,13 @@ This extra support used to last 1 year, and teachers would be called 'newly qual
 
 ## Career progression
 
-There are different ways to progress and increase your salary.
+There are different ways to progress and increase your teacher salary.
 
 For example, you can move into a more senior role, or take on additional responsibilities that help your school.
 
-### Senior teacher pay
+### Senior teacher salary
 
-If you take on extra responsibilities, like being a head of department, you can be put onto a higher pay scale.
+If you take on extra responsibilities, like being a head of department, you can be put onto a higher teacher pay scale.
 
 Teachers in this pay scale are important members of a school’s leadership team, and they often work closely with Headteachers.
 
@@ -115,13 +116,13 @@ Annual salary ranges for senior teachers are:
 | London                        | £39,864 | £50,935  |
 | Rest of England and Wales     | £38,690 | £41,604  |
 
-### Leading practitioner pay
+### Leading practitioner salary
 
 If you’re an established and exceptional teacher, and regularly show the highest standards of classroom teaching, you can be put onto a higher pay scale.
 
 Although they may not lead departments, leading practitioners coach and mentor other teachers and induct trainees and early career teachers (ECTs).
 
-The pay scales for leading practitioners are:
+The teacher pay scales for leading practitioners are:
 
 | Area                          | Minimum | Maximum  |
 | -------                       | -----   | -----    |
@@ -129,7 +130,7 @@ The pay scales for leading practitioners are:
 | Rest of England and Wales     | £42,402 | £64,461  |
 
 
-### Headteacher pay
+### Headteacher salary
 
 A headteacher is the most senior person in a school. They are ultimately responsible for all teachers and pupils. 
 
@@ -157,12 +158,12 @@ These payments are called ‘teaching and learning responsibility’ (TLR) payme
 | TLR 1         | £8,291 | £14,030 |
 | TLR 2         | £2,873 | £7,017  |
 
-### Unqualified teacher pay
+### Unqualified teacher salary
 
 Many schools in England require teachers to have 'qualified teacher status' (QTS). If you do not have this, you can work
 in some schools as an unqualified teacher.
 
-Annual salary ranges for unqualified teachers are:
+Annual unqualified teacher salary ranges are:
 
 | Area                          | Minimum | Maximum   |
 | -------                       | -----   | -----     |


### PR DESCRIPTION
- Discussed 'teacher pay scales' vs 'salary ranges' with Phoebe and given the okay to use 'teacher pay scales' as that's what the sector uses and is also present elsewhere in the content on the page, and discussed with Tom, agreeing that we interpret 'pay scale' and 'salary range' as the same thing
- Changed h3s to say 'salary' rather than 'pay' to target the term 'unqualified teacher salary'

### Trello card

https://trello.com/c/lWuGGlzK/2744-keyword-optimisation

### Context

### Changes proposed in this pull request

### Guidance to review

