### PR TITLE
Split dockerfile for test/release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Build
+  build_release:
+    name: Build (Release)
     runs-on: ubuntu-latest
     outputs:
       DOCKER_IMAGE: ${{ steps.docker.outputs.DOCKER_IMAGE }}
@@ -32,11 +32,6 @@ jobs:
           key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Lint Dockerfile
-        uses: brpaz/hadolint-action@master
-        with:
-             dockerfile: "Dockerfile"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -78,6 +73,75 @@ jobs:
           push: true
           build-args: |
             SHA=${{ steps.sha.outputs.short }}
+            BUILD_TYPE=release
+
+      - name: Slack Notification
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: ${{env.SLACK_ERROR}}
+           SLACK_MESSAGE: 'There has been a failure building the application'
+           SLACK_TITLE: 'Failure Building Application'
+           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
+
+  build_test:
+    name: Build (Test)
+    runs-on: ubuntu-latest
+    outputs:
+      DOCKER_IMAGE_TEST: ${{ steps.docker.outputs.DOCKER_IMAGE_TEST }}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2.4.0
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: INFRA-KEYS
+          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Lint Dockerfile
+        uses: brpaz/hadolint-action@master
+        with:
+             dockerfile: "Dockerfile"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Get Short SHA
+        id: sha
+        run: |
+             echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
+
+      - name: Set DOCKER_IMAGE_TEST environment variable
+        id:   docker
+        run: |
+             if [ "${{github.ref}}" == "refs/heads/master" ]
+             then
+                echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
+                echo ::set-output name=DOCKER_EVENT_TEST::${{ env.DOCKER_REPOSITORY }}:master
+             else
+                echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:review-${{steps.sha.outputs.short }}
+                echo ::set-output name=DOCKER_EVENT_TEST::${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}
+             fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1.13.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
 
       - name: Build and output locally
         uses: docker/build-push-action@v2.9.0
@@ -87,16 +151,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ steps.docker.outputs.DOCKER_IMAGE }}
-            ${{ steps.docker.outputs.DOCKER_EVENT }}
+            ${{ steps.docker.outputs.DOCKER_IMAGE_TEST }}
+            ${{ steps.docker.outputs.DOCKER_EVENT_TEST }}
           build-args: |
             SHA=${{ steps.sha.outputs.short }}
-
+            BUILD_TYPE=test
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: app
+          name: app_test
           path: /tmp/image.tar
 
       - name: Slack Notification
@@ -111,7 +175,7 @@ jobs:
   ruby_linting:
     name: Ruby Linting
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build_test ]
     if: github.ref != 'refs/heads/master'
     steps:
       - name: Check out the repo
@@ -124,11 +188,11 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Load Docker Image
-        run: docker load --input app/image.tar
+        run: docker load --input app_test/image.tar
 
       - name: Lint Ruby
         run: |-
-          docker run -t --rm -v ${PWD}/out:/app/out -e RAILS_ENV=test ${{needs.build.outputs.DOCKER_IMAGE}} \
+          docker run -t --rm -v ${PWD}/out:/app/out -e RAILS_ENV=test ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} \
             rubocop --format json --out=/app/out/rubocop-result.json
 
       - name: Keep Rubocop output
@@ -140,16 +204,16 @@ jobs:
 
       - name: Lint ERB Templates
         run: |-
-          docker run -t --rm ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec erblint --lint-all"
+          docker run -t --rm ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "bundle exec erblint --lint-all"
 
       - name: Lint Markdown
         run: |-
-          docker run -t --rm -v ${PWD}/out:/app/out ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec mdl app/views/**/*.md | tee /app/out/mdl-result.txt"
+          docker run -t --rm -v ${PWD}/out:/app/out ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "bundle exec mdl app/views/**/*.md | tee /app/out/mdl-result.txt"
 
   javascript_tests:
     name: Javascript Tests
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build_test ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
@@ -161,27 +225,27 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Load Docker Image
-        run: docker load --input app/image.tar
+        run: docker load --input app_test/image.tar
 
       - name: ESLint - JavaScript linting
         run: |-
           docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true \
