### PR TITLE
Fix abbr underline styles on Safari mobile

### DIFF
--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -89,7 +89,7 @@
 
   @mixin abbr-styles {
     text-underline-offset: .2em;
-    text-decoration-thickness: 2em;
+    text-decoration-thickness: .1em;
     text-decoration: underline dotted $grey-dark;
   }
 


### PR DESCRIPTION
### Context

Fix the `abbr` styles on Safari mobile.

![52756](https://user-images.githubusercontent.com/128088/156757175-d331fc21-be2a-47de-a7f7-957c7d9068b8.jpg)
