### PR TITLE
Add presentations to about ttt events page

### DIFF
--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -45,6 +45,8 @@
       <li>listen to a step-by-step guide on how to get into teaching, the application process and funding your training</li>
     </ul>
 
+    <p>See the <a href="/presentations">presentations used at Train to Teach events</a>.</p>
+
     <div class="youtube-video-container">
       <iframe src="https://www.youtube.com/embed/eAWwqLLEINI" frameborder="0" allowfullscreen title="Train to Teach Events: Take your next step towards teaching"></iframe>
     </div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/ILXznPng

### Context
Events team requested that a link to the presentations be added to the About Train to Teach events page.

NB the use of the presentations page needs considering more widely following the completion of events split test.