-            ${{needs.build.outputs.DOCKER_IMAGE}} "yarn && yarn js-lint"
+            ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "yarn && yarn js-lint"
 
       - name: Run Javascript Tests
         run: |-
           docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true \
-            ${{needs.build.outputs.DOCKER_IMAGE}} "yarn && yarn spec"
+            ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "yarn && yarn spec"
 
   feature_tests:
-    name: Unit Tests (Feature Branch)
+    name: Unit Tests
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build_test ]
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [5]
-        ci_node_index: [0, 1, 2, 3, 4]
+        ci_node_total: [6]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
@@ -206,13 +270,13 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Load Docker Image
-        run: docker load --input app/image.tar
+        run: docker load --input app_test/image.tar
 
       - name: Run Specs
         run: |-
           docker run -t --rm -v ${PWD}/out:/app/out -v ${PWD}/coverage/coverage-${{ matrix.ci_node_index }}:/app/coverage -e TEST_REPORT_FILE -e TEST_REPORT_FINAL_FILE -e KNAPSACK_PRO_FIXED_QUEUE_SPLIT \
             -e KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC -e KNAPSACK_PRO_COMMIT_HASH -e KNAPSACK_PRO_BRANCH -e KNAPSACK_PRO_CI_NODE_TOTAL -e KNAPSACK_PRO_CI_NODE_INDEX -e \
-            KNAPSACK_PRO_LOG_LEVEL -e RAILS_ENV=test ${{needs.build.outputs.DOCKER_IMAGE}} \
+            KNAPSACK_PRO_LOG_LEVEL -e RAILS_ENV=test ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} \
             "bundle exec rake 'knapsack_pro:queue:rspec[--format RspecSonarqubeFormatter --out /app/out/test-report.xml --format progress]' spec"
         env:
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ steps.keyvault-yaml-secret.outputs.KNAPSACK-PRO-TEST-SUITE-TOKEN-RSPEC }}
@@ -243,7 +307,7 @@ jobs:
   sonarscanner:
     name: Sonar Scanner
     runs-on: ubuntu-latest
-    needs: [ build, feature_tests ]
+    needs: [ build_test, feature_tests ]
     if: github.ref != 'refs/heads/master'
     steps:
       - name: Check out the repo
@@ -272,12 +336,12 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Load Docker Image
-        run: docker load --input app/image.tar
+        run: docker load --input app_test/image.tar
 
       - name: Combine Coverage Reports
         run: |-
           docker run -t --rm -v ${{github.workspace}}/code_coverage:/app/coverage -e RAILS_ENV=test -e COVERAGE_DIR \
-            ${{needs.build.outputs.DOCKER_IMAGE}} "bundle exec rake coverage:collate"
+            ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "bundle exec rake coverage:collate"
         env:
           COVERAGE_DIR: /app/coverage
 
@@ -299,7 +363,7 @@ jobs:
 
   review:
     name: Review Deployment Process
