### PR TITLE
Add link checker step that posts results to Slack

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -33,9 +33,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Upload to Slack
-        uses: adrey/slack-file-upload-action@master
-        with:
-          token: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
-          path: ./lychee/out.md
-          channel: getintoteaching_tech
+      - name: Read Lychee output into var
+        id: lychee-output
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        run: |
+          echo "::set-output name=LYCHEE_OUTPUT::$(cat ./lychee/out.md)"
+
+      - name: Slack Notification
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: ${{env.SLACK_ERROR}}
+           SLACK_MESSAGE: |
+             ${{ steps.lychee-output.outputs.LYCHEE_OUTPUT }}
+           SLACK_TITLE: 'External link check results:'
+           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -20,10 +20,22 @@ jobs:
         with:
           args: --exclude-mail --max-retries 20 app/views/content
 
-      # - name: Create Issue From File
-      #   if: ${{ steps.lychee.outputs.exit_code != 0 }}
-      #   uses: peter-evans/create-issue-from-file@v3
-      #   with:
-      #     title: Link Checker Report
-      #     content-filepath: ./lychee/out.md
-      #     labels: report, automated issue
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: INFRA-KEYS
+          key: SLACK-WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Upload to Slack
+        uses: adrey/slack-file-upload-action@master
+        with:
+          token: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
+          path: ./lychee/out.md
+          channel: getintoteaching_tech


### PR DESCRIPTION
### Trello card

https://trello.com/c/SqBJ6ZOK/2957-missing-link-checker-times-out

### Context

The new link checker appears to be working and reporting sensible results. This change makes it post the output to our `#getintoteaching_tech` Slack channel.
