### PR TITLE
Prevent pages from being indexed by search engines

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,10 @@ protected
     []
   end
 
+  def noindex
+    @noindex = true
+  end
+
 private
 
   def declare_frontmatter

--- a/app/controllers/callbacks/steps_controller.rb
+++ b/app/controllers/callbacks/steps_controller.rb
@@ -5,6 +5,7 @@ module Callbacks
     include DFEWizard::Controller
     self.wizard_class = Callbacks::Wizard
 
+    before_action :noindex
     before_action :set_step_page_title, only: %i[show update]
     before_action :set_completed_page_title, only: [:completed]
     around_action :set_time_zone, only: %i[show update]

--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -1,4 +1,6 @@
 class CookiePreferencesController < ApplicationController
+  before_action :noindex
+
   def show
     # default render
   end

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -22,10 +22,6 @@ protected
 
 private
 
-  def noindex
-    @noindex = true
-  end
-
   def redirect_closed_events
     event_is_closed = EventStatus.new(@event).closed?
     candidate_is_walk_in = wizard_store[:is_walk_in]

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -5,6 +5,7 @@ module MailingList
     include DFEWizard::Controller
     self.wizard_class = MailingList::Wizard
 
+    before_action :noindex, unless: -> { request.path.include?("/name") }
     before_action :set_step_page_title, only: %i[show update]
     before_action :set_completed_page_title, only: [:completed]
 

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -9,7 +9,8 @@ class RobotsController < ApplicationController
     render plain: <<~ROBOTS
       User-agent: *
       Allow: /
