### PR TITLE
Rollback Turbo update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,6 @@ module.exports = {
     },
   ],
   globals: {
-    Turbo: 'readonly',
+    Turbolinks: 'readonly',
   },
 };

--- a/Gemfile
+++ b/Gemfile
@@ -75,8 +75,6 @@ gem "rexml", ">= 3.2.5"
 gem "geometry", github: "bfoz/geometry", ref: "3054ccb"
 gem "victor"
 
-gem "turbo-rails"
-
 # Ignore cloudfront IPs when getting customer IP address
 gem "actionpack-cloudfront", ">= 1.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,8 +464,6 @@ GEM
     thor (1.2.1)
     tomlrb (2.0.1)
     trailblazer-option (0.1.1)
-    turbo-rails (0.9.0)
-      rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -560,7 +558,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   text
-  turbo-rails
   tzinfo-data
   victor
   view_component (~> 2.47.0)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -74,7 +74,7 @@ class PagesController < ApplicationController
       url += "?#{session[:utm].to_param}"
     end
 
-    redirect_to(url, status: :moved_permanently)
+    redirect_to(url, turbolinks: false, status: :moved_permanently)
   end
 
 protected

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,7 +79,7 @@ module ApplicationHelper
 
     return unless paths.present? && id.present?
 
-    javascript_pack_tag "google_optimize", 'data-turbo-track': "reload", data: {
+    javascript_pack_tag "google_optimize", 'data-turbolinks-track': "reload", data: {
       "google-optimize-id": id,
       "google-optimize-paths": paths,
     }

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -2,8 +2,8 @@
 <html lang="en" class="govuk-template">
 <% content_for :head do %>
   <%= csrf_meta_tags %>
-  <%= stylesheet_pack_tag 'internal', 'data-turbo-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'internal', 'data-turbo-track': 'reload', async: true %>
+  <%= stylesheet_pack_tag 'internal', 'data-turbolinks-track': 'reload', media: 'all' %>
+  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
 <% end %>
 
 <%= render "sections/head" %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -17,6 +17,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
-    <%= javascript_pack_tag 'govuk/frontend', 'data-turbo-track': 'reload', async: true %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -25,6 +25,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
-    <%= javascript_pack_tag 'govuk/frontend', 'data-turbo-track': 'reload', async: true %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -22,6 +22,6 @@
     </main>
 
     <%= render FooterComponent.new(talk_to_us: false, feedback: false, mailing_list: false) %>
-    <%= javascript_pack_tag 'govuk/frontend', 'data-turbo-track': 'reload', async: true %>
+    <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
   <% end %>
 </html>

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -6,17 +6,17 @@
   <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no') %>
   <%= tag.meta(name: "google-site-verification", content: "uoqqF4yGEjHx9klftx3ch2fCBpmgI6hHYBS69w17_-g") %>
   <%= tag.link(rel: 'icon', type: 'image/x-icon', href: '/favicon.ico') %>
-  <%= stylesheet_pack_tag 'application', 'data-turbo-track': 'reload', media: 'all' %>
-  <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbo-track': 'reload', media: 'all' %></noscript>
+  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+  <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
   <% if Rails.env.test? && params.key?(:fake_browser_time) %>
-    <%= javascript_pack_tag 'fake_browser_time', 'data-turbo-track': 'reload', id: "fake-browser-time" %>
+    <%= javascript_pack_tag 'fake_browser_time', 'data-turbolinks-track': 'reload', id: "fake-browser-time" %>
   <% end %>
   <%= google_optimize_script %>
-  <%= javascript_pack_tag 'sentry', 'data-turbo-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env } %>
-  <%= javascript_pack_tag 'gtm', 'data-turbo-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
-  <%= javascript_pack_tag 'js_enabled', 'data-turbo-track': 'reload', async: true %>
-  <%= javascript_pack_tag 'lazy_images', 'data-turbo-track': 'reload', async: true %>
-  <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'sentry', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env } %>
+  <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
+  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
   connect() {
     this.prepareChevronOnButtonLinks();
     this.openExternalContentLinksInNewWindow();
+    this.preventTurboLinksOnJumpLinks();
   }
 
   openExternalContentLinksInNewWindow() {
@@ -26,6 +27,16 @@ export default class extends Controller {
         linkOpensInNewWindow.classList.add('govuk-visually-hidden');
         linkOpensInNewWindow.appendChild(text);
         l.appendChild(linkOpensInNewWindow);
+      }
+    });
+  }
+
+  preventTurboLinksOnJumpLinks() {
+    const links = this.contentTarget.querySelectorAll('a');
+
+    links.forEach((l) => {
+      if (l.getAttribute('href')?.includes('#')) {
+        l.dataset.turbolinks = 'false';
       }
     });
   }

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -131,7 +131,7 @@ export default class extends Controller {
     if (chosen && chosen.link) {
       if (this.analyticsSubmitter) this.sendToAnalytics();
 
-      Turbo.visit(chosen.link);
+      Turbolinks.visit(chosen.link);
     }
   }
 

