### PR TITLE
Remove archive event viewing functionality

### DIFF
--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -9,8 +9,6 @@ class EventCategoriesController < ApplicationController
   MAXIMUM_EVENTS_IN_CATEGORY = 1_000
 
   def show
-    @show_archive_link = has_archive?(@type)
-
     @category_name = helpers.pluralised_category_name(@type.id)
     @page_title = @category_name
     @front_matter = {
@@ -20,28 +18,6 @@ class EventCategoriesController < ApplicationController
     }
 
     load_events(:future)
-  end
-
-  def show_archive
-    raise_not_found unless has_archive?(@type)
-
-    @category_name = helpers.past_category_name(@type.id)
-
-    @page_title = @category_name
-    @front_matter = {
-      "description" => "See past #{@category_name} events.",
-      "title" => @category_name,
-      "image" => "media/images/content/hero-images/0015.jpg",
-    }
-
-    load_events(:past)
-
-    future_events_category_name = helpers.pluralised_category_name(@type.id)
-    breadcrumb \
-      future_events_category_name,
-      event_category_path(future_events_category_name.parameterize)
-
-    render :show
   end
 
 protected
@@ -74,10 +50,6 @@ private
   def set_form_action
     @form_action = URI.parse(request.path)
     @form_action.fragment = "searchforevents"
-  end
-
-  def has_archive?(type)
-    EventType.has_archive?(type.id)
   end
 
   # filtering is like searching but limited to a single event type. A custom

--- a/app/models/event_status.rb
+++ b/app/models/event_status.rb
@@ -46,9 +46,7 @@ class EventStatus
   end
 
   def viewable?
-    online_q_a = EventType.new(event).online_qa_event?
-
-    !pending? && (future_dated? || online_q_a)
+    !pending? && future_dated?
   end
 
   def accepts_online_registration?

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -7,11 +7,6 @@ class EventType
       "School or University event" => 222_750_009,
     }.freeze
 
-  WITH_ARCHIVE =
-    {
-      "Online event" => 222_750_008,
-    }.freeze
-
   attr_accessor :type_id
 
   delegate(
@@ -54,10 +49,6 @@ class EventType
 
     def lookup_by_ids(*ids)
       ALL.invert.fetch_values(*ids)
-    end
-
-    def has_archive?(id)
-      WITH_ARCHIVE.values.include?(id)
     end
 
     def all_ids

--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -27,15 +27,3 @@
     <%= link_to("Search for another event type", events_path) %>.
   <% end %>
 <% end %>
-
-<% if @show_archive_link %>
-  <section class="content-cta">
-    <h3><%= past_category_name(@type.id) %></h3>
-    <p>
-      You can see <%= past_category_name(@type.id).downcase %>, including
-      all questions and answers,
-      <%= link_to "on this page",
-                  archive_event_category_path(pluralised_category_name(@type.id).parameterize) %>
-    </p>
-  </section>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,6 @@ Rails.application.routes.draw do
 
   # Needs to have higher priority to redirect the category
   get "event-categories/online-events", to: redirect("/event-categories/online-q-as")
-  get "event-categories/online-events/archive", to: redirect("/event-categories/online-q-as/archive")
 
   resources :event_categories, only: %i[show], path: "event-categories" do
     member do

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -116,11 +116,5 @@ RSpec.feature "Finding an event", type: :feature do
 
     uri = URI.parse(page.current_url)
     expect(uri.fragment).to eq("searchforevents")
-
-    within(:css, ".content-cta") do
-      click_on "on this page"
-    end
-
-    expect(page).to have_text "Search for Past online Q&As"
   end
 end

--- a/spec/models/event_status_spec.rb
+++ b/spec/models/event_status_spec.rb
@@ -62,12 +62,6 @@ describe EventStatus do
       it { is_expected.to be_viewable }
     end
 
-    context "when closed, past, online q&a" do
-      let(:event) { build(:event_api, :closed, :online_event, :past) }
-
-      it { is_expected.to be_viewable }
-    end
-
     context "when closed, past, not online q&a" do
       let(:event) { build(:event_api, :closed, :train_to_teach_event, :past) }
 
@@ -88,12 +82,6 @@ describe EventStatus do
 
     context "when open, future-dated, not online q&a" do
       let(:event) { build(:event_api, :train_to_teach_event) }
-
-      it { is_expected.to be_viewable }
-    end
-
-    context "when open, past, online q&a" do
-      let(:event) { build(:event_api, :past, :online_event) }
 
       it { is_expected.to be_viewable }
     end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -2,18 +2,6 @@ require "rails_helper"
 
 describe EventType do
   describe "class_methods" do
-    describe ".has_archive" do
-      specify "returns true if the event type has an archive" do
-        expect(described_class).to have_archive(222_750_008)
-      end
-
-      specify "returns false if the event type does not have an archive" do
-        expect(described_class).not_to have_archive(222_750_001)
-        expect(described_class).not_to have_archive(222_750_007)
-        expect(described_class).not_to have_archive(222_750_009)
-      end
-    end
-
     describe ".all_ids" do
       subject { described_class.all_ids }
 

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -18,31 +18,6 @@ describe "View events by category", type: :request do
       receive(:search_teaching_events_grouped_by_type) { events_by_type }
   end
 
-  context "when viewing a category archive" do
-    subject { response }
-
-    let(:category) { "online-q-as" }
-
-    before do
-      allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events_grouped_by_type) { events_by_type }
-      get archive_event_category_path(category)
-    end
-
-    it { is_expected.to have_http_status :success }
-    it { expect(response.body).to include "Past online Q&amp;As" }
-
-    it "displays all events in the category, ordered by date descending" do
-      expect(response.body.scan(/Event \d/)).to eq(["Event 5", "Event 4", "Event 3", "Event 2", "Event 1"])
-    end
-
-    context "when the category does not support archives" do
-      let(:category) { "train-to-teach-events" }
-
-      it { is_expected.to have_http_status :not_found }
-    end
-  end
-
   context "when viewing a category" do
     subject { response }
 
@@ -71,20 +46,12 @@ describe "View events by category", type: :request do
     end
   end
 
-  context "when viewing old online-events url" do
+  context "when viewing online-events" do
+    before { get event_category_path "online-events" }
+
     subject { response }
 
-    context "when current events" do
-      before { get event_category_path "online-events" }
-
-      it { is_expected.to redirect_to event_category_path "online-q-as" }
-    end
-
-    context "when archive events" do
-      before { get archive_event_category_path "online-events" }
-
-      it { is_expected.to redirect_to archive_event_category_path "online-q-as" }
-    end
+    it { is_expected.to redirect_to event_category_path "online-q-as" }
   end
 
   context "when viewing the schools and university events category" do

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -234,16 +234,7 @@ describe EventsController, type: :request do
           it { expect(response.body).to include("Page not found") }
         end
 
-        EventType::WITH_ARCHIVE.each do |type, id|
-          context "when the event is a past #{type} type" do
-            let(:event) { build(:event_api, type_id: id, start_at: Time.zone.now.utc - 1.day) }
-
-            it { expect(response).to have_http_status :success }
-            it { expect(response.body).to include(event.name) }
-          end
-        end
-
-        EventType::ALL.except(*EventType::WITH_ARCHIVE.keys).each do |type, id|
+        EventType::ALL.each do |type, id|
           context "when the event is a past #{type} type" do
             let(:event) { build(:event_api, type_id: id, start_at: Time.zone.now.utc - 1.day) }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/YwiyCI5k/3056-remove-past-online-qa-events-from-the-site

### Context

We no longer want to show the archive of past online events along with their transcripts. Only current and future events will be shown.