-    needs: [ build ]
+    needs: [ build_release ]
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     concurrency: Review_${{github.event.inputs.pr}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:2.7.5-alpine3.14 as build-env
+ARG BUILD_TYPE
+
+FROM ruby:2.7.5-alpine3.14 as base
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \
@@ -11,17 +13,19 @@ ENV RAILS_ENV=production \
 RUN mkdir /app
 WORKDIR /app
 
-RUN apk add --no-cache build-base git tzdata shared-mime-info nodejs yarn\
-    wget xvfb unzip chromium chromium-chromedriver \
-    pngquant jpegoptim imagemagick parallel && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache tzdata shared-mime-info nodejs yarn \
+    chromium chromium-chromedriver && rm -rf /var/lib/apt/lists/*
+
+# Copy node_modules/gem as cache
+# hadolint ignore=DL3022
+COPY --from=ghcr.io/dfe-digital/get-into-teaching-frontend:master /usr/local/bundle /usr/local/bundle
+# hadolint ignore=DL3022
+COPY --from=ghcr.io/dfe-digital/get-into-teaching-frontend:master /app/node_modules /app/node_modules
 
 # install NPM packages removign artifacts
 COPY package.json yarn.lock ./
 # hadolint ignore=DL3060
 RUN yarn install
-
-# hadolint ignore=DL3022
-COPY --from=ghcr.io/dfe-digital/get-into-teaching-frontend:master /usr/local/bundle /usr/local/bundle
 
 # Install bundler
 RUN gem install bundler --version=2.3.4
@@ -32,8 +36,17 @@ RUN bundle install --jobs=$(nproc --all) && \
     rm -rf /root/.bundle/cache && \
     rm -rf /usr/local/bundle/cache
 
+FROM base AS build-release
+
+# Extra dependencies for image processing
+# Test packages are also removed (added earlier to benefit the cache)
+RUN apk add --no-cache pngquant jpegoptim imagemagick parallel && \
+    rm -rf /var/lib/apt/lists/* && \
+    apk del chromium chromium-chromedriver
+
 # Add code and compile assets
 COPY . .
+
 # See https://github.com/rails/rails/issues/32947 for why we
 # bypass the credentials here.
 RUN SECRET_KEY_BASE=1 RAILS_BUILD=1 bundle exec rake assets:precompile
@@ -49,33 +62,21 @@ RUN find public -type f \( -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" \
 # At 75% quality the images still look good and they are roughly half the size.
 # We need to convert after the fingerprinting so the file names are consistent.
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN find public -name "*.jpg" -size "+1b" | parallel -eta magick {} -quality 75 "{.}.webp" \ 
-    && find public -name "*.jpeg" -size "+1b" | parallel -eta magick {} -quality 75 "{.}.webp" \
-    && find public -name "*.png" -size "+1b" | parallel -eta magick {} -quality 75 "{.}.webp" \
-    && find public -name "*.jpg" -size "+1b" | parallel -eta magick {} -quality 75 "{.}.jp2" \
-    && find public -name "*.jpeg" -size "+1b" | parallel -eta magick {} -quality 75 "{.}.jp2"
 
-FROM ruby:2.7.5-alpine3.14
+RUN find public \( -type f -a \( -iname "*.jpg" -o -iname ".jpeg" -o -iname ".png" \) \) | parallel -eta magick {} -quality 75 "{.}.webp" \
+    && find public \( -type f -a \( -iname "*.jpg" -o -iname ".jpeg" \) \) | parallel -eta magick {} -quality 75 "{.}.jp2"
 
-ENV RAILS_ENV=production \
-    NODE_ENV=production \
-    RAILS_SERVE_STATIC_FILES=true \
-    RAILS_LOG_TO_STDOUT=true \
-    RACK_TIMEOUT_SERVICE_TIMEOUT=60
+FROM base AS build-test
+
+# Add code and compile assets
+COPY . .
+
+# hadolint ignore=DL3006
+FROM build-${BUILD_TYPE} AS final
 
 EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
 CMD ["rails", "server" ]
-
-RUN apk add --no-cache tzdata nodejs yarn shared-mime-info chromium chromium-chromedriver \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir /app
-WORKDIR /app
-
-COPY --from=build-env /usr/local/bundle/ /usr/local/bundle/
-
-COPY --from=build-env /app .
 
 ARG SHA
 RUN echo "sha-${SHA}" > /etc/get-into-teaching-app-sha


### PR DESCRIPTION
We don't need to do a bunch of time-consuming tasks (mainly related to asset preprocessing) for the test docker image.

If we split the dockerfile (so we can either build it for test or production) we should be able to start running the tests much sooner and the longer, production docker build process won't delay things.

Copies the `node_modules` from previous builds to speed up the `yarn install`.

We install the test packages (chromium/driver) in the initial `apk add` to benefit from the layer cache; it's more efficient to remove these from the production image than to add them separately later to the test image.

Brings the build time from ~11m down to ~8m.