### PR TITLE
Migrate Cypress integration tests into the app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -549,10 +549,9 @@ jobs:
           SLACK_MESSAGE: Failure with initialising QA deployment for ${{env.APPLICATION}}
           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
 
-  cypress:
-    name: Run Cypress Tests on QA
+  integration:
+    name: Run Integration Tests on QA
     runs-on: ubuntu-latest
-    concurrency: Cypress
     needs: [ qa ]
     steps:
       - name: Check out the repo
@@ -570,38 +569,29 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: HTTP-USERNAME, HTTP-PASSWORD, MAILSAC-API-KEY
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Trigger Cypress Tests (DFE-Digital/get-into-teaching-frontend-tests )
-        uses: benc-uk/workflow-dispatch@v1.1
-        with:
-          repo: DFE-Digital/get-into-teaching-frontend-tests
-          workflow: Cypress
-          token: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
-          inputs: '{"application": "APP" , "reference": "${{ github.sha }}" }'
-          ref: refs/heads/master
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
 
-      - name: Wait for Cypress Tests
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-tests
-        with:
-          token: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
-          checkName: ${{ github.sha }}
-          ref: refs/heads/master
-          repo: get-into-teaching-frontend-tests
-          intervalSeconds: 30
-          timeoutSeconds: 600
+      - name: Load Docker Image
+        run: docker load --input app_test/image.tar
 
-      - name: Check for test failure
-        if: steps.wait-for-tests.outputs.conclusion == 'failure'
-        run: exit 1
+      - name: Run Integration Tests
+        run: |-
+          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true -e HTTP_USERNAME -e HTTP_PASSWORD -e MAILSAC_API_KEY \
+            ${{needs.build_test.outputs.DOCKER_IMAGE_TEST}} "bundle exec rspec --tag integration"
+        env:
+          HTTP_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.HTTP-USERNAME }}
+          HTTP_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.HTTP-PASSWORD }}
+          MAILSAC_API_KEY: ${{ steps.keyvault-yaml-secret.outputs.MAILSAC-API-KEY }}
 
   production:
     name: Production Deployment
     runs-on: ubuntu-latest
-    needs: [ cypress, development ]
+    needs: [ integration, development ]
     concurrency: Production
     environment:
        name: Production

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,8 @@ Rails.application.configure do
   config.middleware.insert_before ActionDispatch::Static, Rack::HostRedirect, {
     "beta-getintoteaching.education.gov.uk" => "getintoteaching.education.gov.uk",
   }
+
+  config.x.integration_host = "get-into-teaching-app-test.london.cloudapps.digital"
+  config.x.integration_credentials = { username: ENV["HTTP_USERNAME"], password: ENV["HTTP_PASSWORD"] }
+  config.x.mailsac_api_key = ENV["MAILSAC_API_KEY"]
 end

--- a/spec/integration/events_spec.rb
+++ b/spec/integration/events_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.feature "Event sign up", :integration, type: :feature, js: true do
+  let(:event_selector) { ".events-featured__list__item" }
+
+  before do
+    config_capybara
+    navigate_to_last_page_of_events
+  end
+
+  around do |example|
+    WebMock.enable_net_connect!
+    example.run
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  scenario "Full journey as a new candidate" do
+    return unless an_event_exists?
+
+    navigate_to_last_event_sign_up
+    sign_up(rand_first_name, rand_last_name, rand_email)
+  end
+
+  scenario "Full journey as a new candidate (including mailing list step)" do
+    return unless an_event_exists?
+
+    navigate_to_last_event_sign_up
+    sign_up(rand_first_name, rand_last_name, rand_email, mailing_list: true)
+  end
+
+  scenario "Full journey as an existing candidate" do
+    return unless an_event_exists?
+
+    navigate_to_last_event_sign_up
+    email = "eventsignupuser@mailsac.com"
+    submit_personal_details(rand_first_name, rand_last_name, email)
+
+    submit_code(email)
+
+    within_fieldset "Are you over 16 and do you agree" do
+      click_label "Yes"
+    end
+
+    click_on "Complete sign up"
+  end
+
+  def sign_up(_first_name, _last_name, email, mailing_list: false)
+    submit_personal_details(rand_first_name, rand_last_name, email)
+
+    fill_in "What is your telephone number? (optional)", with: "01234567890"
+    click_on "Next step"
+
+    within_fieldset "Are you over 16 and do you agree" do
+      click_label "Yes"
+    end
+
+    within_fieldset "Would you like to receive email updates" do
+      click_label mailing_list ? "Yes" : "No"
+    end
+
+    if mailing_list
+      click_on "Next step"
+      complete_mailing_list_sign_up
+    end
+
+    click_on "Complete sign up"
+
+    expect(page).to have_text("Sign up complete")
+  end
+
+  def complete_mailing_list_sign_up
+    select "Final year"
+    select "It’s just an idea"
+    fill_in "What is your postcode? (optional)", with: "TE5 1NG"
+    select "Maths"
+  end
+
+  def an_event_exists?
+    page.has_css?(event_selector)
+  end
+
+  def navigate_to_last_event_sign_up
+    all(event_selector).last.click
+    first("a", text: "Sign up for this event").click
+  end
+
+  def navigate_to_last_page_of_events
+    visit event_category_path("train-to-teach-events")
+    click_link "Accept all cookies"
+
+    if page.has_css?(".pagination")
+      all(".pagination .page a").last.click
+    end
+  end
+end

