### PR TITLE
Fix cumulative layout shift on desktop

### DIFF
--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -13,10 +13,10 @@
   <% end %>
   <%= google_optimize_script %>
   <%= javascript_pack_tag 'sentry', 'data-turbolinks-track': 'reload', data: { "sentry-dsn": sentry_dsn, "sentry-environment": Rails.env } %>
-  <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] }, async: true if gtm_enabled? %>
-  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', async: false %>
-  <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', async: true %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'gtm', 'data-turbolinks-track': 'reload', data: { "gtm-id": ENV["GTM_ID"] } if gtm_enabled? %>
+  <%= javascript_pack_tag 'js_enabled', 'data-turbolinks-track': 'reload', defer: true %>
+  <%= javascript_pack_tag 'lazy_images', 'data-turbolinks-track': 'reload', defer: true %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -90,8 +90,10 @@ export default class extends Controller {
     // auto-complete input and also co-locate the label next to the
     // input. One or both of these may not be necessary, but we won't
     // know until the next Silktide report.
-    this.input.ariaLabel = this.labelTarget.textContent;
-    this.input.parentNode.insertBefore(this.labelTarget, this.input);
+    if (this.hasLabelTarget) {
+      this.input.ariaLabel = this.labelTarget.textContent;
+      this.input.parentNode.insertBefore(this.labelTarget, this.input);
+    }
   }
 
   searchParams(query) {


### PR DESCRIPTION
- Fix cumulative layout shift on desktop

Loading the Javascript async in the `<head>` appears to result in fairly random Cumulative Layout Shift (CLS) on the page. It appears to effect the header section in particular, but I'm not certain why (it event causes hidden elements to result in a layout shift!).

Changing the Javascript to defer loading clears _most_ of this up, and doesn't appear to have any negative impact.

- Fix intermittent JS exception

We are seeing an intermittent exception where the `labelTarget` is no longer available; it appears to get removed from the DOM on occasion when changing pages. I think it may be something to do with the Turbolinks page cache, but I'm not certain what yet.

Putting in a conditional check to ensure the target is available quietens the error for now, and as the input still appears to have the correct `aria-label` set when this happens it should still remain accessible.