### PR TITLE
Fix typo and link in the footer component

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -61,7 +61,7 @@
         <%= link_to "Privacy notice", privacy_policy_path %>
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>
         <a target="_blank" rel="noopener" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
-        <div class="site-footer-bottom__links-container__license">All content is available under the <a href="/">Open Government License v.3.0,</a> except where otherwise stated.</div>
+        <div class="site-footer-bottom__links-container__license">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0,</a> except where otherwise stated.</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/gKJlooqq/2770-correct-licence-typo-and-link-in-footer

### Context and changes

Licence had the American spelling 'License', referred to the wrong version and linked to the root of the site.
