### PR TITLE
Add googleapis.com to CSP for Google Maps

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -29,7 +29,7 @@ SecureHeaders::Configuration.default do |config|
   google_supported   = %w[*.google.com *.google.co.uk]
   google_adservice   = %w[adservice.google.com adservice.google.co.uk]
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
-  google_apis        = %w[*.googleapis.com https://fonts.googleapis.com]
+  google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
   optimize  = %w[optimize.google.com www.googleoptimize.com]
   zendesk   = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]


### PR DESCRIPTION
### Trello card

[Trello-3065](https://trello.com/c/UFo5ttfm/3065-allow-googleapiscom-on-the-script-csp)

### Context

We need to add this domain according to a notification from Google; I'm not sure if we still need `*.googleapis.com` as well, but in my experience the CSP is pernickety in that including the wildcard means all subdomains _but not_ the root domain.

>We’re writing to let you know that support in Maps JavaScript API for websites
>and web apps using a Content Security Policy (CSP) that does not allow
>googleapis.com is ending.
>Version 3.49 (releases May 2022) will be the last version to support such
>configurations; we will end support for such configurations starting with
>version 3.50.

### Changes proposed in this pull request

- Add googleapis.com to CSP for Google Maps

### Guidance to review

After this change comes into effect (May 2022) we can look to remove the `*.googleapis.com` if its no longer needed.