### PR TITLE
Remove automatic heading punctuation

### DIFF
--- a/app/webpacker/styles/components/mixins/headings.scss
+++ b/app/webpacker/styles/components/mixins/headings.scss
@@ -1,4 +1,4 @@
-@mixin content-heading($add_full_stops: true) {
+@mixin content-heading {
   display: inline-block;
   margin-top: 0;
   padding: .4rem $indent-amount;
@@ -8,12 +8,6 @@
   box-sizing: border-box;
   max-width: calc(100% - 1.25rem);
   color: $white;
-
-  @if $add_full_stops {
-    &:after {
-      content: ".";
-    }
-  }
 
   &.purple {
     background-color: $purple;

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -144,10 +144,6 @@
       color: $black;
       margin: 1rem auto .5rem;
       font-size: 1.4rem;
-
-      &:after {
-        content: unset;
-      }
     }
 
     h3 {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -172,10 +172,6 @@ $mobile-cutoff: 800px;
         // text-underline-offset: .3em;
         // text-decoration-thickness: .1em;
 
-        &:after {
-          content: ".";
-        }
-
         @include mq($from: tablet) {
           @include font-size("xxlarge");
           border-bottom: 6px solid $black;

--- a/app/webpacker/styles/urgent-call-for-qualified-teachers.scss
+++ b/app/webpacker/styles/urgent-call-for-qualified-teachers.scss
@@ -4,7 +4,7 @@ article.urgent-call-for-qualified-teachers {
   }
 
   .region-heading {
-    @include content-heading($add_full_stops: false);
+    @include content-heading;
 
     margin-top: 2em;
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/r8rAjKID/2855-allow-for-more-flexible-punctuation-in-headings

### Context

We currently automatically add full stops to the end of some headings. We're removing the functionality because:

* full stops in headings don't really make sense
* they prevent us from using other kinds of punctuation as the full stop is _always_ added regardless of whether there's already a question mark

### Changes proposed in this pull request

- Remove automatic full stop from blue h2
- Remove full stop from hero h1

| Before | After |
| ----- | ------ |
|![Screenshot from 2022-01-24 10-24-25](https://user-images.githubusercontent.com/128088/150766623-cf858e54-0809-47e8-a9ab-9b30bbcceff5.png) | ![Screenshot from 2022-01-24 10-24-33](https://user-images.githubusercontent.com/128088/150766652-497cd497-71d3-4ae4-aa0c-9df16715e832.png) |
| ![Screenshot from 2022-01-24 10-26-10](https://user-images.githubusercontent.com/128088/150766677-1f08ca3d-7cd7-46b3-b10b-0ab517098fe2.png) | ![Screenshot from 2022-01-24 10-26-03](https://user-images.githubusercontent.com/128088/150766709-bf3928e2-d0c8-4bd4-a01c-f3e477362222.png) |