### PR TITLE
Move teaching events over to new icons

### DIFF
--- a/app/webpacker/images/content/icons/icon-calendar.svg
+++ b/app/webpacker/images/content/icons/icon-calendar.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <clipPath id="clip-icon-calendar">
+      <rect width="64" height="64"/>
+    </clipPath>
+  </defs>
+  <g id="icon-calendar" clip-path="url(#clip-icon-calendar)">
+    <g id="Group_950" data-name="Group 950" transform="translate(14 14)">
+      <path id="Path_1313" data-name="Path 1313" d="M1348.875,445.282c-.611-1.221-1.1-2.443-1.71-3.664-.611,1.221-1.1,2.443-1.71,3.664l-4.03.366c.977.855,2.076,1.832,3.053,2.687-.244,1.344-.611,2.687-.855,4.031,1.221-.733,2.321-1.344,3.542-2.076,1.222.733,2.321,1.344,3.542,2.076-.244-1.344-.611-2.687-.855-4.031.977-.855,2.076-1.832,3.053-2.687a22.488,22.488,0,0,1-4.031-.366" transform="translate(-1329.578 -423.786)"/>
+      <path id="Path_1314" data-name="Path 1314" d="M1333.221,394.328v-3.664h-3.664v3.664h-8.55v-3.664h-3.664v3.664h-9.771v31.756h35.42V394.328Zm-15.878,3.664v2.443h3.664v-2.443h8.55v2.443h3.664v-2.443h6.107v4.885h-28.092v-4.885Zm-6.107,8.55h28.092V422.42h-28.092Z" transform="translate(-1307.572 -390.664)"/>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/images/content/icons/icon-location.svg
+++ b/app/webpacker/images/content/icons/icon-location.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <clipPath id="clip-icon-location">
+      <rect width="64" height="64"/>
+    </clipPath>
+  </defs>
+  <g id="icon-location" clip-path="url(#clip-icon-location)">
+    <g id="icon.location" transform="translate(19 12)">
+      <path id="Subtraction_10" data-name="Subtraction 10" d="M12.208,40v0L8.251,31.805V24.266A12.565,12.565,0,0,1,2.32,19.754,12.452,12.452,0,0,1,3.692,3.666a12.671,12.671,0,0,1,17.828,0,12.452,12.452,0,0,1,1.13,16.417,12.7,12.7,0,0,1-6.485,4.445v7.278L12.209,40ZM10.782,24.9v6.332l1.426,2.954,1.426-2.954V24.992c-.342.028-.688.041-1.027.041A12.839,12.839,0,0,1,10.782,24.9ZM12.607,2.945a9.572,9.572,0,1,0,9.64,9.572A9.617,9.617,0,0,0,12.607,2.945Z" transform="translate(0 0)"/>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/images/content/icons/icon-online.svg
+++ b/app/webpacker/images/content/icons/icon-online.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <clipPath id="clip-icon-online">
+      <rect width="64" height="64"/>
+    </clipPath>
+  </defs>
+  <g id="icon-online" clip-path="url(#clip-icon-online)">
+    <g id="Group_951" data-name="Group 951" transform="translate(9 16.999)">
+      <path id="Path_1329" data-name="Path 1329" d="M1189.925,594.837h29.353l2.474,4.807h-34.74Zm.684-19h27.932v15.791h-27.932Zm31.125,16.808V572.625h-34.319v20.16l-6.071,10.053h45.67Z" transform="translate(-1181.345 -572.625)"/>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -1,4 +1,5 @@
 $slightly-darker-grey: darken($grey, 10%);
+$icon-size: 3rem;
 
 @mixin train-to-teach-event-box {
   border: 2px solid $pink;
@@ -239,9 +240,9 @@ $slightly-darker-grey: darken($grey, 10%);
 
         @include mq($from: mobile) {
           padding: .2em 1em .2em 4.3em;
-          background: url(../images/icon-calendar.svg) no-repeat left center;
-          background-size: 2em;
-          background-position: 1em;
+          background: url(../images/content/icons/icon-calendar.svg) no-repeat left center;
+          background-position: .7em;
+          background-size: $icon-size;
         }
       }
 
