### PR TITLE
Ensure events start and finish on the same day

### DIFF
--- a/app/models/internal/event.rb
+++ b/app/models/internal/event.rb
@@ -47,6 +47,7 @@ module Internal
     validates :venue_type, inclusion: { in: VENUE_TYPES.values }
     validate :dates_in_future
     validate :end_after_start
+    validate :starts_and_ends_on_same_day
     validate :existing_building_present
 
     def self.initialize_with_api_event(api_event)
@@ -135,6 +136,14 @@ module Internal
 
       if end_at <= start_at
         errors.add(:end_at, "Must be after the start date")
+      end
+    end
+
+    def starts_and_ends_on_same_day
+      return if end_at.blank? || start_at.blank?
+
+      unless end_at.to_date == start_at.to_date
+        errors.add(:end_at, "Events must start and end on the same day")
       end
     end
 

--- a/spec/factories/internal/event_factory.rb
+++ b/spec/factories/internal/event_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     name { "Test" }
     summary { "Test" }
     description { "Test" }
-    start_at { Time.zone.now + 1.day }
-    end_at { Time.zone.now + 2.days }
+    start_at { 1.day.from_now.at_midday }
+    end_at { start_at + 1.hour }
   end
 
   trait :online_event do

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -278,7 +278,7 @@ private
     find(:id, "internal_event_description", visible: false)
       .click
       .set "test"
-    fill_in "internal_event[start_at]", with: Time.zone.now + 1.day
-    fill_in "internal_event[end_at]", with: Time.zone.now + 2.days
+    fill_in "internal_event[start_at]", with: Time.zone.now.at_midday + 1.hour
+    fill_in "internal_event[end_at]", with: Time.zone.now.at_midday + 2.hours
   end
 end

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -72,6 +72,12 @@ describe Internal::Event do
         subject.start_at = now + 1.minute
         is_expected.to allow_value(now + 2.minutes).for :end_at
       end
+
+      it "is expected to ensure events start and end on the same day" do
+        subject.start_at = Time.zone.now.at_midday
+        is_expected.to allow_value(subject.start_at + 1.hour).for :end_at
+        is_expected.not_to allow_value(subject.start_at + 1.day).for :end_at
+      end
     end
 
     context "when online event" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/oWIFRMYc/2942-add-validation-on-the-event-editor-finish-date

### Context and changes

Currently all events are meant to start and finish on the same day but with no validation some bad records have crept in, like a typo where the end_at value was in 2202.

This provides a bit more safety on that front. It also means we can't really support multi-day events, they (if they do ever occur) will need to be added as separate slots.
