### PR TITLE
Make location display consistent on teaching events

### DIFF
--- a/app/components/teaching_events/event_component.html.erb
+++ b/app/components/teaching_events/event_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.li(class: classes) %>
+<%= tag.li(class: classes) do %>
   <% if train_to_teach? %>
 
     <div class="event__info">
@@ -87,4 +87,4 @@
       <% end %>
     </div>
   <% end %>
-</li>
+<% end %>

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -32,18 +32,28 @@ module TeachingEvents
     )
 
     def venue_address
-      building = @event.building
-
-      return if building.blank?
+      return if event_building.blank?
 
       [
-        building.venue,
-        building.address_line1,
-        building.address_line2,
-        building.address_line3,
-        building.address_city,
-        building.address_postcode,
+        event_building.venue,
+        event_building.address_line1,
+        event_building.address_line2,
+        event_building.address_line3,
+        event_building.address_city,
+        event_building.address_postcode,
       ].compact
+    end
+
+    def has_location?
+      event_building.present?
+    end
+
+    def location
+      [
+        event_building.venue,
+        event_building.address_city,
+        (event_building.address_postcode if show_venue_information?),
+      ].compact.join(", ")
     end
 
     def event_type
@@ -94,6 +104,12 @@ module TeachingEvents
 
     def show_venue_information?
       !@event.is_virtual && @event.building.present?
+    end
+
+  private
+
+    def event_building
+      @event.building
     end
   end
 end

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -49,11 +49,13 @@ module TeachingEvents
     end
 
     def location
-      [
-        event_building.venue,
-        event_building.address_city,
-        (event_building.address_postcode if show_venue_information?),
-      ].compact.join(", ")
+      if show_venue_information?
+        [event_building.venue,
+         event_building.address_city,
+         event_building.address_postcode].compact.join(", ")
+      else
+        event_building.address_city
+      end
     end
 
     def event_type

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -105,7 +105,7 @@ module TeachingEvents
     end
 
     def show_venue_information?
-      !@event.is_virtual && @event.building.present?
+      !@event.is_online && @event.building.present?
     end
 
   private

--- a/app/views/teaching_events/show/_location-and-setting.html.erb
+++ b/app/views/teaching_events/show/_location-and-setting.html.erb
@@ -1,7 +1,6 @@
 <div class="location-and-setting">
-  <% if @event.building.present? && !@event.is_online %>
-    <%= @event.building.venue %>,
-    <%= @event.building.address_postcode %>
+  <% if @event.has_location? %>
+    <%= @event.location %>
   <% end %>
 
   <% if @event.is_online %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -648,6 +648,9 @@ $icon-size: 3rem;
 
   @include mq($from: mobile) {
     flex-direction: row;
+  }
+
+  @include mq($from: tablet) {
     margin-inline: 1em;
   }
 

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -194,26 +194,26 @@ describe TeachingEvents::EventPresenter do
     describe "#show_venue_information?" do
       subject { described_class.new(event).show_venue_information? }
 
-      context "when the event is virtual and has no building" do
-        let(:event) { build(:event_api, :virtual, :no_location) }
+      context "when the event is online and has no building" do
+        let(:event) { build(:event_api, :no_location, is_online: true) }
 
         it { is_expected.to be false }
       end
 
-      context "when the event is virtual and has a building" do
-        let(:event) { build(:event_api, :virtual) }
+      context "when the event is online and has a building" do
+        let(:event) { build(:event_api, is_online: true) }
 
         it { is_expected.to be false }
       end
 
-      context "when the event not virtual and has no building" do
-        let(:event) { build(:event_api, :online, :no_location) }
+      context "when the event not online and has no building" do
+        let(:event) { build(:event_api, :no_location, is_online: false) }
 
         it { is_expected.to be false }
       end
 
-      context "when the event not virtual and has a building" do
-        let(:event) { build(:event_api) }
+      context "when the event not online and has a building" do
+        let(:event) { build(:event_api, is_online: false) }
 
         it { is_expected.to be true }
       end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -48,6 +48,35 @@ describe TeachingEvents::EventPresenter do
       specify { expect(subject.venue_address).to include(*address_parts.compact) }
     end
 
+    describe "#has_location?" do
+      context "when the event has no building" do
+        let(:event) { build(:event_api, :no_location) }
+
+        it { is_expected.not_to have_location }
+      end
+
+      context "when the event has a building" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.to have_location }
+      end
+    end
+
+    describe "#location" do
+      context "when show_venue_information? is false" do
+        let(:event) { build(:event_api, :virtual) }
+
+        specify { expect(subject.location).to eql("#{event.building.venue}, #{event.building.address_city}") }
+      end
+
+      context "when show_venue_information? is true" do
+        let(:event) { build(:event_api) }
+        let(:expected_location) { "#{event.building.venue}, #{event.building.address_city}, #{event.building.address_postcode}" }
+
+        specify { expect(subject.location).to eql(expected_location) }
+      end
+    end
+
     describe "#quote" do
       subject { described_class.new(event).quote }
 

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -66,7 +66,7 @@ describe TeachingEvents::EventPresenter do
       context "when show_venue_information? is false" do
         let(:event) { build(:event_api, :virtual) }
 
-        specify { expect(subject.location).to eql("#{event.building.venue}, #{event.building.address_city}") }
+        specify { expect(subject.location).to eql(event.building.address_city) }
       end
 
       context "when show_venue_information? is true" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/k6xgu94J/2830-investigate-why-location-of-some-providers-does-not-appear-in-events-listing-in-new-design

### Context and changes

Change the location behaviour slightly in the teaching events listing so it's only shown when the event's online status is false. This is in-line with both the 'show' page and the corresponding page in the old events listing.