--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.feature "Mailing list sign up", :integration, type: :feature, js: true do
+  before { config_capybara }
+
+  around do |example|
+    WebMock.enable_net_connect!
+    example.run
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  scenario "Full journey as a new candidate" do
+    visit mailing_list_steps_path
+    click_link "Accept all cookies"
+    sign_up(rand_first_name, rand_last_name, rand_email)
+  end
+
+  scenario "Full journey as an existing candidate" do
+    visit mailing_list_steps_path
+    click_link "Accept all cookies"
+
+    email = "mailinglistuser@mailsac.com"
+    submit_personal_details(rand_first_name, rand_last_name, email)
+
+    submit_code(email)
+
+    expect(page).to have_text("You've already signed up")
+  end
+
+  scenario "Booking a callback on completion of the mailing list sign up" do
+    visit callbacks_steps_path
+    click_link "Accept all cookies"
+
+    email = "mailinglistuser@mailsac.com"
+    submit_personal_details(rand_first_name, rand_last_name, email)
+
+    click_on "Send another code to verify my details."
+    expect(page).to have_text("We've sent you another email")
+
+    submit_code(email)
+
+    fill_in "Phone number", with: "1234567890"
+    click_on "Next step"
+
+    select "Eligibility to become a teacher"
+    click_on "Next step"
+
+    expect(page).to have_text("Accept privacy policy")
+    click_label "Yes"
+
+    click_on "Book your callback"
+    expect(page).to have_text("Callback confirmed")
+  end
+
+  def sign_up(first_name, last_name, email)
+    submit_personal_details(first_name, last_name, email)
+
+    expect(page).to have_text("Do you have a degree?")
+    click_label "Yes, I already have a degree"
+    click_on "Next step"
+
+    expect(page).to have_text("How close are you to applying for teacher training?")
+    click_label "I’m not sure and finding out more"
+    click_on "Next step"
+
+    expect(page).to have_text "Which subject do you want to teach?"
+    select "Chemistry"
+    click_on "Next step"
+
+    expect(page).to have_text("Would you like to hear about teacher training events in your area?")
+    click_label "Yes"
+    fill_in "Your postcode", with: "TE57 1NG"
+    click_on "Next step"
+
+    expect(page).to have_text("Accept privacy policy")
+    click_label "Yes"
+    click_on "Complete sign up"
+
+    expect(page).to have_text("you're signed up")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include SpecHelpers::Events
   config.include SpecHelpers::BasicAuth
+  config.include SpecHelpers::Integration, type: :feature
   config.include Webpacker::Helper, type: :helper
 
   config.verbose_retry = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,4 +129,5 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
 
   config.filter_run_excluding :onschedule
+  config.filter_run_excluding :integration
 end

--- a/spec/support/spec_helpers/integration.rb
+++ b/spec/support/spec_helpers/integration.rb
@@ -1,0 +1,63 @@
+module SpecHelpers
+  module Integration
+    def config_capybara
+      host = Rails.application.config.x.integration_host
+      creds = Rails.application.config.x.integration_credentials
+      Capybara.run_server = false
+      Capybara.app_host = "https://#{creds[:username]}:#{creds[:password]}@#{host}"
+    end
+
+    def submit_personal_details(first_name, last_name, email)
+      fill_in "First name", with: first_name
+      fill_in "Last name", with: last_name
+      fill_in "Email address", with: email
+      click_on "Next step"
+    end
+
+    def submit_code(email)
+      wait_for_jobs
+      expect(page).to have_text("You're already registered with us")
+      code = retrieve_verification_code(email)
+      fill_in "To verify your details, we've sent a code to your email address.", with: code
+      click_on "Next step"
+    end
+
+    def rand
+      Random.rand(1...10_000)
+    end
+
+    def click_label(text)
+      # Capybara choose/check methods aren't working
+      # for radio/checkbox inputs on integration tests.
+      find("label", text: text).click
+    end
+
+    def rand_first_name
+      "First-#{rand}"
+    end
+
+    def rand_last_name
+      "Last-#{rand}"
+    end
+
+    def rand_email
+      "#{rand}@#{rand}.com"
+    end
+
+    def wait_for_jobs
+      sleep 5
+    end
+
+    def retrieve_verification_code(email)
+      api_key = Rails.application.config.x.mailsac_api_key
+      emails_response = Faraday.get("https://mailsac.com/api/addresses/#{email}/messages?_mailsacKey=#{api_key}")
+      emails = JSON.parse(emails_response.body)
+      latest_email_id = emails.first["_id"]
+
+      email_response = Faraday.get("https://mailsac.com/api/text/#{email}/#{latest_email_id}?_mailsacKey=#{api_key}")
+      email_body = email_response.body
+
+      email_body[/\d{6}/, 0]
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-2978](https://trello.com/c/gTxvgRKZ/2978-pull-cypress-tests-into-the-respective-apps)

### Context

We have another repository of integration tests written with Cypress. Often we find a change in the app has a knock-on effect of breaking these tests and its a pain to dive into a separate repository to fix them. Having them as part of the app means we're less likely to inadvertently break them and, if they do break, it's going to be easier to fix them. The CI run is also over-complicated as they are in a different repository; bringing them into the same repo makes this much simpler and hopefully quicker to run as well.

### Changes proposed in this pull request

- Migrate Cypress integration tests into the app

### Guidance to review

You can run them locally with `rspec --tag integration`. You will also need to set these environment variables (found in the dev/test `INFRA-KEYS` key vault in Azure):

```
HTTP_USERNAME
HTTP_PASSWORD
MAILSAC_API_KEY
```