### PR TITLE
Improve Core Web Vitals scores

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -53,7 +53,9 @@
       <div class="site-footer-bottom__logo-container">
         <%= image_pack_tag 'media/images/dfelogo-white.svg', alt: "Department for Education", size: "124x73" %>
         <%# image_pack_tag 'media/images/plan-for-jobs.svg', alt: "Plan for jobs", size: "124x73" %>
-        <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/book-coronavirus-vaccination/"><%= image_pack_tag 'media/images/get-boosted-now.png', alt: "Get boosted now", height: "80" %></a>
+        <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/book-coronavirus-vaccination/">
+          <%= image_pack_tag 'media/images/get-boosted-now.png', alt: "Get boosted now", width: "274", height: "80" %>
+        </a>
       </div>
       <div class="site-footer-bottom__links-container">
         <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform">Feedback</a>

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -47,6 +47,7 @@
         <%= link_to("Three things to help you get into teaching", page_path(page: "three-things-to-help-you-get-into-teaching")) %>
         <%= link_to("COVID-19", page_path(page: "covid-19")) %>
         <%= link_to("Teach supply", page_path(page: "urgent-call-for-qualified-teachers")) %>
+        <%= link_to("Search", search_path) %>
       </div>
     </div>
     <div class="site-footer-bottom">

--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,15 +1,13 @@
 <%= tag.div(class: classes) do %>
   <ul class="extra-navigation__list">
-    <li class="extra-navigation__link "><%= link_to("Register your interest", "/mailinglist/signup/name" ) %><%= helpers.fas_icon "envelope" %></li>
-
-    <li class="extra-navigation__link extra-navigation__search-fallback">
-      <%= link_to("Search", search_path) %></li>
+    <li class="extra-navigation__link">
+      <%= link_to("Register your interest", "/mailinglist/signup/name" ) %><%= helpers.fas_icon "envelope" %>
     </li>
 
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search], data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden], data: { "searchbox-target": "label" }) %>
       <%= tag.div(data: { "searchbox-target" => "searchbar" }) %>
-      <span class="fas fa-search"></span>
+      <%= helpers.fas_icon "search" %>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -14,7 +14,7 @@
   <%= google_optimize_script %>
   <%= javascript_pack_tag 'sentry', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env } %>
   <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
-  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: false %>
   <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
   <%= yield :head %>

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -13,6 +13,8 @@ export default class extends Controller {
     this.setupAccessibleAutocomplete();
     this.fixLabelAccessibility();
 
+    this.element.classList.add('ready');
+
     this.mobileMenuHandler = this.hide.bind(this);
     document.addEventListener('navigation:menu', this.mobileMenuHandler);
   }

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -6,13 +6,6 @@
       header {
         flex-grow: 1;
       }
-
-      img {
-        width: 170px;
-        aspect-ratio: 4 / 3;
-        object-fit: cover;
-        object-position: center;
-      }
     }
   }
 
@@ -25,10 +18,6 @@
     .published-date {
       margin-top: $indent-amount;
     }
-  }
-
-  img {
-    width: 100%;
   }
 }
 
@@ -99,6 +88,13 @@
 
     li > .blog-article {
       @include blog-article;
+
+      img {
+        width: 170px;
+        height: 120px;
+        object-fit: cover;
+        object-position: center;
+      }
     }
 
     li:last-child hr {
@@ -116,11 +112,18 @@
     }
 
     img {
-      aspect-ratio: 4 / 3;
-      max-width: 100%;
+      width: 100%;
+      height: 300px;
       object-position: center;
-      width: fit-content;
       object-fit: cover;
+
+      @include mq($from: mobile) {
+        height: 450px;
+      }
+
+      @include mq($from: desktop) {
+        height: 550px;
+      }
     }
   }
 

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -1,7 +1,7 @@
 @import "accessible-autocomplete";
 
