### PR TITLE
Remove alt text from CTA icons

### DIFF
--- a/app/components/calls_to_action/chat_online_component.rb
+++ b/app/components/calls_to_action/chat_online_component.rb
@@ -13,7 +13,7 @@ module CallsToAction
       image_pack_tag("media/images/icon-question.svg",
                      width: 50,
                      height: 50,
-                     alt: "Chat with a adviser online",
+                     alt: "",
                      class: "call-to-action__icon")
     end
 

--- a/app/components/calls_to_action/ect_component.rb
+++ b/app/components/calls_to_action/ect_component.rb
@@ -4,7 +4,7 @@ module CallsToAction
       image_pack_tag("media/images/icon-school-black.svg",
                      width: 50,
                      height: 50,
-                     alt: "Mortar board icon",
+                     alt: "",
                      class: "call-to-action__icon")
     end
   end

--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -28,7 +28,7 @@ module CallsToAction
       image_pack_tag("media/images/#{icon}.svg",
                      width: 50,
                      height: 50,
-                     alt: "#{icon} icon",
+                     alt: "",
                      class: "call-to-action__icon")
     end
   end

--- a/app/components/calls_to_action/multiple_buttons_component.rb
+++ b/app/components/calls_to_action/multiple_buttons_component.rb
@@ -21,7 +21,7 @@ module CallsToAction
       image_pack_tag("media/images/#{icon}.svg",
                      width: 50,
                      height: 50,
-                     alt: "#{icon} icon",
+                     alt: "",
                      class: "call-to-action__icon")
     end
   end

--- a/app/components/calls_to_action/next_steps_component.rb
+++ b/app/components/calls_to_action/next_steps_component.rb
@@ -4,7 +4,7 @@ module CallsToAction
       image_pack_tag("media/images/icon-person.svg",
                      width: 50,
                      height: 50,
-                     alt: "Chat with a adviser online",
+                     alt: "",
                      class: "call-to-action__icon")
     end
   end

--- a/app/components/calls_to_action/simple_component.rb
+++ b/app/components/calls_to_action/simple_component.rb
@@ -29,7 +29,7 @@ module CallsToAction
       image_pack_tag("media/images/#{icon}.svg",
                      width: 50,
                      height: 50,
-                     alt: "#{icon} icon",
+                     alt: "",
                      class: "call-to-action__icon")
     end
 

--- a/app/components/content/generic_block_component.rb
+++ b/app/components/content/generic_block_component.rb
@@ -2,19 +2,18 @@ module Content
   class GenericBlockComponent < ViewComponent::Base
     attr_reader :title, :classes
 
-    def initialize(title:, icon_image:, icon_alt:, icon_size: nil, classes: [])
+    def initialize(title:, icon_image:, icon_size: nil, classes: [])
       super
 
       @title      = title
       @icon_image = icon_image
-      @icon_alt   = icon_alt
       @icon_size  = icon_size
       @classes    = classes
     end
 
     def icon
       tag.div(class: "blocks__icon") do
-        image_pack_tag(@icon_image, alt: @icon_alt, size: @icon_size)
+        image_pack_tag(@icon_image, size: @icon_size, alt: "")
       end
     end
   end

--- a/app/views/callbacks/steps/completed.html.erb
+++ b/app/views/callbacks/steps/completed.html.erb
@@ -13,7 +13,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
-    icon_alt: "mortarboard icon",
     icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
@@ -27,7 +26,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Your next steps",
     icon_image: "icon-doc-black.svg",
-    icon_alt: "icon containing learning materials",
     icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
@@ -41,7 +39,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Sign up to get a teacher training adviser",
     icon_image: "icon-git-black.svg",
-    icon_alt: "site icon logo checkmark",
     icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>

--- a/app/views/content/home/_directory.html.erb
+++ b/app/views/content/home/_directory.html.erb
@@ -2,7 +2,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
-    icon_alt: "",
     icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
@@ -16,7 +15,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Your training",
     icon_image: "icon-doc-black.svg",
-    icon_alt: "",
     icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
@@ -33,7 +31,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Take the next step",
     icon_image: "icon-arrow.svg",
-    icon_alt: "",
     icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -25,7 +25,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Life as a teacher",
       icon_image: "icon-school-black.svg",
