### PR TITLE
Make urgent call banner less imposing

### DIFF
--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -15,5 +15,6 @@
   content:
     - content/home/purple-box
     - content/home/calls-to-action
+    - content/home/urgent-call
     - content/home/directory
 ---

--- a/app/views/content/home/_urgent-call.html.erb
+++ b/app/views/content/home/_urgent-call.html.erb
@@ -1,7 +1,3 @@
-<section class="urgent-call-for-qualified-teachers-cta">
-  <div class="urgent-call-for-qualified-teachers-cta__content">
-    <div class="urgent-call-for-qualified-teachers-cta__text">
-      Urgent call for qualified teachers to <%= link_to("register with a supply agency", "/urgent-call-for-qualified-teachers") %>.
-    </div>
-  </div>
+<section class="urgent-call-for-qualified-teachers-cta narrow-top-margin">
+  Urgent call for qualified teachers <span>to <%= link_to("register with a supply agency", "/urgent-call-for-qualified-teachers") %>.</span>
 </section>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -6,10 +6,6 @@
 
     <%= render HeaderComponent.new do |c| %>
       <%= c.hero(@front_matter) %>
-
-      <% c.above_hero do %>
-        <%= render(partial: "/content/home/urgent-call") %>
-      <% end %>
     <% end %>
 
     <main class="home" id="main-content">

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -8,6 +8,10 @@ main.home {
   section {
     margin-top: $space-between-sections;
     max-width: $homepage-max-width;
+
+    &.narrow-top-margin {
+      margin-top: $indent-amount;
+    }
   }
 
   .homepage-feature {
@@ -178,34 +182,13 @@ main.home {
 }
 
 .urgent-call-for-qualified-teachers-cta {
-  margin-block: .2em;
-  $bg: $black;
-  $fg: $white;
+  background-color: $grey;
+  font-weight: bold;
+  margin: 1em 15px;
+  padding: 1.5em;
 
-  background: $bg;
-
-  &__content {
-    color: $fg;
-    padding: 1em;
-    margin-block: .4em;
-
-    @include mq($from: tablet) {
-      text-align: center;
-    }
-  }
-
-  &__text {
-    font-weight: bold;
-
-    a {
-      color: $fg;
-      text-decoration: underline;
-      text-underline-offset: .3em;
-      text-decoration-thickness: .1em;
-
-      &:focus {
-        color: $black;
-      }
-    }
+  span, a {
+    font-weight: normal;
+    color: $black;
   }
 }


### PR DESCRIPTION
### Trello card

[Trello-2900](https://trello.com/c/PRT6Nn93/2900-review-supply-teacher-call-to-arms-messaging-and-banner)

### Context

Move the urgent call for qualified teachers banner further down the home page and give it a less prominent appearance.

### Changes proposed in this pull request

- Make urgent call banner less imposing

### Guidance to review

