### PR TITLE
Fix a welcome guide attribute bug and make clearer

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,5 +1,5 @@
 module WelcomeHelper
-  def show_welcome_guide?(degree_status = degree_status_id, consideration_journey_stage = consideration_journey_stage_id)
+  def show_welcome_guide?(degree_status: degree_status_id, consideration_journey_stage: consideration_journey_stage_id)
     gradudate_or_postgraduate = OptionSet.lookup_by_keys(:degree_status, :graduate_or_postgraduate)
     allowed_graduate_consideration_stages = OptionSet.lookup_by_keys(
       :consideration_journey_stage,

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -68,8 +68,8 @@ module MailingList
       export = export_data.slice(*attributes.map(&:to_s))
 
       show_welcome_guide = ApplicationController.helpers.show_welcome_guide?(
-        export["degree_status_id"],
-        export["preferred_teaching_subject_id"],
+        degree_status: export["degree_status_id"],
+        consideration_journey_stage: export["consideration_journey_stage_id"],
       )
 
       return export unless show_welcome_guide

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe WelcomeHelper, type: :helper do
     context "when degree_status is second year" do
       let(:second_year) { OptionSet.lookup_by_key(:degree_status, :second_year) }
 
-      it { expect(show_welcome_guide?(second_year)).to be false }
+      it { expect(show_welcome_guide?(degree_status: second_year)).to be false }
     end
 
     context "when degree_status is final year" do
       let(:final_year) { OptionSet.lookup_by_key(:degree_status, :final_year) }
 
-      it { expect(show_welcome_guide?(final_year)).to be true }
+      it { expect(show_welcome_guide?(degree_status: final_year)).to be true }
     end
 
     context "when degree_status is 'graduate or postgraduate'" do
@@ -37,19 +37,19 @@ RSpec.describe WelcomeHelper, type: :helper do
       context "when consideration journey stage is 'it's just an idea'" do
         let(:just_an_idea) { OptionSet.lookup_by_key(:consideration_journey_stage, :it_s_just_an_idea) }
 
-        it { expect(show_welcome_guide?(graduate, just_an_idea)).to be true }
+        it { expect(show_welcome_guide?(degree_status: graduate, consideration_journey_stage: just_an_idea)).to be true }
       end
 
       context "when consideration journey stage is 'I’m not sure and finding out more'" do
         let(:finding_out_more) { OptionSet.lookup_by_key(:consideration_journey_stage, :i_m_not_sure_and_finding_out_more) }
 
-        it { expect(show_welcome_guide?(graduate, finding_out_more)).to be true }
+        it { expect(show_welcome_guide?(degree_status: graduate, consideration_journey_stage: finding_out_more)).to be true }
       end
 
       context "when consideration journey stage is 'I’m fairly sure and exploring my options'" do
         let(:fairly_sure) { OptionSet.lookup_by_key(:consideration_journey_stage, :i_m_fairly_sure_and_exploring_my_options) }
 
-        it { expect(show_welcome_guide?(graduate, fairly_sure)).to be false }
+        it { expect(show_welcome_guide?(degree_status: graduate, consideration_journey_stage: fairly_sure)).to be false }
       end
     end
   end


### PR DESCRIPTION
We were passing in `preferred_teaching_subject_id` to `#show_welcome_guide?` instead of `consideration_journey_stage_id`, so would default to showing the generic version in some cases.

I've changed the method over to keyword arguments too so it's more obvious what's expected by the method.
