### PR TITLE
Only send virtual page view on Turbo page change

### DIFF
--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -6,6 +6,8 @@ export default class Gtm {
   }
 
   init() {
+    this.firstLoad = true;
+
     this.initWindow();
     this.sendDefaultConsent();
     this.initContainer();
@@ -49,6 +51,13 @@ export default class Gtm {
 
   listenForHistoryChange() {
     document.addEventListener('turbo:load', () => {
+      // Ignore the first turbo:load call, as the GA script will
+      // track that page view for us.
+      if (this.firstLoad) {
+        this.firstLoad = false;
+        return;
+      }
+
       window.gtag('set', 'page_path', window.location.pathname);
       window.gtag('event', 'page_view');
     });

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -78,6 +78,9 @@ describe('Google Tag Manager', () => {
     it('updates the page_path in GTM', () => {
       window.location.pathname = '/new-path';
 
+      // We receive a turbo:load call on the initial (non-turbo) page load.
+      document.dispatchEvent(new Event('turbo:load'));
+      // And then on the turbo page load for the subsequent page change.
       document.dispatchEvent(new Event('turbo:load'));
 
       expect(window.gtag).toHaveBeenCalledWith('set', 'page_path', '/new-path');


### PR DESCRIPTION
When we were using Turbolinks the `turbolinks:load` event was only called when Turbolinks performed the page change (even though the documentation says it should be called on the initial page load). Turbo calls `turbo:load` on the initial page load. To keep the behaviour consistent we need to ignore the first `turbo:load` event.

We are seeing high bounce rates in GA and it _could_ be related to this behaviour.