### PR TITLE
Ensure build_test dependency is present in integration step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -552,7 +552,7 @@ jobs:
   integration:
     name: Run Integration Tests on QA
     runs-on: ubuntu-latest
-    needs: [ qa ]
+    needs: [ build_test, qa ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2.4.0


### PR DESCRIPTION
As we reference the output of this step when we run the docker image we need it to depend on it (it doesn't work without this, even though this step will always run after it anyway - it has to be explicit).