-
+      Disallow: /packs$
+      Disallow: /packs/*
       Sitemap: https://getintoteaching.education.gov.uk/sitemap.xml
     ROBOTS
   end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,5 @@
 class SearchesController < ApplicationController
-  before_action :set_page_title
+  before_action :set_page_title, :noindex
 
   def show
     @search = Search.new(search_params)

--- a/app/views/content/thank-you.md
+++ b/app/views/content/thank-you.md
@@ -5,6 +5,7 @@ description: |-
 date: "2021-11-01"
 image: "media/images/content/hero-images/0007.jpg"
 backlink: "../../"
+noindex: true
 ---
 ### Thank you for letting us know. 
 

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -28,6 +28,7 @@ describe Callbacks::StepsController, type: :request do
     before { get step_path }
 
     it { is_expected.to have_http_status :success }
+    it { is_expected.not_to be_indexed }
 
     context "with an invalid step" do
       let(:step_path) { callbacks_step_path :invalid }
@@ -54,12 +55,14 @@ describe Callbacks::StepsController, type: :request do
       let(:details_params) { { "first_name" => "test" } }
 
       it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.not_to be_indexed }
     end
 
     context "with no data" do
       let(:details_params) { {} }
 
       it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.not_to be_indexed }
     end
 
     context "with last step" do
@@ -106,5 +109,6 @@ describe Callbacks::StepsController, type: :request do
     end
 
     it { is_expected.to have_http_status :success }
+    it { is_expected.not_to be_indexed }
   end
 end

--- a/spec/requests/cookie_preferences_controller_spec.rb
+++ b/spec/requests/cookie_preferences_controller_spec.rb
@@ -6,7 +6,10 @@ describe CookiePreferencesController, type: :request do
 
     before { get cookie_preference_path, params: {}, headers: { "HTTP_REFERER" => referer } }
 
-    it { expect(response).to have_http_status :success }
+    subject { response }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.not_to be_indexed }
     it { expect(response.body).to match "Cookie settings" }
     it { expect(response.body).to include("Go to home page") }
     it { expect(response.body).not_to include("Live chat") }

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -37,7 +37,7 @@ describe EventStepsController, type: :request do
     before { get step_path }
 
     it { is_expected.to have_http_status :success }
-    it { expect(response.body).to include(%(<meta name="robots" content="noindex">)) }
+    it { is_expected.not_to be_indexed }
 
     context "when the event is closed" do
       let(:event) { build :event_api, :closed, readable_id: readable_event_id }

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -21,6 +21,7 @@ describe MailingList::StepsController, type: :request do
     before { get mailing_list_steps_path(query: "param") }
 
     it { is_expected.to redirect_to(mailing_list_step_path({ id: :name, query: "param" })) }
+    it { is_expected.to be_indexed }
   end
 
   describe "#show" do
@@ -29,11 +30,18 @@ describe MailingList::StepsController, type: :request do
     before { get step_path }
 
     it { is_expected.to have_http_status :success }
+    it { is_expected.to be_indexed }
 
     context "with an invalid step" do
       let(:step_path) { mailing_list_step_path :invalid }
 
       it { is_expected.to have_http_status :not_found }
+    end
+
+    context "when not the first step in the wizard" do
+      let(:model) { MailingList::Steps::DegreeStatus }
+
+      it { is_expected.not_to be_indexed }
     end
   end
 
@@ -103,12 +111,14 @@ describe MailingList::StepsController, type: :request do
       let(:details_params) { { "first_name" => "test" } }
 
       it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.to be_indexed }
     end
 
     context "with no data" do
       let(:details_params) { {} }
 
       it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.to be_indexed }
     end
 
     context "with last step" do
@@ -137,6 +147,7 @@ describe MailingList::StepsController, type: :request do
         let(:details_params) { attributes_for :"mailing_list_#{model.key}" }
 
         it { is_expected.to redirect_to mailing_list_step_path steps.first.key }
+        it { is_expected.to be_indexed }
       end
     end
   end
@@ -148,5 +159,6 @@ describe MailingList::StepsController, type: :request do
     end
 
     it { is_expected.to have_http_status :success }
+    it { is_expected.not_to be_indexed }
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -22,9 +22,9 @@ describe PagesController, type: :request do
     context "when the page is noindexed" do
       before { get "/test/a" }
 
-      subject { response.body }
+      subject { response }
 
-      it { is_expected.to include(%(<meta name="robots" content="noindex">)) }
+      it { is_expected.not_to be_indexed }
     end
 
     context "with invalid page" do

--- a/spec/requests/robots_controller_spec.rb
+++ b/spec/requests/robots_controller_spec.rb
@@ -10,7 +10,8 @@ describe RobotsController, type: :request do
       <<~ROBOTS,
         User-agent: *
         Allow: /
-
+        Disallow: /packs$
+        Disallow: /packs/*
         Sitemap: https://getintoteaching.education.gov.uk/sitemap.xml
       ROBOTS
     )

--- a/spec/requests/searches_controller_spec.rb
+++ b/spec/requests/searches_controller_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe SearchesController, type: :request do
 
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: "text/html" }
+        it { is_expected.not_to be_indexed }
       end
 
       context "without search term" do
@@ -46,6 +47,7 @@ RSpec.describe SearchesController, type: :request do
 
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: "text/html" }
+        it { is_expected.not_to be_indexed }
       end
 
       context "with a search key but no value" do
@@ -53,6 +55,7 @@ RSpec.describe SearchesController, type: :request do
 
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: "text/html" }
+        it { is_expected.not_to be_indexed }
       end
     end
   end

--- a/spec/support/matchers/be_indexed_matcher.rb
+++ b/spec/support/matchers/be_indexed_matcher.rb
@@ -1,0 +1,15 @@
+require "rspec/expectations"
+
+RSpec::Matchers.define :be_indexed do |_expected|
+  match do |response|
+    !response.body.include?(%(<meta name="robots" content="noindex">))
+  end
+
+  failure_message do |response|
+    "expected #{response.request.path} to be indexed"
+  end
+
+  failure_message_when_negated do |response|
+    "expected #{response.request.path} not to be indexed"
+  end
+end


### PR DESCRIPTION
### Trello card

### Context

We want to prevent certain pages from being indexed by search engines:

- The entire callback booking form
- The cookie preferences page
- All the mailing list steps apart from the first step
- The search page (for non-JS users only)
- The generic thank you page used by the marketing team (also needs removing from the sitemap)
- All the PDF documents/assets (served under /packs)

### Changes proposed in this pull request

- Prevent pages from being indexed by search engines

### Guidance to review

