### PR TITLE
Update teaching events to teacher training events

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -32,7 +32,7 @@ class TeachingEventsController < ApplicationController
   end
 
   def show
-    breadcrumb "Teaching events", "/teaching-events"
+    breadcrumb "Get into Teaching events", "/teaching-events"
 
     api_event = GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id])
     @event = TeachingEvents::EventPresenter.new(api_event)
@@ -43,7 +43,7 @@ class TeachingEventsController < ApplicationController
   end
 
   def about_ttt_events
-    breadcrumb "Teaching events", "/teaching-events"
+    breadcrumb "Get into Teaching events", "/teaching-events"
   end
 
 private

--- a/app/views/content/get-school-experience.md
+++ b/app/views/content/get-school-experience.md
@@ -60,9 +60,9 @@ If you cannot find what you’re looking for, you can call a school directly. Yo
 
 You may be eligible for a [maths or physics teaching internship](/teaching-internship-providers) earning £300 a week if you're doing a undergraduate degree in science, technology, engineering or maths. --->
 
-## Attend teaching events
+## Attend teacher training events
 
-[Teaching events](/events) can also give you an insight into teaching. You can choose from our Train to Teach events, online Q&A sessions and events run by training providers.
+[Teacher training events](/events) can also give you an insight into teaching. You can choose from our Train to Teach events, online Q&A sessions and events run by training providers.
 
 ## Watch pre-recorded lessons
 

--- a/app/views/content/three-things-to-help-you-get-into-teaching.md
+++ b/app/views/content/three-things-to-help-you-get-into-teaching.md
@@ -46,7 +46,7 @@ Get personalised information straight to your inbox with everything you need to 
 
 <div id="speak-to-current-teachers-at-a-teaching-event" class="numbered-heading">
   <span class="pink-number">2</span>
-  <h2>Speak to current teachers at a teaching event</h2>
+  <h2>Speak to current teachers at a teacher training event</h2>
 </div>
 
 Chat with teachers, experts and training providers about every aspect of teaching and teacher training at an event. There are a variety of events available that cover everything from funding your training, what a career in teaching is really like, to submitting a successful application.

--- a/app/views/content/three-things-to-help-you-get-into-teaching.md
+++ b/app/views/content/three-things-to-help-you-get-into-teaching.md
@@ -8,7 +8,7 @@
   layout: layouts/campaigns/landing_page_with_hero_nav
   hero_nav:
     Receive personalised email updates and tips: "#receive-personalised-email-updates-and-tips"
-    Speak to current teachers at a teaching event: "#speak-to-current-teachers-at-a-teaching-event"
+    Speak to current teachers at a teacher training event: "#speak-to-current-teachers-at-a-teaching-event"
     Get free one-to-one advice from a teacher training adviser: "#get-free-one-to-one-advice-from-a-teacher-training-adviser"
     
   keywords:


### PR DESCRIPTION
### Trello card
https://trello.com/c/0D0UPG1b/2828-update-teaching-events-across-the-website-to-be-teacher-training-events

### Context and changes
renaming teaching events to say teacher training events 


