### PR TITLE
Removed call to arms. Added in lower down the page

### DIFF
--- a/app/views/content/returning-to-teaching.md
+++ b/app/views/content/returning-to-teaching.md
@@ -155,8 +155,8 @@ If you’re returning to teaching, you might want to re-familiarise yourself wit
 #### Other things to consider
 
 * attend an [online return to teaching event](/event-categories/online-q-as)
-* return to the classroom by [registering with a supply teaching agency](/urgent-call-for-qualified-teachers)
 * join the [Chartered College of Teaching](https://chartered.college/), the
   professional body for teachers
 * join a [teaching union](https://www.tes.com/jobs/careers-advice/pay-and-conditions/which-teachers-union)
 * ensure your [pension](https://www.teacherspensions.co.uk/members/working-life/deferring-your-pension/return-to-pensionable-service.aspx), one of your key benefits, is up to date
+* return to the classroom by [registering with a supply teaching agency](/urgent-call-for-qualified-teachers)


### PR DESCRIPTION
### Trello card
https://trello.com/c/Q7A3cBCr/3103-remove-urgent-call-to-arms-callout-from-return-to-teaching-page

### Context
Removed urgent call to arms from the top of the page. Added a link to this and small description under 'other things to consider' lower down the page.