### PR TITLE
Add section on alt text to the content docs

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -94,6 +94,23 @@ If you need to include a link to a document or embed an image in your page conte
 
 Images should be appropriately scaled and compressed prior to adding them to the website.
 
+#### Alt text
+
+The images used in the hero and on blog posts now pull their alt text from a central store. This allows us to set it once and include it wherever the image is used. The data is stored in `config/images.yml` and the format is as follows:
+
+```yaml
+"media/images/content/hero-images/0001.jpg":
+  alt: "Maths teacher standing in front of a whiteboard with maths equations."
+  variants:
+    - "media/images/content/hero-images/0001--mobile.jpg"
+    - "media/images/content/hero-images/0001--tablet.jpg"
+```
+
+The key (`"media/images/content/hero-images/0001.jpg"`) is the **primary** variant of the image, the full resolution one. Beneath it the following items are nested:
+
+* `alt:` - the alt text for the image, wrapped in quotes
+* `variants` - a list of **other versions of the same image**. The alternate versions can be thumbnails or crops and are considered alternates if the same `alt` text can be applied to them as the primary variant
+
 ### Jump Links
 
 You can include jump links in the frontmatter of a page if it has a lot of content in order to make it easier for the user to navigate:
@@ -121,7 +138,9 @@ Lots of text.
 
 The above example would render out as follows:
 
+```
 <img src="images/jump_link_examples.png" alt="Example Jump Links" style="width: 500px;">
+```
 
 ### Calls to Action
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/34oqfJm3/2870-update-content-guidance-regarding-centralised-alt-text

### Context and changes

This outlines the format of the centralised image list and gives a short description of why it's set out the way it is.
