### PR TITLE
Prevent duplicate canonical tags on events pages

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -7,6 +7,6 @@ module TextFormattingHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[strong a ul li p b br div span h1 h2 h3 h4 h5], attributes: %w[href target]
+    sanitize html, tags: %w[link strong a ul li p b br div span h1 h2 h3 h4 h5], attributes: %w[href target rel]
   end
 end

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -2,7 +2,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
   <%= csp_meta_tag %>
-  <%= canonical_tag %>
+  <%= content_for?(:canonical) ? yield(:canonical) : canonical_tag %>
   <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no') %>
   <%= tag.meta(name: "google-site-verification", content: "uoqqF4yGEjHx9klftx3ch2fCBpmgI6hHYBS69w17_-g") %>
   <%= tag.link(rel: 'icon', type: 'image/x-icon', href: '/favicon.ico') %>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -1,5 +1,5 @@
-<%= content_for(:head) do %>
-  <%= tag.link(rel: "canonical", href: events_url) %>
+<%= content_for(:canonical) do %>
+  <%= safe_html_format(canonical_tag.sub(teaching_events_path, events_path)) %>
 <% end %>
 
 <section class="teaching-events">

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -1,5 +1,5 @@
-<%= content_for(:head) do %>
-  <%= tag.link(rel: "canonical", href: event_url(@event.readable_id)) %>
+<%= content_for(:canonical) do %>
+  <%= safe_html_format(canonical_tag.sub(teaching_event_path(@event.readable_id), event_path(@event.readable_id))) %>
 <% end %>
 
 <div class="teaching-event">

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -37,6 +37,7 @@ describe TextFormattingHelper, type: :helper do
           <h3>heading1</h3>
           <h4>heading1</h4>
           <h5>heading1</h5>
+          <link href="/test" rel="canonical">
         HTML
       end
 


### PR DESCRIPTION
### Trello card
[Trello-3113](https://trello.com/c/9XC6fJq0/3113-set-canonical-urls-to-prevent-pages-with-query-parameters-being-indexed-by-google-search-console)

### Context

We have custom canonical tags on the new teaching events pages that point back to the original events pages (we do this to keep search engines happy because they are A/B tested).

We have since added a canonical tag to _all_ web pages (to avoid an issue where our assets domain was being indexed). This has resulted in multiple canonical tags on the events pages. To avoid this we make the canonical tag overridable
by templates.

### Changes proposed in this pull request

- Prevent duplicate canonical tags on events pages

Also adds full domain to the custom events canonical tags (to be inline with the others).

### Guidance to review

