### PR TITLE
Update blog post link for accessibility

### DIFF
--- a/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
+++ b/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
@@ -43,4 +43,4 @@ Alongside online research, think about calling or emailing these providers, or t
 >
 >_Jane Wilkinson, former teacher and teacher training adviser._
 
-Due to the individual nature of teacher training courses, what might be a good fit for others you know may not be the best fit for you, so doing careful research is vital! Speak to one of our [teacher training advisers](/teacher-training-advisers), who can help you personalise your choices.
+Due to the individual nature of teacher training courses, what might be a good fit for others you know may not be the best fit for you, so doing careful research is vital! [Speak to one of our teacher training advisers](/teacher-training-advisers), who can help you personalise your choices.


### PR DESCRIPTION
### Trello card
https://trello.com/c/a8Q9GGed

### Context
Two links in a blog post had the link text 'teacher training advisers' but they went to different locations (TTA page and blog tag page) which is confusing for screen readers.

