### PR TITLE
Add Lychee link checker

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,0 +1,29 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 3 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          args: --exclude-mail --max-retries 20 app/views/content
+
+      # - name: Create Issue From File
+      #   if: ${{ steps.lychee.outputs.exit_code != 0 }}
+      #   uses: peter-evans/create-issue-from-file@v3
+      #   with:
+      #     title: Link Checker Report
+      #     content-filepath: ./lychee/out.md
+      #     labels: report, automated issue


### PR DESCRIPTION
### Trello card

https://trello.com/c/SqBJ6ZOK/2957-missing-link-checker-times-out

### Context and changes

The link checker, which runs as part of the RSpec suite (tagged with `onschedule`) occasionally times out.

Checking the status of external links isn't really one of RSpec's strenghts.

This PR is intended to test out [Lychee](https://github.com/lycheeverse/lychee), a standalone tool that could potentially replace our external link checker. It has plenty of config options and is *much faster* than our Ruby version as it's compiled and multithreaded.

I've left the part of the flow (borrowed from [the readme](https://github.com/lycheeverse/lychee-action/)) that automatically creates GitHub issues out for the time being.