--- a/app/webpacker/javascript/google_optimize.js
+++ b/app/webpacker/javascript/google_optimize.js
@@ -9,8 +9,6 @@ export default class GoogleOptimize {
   }
 
   init() {
-    this.applyRedirectExperimentFix();
-
     if (this.canExperiment()) {
       this.initGoogleOptimize();
     }
@@ -42,17 +40,6 @@ export default class GoogleOptimize {
       'turbolinks:before-visit',
       this.turbolinksBeforeVisitHandler
     );
-  }
-
-  applyRedirectExperimentFix() {
-    // Google Optimize drops a cookie for 5 seconds that prevents it redirecting
-    // again. This is designed to avoid redirect loops, however it means if a user
-    // navigates to a redirect experiment twice in quick succession they don't get
-    // redirected the second time (and can end up seeing the control instead of the
-    // variant). Manually removing this cookie prevents that happening, but will
-    // leave us vulnerable to redirect loops if we don't set up experiments correctly;
-    // as we run few experiments this seems like the lesser of two evils.
-    CookiePreferences.clearCookie('_gaexp_rc');
   }
 
   initGoogleOptimize() {

--- a/app/webpacker/javascript/google_optimize.js
+++ b/app/webpacker/javascript/google_optimize.js
@@ -15,7 +15,7 @@ export default class GoogleOptimize {
       this.initGoogleOptimize();
     }
 
-    this.listenForTurboBeforeVisit();
+    this.listenForTurbolinksBeforeVisit();
     this.listenForConsentChange();
 
     if (!this.seenCookieDialog && this.isExperimentPath()) {
@@ -39,8 +39,8 @@ export default class GoogleOptimize {
     );
 
     document.removeEventListener(
-      'turbo:before-visit',
-      this.turboBeforeVisitHandler
+      'turbolinks:before-visit',
+      this.turbolinksBeforeVisitHandler
     );
   }
 
@@ -119,23 +119,24 @@ export default class GoogleOptimize {
     }
   }
 
