### PR TITLE
Removed reference to Transititon to Teach

### DIFF
--- a/app/views/content/ways-to-train.md
+++ b/app/views/content/ways-to-train.md
@@ -219,5 +219,5 @@ Entry criteria may vary by teacher training provider. Ask them about eligibility
 A career change into teaching allows you to use your experience and
 passion to inspire young people.
 
-As well as the options above, [Now Teach](https://nowteach.org.uk/) and [Transition to Teach](https://www.transitiontoteach.co.uk/) are services that can specifically help you with changing careers.
+As well as the options above, [Now Teach](https://nowteach.org.uk/) is a service that can specifically help you with changing careers.
 


### PR DESCRIPTION
Also reworded the sentence to make sense as it is now referring to a single link rather than multiple

### Trello card
https://trello.com/c/cEZuk8Dn/2844-remove-references-to-transition-to-teach

### Context

### Changes proposed in this pull request

### Guidance to review

