### PR TITLE
Prevent welcome guide strings with spaces

### DIFF
--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -84,7 +84,7 @@ module MailingList
     def welcome_guide_variant(degree_status_id: nil, preferred_teaching_subject_id: nil)
       %w[/email].tap { |path|
         if preferred_teaching_subject_id
-          path << ["subject", TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id).downcase]
+          path << ["subject", TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id).parameterize(separator: "_")]
         end
 
         if degree_status_id

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -5,7 +5,7 @@ describe MailingList::Wizard do
 
   let(:uuid) { SecureRandom.uuid }
   let(:degree_status_id) { OptionSet.lookup_by_key(:degree_status, :final_year) }
-  let(:preferred_teaching_subject_id) { TeachingSubject.lookup_by_key(:maths) }
+  let(:preferred_teaching_subject_id) { TeachingSubject.lookup_by_key(:physics_with_maths) }
   let(:store) do
     { uuid => {
       "email" => "email@address.com",
@@ -42,7 +42,7 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
-    let(:variant) { "/email/subject/maths/degree-status/final_year" }
+    let(:variant) { "/email/subject/physics_with_maths/degree-status/final_year" }
     let(:request) do
       GetIntoTeachingApiClient::MailingListAddMember.new({
         email: wizardstore[:email],


### PR DESCRIPTION
### Trello card

N/A

### Context

This happens when subjects with spaces (eg. "Physics with maths") are selected and the code simply calls `#downcase` rather than `#parameterize`.