-  handleTurboBeforeVisit(event) {
-    const path = new URL(event.detail.url).pathname;
+  handleTurbolinksBeforeVisit(event) {
+    const path = new URL(event.data.url).pathname;
 
     if (this.canExperiment(path)) {
-      // Cancel Turbo page change.
+      // Cancel Turbolinks page change.
       event.preventDefault();
       // Force a full page reload to initialize the optimize script
       // and serve the correct variant.
-      window.location.href = event.detail.url;
+      window.location.href = event.data.url;
     }
   }
 
-  listenForTurboBeforeVisit() {
-    this.turboBeforeVisitHandler = this.handleTurboBeforeVisit.bind(this);
+  listenForTurbolinksBeforeVisit() {
+    this.turbolinksBeforeVisitHandler =
+      this.handleTurbolinksBeforeVisit.bind(this);
     document.addEventListener(
-      'turbo:before-visit',
-      this.turboBeforeVisitHandler
+      'turbolinks:before-visit',
+      this.turbolinksBeforeVisitHandler
     );
   }
 

--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -6,8 +6,6 @@ export default class Gtm {
   }
 
   init() {
-    this.firstLoad = true;
-
     this.initWindow();
     this.sendDefaultConsent();
     this.initContainer();
@@ -20,7 +18,7 @@ export default class Gtm {
 
     // We use this to retain Google Ads tracking parameters in the
     // URL of the landing page (or they are subsequently lost when
-    // Turbo transitions).
+    // Turbolinks transitions).
     window.dataLayer.push({ originalLocation: this.originalLocation });
 
     function gtag() {
@@ -50,14 +48,7 @@ export default class Gtm {
   }
 
   listenForHistoryChange() {
-    document.addEventListener('turbo:load', () => {
-      // Ignore the first turbo:load call, as the GA script will
-      // track that page view for us.
-      if (this.firstLoad) {
-        this.firstLoad = false;
-        return;
-      }
-
+    document.addEventListener('turbolinks:load', () => {
       window.gtag('set', 'page_path', window.location.pathname);
       window.gtag('event', 'page_view');
     });

--- a/app/webpacker/javascript/zendesk_chat_reload.js
+++ b/app/webpacker/javascript/zendesk_chat_reload.js
@@ -1,7 +1,7 @@
 // Ensure the Zendesk Chat widget gets reloaded on page change.
 // Without this, it works on the first page load but then does not
 // appear if you change page and try and open it.
-window.addEventListener('turbo:before-render', function () {
+window.addEventListener('turbolinks:before-render', function () {
   window.zEACLoaded = undefined;
   window.$zopim = undefined;
 });

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,7 +3,7 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 import '../styles/application.scss';
 import Rails from 'rails-ujs';
-import '@hotwired/turbo-rails'
+import Turbolinks from 'turbolinks';
 
 import 'controllers';
 
@@ -14,3 +14,4 @@ require.context('../documents', true);
 require('../javascript/zendesk_chat_reload');
 
 Rails.start();
+Turbolinks.start();

--- a/app/webpacker/packs/lazy_images.js
+++ b/app/webpacker/packs/lazy_images.js
@@ -1,6 +1,8 @@
 import lazySizes from 'lazysizes';
 lazySizes.cfg.init = false;
 
-document.addEventListener('turbo:load', function () {
+lazySizes.init();
+
+document.addEventListener('turbolinks:load', function () {
   lazySizes.init();
 });

--- a/app/webpacker/styles/components/turbolinks-progress-bar.scss
+++ b/app/webpacker/styles/components/turbolinks-progress-bar.scss
@@ -1,4 +1,4 @@
-.turbo-progress-bar {
+.turbolinks-progress-bar {
   height: 5px;
   background-color: $blue-dark;
 }

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -59,7 +59,7 @@
 @import './components/type-description';
 @import './components/events/no-results';
 @import './components/events/signup-info';
-@import './components/turbo-progress-bar';
+@import './components/turbolinks-progress-bar';
 @import './components/grouped-cards';
 
 @import './campaigns/numbered-headings';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@hotwired/turbo-rails": "^7.0.1",
     "@rails/webpacker": "5.4.3",
     "@sentry/browser": "^6.16.1",
     "@sentry/tracing": "^6.16.1",
@@ -21,6 +20,7 @@
     "sinon": "^12.0.1",
     "stimulus": "^2.0.0",
     "trix": "^1.3.1",
+    "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "3.3.12"
   },

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -184,7 +184,7 @@ describe ApplicationHelper do
           regex = %r{
             <script\s
             src="/packs-test/v1/js/google_optimize.*\.js"\s
-            data-turbo-track="reload"\s
+            data-turbolinks-track="reload"\s
             data-google-optimize-id="ABC-123"\s
             data-google-optimize-paths="\[&quot;/experiment&quot;\]"
             ></script>

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -2,6 +2,47 @@ import { Application } from 'stimulus';
 import LinkController from 'link_controller.js';
 
 describe('LinkController', () => {
+  describe('disabling turbolinks for links containing anchors', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="link" data-link-target="content">
+        <a href="path/to#position">Jump Link</a>
+        <div id="level-1" class="video-overlay" data-video-target="player" data-action="click->video#close">
+          <a href="#level-3" />
+          <div id="level-2">
+            <a href="#level-1" />
+            <div id="level-3">
+              <a href="#level-1" />
+            </div>
+          </div>
+        </div>
+      </div>`;
+    });
+
+    beforeEach(() => {
+      const application = Application.start();
+      application.register('link', LinkController);
+    });
+
+    describe('when first loaded', () => {
+      it('adds data-turbolinks attribute to all jump links', () => {
+        const linkNodes = [...document.getElementsByTagName('a')];
+
+        linkNodes.forEach((link) => {
+          expect(link.hasAttribute('data-turbolinks')).toBe(true);
+        });
+      });
+
+      it('sets data-turbolinks attribute to value of false', () => {
+        const linkNodes = [...document.getElementsByTagName('a')];
+
+        linkNodes.forEach((link) => {
+          expect(link.getAttribute('data-turbolinks')).toEqual('false');
+        });
+      });
+    });
+  });
+
   describe('making external links open in new windows', () => {
     beforeEach(() => {
       document.body.innerHTML = `

--- a/spec/javascript/google_optimize_spec.js
+++ b/spec/javascript/google_optimize_spec.js
@@ -35,9 +35,9 @@ describe('Google Optimize', () => {
   };
 
   const dispatchBeforeVisit = (url) => {
-    const event = new CustomEvent('turbo:before-visit', {
-      detail: { url: url },
-    });
+    const event = document.createEvent('Events');
+    event.initEvent('turbolinks:before-visit', true, true);
+    event.data = { url: url };
     document.dispatchEvent(event);
   };
 
@@ -187,7 +187,7 @@ describe('Google Optimize', () => {
         ).toBeNull();
       });
 
-      describe('when Turbo transitions to an experiment path', () => {
+      describe('when Turbolinks transitions to an experiment path', () => {
         beforeEach(() =>
           dispatchBeforeVisit(`https://test.com${experimentPath}`)
         );
@@ -199,7 +199,7 @@ describe('Google Optimize', () => {
         });
       });
 
-      describe('when Turbo transitions to a non-experiment path', () => {
+      describe('when Turbolinks transitions to a non-experiment path', () => {
         beforeEach(() => dispatchBeforeVisit('https://test.com/no-experiment'));
 
         it('does not hijack the transition', () => {

--- a/spec/javascript/google_optimize_spec.js
+++ b/spec/javascript/google_optimize_spec.js
@@ -41,16 +41,11 @@ describe('Google Optimize', () => {
     document.dispatchEvent(event);
   };
 
-  const setGoogleOptimizeRedirectLoopCookie = () => {
-    Cookies.set('_gaexp_rc', '1');
-  };
-
   beforeEach(() => {
     jest.useFakeTimers();
     clearCookies();
     setupHtml();
     mockWindowLocation();
-    setGoogleOptimizeRedirectLoopCookie();
   });
 
   afterEach(() => {
@@ -65,10 +60,6 @@ describe('Google Optimize', () => {
   describe('when cookies have not yet been accepted', () => {
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
-
-      it('clears the _gaexp_rc cookie', () => {
-        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
-      });
 
       it('blurs the cookie acceptance background to obscure the content', () => {
         expect(
@@ -98,10 +89,6 @@ describe('Google Optimize', () => {
 
     describe('when not on an experiment path', () => {
       beforeEach(() => run('/no-experiment'));
-
-      it('clears the _gaexp_rc cookie', () => {
-        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
-      });
 
       it('does not blur the cookie acceptance background', () => {
         expect(
@@ -142,10 +129,6 @@ describe('Google Optimize', () => {
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
 
-      it('clears the _gaexp_rc cookie', () => {
-        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
-      });
-
       it('does not blur the cookie acceptance background', () => {
         expect(
           document.querySelector('.cookie-acceptance .dialog__background')
@@ -174,10 +157,6 @@ describe('Google Optimize', () => {
 
     describe('when not on an experiment path', () => {
       beforeEach(() => run('/no-experiment'));
-
-      it('clears the _gaexp_rc cookie', () => {
-        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
-      });
 
       it('does not append the Google Optimize script to the head', () => {
         expect(
@@ -220,10 +199,6 @@ describe('Google Optimize', () => {
 
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
-
-      it('clears the _gaexp_rc cookie', () => {
-        expect(Cookies.get('_gaexp_rc')).toBeUndefined();
-      });
 
       it('does not blur the cookie acceptance background', () => {
         expect(

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -69,7 +69,7 @@ describe('Google Tag Manager', () => {
     });
   });
 
-  describe('on Turbo page changes', () => {
+  describe('on Turbolinks page changes', () => {
     beforeEach(() => {
       mockGtag();
       run();
@@ -78,10 +78,8 @@ describe('Google Tag Manager', () => {
     it('updates the page_path in GTM', () => {
       window.location.pathname = '/new-path';
 
-      // We receive a turbo:load call on the initial (non-turbo) page load.
-      document.dispatchEvent(new Event('turbo:load'));
-      // And then on the turbo page load for the subsequent page change.
-      document.dispatchEvent(new Event('turbo:load'));
+      // We receive a turbolinks:load call on the initial (non-turbolinks) page load.
+      document.dispatchEvent(new Event('turbolinks:load'));
 
       expect(window.gtag).toHaveBeenCalledWith('set', 'page_path', '/new-path');
       expect(window.gtag).toHaveBeenCalledWith('event', 'page_view');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,19 +1207,6 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.36"
 
-"@hotwired/turbo-rails@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.1.tgz#d39816eef215e83468fa306a963e7c874ffe70f7"
-  integrity sha512-0cV7zG9aCzF/foidgfx6WvqKDcRKXJt2aT1fenNFywO7armGTD8S86V8U1IyUAHq+ZkIL26moc+AB40uTZt0oA==
-  dependencies:
-    "@hotwired/turbo" "^7.0.1"
-    "@rails/actioncable" "^6.0.0"
-
-"@hotwired/turbo@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.1.tgz#2a8c6ab2f24914d1d47f3a7a7779e2881e8c61a0"
-  integrity sha512-awqraytYXbHV2NT0WAOnDDDGJeHHnFtnztdXvRuIqgsStUtPKM8B9H7ISm77SwbHemEjxEOB8Ku4RfNbEEXsPQ==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1447,11 +1434,6 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
-
-"@rails/actioncable@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.4.tgz#c3c5a9f8302c429af9722b6c50ab48049016d2a3"
-  integrity sha512-0LmSKJTuo2dL6BQ+9xxLnS9lbkyfz2mBGeBnQ2J7o9Bn0l0q+ZC6VuoZMZZXPvABI4QT7Nfknv5WhfKYL+boew==
 
 "@rails/webpacker@5.4.3":
   version "5.4.3"
@@ -9817,6 +9799,11 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Rolls us back to Turbolinks to see if it fixes an issue with the PPC adverts.
 
- Stop manually clearing Google Optimize redirect cookie

It turns out if you're on a very slow connection you can hit a redirect loop because we are manually clearing the protection mechanism Google Optimize uses to prevent this.

Originally I thought you could get stuck in a loop only if you set up an experiment wrong (and essentially made a redirect loop in the experiment) but it looks like this is another scenario that can cause it.

The downside to removing this bit of code is that if someone navigates to the A/B test page twice in quick succession (< 5 seconds) they may see the control instead of the variant.