### PR TITLE
Make teaching events attend guidance match events

### DIFF
--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -27,6 +27,7 @@ module TeachingEvents
       :type_id,
       :status_id,
       :video_url,
+      :web_feed_id,
       to: :event,
     )
 
@@ -77,6 +78,14 @@ module TeachingEvents
 
     def allow_registration?
       EventStatus.new(@event).accepts_online_registration?
+    end
+
+    def open?
+      EventStatus.new(@event).open?
+    end
+
+    def closed?
+      EventStatus.new(@event).closed?
     end
 
     def show_provider_information?

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -64,6 +64,7 @@
   <% end %>
 
   <% unless EventStatus.new(@event).closed? %>
+
     <% if can_sign_up_online?(@event) %>
       <h2>How to attend</h2>
       <% if @event.is_online %>
@@ -84,6 +85,7 @@
     <% elsif is_event_type?(@event, "School or University event") %>
       <h2>How to attend</h2>
       <p>To register for this event, follow the instructions in the event information section.</p>
+
     <% elsif @event.provider_website_url %>
       <h2>How to attend</h2>
       <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i>.<p>
@@ -94,6 +96,7 @@
     <% if @event.scribble_id %>
       <h2>Attend online</h2>
     <% end %>
+
   <% end %>
 
   <% if @event.providers_list %>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -24,7 +24,7 @@
       <%= render(partial: "teaching_events/show/event-summary") %>
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
       <%= render(partial: "teaching_events/show/scribble") if @event.scribble_id.present? %>
-      <%= render(partial: "teaching_events/show/how-to-attend") if @event.allow_registration? %>
+      <%= render(partial: "teaching_events/show/how-to-attend") %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
     </article>
 

--- a/app/views/teaching_events/show/_how-to-attend.html.erb
+++ b/app/views/teaching_events/show/_how-to-attend.html.erb
@@ -1,12 +1,36 @@
-<section class="teaching-event__how-to-attend">
-  <h2>How to attend</h2>
+<%
+    if @event.open? && [
+      can_sign_up_online?(@event),
+      is_event_type?(@event, "School or University event"),
+      @event.provider_website_url,
+      @event.provider_contact_email
+    ].any?
+%>
+  <section class="teaching-event__how-to-attend">
+    <h2>How to attend</h2>
 
-  <p>Registration for this event is free.</p>
+    <% if can_sign_up_online?(@event) %>
+      <p>
+        To attend this event, you must register for a place. Once registered,
+        you will receive log-in information and joining instructions via email.
+        Please note: to access this event you will require a laptop/desktop PC
+        and be using Google Chrome as your browser.
+      </p>
+    <% elsif is_event_type?(@event, "School or University event") %>
+      <p>
+        To register for this event, follow the instructions in the event information section.
+      </p>
+    <% elsif @event.provider_website_url %>
+      <p>
+        To attend this event, please <%= link_to("visit this website", @event.provider_website_url) %>.
+      </p>
+    <% elsif @event.provider_contact_email %>
+      <p>
+        To attend this event, please
+        <%= mail_to(@event.provider_contact_email, "email us") %>.
+      </p>
+    <% end %>
 
-  <p>
-    By registering, you will receive information about what to expect and how
-    to make the most of your experience at the event.
-  </p>
-
-  <%= render(partial: 'teaching_events/show/register-button') %>
-</section>
+    <%= render(partial: 'teaching_events/show/register-button') %>
+  </section>
+<% end %>

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -27,6 +27,7 @@ describe TeachingEvents::EventPresenter do
       type_id
       status_id
       video_url
+      web_feed_id
     ].each { |attribute| it { is_expected.to delegate_method(attribute).to(:event) } }
   end
 
@@ -102,6 +103,34 @@ describe TeachingEvents::EventPresenter do
         let(:event) { build(:event_api, :online_event) }
 
         specify { expect(subject).to be_nil }
+      end
+    end
+
+    describe "#open?" do
+      context "when event is open" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.to be_open }
+      end
+
+      context "when event is closed" do
+        let(:event) { build(:event_api, :closed) }
+
+        it { is_expected.not_to be_open }
+      end
+    end
+
+    describe "#closed?" do
+      context "when event is closed" do
+        let(:event) { build(:event_api, :closed) }
+
+        it { is_expected.to be_closed }
+      end
+
+      context "when event is open" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.not_to be_closed }
       end
     end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/TnMyQbOh/2880-fix-how-to-attend-display-in-new-teaching-events

### Context

Make the 'how to attend' section match the old one in events more closely.

Currenly the new and old events pages are sharing helpers, when the new supersedes the old we should move these to a single component and simplify the logic (and the big opening `if` statement) further.