@@ -268,7 +269,7 @@ $slightly-darker-grey: darken($grey, 10%);
 
     &__bottom-bar {
       background: $grey;
-      padding: .4em 1em;
+      padding: .4em .5em;
       display: flex;
 
       &--left {
@@ -321,11 +322,17 @@ $slightly-darker-grey: darken($grey, 10%);
           &__setting {
             padding-left: 3rem;
             min-height: 2em;
+
+            // vertical centre
+            display: flex;
+            align-items: center;
           }
 
           &__date-and-time {
-            background: url(../images/icon-calendar.svg) no-repeat left center;
-            background-size: 2em;
+            background: url(../images/content/icons/icon-calendar.svg) no-repeat left center;
+            background-size: $icon-size;
+            flex-direction: column;
+            align-items: baseline;
           }
 
           &__name {
@@ -336,15 +343,21 @@ $slightly-darker-grey: darken($grey, 10%);
             }
           }
 
+          &__location {
+            background: url(../images/content/icons/icon-location.svg) no-repeat left center;
+            background-size: $icon-size;
+          }
+
           &__setting {
-            background-size: 2.4em;
 
             &.online {
-              background: url(../images/icon-online-black.svg) no-repeat left center;
+              background: url(../images/content/icons/icon-online.svg) no-repeat left center;
+              background-size: $icon-size;
             }
 
             &.in-person {
               background: url(../images/icon-building.svg) no-repeat left center;
+              background-size: 2em; // using 2em because it's an old icon and is bigger than the others
             }
           }
         }
@@ -374,7 +387,7 @@ $slightly-darker-grey: darken($grey, 10%);
           @include font-size(xsmall);
 
           @include mq($from: mobile) {
-            padding: 1em 1em 1em 2.5rem;
+            padding: 1em 1em 1em 3.2rem;
           }
         }
 
@@ -382,19 +395,19 @@ $slightly-darker-grey: darken($grey, 10%);
 
           &__setting {
             &.online {
-              background: url(../images/icon-online-black.svg) no-repeat left center;
-              background-size: 2em;
+              background: url(../images/content/icons/icon-online.svg) no-repeat left center;
+              background-size: $icon-size;
             }
 
             &.in-person {
               background: url(../images/icon-building.svg) no-repeat left center;
-              background-size: 1.6em;
+              background-size: 2em; // using 2em because it's an old icon and is bigger than the others
             }
           }
 
           &__location {
-            background: url(../images/icon-pin.svg) no-repeat left center;
-            background-size: 1.2em;
+            background: url(../images/content/icons/icon-location.svg) no-repeat left center;
+            background-size: $icon-size;
           }
         }
       }


### PR DESCRIPTION
### Trello card

https://trello.com/c/y1xxAazp/2814-standardise-the-aspect-ratios-of-all-icons

### Context

The original icons had various aspect ratios which meant having to size and place them individually. The new ones are consistent so we can size them in one place, `$icon-size`, and they should always align.

| Before | After | 
| ------ | ------- |
| ![Screenshot from 2022-01-17 12-34-04](https://user-images.githubusercontent.com/128088/149770638-e3353c77-ad62-4965-98f0-6724bc0ad2b5.png) | ![Screenshot from 2022-01-17 12-33-46](https://user-images.githubusercontent.com/128088/149770646-fddc57f7-ae97-4288-a8ba-e3ab187cc0bf.png) |
| ![Screenshot from 2022-01-17 12-36-02](https://user-images.githubusercontent.com/128088/149770695-50f432db-3268-4362-8b56-99a20496963d.png) | ![Screenshot from 2022-01-17 12-36-15](https://user-images.githubusercontent.com/128088/149770712-afa418d5-a3d1-4715-96ac-d7edc01e401f.png) |
