### PR TITLE
Add mermaid flow diagrams to the docs

### DIFF
--- a/docs/event-flow.md
+++ b/docs/event-flow.md
@@ -1,0 +1,16 @@
+## Event signup flow
+
+```mermaid
+graph TD;
+  chooses_event[/Chooses a Train to Teach event/] --> sign_up_for_this_event
+  sign_up_for_this_event[Sign up for this event] -- Doesn't exist in CRM --> telephone_number[What is your telephone number?] --> accept_privacy_policy[Accept privacy policy]
+
+  sign_up_for_this_event -- Exists in CRM --> already_registered[You've already registered with us]
+  already_registered --> telephone_number
+
+  accept_privacy_policy -- I want email updates --> how_close_are_you_to_applying[How close are you to applying?]
+  accept_privacy_policy -- No email updates --> complete[Sign up complete]
+
+  how_close_are_you_to_applying --> complete
+
+```

--- a/docs/mailing-list-flow.md
+++ b/docs/mailing-list-flow.md
@@ -1,0 +1,32 @@
+# Mailing list signup flow
+
+```mermaid
+graph TD;
+  name_and_email[Get personalised guidance to your inbox] -- Doesn't exist in CRM --> degree[Do you have a degree?]
+  name_and_email -- Exists in CRM --> already_registered[You're already registered with us]
+  
+  already_registered -- Not on mailing list --> degree
+  already_registered -- On mailing list --> signed_up_already[You've already signed up]
+  degree --> journey_stage[How close are you to applying?]
+  
+  journey_stage --> subject[Which subject do you want to teach?]
+  subject --> events[Would you like to hear about events in your area?]
+  
+  events --> privacy_policy[Accept privacy policy]
+  
+  privacy_policy --> show_welcome_guide{Show welcome guide?}
+  
+  show_welcome_guide --> signed_up_no_wg[You've signed up]  
+  show_welcome_guide --> signed_up_wg[You've signed up with Welcome Guide link]  
+  
+  signed_up_wg --> welcome_guide[Welcome guide]
+```
+
+## Show welcome guide logic
+
+In order to display the welcome guide to a candidate they must:
+
+* be a final year student
+* be a graduate who in the 'how close are you to applying' question answered:
+  * It’s just an idea
+  * I’m not sure and finding out more


### PR DESCRIPTION
Add diagrams based on @gazcarr's Lucid flow charts for:

* [the mailing list flow](https://github.com/DFE-Digital/get-into-teaching-app/blob/0dfb0e78a45d62d848853f3595b982813c55d1d9/docs/mailing-list-flow.md)
* [the events signup](https://github.com/DFE-Digital/get-into-teaching-app/blob/0dfb0e78a45d62d848853f3595b982813c55d1d9/docs/event-flow.md)

Also see DFE-Digital/get-teacher-training-adviser-service/pull/948