### PR TITLE
Retry Net::ReadTimeout exceptions during test run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :development do
 end
 
 group :test do
+  gem "rspec-retry"
   gem "selenium-webdriver", "~> 3.142"
   gem "shoulda-matchers"
   gem "webmock", ">= 3.14.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,8 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-sonarqube-formatter (1.5.0)
       htmlentities (~> 4.3.3)
       rspec (~> 3.0)
@@ -543,6 +545,7 @@ DEPENDENCIES
   rexml (>= 3.2.5)
   rinku
   rspec-rails (~> 5.0.2)
+  rspec-retry
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk (~> 4.2.0)
   secure_headers

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,13 @@ RSpec.configure do |config|
   config.include SpecHelpers::BasicAuth
   config.include Webpacker::Helper, type: :helper
 
+  config.verbose_retry = true
+  config.default_retry_count = 2
+  # We occasionally see timeout errors on features/chat_spec.rb.
+  # The source of the flakiness isn't clear, so allowing retries
+  # for now to hopefully avoid it failing builds outright.
+  config.exceptions_to_retry = [Net::ReadTimeout]
+
   config.before(:suite) do
     Webpacker.compile
   end


### PR DESCRIPTION
### Trello card

[Trello-2824](https://trello.com/c/E7ZXjg5O/2824-investigate-frequent-github-failures?filter=member:rossoliver15)

### Context

We occasionally see timeout errors on `features/chat_spec.rb`. The source of the flakiness isn't clear, so allowing retries for now to hopefully avoid it failing builds outright.

The other alternative is to remove these specs as there is reasonable coverage in the JS tests, however they don't cover the
scenario when JS is disabled (which these specs do).

### Changes proposed in this pull request

- Retry Net::ReadTimeout exceptions during test run 

### Guidance to review

The error is not easily reproducible (using the seed doesn't cause it to occur in an `rspec --bisect`:

```
Failures:

  1) Chat when Javascript is enabled when chat is offline viewing the chat section of the talk to us component
     Failure/Error: visit "#{path}?fake_browser_time=#{date.to_i * 1000}"

     Net::ReadTimeout:
       Net::ReadTimeout
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:299:in `rbuf_fill'
     # /usr/local/bundle/gems/sentry-ruby-core-4.8.1/lib/sentry/net/http.rb:40:in `request'
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:97:in `block in request'
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:105:in `block in request'
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:137:in `start_with_connect_without_finish'
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:104:in `request'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/default.rb:129:in `response_for'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/default.rb:82:in `request'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/common.rb:64:in `call'
     # /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/bridge.rb:167:in `execute'
```