### PR TITLE
Fix spec causing future time validation to fail

### DIFF
--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -278,7 +278,7 @@ private
     find(:id, "internal_event_description", visible: false)
       .click
       .set "test"
-    fill_in "internal_event[start_at]", with: Time.zone.now.at_midday + 1.hour
-    fill_in "internal_event[end_at]", with: Time.zone.now.at_midday + 2.hours
+    fill_in "internal_event[start_at]", with: Time.zone.tomorrow.at_midday + 1.hour
+    fill_in "internal_event[end_at]", with: Time.zone.tomorrow.at_midday + 2.hours
   end
 end

--- a/spec/models/internal/event_spec.rb
+++ b/spec/models/internal/event_spec.rb
@@ -74,7 +74,7 @@ describe Internal::Event do
       end
 
       it "is expected to ensure events start and end on the same day" do
-        subject.start_at = Time.zone.now.at_midday
+        subject.start_at = Time.zone.tomorrow.at_midday
         is_expected.to allow_value(subject.start_at + 1.hour).for :end_at
         is_expected.not_to allow_value(subject.start_at + 1.day).for :end_at
       end


### PR DESCRIPTION
The `Time.zone.now.at_midday` won't trigger a validation failure in the morning but will in the afternoon because events must be set in the future 🤦
