### PR TITLE
Move event descriptions to the filter

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -9,23 +9,6 @@
     <p>
       All events listed here are designed to help you get into teacher training. They are all free to attend.
     </p>
-
-    <dl>
-      <div>
-        <dt>DfE Train to Teach events</dt>
-        <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers.</dd>
-      </div>
-
-      <div>
-        <dt>DfE Online Q&amp;As</dt>
-        <dd>Get answers to your specific questions from an online panel of teacher training advisers.</dd>
-      </div>
-
-      <div>
-        <dt>Training provider events</dt>
-        <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-      </div>
-    </dl>
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,9 +18,9 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "DfE Train to Teach" } %>
-      <%= f.govuk_check_box :type, "222_750_008", label: { text: "DfE Online Q&A" } %>
-      <%= f.govuk_check_box :type, "222_750_009", label: { text: "Training provider" } %>
+      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "DfE Train to Teach" }, hint: { text: "Hear from teachers and meet local training providers" } %>
+      <%= f.govuk_check_box :type, "222_750_008", label: { text: "DfE Online Q&A" }, hint: { text: "Have your questions answered by experts" } %>
+      <%= f.govuk_check_box :type, "222_750_009", label: { text: "Training provider" }, hint: { text: "Find out about local courses and how to apply" } %>
     <% end %>
   </div>
 


### PR DESCRIPTION
### Context

This allows the event list to be higher up the page and above the fold on smaller desktop screens.

| Before | After | After (filter) |
| ------ | ------ | ------ |
| ![Screenshot from 2022-03-07 13-04-47](https://user-images.githubusercontent.com/128088/157039895-2d2aa21d-3137-4b36-a85d-934d83287d39.png) | ![Screenshot from 2022-03-07 12-53-36](https://user-images.githubusercontent.com/128088/157039928-e1df7589-7a89-4fbf-8c24-79f9dc3a0920.png) | ![Screenshot from 2022-03-07 12-56-32](https://user-images.githubusercontent.com/128088/157039942-cb97b1d5-0f3c-470b-bf05-6b15ebb6a088.png) |

This is an experiment, text suggestions welcome