### PR TITLE
Send Perfume.JS events to GA

### DIFF
--- a/app/webpacker/javascript/perfume.js
+++ b/app/webpacker/javascript/perfume.js
@@ -1,0 +1,33 @@
+import Perfume from 'perfume.js';
+
+/* eslint-disable no-new */
+new Perfume({
+  analyticsTracker: (options) => {
+    const { metricName, data, navigatorInformation } = options;
+    const metricNames = [
+      'fp',
+      'fcp',
+      'lcp',
+      'lcpFinal',
+      'fid',
+      'cls',
+      'clsFinal',
+      'tbt',
+      'tbt10S',
+      'tbtFinal',
+    ];
+
+    if (window.dataLayer && metricNames.includes(metricName)) {
+      window.dataLayer.push({
+        event: 'perfumeJs',
+        category: 'perfume.js',
+        action: metricName,
+        label: navigatorInformation.isLowEndExperience
+          ? 'lowEndExperience'
+          : 'highEndExperience',
+        // Google Analytics metrics must be integers, so the value is rounded
+        value: metricName === 'cls' ? data * 1000 : data,
+      });
+    }
+  },
+});

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,6 +11,7 @@ require.context('../fonts', true);
 require.context('../images', true);
 require.context('../documents', true);
 
+require('../javascript/perfume');
 require('../javascript/zendesk_chat_reload');
 
 Rails.start();

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.1",
     "lazysizes": "^5.3.2",
+    "perfume.js": "^6.3.0",
     "rails-ujs": "^5.2.5",
     "sass-mq": "^5.0.1",
     "serialize-javascript": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,6 +7616,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+perfume.js@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/perfume.js/-/perfume.js-6.3.0.tgz#c8fbbc306d6c050a1da767755190ffc0cd75132b"
+  integrity sha512-M9LTtPD6DfU0tswgmSDW6jBQdYLvmhu+5HmrnjG+aojnvjWKAszPoK0tNLbmmSILHm8GP2wcdozRuPnuUT6WlA==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"


### PR DESCRIPTION
### Trello card

[Trello-2974](https://trello.com/c/odQAjCfC/2974-setup-more-accurate-core-web-vitals-page-speed-metrics)

### Context

Perfume.JS records various performance metrics around the page loading in the users browser. We can capture these and send them to GA via GTM to give an insight into real end-user performance of web pages.

### Changes proposed in this pull request

- Send Perfume.JS events to GA

### Guidance to review

I think this is probably going to be more hassle than its worth to try and unit test; I've checked it manually and its all pulling through into GA.

The averages are high in the screenshot as they were collected from my local instance:

<img width="1202" alt="Screenshot 2022-02-16 at 14 50 17" src="https://user-images.githubusercontent.com/29867726/154289803-fb820412-ec0c-439d-9730-0004de22c235.png">
