### PR TITLE
Fix missing review App

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,7 +316,6 @@ jobs:
         run: exit 1
 
       - name: Post sticky pull request comment
-        if: matrix.environment == 'Review' 
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true


### PR DESCRIPTION
We had to change the review app to use a GitHub action rather than curl the data in directly and I had copied the code from another location, but forgot to remove the IF statement. 
I have taken myself off and self-flagellated.

HINT: This method should only tag the comments once with the Review App URL unless for some reason the comment changes. so there will be less review app spam in comments