### PR TITLE
Make past events not viewable

### DIFF
--- a/app/views/teaching_events/not_found.md
+++ b/app/views/teaching_events/not_found.md
@@ -1,0 +1,7 @@
+---
+title: Unfortunately that event has already happened
+---
+
+Would you like to see what's coming up?
+
+[All events](/teaching-events){: .button}

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -142,4 +142,19 @@ RSpec.feature "Searching for teaching events", type: :feature do
       end
     end
   end
+
+  describe "viewing a past event" do
+    let(:event) { build(:event_api) }
+
+    before do
+      allow_any_instance_of(EventStatus).to receive(:viewable?).and_return(false)
+    end
+
+    scenario do
+      visit teaching_event_path(event.readable_id)
+
+      expect(page).to have_css("h1", text: "Unfortunately that event has already happened")
+      expect(page).to have_link("All events", href: "/teaching-events", class: "button")
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/e9ZCZKQb/2893-apply-the-rules-for-historic-events-to-the-new-events-pages

### Context and changes

Some kinds of past events should not be viewable by users and some (online events with transcripts) should be.

The logic for this is already implemented in `EventStatus.viewable?` so we're reusing it here.

When an event is not `viewable?` we raise an EventNotViewableError which is handled with `render_not_found`, showing a page that explains what's going on and provides a link back to the events listing.
