### PR TITLE
Send sub_channel to BAM tracking pixel

### DIFF
--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -7,6 +7,7 @@ module MailingList
       attribute :last_name
       attribute :email
       attribute :channel_id, :integer
+      attribute :sub_channel_id
 
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true, length: { maximum: 256 }
@@ -27,6 +28,10 @@ module MailingList
 
       def channel_ids
         query_channels.map { |channel| channel.id.to_i }
+      end
+
+      def export
+        super.except("sub_channel_id")
       end
 
     private

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -12,7 +12,6 @@ module MailingList
       validates :email, presence: true, email_format: true
       validates :first_name, presence: true, length: { maximum: 256 }
       validates :last_name, presence: true, length: { maximum: 256 }
-      validates :channel_id, inclusion: { in: :channel_ids, allow_nil: true }
 
       before_validation if: :email do
         self.email = email.to_s.strip
@@ -34,7 +33,17 @@ module MailingList
         super.except("sub_channel_id")
       end
 
+      def save
+        self.channel_id = nil if channel_invalid?
+
+        super
+      end
+
     private
+
+      def channel_invalid?
+        channel_id.present? && !channel_id.in?(channel_ids)
+      end
 
       def query_channels
         @query_channels ||= GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_mailing_list_subscription_channels

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -8,6 +8,7 @@ module MailingList
       preferred_teaching_subject_id
       consideration_journey_stage_id
       degree_status_id
+      sub_channel_id
     ].freeze
 
     self.steps = [

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -16,4 +16,5 @@
 <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
 <%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
 <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>
-<%= f.hidden_field :channel_id, value: params[:channel] %>
+<%= f.hidden_field :channel_id, value: f.object.channel_id || params[:channel] %>
+<%= f.hidden_field :sub_channel_id, value: f.object.sub_channel_id || params[:sub_channel] %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -3,7 +3,7 @@
 <% if show_welcome_guide? %>
   <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% else %>
-  <section class="text-content">
+  <section class="text-content" data-sub-channel-id="<%= session.dig("mailinglist", "sub_channel_id") %>">
     <h2 class="green">You've signed up</h2>
 
     <p>

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -99,6 +99,48 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_selector("[data-sub-channel-id='#{sub_channel_id}']")
   end
 
+  scenario "Full journey as an on-campus candidate (invalid channel_id)" do
+    sub_channel_id = "abc123"
+
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
+
+    visit mailing_list_steps_path({ id: :name, channel: "invalid", sub_channel: sub_channel_id })
+
+    expect(page).to have_text "Get personalised guidance to your inbox"
+    fill_in_name_step
+    click_on "Next step"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "Not yet, I'm a first year student"
+    click_on "Next step"
+
+    expect(page).to have_text "How close are you to applying"
+    choose "I'm not sure and finding out more"
+    click_on "Next step"
+
+    expect(page).to have_text "Which subject do you want to teach"
+    select "Maths"
+    click_on "Next step"
+
+    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
+    choose "Yes"
+    fill_in "Your postcode", with: "TE57 1NG"
+    click_on "Next step"
+
+    expect(page).to have_text "Accept privacy policy"
+    click_on "Complete sign up"
+
+    expect(page).to have_text "Accept privacy policy"
+    expect(page).to have_text "There is a problem"
+    expect(page).to have_text "Accept the privacy policy to continue"
+    check "Yes"
+    click_on "Complete sign up"
+
+    expect(page).to have_text "You've signed up"
+    expect(page).to have_text("You'll receive a welcome email shortly")
+  end
+
   scenario "Full journey as an existing candidate" do
     first_name = "Joey"
 

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -51,4 +51,14 @@ describe MailingList::Steps::Name do
     it { is_expected.to allow_value(nil, "").for :channel_id }
     it { is_expected.not_to allow_value(12_345).for :channel_id }
   end
+
+  describe "#export" do
+    subject { instance.export }
+
+    %i[channel_id email first_name last_name].each do |key|
+      it { is_expected.to have_key(key.to_s) }
+    end
+
+    it { is_expected.not_to have_key("sub_channel_id") }
+  end
 end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -44,14 +44,6 @@ describe MailingList::Steps::Name do
     it { is_expected.not_to allow_value("me@you").for :email }
   end
 
-  describe "validations for channel_id" do
-    let(:options) { channels.map(&:id) }
-
-    it { is_expected.to allow_values(options).for :channel_id }
-    it { is_expected.to allow_value(nil, "").for :channel_id }
-    it { is_expected.not_to allow_value(12_345).for :channel_id }
-  end
-
   describe "#export" do
     subject { instance.export }
 
@@ -60,5 +52,19 @@ describe MailingList::Steps::Name do
     end
 
     it { is_expected.not_to have_key("sub_channel_id") }
+  end
+
+  describe "#save" do
+    it "clears the channel_id on save when invalid" do
+      subject.channel_id = "invalid"
+      subject.save
+      expect(subject.channel_id).to be_nil
+    end
+
+    it "retains the channel_id on save when valid" do
+      subject.channel_id = channels.first.id
+      subject.save
+      expect(subject.channel_id).to eq(channels.first.id)
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-2925](https://trello.com/c/TDCO8mZL/2925-investigate-request-from-bam-re-tracking-sign-ups-by-iphone-safari-users)

### Context

BAM are struggling to track conversions due to Safari blocking their session cookie. To work around this while still maintaining user privacy we are going to accept a `sub_channel` parameter as part of the mailing list sign up; when the user reaches the completion page we should include the `sub_channel` in the tracking pixel request.

### Changes proposed in this pull request

- Send sub_channel to BAM tracking pixel

Also fixes an issue where the channel/sub-channel was dropped when a candidate hit a validation error and the page reloaded.

### Guidance to review