-      icon_alt: "mortarboard icon",
       icon_size: "40x30",
       classes: "blocks__directory"
     ) do %>
@@ -39,7 +38,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Your training",
       icon_image: "icon-doc-black.svg",
-      icon_alt: "icon containing learning materials",
       icon_size: "40x35",
       classes: "blocks__directory"
     ) do %>
@@ -54,7 +52,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Take the next step",
       icon_image: "icon-git-black.svg",
-      icon_alt: "site icon logo checkmark",
       icon_size: "33x33",
       classes: "blocks__directory"
     ) do %>

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -40,7 +40,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
-    icon_alt: "mortarboard icon",
     icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
@@ -54,7 +53,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Your next steps",
     icon_image: "icon-doc-black.svg",
-    icon_alt: "icon containing learning materials",
     icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
@@ -68,7 +66,6 @@
   <%= render Content::GenericBlockComponent.new(
     title: "Sign up to get a teacher training adviser",
     icon_image: "icon-git-black.svg",
-    icon_alt: "site icon logo checkmark",
     icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -30,7 +30,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Life as a teacher",
       icon_image: "icon-school-black.svg",
-      icon_alt: "mortarboard icon",
       icon_size: "40x30",
       classes: "blocks__directory"
     ) do %>
@@ -43,7 +42,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Your next steps",
       icon_image: "icon-doc-black.svg",
-      icon_alt: "icon containing learning materials",
       icon_size: "40x35",
       classes: "blocks__directory"
     ) do %>
@@ -56,7 +54,6 @@
     <%= render Content::GenericBlockComponent.new(
       title: "Speak to teachers",
       icon_image: "icon-git-black.svg",
-      icon_alt: "site icon logo checkmark",
       icon_size: "33x33",
       classes: "blocks__directory"
     ) do %>

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
       expect(page).to have_css(".call-to-action")
     end
 
-    specify "the icon is present" do
+    specify "the icon is present and is decorative" do
       image_element = page.find(".call-to-action__icon")
       expect(image_element[:src]).to match(Regexp.new(icon))
+      expect(image_element[:alt]).to eql("")
     end
 
     specify "the title is present" do

--- a/spec/components/calls_to_action/multiple_buttons_component_spec.rb
+++ b/spec/components/calls_to_action/multiple_buttons_component_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe CallsToAction::MultipleButtonsComponent, type: :component do
 
   before { render_inline(component) }
 
+  specify "renders the icon and marks it as decorative" do
+    image_element = page.find(".call-to-action__icon")
+
+    expect(image_element[:src]).to match(Regexp.new(icon))
+    expect(image_element[:alt]).to eql("")
+  end
+
   specify "renders the call to action" do
     expect(page).to have_css(".call-to-action.call-to-action--multiple-buttons")
   end

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
 
     specify "the icon is present" do
       image_element = page.find("img")
+
       expect(image_element[:src]).to match(Regexp.new(icon))
+      expect(image_element[:alt]).to eql("")
     end
 
     specify "the title is present" do

--- a/spec/components/content/generic_block_component_spec.rb
+++ b/spec/components/content/generic_block_component_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Content::GenericBlockComponent, type: "component" do
   subject! do
-    render_inline(described_class.new(title: title, icon_image: icon_image, icon_alt: icon_alt, icon_size: icon_size, classes: Array.wrap(custom_class))) do
+    render_inline(described_class.new(title: title, icon_image: icon_image, icon_size: icon_size, classes: Array.wrap(custom_class))) do
       content
     end
     page
@@ -11,14 +11,12 @@ describe Content::GenericBlockComponent, type: "component" do
   let(:title) { "Block of content" }
   let(:content) { "Some content" }
   let(:icon_image) { "icon-school-black.svg" }
-  let(:icon_alt) { "description of image" }
   let(:custom_class) { "purple" }
   let(:icon_size) { "30x50" }
 
   it { is_expected.to have_css("div.#{custom_class}") }
   it { is_expected.to have_css("h3", text: title) }
   it { is_expected.to have_content(content) }
-  it { is_expected.to have_css(%(img[alt="#{icon_alt}"])) }
   it { is_expected.to have_css(%(img[width="30"])) }
   it { is_expected.to have_css(%(img[height="50"])) }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/A5arEJ69/3025-mark-icons-as-decorative

### Context

The alt text is generated from the icon used, it's not helpful and should be removed.
