### PR TITLE
Run all tests on deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,46 +108,6 @@ jobs:
            SLACK_TITLE: 'Failure Building Application'
            SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
 
-  master_tests:
-    name: Unit Tests (Master Branch)
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2.4.0
-
-      - name: set-up-environment
-        uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - uses: Azure/login@v1
-        with:
-            creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id:  keyvault-yaml-secret
-        with:
-          keyvault: ${{ secrets.KEY_VAULT}}
-          secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Check Content pages
-        run: |-
-          docker run -t --rm -e RAILS_ENV=test \
-            ${{ needs.build.outputs.DOCKER_IMAGE }} \
-            rspec --format progress spec/features/content_pages_spec.rb
-
-      - name: Slack Notification
-        if: failure()
-        uses: rtCamp/action-slack-notify@master
-        env:
-           SLACK_COLOR: ${{env.SLACK_ERROR}}
-           SLACK_MESSAGE: 'There has been a failure unit testing the application'
-           SLACK_TITLE: 'Failure Unit Testing Application'
-           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
-
   ruby_linting:
     name: Ruby Linting
     runs-on: ubuntu-latest
@@ -394,7 +354,7 @@ jobs:
 
   development:
     name: Development Deployment
-    needs: [  master_tests  ]
+    needs: [  feature_tests, javascript_tests, ruby_linting  ]
     if: github.ref == 'refs/heads/master'
     concurrency: Development
     runs-on: ubuntu-latest
@@ -487,7 +447,7 @@ jobs:
 
   qa:
     name: Quality Assurance Deployment
-    needs: [ master_tests ]
+    needs: [  feature_tests, javascript_tests, ruby_linting  ]
     if: github.ref == 'refs/heads/master'
     concurrency: QA
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously we were only running a subset of the tests (presumably for deployment speed?). As we now run tests in parallel there's no reason not to run them, and given a merge commit may create a failure case its worthwhile.