### PR TITLE
Added full stops to all Contact sentences

### DIFF
--- a/app/views/content/international-returners/_after-accordion.md
+++ b/app/views/content/international-returners/_after-accordion.md
@@ -31,8 +31,8 @@ learn more.
 
 Sign up for an [online Q&A for returners](/events).
 
-Email us at international.teacherrecruitment@education.gov.uk
+Email us at international.teacherrecruitment@education.gov.uk.
 
 Join us on [Facebook](https://www.facebook.com/getintoteaching),
 [Instagram](https://www.instagram.com/get_into_teaching/) and
-[Twitter](https://twitter.com/getintoteaching)
+[Twitter](https://twitter.com/getintoteaching).


### PR DESCRIPTION
### Trello card
https://trello.com/c/fQDsnQ55/3104-consistency-in-full-stops-on-international-returners-page

### Context
Full stops weren't consistent in 'contact' section.

