### PR TITLE
Remove rotated text

### DIFF
--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -25,13 +25,11 @@ module CallsToAction
     end
 
     def icon_element(icon)
-      img = image_pack_tag("media/images/#{icon}.svg",
-                           width: 50,
-                           height: 50,
-                           alt: "#{icon} icon",
-                           class: "call-to-action__icon")
-
-      tag.div(img, class: "call-to-action__icon__box")
+      image_pack_tag("media/images/#{icon}.svg",
+                     width: 50,
+                     height: 50,
+                     alt: "#{icon} icon",
+                     class: "call-to-action__icon")
     end
   end
 end

--- a/app/views/content/three-things-to-help-you-get-into-teaching.md
+++ b/app/views/content/three-things-to-help-you-get-into-teaching.md
@@ -30,7 +30,7 @@
 ---
 
 <div id="receive-personalised-email-updates-and-tips" class="numbered-heading">
-  <span class="pink-rotated-number">1</span>
+  <span class="pink-number">1</span>
   <h2>Receive personalised email updates and tips</h2>
 </div>
 
@@ -45,7 +45,7 @@ Get personalised information straight to your inbox with everything you need to 
 <a class="button" href="/mailinglist/signup/name"><span>Get email updates</span></a>
 
 <div id="speak-to-current-teachers-at-a-teaching-event" class="numbered-heading">
-  <span class="pink-rotated-number">2</span>
+  <span class="pink-number">2</span>
   <h2>Speak to current teachers at a teaching event</h2>
 </div>
 
@@ -54,7 +54,7 @@ Chat with teachers, experts and training providers about every aspect of teachin
 <a class="button" href="/events"><span>Find an event</span></a>
 
 <div id="get-free-one-to-one-advice-from-a-teacher-training-adviser" class="numbered-heading">
-  <span class="pink-rotated-number">3</span>
+  <span class="pink-number">3</span>
   <h2>Get free one-to-one advice from a teacher training adviser</h2>
 </div>
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -129,20 +129,14 @@
       @include reset;
 
       grid-area: 1 / 1 / 3 / 2;
-      transform: rotate(-3deg);
 
