### PR TITLE
Dependabot ruby updates 2022-03

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "addressable", "~> 2.8.0"
 
 gem "rack-attack"
 
-gem "faraday", "~> 1.9.3"
+gem "faraday", "~> 1.10.0"
 gem "faraday-encoding"
 gem "faraday-http-cache"
 gem "faraday_middleware"

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "redis"
 gem "redis-session-store", ">= 0.11.4"
 
 gem "kaminari", "~> 1.2", ">= 1.2.2"
-gem "view_component", "~> 2.48.0"
+gem "view_component", "~> 2.49.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "foreman"
 gem "secure_headers"
 
 # Canonical meta tag
-gem "canonical-rails", ">= 0.2.13"
+gem "canonical-rails", ">= 0.2.14"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
 gem "kramdown", ">= 2.3.1"

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,8 @@ gem "loaf", ">= 0.10.0"
 
 gem "prometheus-client"
 
-gem "sentry-rails", ">= 5.0.2"
-gem "sentry-ruby", "~> 5.0.2"
+gem "sentry-rails", ">= 5.1.1"
+gem "sentry-ruby", "~> 5.1.1"
 
 gem "skylight", "~> 5.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.9.3)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -524,7 +524,7 @@ DEPENDENCIES
   dotenv-rails (>= 2.7.6)
   erb_lint (>= 0.1.1)
   factory_bot_rails (>= 6.2.0)
-  faraday (~> 1.9.3)
+  faraday (~> 1.10.0)
   faraday-encoding
   faraday-http-cache
   faraday_middleware

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,8 @@ GEM
     brakeman (5.2.1)
     builder (3.2.4)
     byebug (11.1.3)
-    canonical-rails (0.2.13)
-      rails (>= 4.1, <= 7.0)
+    canonical-rails (0.2.14)
+      rails (>= 4.1, <= 7.1)
     capybara (3.36.0)
       addressable
       matrix
@@ -517,7 +517,7 @@ DEPENDENCIES
   bootsnap (>= 1.10.3)
   brakeman (~> 5.2.1)
   byebug
-  canonical-rails (>= 0.2.13)
+  canonical-rails (>= 0.2.14)
   capybara (~> 3.36, >= 3.36.0)
   delegate (>= 0.2.0)
   dfe_wizard!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.1.0)
     victor (0.3.3)
-    view_component (2.48.0)
+    view_component (2.49.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.2.0)
@@ -571,7 +571,7 @@ DEPENDENCIES
   text
   tzinfo-data
   victor
-  view_component (~> 2.48.0)
+  view_component (~> 2.49.0)
   web-console (>= 4.2.0)
   webmock (>= 3.14.0)
   webpacker (>= 5.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,13 +434,13 @@ GEM
     semantic_logger (4.10.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.0.2)
+    sentry-rails (5.1.1)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.0.2)
-    sentry-ruby (5.0.2)
+      sentry-ruby-core (~> 5.1.1)
+    sentry-ruby (5.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.0.2)
-    sentry-ruby-core (5.0.2)
+      sentry-ruby-core (= 5.1.1)
+    sentry-ruby-core (5.1.1)
       concurrent-ruby
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -561,8 +561,8 @@ DEPENDENCIES
   rubocop-govuk (~> 4.2.0)
   secure_headers
   selenium-webdriver (~> 3.142)
-  sentry-rails (>= 5.0.2)
-  sentry-ruby (~> 5.0.2)
+  sentry-rails (>= 5.1.1)
+  sentry-ruby (~> 5.1.1)
   shoulda-matchers
   simplecov
   skylight (~> 5.2.0)


### PR DESCRIPTION
### Context and changes

- Update view_component to 2.49.0
- Update faraday to 1.10.0
- ~~Update skylight to 5.3.0~~ removed because it fails to compile
- Update sentry-ruby and sentry-rails to 5.1.1
- Update canonical-rails to 0.2.14
