### PR TITLE
Remove external link icons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,11 +84,8 @@ private
       next anchor && Sentry.capture_message("#{request.url} contains invalid anchor link") if anchor[:href].nil?
 
       external_link = anchor[:href].include?("//")
-      externally_hosted_internal_asset = ENV["APP_ASSETS_URL"].present? && anchor[:href].start_with?(ENV["APP_ASSETS_URL"])
 
-      if external_link && !externally_hosted_internal_asset
-        anchor.add_child(helpers.image_pack_tag("media/images/icon-external.svg", class: "external-link-icon", alt: ""))
-      end
+      anchor.add_child(helpers.tag.span("(opens in new window)", class: "visually-hidden")) if external_link
     end
 
     doc.to_html(encoding: "UTF-8", indent: 2)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -88,7 +88,7 @@
 
     <% elsif @event.provider_website_url %>
       <h2>How to attend</h2>
-      <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %><i class="icon icon-external"></i>.<p>
+      <p>To attend this event, please <%= link_to("visit this website", @event.provider_website_url, { target: "blank" }) %>.</p>
     <% elsif @event.provider_contact_email %>
       <h2>How to attend</h2>
       <p>To attend this event, please <%= mail_to(@event.provider_contact_email, "email us") %>.<p>

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -13,22 +13,14 @@ export default class extends Controller {
   }
 
   openExternalContentLinksInNewWindow() {
-    const links = this.contentTarget.querySelectorAll('a');
+    const links = Array.from(this.contentTarget.querySelectorAll('a'));
 
-    links.forEach((l) => {
-      if (this.isExternal(l)) {
+    links
+      .filter((l) => this.isExternal(l))
+      .forEach((l) => {
         l.setAttribute('target', '_blank');
         l.setAttribute('rel', 'noopener');
-
-        // add hidden text to inform screen reader users that
-        // link will open in a new window
-        const linkOpensInNewWindow = document.createElement('span');
-        const text = document.createTextNode('(Link opens in new window)');
-        linkOpensInNewWindow.classList.add('govuk-visually-hidden');
-        linkOpensInNewWindow.appendChild(text);
-        l.appendChild(linkOpensInNewWindow);
-      }
-    });
+      });
   }
 
   preventTurboLinksOnJumpLinks() {
@@ -44,7 +36,10 @@ export default class extends Controller {
   isExternal(link) {
     const href = link.getAttribute('href');
 
-    return href?.startsWith('http') && !href?.includes(this.assetsUrlValue);
+    return (
+      href?.startsWith('http') &&
+      !href?.includes(this.assetsUrlValue || window.location.host)
+    );
   }
 
   prepareChevronOnButtonLinks() {

--- a/app/webpacker/images/icon-external.svg
+++ b/app/webpacker/images/icon-external.svg
@@ -1,4 +1,0 @@
-<svg id="External_link_icon" data-name="External link icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-  <path id="Subtraction_3" data-name="Subtraction 3" d="M14,14H0V0H6.589V1.647H1.648V12.353h10.7V8.236H14V14Zm0-7.41H12.353V1.647H8.236V0H14V6.589Z" fill="#2781be"/>
-  <rect id="Rectangle_351" data-name="Rectangle 351" width="9.637" height="1.752" transform="translate(5.746 7.274) rotate(-45)" fill="#2781be"/>
-</svg>

--- a/app/webpacker/styles/icons.scss
+++ b/app/webpacker/styles/icons.scss
@@ -20,14 +20,6 @@
   height: 20px;
 }
 
-.icon-external {
-  @include icon;
-  background-image: url("../images/icon-external.svg");
-  width: 20px;
-  height: 15px;
-  margin: 0 0 5px 5px;
-}
-
 .icon-online-event {
   @include icon;
   background-image: url("../images/icon-online-blue.svg");

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -80,13 +80,6 @@ describe('LinkController', () => {
         );
       });
 
-      it('adds a description of where the link will open for screen reader users', () => {
-        const hiddenText = document.querySelector(
-          'a#content-external-link > span'
-        );
-        expect(hiddenText.textContent).toEqual('(Link opens in new window)');
-      });
-
       it("doesn't add target='_blank' to links to assets", () => {
         const assetLink = document.getElementById('asset-link');
         expect(assetLink.hasAttribute('target')).toBe(false);

--- a/spec/requests/external_links_description_spec.rb
+++ b/spec/requests/external_links_description_spec.rb
@@ -20,9 +20,16 @@ describe "External link icon images", type: :request do
   context "when linking to an external website" do
     let(:link) { markdown_links[0] }
 
-    it { expect(link[:href]).to eq("https://external.website/link") }
-    it { is_expected.to include('class="external-link-icon') }
-    it { is_expected.to include('alt=""') }
+    it { expect(link[:href]).to eql("https://external.website/link") }
+
+    it "has visually hidden text informing the user the link will open in a new window" do
+      expect(link.at_css("span")).to be_present
+
+      link.at_css("span").tap do |span|
+        expect(span.classes).to include("visually-hidden")
+        expect(span.text).to eql("(opens in new window)")
+      end
+    end
   end
 
   context "when linking to an internal path" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/I8LV7KMd/2613-remove-external-link-icons

### Context and changes

- Replace external link icons with descriptive text
- Remove manual external link icon from events page
- Remove external link icon and remaining references

### Guidance to review

I think it's worth evaluating how the site looks (and reads) without the icons before merging. Does all the extra `visually-hidden` 'link opens in new window' text add to the noise for screen reader users?
