### PR TITLE
Make 'Not now' button accessible

### DIFF
--- a/app/components/footer/mailing_list_component.html.erb
+++ b/app/components/footer/mailing_list_component.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="mailing-list-bar__right">
       <a id="mailing-list-bar-accept" href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
-      <a id="mailing-list-bar-dismiss" href="" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss">Not now</a>
+      <a id="mailing-list-bar-dismiss" href="javascript:void(0)" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss" role="button">Not now</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Trello card

[Trello-2924](https://trello.com/c/4wtGkNbp/2924-ensure-mailing-list-bar-buttons-can-be-understood-by-screen-readers)

### Context

Silktide flagged the mailing list banner 'Not now' button as inaccessible because it doesn't provide a `href` and is therefore not behaving like a link.

To fix this we can give the anchor link a role of `button`. I've also given it an explicit `href` that does nothing.

### Changes proposed in this pull request

- Make 'Not now' button accessible

### Guidance to review

