### PR TITLE
Update and improve the subject-specific styling

### DIFF
--- a/app/views/content/subjects/maths.md
+++ b/app/views/content/subjects/maths.md
@@ -3,7 +3,7 @@ title: Get into teaching maths
 layout: "layouts/minimal"
 main_class: "subject-specific"
 colour: "yellow"
-image: "media/images/content/hero-images/0024.jpg"
+image: "media/images/content/hero-images/0004.jpg"
 content:
   - "content/subjects/maths/header"
   - "content/subjects/maths/article"

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -41,7 +41,7 @@
     colour: "pink",
     image_1_path: "media/images/content/hero-images/0017.jpg",
     image_1_alt: "A teacher sitting with a student helping them with a maths problem",
-    image_2_path: "media/images/content/hero-images/0004.jpg",
+    image_2_path: "media/images/content/hero-images/0024.jpg",
     image_2_alt: "A maths teacher standing at the front of a full classroom delivering a lesson",
   ) do %>
 

--- a/app/webpacker/styles/subject-specific/_header.scss
+++ b/app/webpacker/styles/subject-specific/_header.scss
@@ -87,7 +87,6 @@ header {
     }
 
     img {
-      transform: rotate(2deg);
       max-width: 90%;
 
       @include mq($from: tablet) {

--- a/app/webpacker/styles/subject-specific/_header.scss
+++ b/app/webpacker/styles/subject-specific/_header.scss
@@ -11,14 +11,17 @@ header {
   min-height: 15em;
 
   .container {
-    max-width: 65ch;
+    max-width: 80ch;
     margin-top: 0;
-    flex-direction: column;
+
     align-items: center;
     padding-block: 1em;
 
+    display: grid;
+    grid-template-columns: 1fr;
+
     @include mq($from: mobile) {
-      flex-direction: row;
+      grid-template-columns: 1fr 10em 1fr;
     }
   }
 
@@ -56,28 +59,35 @@ header {
   }
 
   h1 {
-    flex: 1 0 60%;
     margin: 1em auto;
+    z-index: 5;
+
+    @include mq($from: mobile) {
+      grid-area: 1 / 1 / 2 / 3;
+    }
 
     @include mq($from: tablet) {
       margin: 1em inherit;
     }
 
     span {
-      @include font-size(xlarge);
+      @include font-size(xxlarge);
 
       padding: .05rem .7rem;
     }
 
     span:last-of-type {
-      @include font-size(xxxlarge);
+      @include font-size(xxxlarge, $adjust: 2rem);
     }
   }
 
   picture {
-    flex: 0 1 40%;
+    @include mq($from: mobile) {
+      grid-area: 1 / 2 / 2 / 4;
+    }
 
     img {
+      transform: rotate(2deg);
       max-width: 90%;
 
       @include mq($from: tablet) {

--- a/app/webpacker/styles/subject-specific/_text-blocks-with-images.scss
+++ b/app/webpacker/styles/subject-specific/_text-blocks-with-images.scss
@@ -53,7 +53,7 @@
 
   @include mq($from: tablet) {
     grid-template-columns: repeat(2, 1fr) repeat(2, .8fr) 1fr;
-    grid-template-rows: repeat(2, .5fr) .2fr repeat(2, minmax(.5fr, max-content));
+    grid-template-rows: .2fr 15em 1fr;
   }
 
   .statement {


### PR DESCRIPTION
### Trello card

No card, just minor visual tweaks.

### Context

The images on the subject specific page were positioned a bit awkwardly. This is an attempt to improve them.

| Before | After |
| ----- | ----- |
| ![Screenshot from 2022-03-30 15-11-43](https://user-images.githubusercontent.com/128088/160855834-45c57755-fee3-442b-977c-e902405aa25c.png) | ![Screenshot from 2022-03-30 15-11-37](https://user-images.githubusercontent.com/128088/160855860-45ce02ec-ce4d-436d-9d4d-60061f223fa2.png) |
| ![Screenshot from 2022-03-30 15-11-10](https://user-images.githubusercontent.com/128088/160855723-5413ecfa-4efc-411e-8fad-56c2ce081461.png) | ![Screenshot from 2022-03-30 15-11-24](https://user-images.githubusercontent.com/128088/160855792-10d764b4-a637-45f8-bf0d-1edaafc8fece.png) |