-html.js-enabled {
-  .extra-navigation__search-fallback {
+html:not(.js-enabled) {
+  .extra-navigation__search {
     display: none;
   }
 }
@@ -47,7 +47,6 @@ html.js-enabled {
     padding: 0;
     position: relative;
     min-width: 240px;
-    height: 36px;
 
     input {
       @include reset;
@@ -60,8 +59,12 @@ html.js-enabled {
       font-size: .9rem;
     }
 
-    div[data-searchbox-target='searchbar'] {
+    &.ready div[data-searchbox-target='searchbar'] {
       display: inline-block;
+    }
+
+    &:not(.ready) > * {
+      display: none;
     }
 
     .fa-search {
@@ -85,7 +88,6 @@ html.js-enabled {
   }
 
   ul.extra-navigation__list {
-    // @include font-size("xsmall");
     font-size: .9rem;
 
     list-style: none;
@@ -94,6 +96,7 @@ html.js-enabled {
     justify-content: flex-end;
     align-items: center;
     padding: 0;
+    height: 36px;
 
     li.extra-navigation__link {
       margin-left: 2em;
@@ -101,11 +104,6 @@ html.js-enabled {
       &.extra-navigation__search__icon {
         margin-left: 0;
       }
-    }
-
-    @include mq($until: tablet) {
-      align-items: flex-start;
-      flex-direction: column;
     }
 
     // mobile and tablet
@@ -118,6 +116,7 @@ html.js-enabled {
       text-align: left;
       background-color: $grey;
       padding: 1.5em 0 1.5em 4em;
+      height: auto;
 
       input {
         margin: 0;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -110,7 +110,7 @@ $mobile-cutoff: 800px;
           4,
           minmax(100px, 1fr)
         );
-      grid-template-rows: 2em fit-content(1em) fit-content(1em) fit-content(1em) fit-content(1em) fit-content(1em) 2em;
+      grid-template-rows: 2em repeat(5, fit-content(0)) 2em;
 
       &__title {
         grid-area: 3 / 1 / 5 / 5;

--- a/spec/components/header/extra_navigation_component_spec.rb
+++ b/spec/components/header/extra_navigation_component_spec.rb
@@ -9,7 +9,7 @@ describe Header::ExtraNavigationComponent, type: "component" do
 
   specify "renders the extra navigation container with contents" do
     expect(page).to have_css(".extra-navigation") do |en|
-      expect(en).to have_css("ul.extra-navigation__list > li", count: 3)
+      expect(en).to have_css("ul.extra-navigation__list > li", count: 2)
     end
   end
 

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -3,7 +3,7 @@ import SearchboxController from 'searchbox_controller.js';
 
 describe('SearchboxController', () => {
   const searchboxTemplate = `
-    <div data-controller="searchbox" data-searchbox-search-input-id-value="searchbox__input" class="searchbox">
+    <div id="search" data-controller="searchbox" data-searchbox-search-input-id-value="searchbox__input" class="searchbox">
       <a href="#" data-action="searchbox#toggle">
         Toggle
       </a>
@@ -25,6 +25,11 @@ describe('SearchboxController', () => {
 
       expect(autocompletes.length).toBe(1);
     });
+
+    it('adds the ready class to the controller element', () => {
+      const element = document.getElementById('search');
+      expect(element.classList).toContain('ready');
+    })
 
     it('adds an aria-label attribute to the input', () => {
       const input = document.querySelector('input');

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -25,7 +25,7 @@ describe MailingList::Steps::Postcode do
 
   describe "validations for send_event_emails" do
     it { is_expected.not_to allow_value(nil).for(:send_event_emails) }
-    it { is_expected.to validate_inclusion_of(:send_event_emails).in_array([true, false]) }
+    it { is_expected.to allow_values(true, false).for(:send_event_emails) }
   end
 
   describe "#export" do


### PR DESCRIPTION
### Trello card

[Trello-2912](https://trello.com/c/4JkZiePw/2912-investigate-increase-in-core-web-vitals-cls-warnings-for-desktop)

### Context

Our Core Web Vitals scores are indicating a number of pages that could be improved. The majority are related to Cumulative Layout Shift and appear to be pretty much globally across pages. A smaller subset is a long Largest Contentful Paint; this appears to be related to a particular event that is no longer active, but I expect the image was particularly large and resulted in a longer LCP (although it was only 0.1s over the 2.5s threshold!). As this event is in the past I think its safe to ignore this one and focus on the CLS issues.

### Changes proposed in this pull request

- Add explicit width to get boosted image

An image without a width/height causes cumulative layout shift.

- Remove aspect-ratio sizing of images

Sizing images with an aspect ratio results in Cumulative Layout Shift; we need to be  explicit with the dimensions to avoid that.

- Prevent search in header causing CLS

The search link in the header, along with the search autocomplete input, cause
an amount of Cumulative Layout Shift.

To prevent this we ensure there is enough space for the autocomplete input to render into. The JS disabled search link is causing the majority of the CLS, though I have absolutely no idea why and no combination of moving it around/messing with the CSS appears to resolve it. Instead, we're ripping it out of the header and putting a link in the footer so that those users can still access search (there have only been 35 page views of it in the last 6
months).

Load `js_enabled.js` pack synchronously so that we don't get flashes of JS enabled/disabled content that is later hidden (also a cause of CLS).

- Reduce content shift from image in hero section

Defaulting the `fit-content` declarations to 0 reduces the amount of content shift when laying out the image in the grid.

### Guidance to review