-      // the box exists so we can rotate the icon's background
-      // and the icon itself separately in opposite directions
-      .call-to-action__icon__box {
-        margin: 1em auto auto -.2em;
-        padding-left: .2em;
-        background-color: $yellow;
-        display: inline-block;
-      }
+      margin: 1em auto auto -.2em;
+      padding-left: .2em;
+      background-color: $yellow;
+      display: inline-block;
 
       .call-to-action__icon {
         background: transparent;
-        transform: rotate(3deg);
       }
     }
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -213,7 +213,6 @@
     .call-to-action__heading {
       color: $white;
       background: $green;
-      transform: rotate(-3deg);
       display: inline-block;
       padding: .625em 1.25em;
       margin-left: -22px;
@@ -253,7 +252,6 @@
     .call-to-action__heading {
       color: white;
       background: $purple;
-      transform: rotate(-3deg);
       display: inline-block;
       padding: 0.5em 1.25em;
       margin-left: -22px;

--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -10,7 +10,7 @@
     display: flex;
     align-items: center;
 
-    .pink-rotated-number {
+    .pink-number {
       background-color: $pink-dark;
       color: $white;
       padding: .6em .8em;

--- a/app/webpacker/styles/campaigns/numbered-headings.scss
+++ b/app/webpacker/styles/campaigns/numbered-headings.scss
@@ -12,7 +12,6 @@
 
     .pink-rotated-number {
       background-color: $pink-dark;
-      @include rotated-block;
       color: $white;
       padding: .6em .8em;
       font-weight: bold;

--- a/app/webpacker/styles/eligibility-checker.scss
+++ b/app/webpacker/styles/eligibility-checker.scss
@@ -4,8 +4,6 @@
   overflow: hidden;
 
   header {
-    @include rotated-block;
-
     background-color: $purple-dark;
     color: $white;
     margin-left: -2em;

--- a/app/webpacker/styles/featured.scss
+++ b/app/webpacker/styles/featured.scss
@@ -22,7 +22,6 @@
     overflow: auto;
 
     .more-stories__thumbs__thumb__play {
-      @include rotated-block(-3deg, $blur: 4px);
       background-color: $pink-dark-90;
       padding: 1em 1em 1em 1.5em;
       position: absolute;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -153,7 +153,7 @@ $mobile-cutoff: 800px;
     z-index: 20;
 
     h1 {
-      background-color: $yellow-dark-90;
+      background-color: $yellow-dark;
       padding: .8em .75em 1.2em 1.75em;
       margin-left: -1em;
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -142,13 +142,6 @@ $mobile-cutoff: 800px;
   background-color: $grey;
   overflow: hidden;
 
-  &__title,
-  &__subtitle {
-    > * {
-      @include rotated-block;
-    }
-  }
-
   &__title {
     z-index: 20;
 

--- a/app/webpacker/styles/sections/hero/content.scss
+++ b/app/webpacker/styles/sections/hero/content.scss
@@ -15,7 +15,6 @@
         &:before {
           content: counter(item);
           flex: 0 0 1.5em;
-          @include rotated-block;
           background-color: $pink-dark;
           text-align: center;
           color: $white;

--- a/app/webpacker/styles/video.scss
+++ b/app/webpacker/styles/video.scss
@@ -47,7 +47,6 @@
     margin: 40px;
 
     &__dismiss {
-      @include rotated-block($degrees: 3px);
       position: absolute;
       top: -25px;
       right: -25px;


### PR DESCRIPTION
### Trello card

https://trello.com/c/mAtMElkP/2847-change-sloping-text-to-horizontal-and-change-colour-blocks-behind-icons-to-be-set-square-and-not-on-an-angle

### Context and changes

- Remove the transparency from hero title
- Remove rotated-block from everywhere but title
- Remove slanted yellow box on home page CTAs

### Preview

#### Homepage 🖥️

| Before | After (with transparency) | After (without transparency) |
| ----- | ------ |------ |
| ![Screenshot from 2022-01-18 16-35-57](https://user-images.githubusercontent.com/128088/149981938-0355f717-e5fa-4d7d-bc18-6d1be3f0c767.png) | ![Screenshot from 2022-01-18 16-36-11](https://user-images.githubusercontent.com/128088/149982163-ffd71a9b-539a-4cf2-a8c9-2c27a31fe9e4.png) |![Screenshot from 2022-01-18 16-37-37](https://user-images.githubusercontent.com/128088/149982219-a24b1516-e1df-4d4a-aad8-313ca5e1f08a.png) |

#### Homepage 📱

| Before | After (with transparency) | After (without transparency) |
| ------ | ------- | ------- |
| ![Screenshot from 2022-01-18 16-36-48](https://user-images.githubusercontent.com/128088/149982389-6c7481e9-57c1-4a84-946e-50cc43392d03.png) |![Screenshot from 2022-01-18 16-36-32](https://user-images.githubusercontent.com/128088/149982009-04d7e475-14bb-42ec-b2b7-c77a15c1c9ea.png) | ![Screenshot from 2022-01-18 16-37-26](https://user-images.githubusercontent.com/128088/149982066-14d46405-a05a-425c-abf6-9e0b141461c5.png)|

#### Homepage CTAs (after)

| Desktop | Mobile |
| ------ | ------ |
| ![Screenshot from 2022-01-18 16-46-37](https://user-images.githubusercontent.com/128088/149982614-da63bf24-2ea7-436c-9689-070eb95c73d8.png) | ![Screenshot from 2022-01-18 16-46-48](https://user-images.githubusercontent.com/128088/149982673-7d193c7c-dd0d-40c5-abb6-8c006ad61699.png) |

#### Funding widget

| Before | After |
| ------ | ------ |
| ![Screenshot from 2022-01-18 16-50-05](https://user-images.githubusercontent.com/128088/149983358-2b108504-ebd9-4ead-9226-83bf526a09b4.png) | ![Screenshot from 2022-01-18 16-49-54](https://user-images.githubusercontent.com/128088/149983372-9e9e7db6-0f9e-4889-85a0-e8df06c5f060.png) |

