### PR TITLE
Composite Actions Need Shell

### DIFF
--- a/.github/workflows/actions/owasp/action.yml
+++ b/.github/workflows/actions/owasp/action.yml
@@ -48,6 +48,7 @@ runs:
 
       - name: Setup Application Name
         id:   app_name
+        shell: bash
         run: |
              if [[ "${{ inputs.environment }}" == "Production" ]] ; then 
                  rval="${{env.PAAS_APPLICATION_NAME}}-prod.${{env.DOMAIN}}"


### PR DESCRIPTION
Composite Actions Need their Shell to be identified, when using RUN



