### PR TITLE
Add canonical tags to all web pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
                 echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
                 echo ::set-output name=DOCKER_EVENT::${{ env.DOCKER_REPOSITORY }}:master
              else
+                echo ::set-output name=DOCKER_SHA::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
                 echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:review-${{steps.sha.outputs.short }}
                 echo ::set-output name=DOCKER_EVENT::${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}
              fi
@@ -74,6 +75,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ${{ steps.docker.outputs.DOCKER_IMAGE }}
+            ${{ steps.docker.outputs.DOCKER_SHA }}
             ${{ steps.docker.outputs.DOCKER_EVENT }}
           push: true
           build-args: |

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -2,7 +2,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
   <%= csp_meta_tag %>
-  <%#= canonical_tag %>
+  <%= canonical_tag %>
   <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no') %>
   <%= tag.meta(name: "google-site-verification", content: "uoqqF4yGEjHx9klftx3ch2fCBpmgI6hHYBS69w17_-g") %>
   <%= tag.link(rel: 'icon', type: 'image/x-icon', href: '/favicon.ico') %>

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -7,8 +7,8 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  config.host = "www.education.gov.uk"
-  config.port # = '3000'
+  config.host = "getintoteaching.education.gov.uk"
+  config.port = "443"
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
@@ -19,10 +19,10 @@ CanonicalRails.setup do |config|
   config.collection_actions # = [:index]
 
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
-  # Unless whitelisted, these parameters will be omitted
+  # Unless allowed, these parameters will be omitted
 
-  config.whitelisted_parameters # = []
+  config.allowed_parameters # = []
 
   # Output a matching OpenGraph URL meta tag (og:url) with the canonical URL, as recommended by Facebook et al
-  config.opengraph_url = true
+  config.opengraph_url #= true
 end

--- a/spec/requests/canonical_urls_spec.rb
+++ b/spec/requests/canonical_urls_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Canonical URLs", type: :request do
+  subject { response.body }
+
+  context "when requesting the root path" do
+    before { get root_path }
+
+    it { is_expected.to include(canonical_tag) }
+  end
+
+  context "when requesting a nested path" do
+    before { get blog_path("choosing-the-right-teacher-training-course-provider") }
+
+    it { is_expected.to include(canonical_tag("/blog/choosing-the-right-teacher-training-course-provider")) }
+  end
+
+  context "when requesting a path with query parameters" do
+    before { get "/ways-to-train", params: { some: "param" } }
+
+    it { is_expected.to include(canonical_tag("/ways-to-train")) }
+  end
+
+  def canonical_tag(path = nil)
+    %(<link href="https://getintoteaching.education.gov.uk#{path}" rel="canonical">)
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-2986](https://trello.com/c/4Dm3u0rf/2986-avoid-serving-web-pages-on-the-assets-domain)

### Context

We serve the app assets from another domain in production (app-assets-getintoteaching.education.gov.uk) and Google is indexing some of our pages on this domain instead of the production domain (as we serve the web pages as well as the assets).

To prevent this and avoid it happening again in the future we can indicate to Google that we want getintoteaching.education.gov.uk to be used as the canonical domain.

### Changes proposed in this pull request

- Add canonical URL tags to all pages

- Set DOCKER_SHA env variable

We do this so that we can setup a manual release to test.

### Guidance to review

I also tried to make it so the routes didn't exist for asset domains (hence the second commit in this PR, which I've left in in case we need to push to test in the future), but it ended up feeling a bit hacky and I think the canonical tags should resolve the issue.