### PR TITLE
Gem updates Feb 2022 part 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,8 @@ gem "loaf", ">= 0.10.0"
 
 gem "prometheus-client"
 
-gem "sentry-rails", ">= 4.8.1"
-gem "sentry-ruby", "~> 4.8.1"
+gem "sentry-rails", ">= 4.8.3"
+gem "sentry-ruby", "~> 4.8.3"
 
 gem "skylight", "~> 5.1.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ group :development, :test do
   gem "pry-rails"
 
   # Testing framework
-  gem "rspec-rails", "~> 5.0.2"
+  gem "rspec-rails", "~> 5.1.0"
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.36", ">= 3.36.0"
   gem "factory_bot_rails", ">= 6.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,14 +426,14 @@ GEM
     semantic_logger (4.9.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (4.8.1)
+    sentry-rails (4.8.3)
       railties (>= 5.0)
-      sentry-ruby-core (~> 4.8.1)
-    sentry-ruby (4.8.1)
+      sentry-ruby-core (~> 4.8.3)
+    sentry-ruby (4.8.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      faraday (>= 1.0)
-      sentry-ruby-core (= 4.8.1)
-    sentry-ruby-core (4.8.1)
+      faraday (~> 1.0)
+      sentry-ruby-core (= 4.8.3)
+    sentry-ruby-core (4.8.3)
       concurrent-ruby
       faraday
     shoulda-matchers (5.1.0)
@@ -554,8 +554,8 @@ DEPENDENCIES
   rubocop-govuk (~> 4.2.0)
   secure_headers
   selenium-webdriver (~> 3.142)
-  sentry-rails (>= 4.8.1)
-  sentry-ruby (~> 4.8.1)
+  sentry-rails (>= 4.8.3)
+  sentry-ruby (~> 4.8.3)
   shoulda-matchers
   simplecov
   skylight (~> 5.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.0.2)
+    rspec-rails (5.1.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -548,7 +548,7 @@ DEPENDENCIES
   redis
   rexml (>= 3.2.5)
   rinku
-  rspec-rails (~> 5.0.2)
+  rspec-rails (~> 5.1.0)
   rspec-retry
   rspec-sonarqube-formatter (~> 1.5)
   rubocop-govuk (~> 4.2.0)


### PR DESCRIPTION
### Context and changes

- Update sentry-ruby and sentry-rails to 4.8.3
- Update rspec-rails to 5.1.0
