### PR TITLE
Wrap the events descriptions in a details dropdown

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -10,22 +10,25 @@
       All events listed here are designed to help you get into teacher training. They are all free to attend.
     </p>
 
-    <dl>
-      <div>
-        <dt>DfE Train to Teach events</dt>
-        <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers.</dd>
-      </div>
+    <details>
+      <summary>Types of train to teach event</summary>
+      <dl>
+        <div>
+          <dt>DfE Train to Teach events</dt>
+          <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers.</dd>
+        </div>
 
-      <div>
-        <dt>DfE Online Q&amp;As</dt>
-        <dd>Get answers to your specific questions from an online panel of teacher training advisers.</dd>
-      </div>
+        <div>
+          <dt>DfE Online Q&amp;As</dt>
+          <dd>Get answers to your specific questions from an online panel of teacher training advisers.</dd>
+        </div>
 
-      <div>
-        <dt>Training provider events</dt>
-        <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-      </div>
-    </dl>
+        <div>
+          <dt>Training provider events</dt>
+          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
+        </div>
+      </dl>
+    </details>
   </header>
 
   <div class="teaching-events__container">

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -48,8 +48,6 @@ $icon-size: 3rem;
         flex-direction: column;
 
         @include mq($from: tablet) {
-          flex-direction: row;
-          gap: 1rem;
           padding-inline: 1rem;
         }
       }


### PR DESCRIPTION
This is just an experimental PR to see how much of an improvement this minor change has on the teaching events page.
