### PR TITLE
Gem updates for Feb 2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "webpacker", ">= 5.4.3"
 # gem 'mini_magick', '~> 4.8'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.9.3", require: false
+gem "bootsnap", ">= 1.10.2", require: false
 
 # Manage multiple processes i.e. web server and webpack
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,8 +114,8 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    bootsnap (1.9.3)
-      msgpack (~> 1.0)
+    bootsnap (1.10.2)
+      msgpack (~> 1.2)
     brakeman (5.2.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -278,7 +278,7 @@ GEM
       tomlrb
     mixlib-shellout (3.2.5)
       chef-utils
-    msgpack (1.4.2)
+    msgpack (1.4.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
@@ -504,7 +504,7 @@ DEPENDENCIES
   addressable (~> 2.8.0)
   amazing_print
   better_html (>= 1.0.16)
-  bootsnap (>= 1.9.3)
+  bootsnap (>= 1.10.2)
   brakeman (~> 5.2.0)
   byebug
   canonical-rails (>= 0.2.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,11 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: dc673e63f1ee99c53fbf0e1d7db873dea3bad783
+  revision: cf858eb830316acbb9a7cb1f2991a7eb89f17f36
   specs:
-    get_into_teaching_api_client (2.0.0)
+    get_into_teaching_api_client (2.1.0)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (2.0.0)
+    get_into_teaching_api_client_faraday (2.1.0)
       activesupport
       faraday
       faraday-encoding
@@ -230,7 +230,7 @@ GEM
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     kaminari (1.2.1)
@@ -492,7 +492,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
-    rack-attack (6.5.0)
+    rack-attack (6.6.0)
       rack (>= 1.0, < 3)
     rack-host-redirect (1.3.0)
       rack


### PR DESCRIPTION
### Context and changes

- Update rack-attack to 6.6.0
- Update get_into_teaching_api_client_faraday
- Update bootsnap to 1.10.2
