### PR TITLE
Remove underlines from the hero h1

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -147,34 +147,19 @@ $mobile-cutoff: 800px;
 
     h1 {
       background-color: $yellow-dark;
-      padding: .8em .75em 1.2em 1.75em;
+      padding: .8em .75em .8em 1.75em;
       margin-left: -1em;
 
       @include mq($from: tablet) {
         margin-top: 2em;
-        padding: .8em 2em 1.2em;
+        padding: .8em 2em;
       }
 
       > span {
         @include font-size("large");
 
-        // user a border bottom to simulate a underline that
-        // looks like the branding. It's not perfect as the line
-        // extends beyond the edges of the text by a few px
-        border-bottom: 3px solid $black;
-
-        // proper underline styles - switch to this when (if) we
-        // start using a standard font. while we're relying on
-        // user-installed default sans fonts we run the risk
-        // of descenders breaking up the line
-        //
-        // text-decoration: underline;
-        // text-underline-offset: .3em;
-        // text-decoration-thickness: .1em;
-
         @include mq($from: tablet) {
           @include font-size("xxlarge");
-          border-bottom: 6px solid $black;
         }
       }
     }


### PR DESCRIPTION
### Trello card

https://trello.com/c/JSzS7iRo/2846-remove-the-header-underline-inspire-the-next-generation-etc

### Context and changes

This also allows us to simplify the padding as we no longer need to take the `border-bottom` into account.

The h1 font size has also been increased to make the heading stand out from other similarly-sized text in/around the hero. The reduced padding (from removing the underline/bottom-border) means it doesn't take up much more space but definitely looks more heading-like.


| Before | After |
| ------- | ------- |
| ![Screenshot from 2022-01-26 11-45-18](https://user-images.githubusercontent.com/128088/151159148-7044c119-e464-4903-8980-53d3d011d77e.png) | ![Screenshot from 2022-01-26 11-45-16](https://user-images.githubusercontent.com/128088/151159188-05ece8a7-34ef-4eec-b3e2-c1d6aa64c7cc.png) |
| ![Screenshot from 2022-01-26 11-45-32](https://user-images.githubusercontent.com/128088/151159222-14f094da-9bb4-4c0a-b44c-18429af73dd1.png)| ![Screenshot from 2022-01-26 11-45-34](https://user-images.githubusercontent.com/128088/151159230-acf80797-e08e-4133-8279-c63776fd9932.png) |
| ![Screenshot from 2022-01-26 11-46-08](https://user-images.githubusercontent.com/128088/151159268-77a6c26f-e89b-4493-a607-b77b41cfe167.png) | ![Screenshot from 2022-01-26 11-45-56](https://user-images.githubusercontent.com/128088/151159291-91baac44-9093-480b-bdd8-b990efc72ef6.png) |
| ![Screenshot from 2022-01-26 11-46-39](https://user-images.githubusercontent.com/128088/151159314-be2807c9-e45f-4d2a-ab85-654ffeb1c0ca.png) | ![Screenshot from 2022-01-26 11-46-33](https://user-images.githubusercontent.com/128088/151159330-2727e66e-ba0b-4921-9ee0-b1cfb24b74bf.png) |
