### PR TITLE
Remove references to Rails credentials

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,11 +54,9 @@ Rails.application.configure do
 
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
-  config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence || \
-    Rails.application.credentials.google_maps_key.presence
+  config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence
 
-  config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence || \
-    Rails.application.credentials.basic_auth_credentials.presence
+  config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence
 
   config.x.api_client_cache_store = ActiveSupport::Cache::MemoryStore.new
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,11 +106,9 @@ Rails.application.configure do
 
   config.x.git_api_endpoint = \
     "https://get-into-teaching-api-prod.london.cloudapps.digital/api"
-  config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence || \
-    Rails.application.credentials.google_maps_key.presence
+  config.x.google_maps_key = ENV["GOOGLE_MAPS_KEY"].presence
 
-  config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence || \
-    Rails.application.credentials.basic_auth_credentials.presence
+  config.x.http_auth = ENV["BASIC_AUTH_CREDENTIALS"].presence
 
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-HTTP")
 

--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -1,7 +1,5 @@
 GetIntoTeachingApiClient.configure do |config|
-  config.api_key["apiKey"] = \
-    ENV["GIT_API_TOKEN"].presence || \
-    Rails.application.credentials.git_api_token.presence
+  config.api_key["apiKey"] = ENV["GIT_API_TOKEN"].presence
 
   endpoint = ENV["GIT_API_ENDPOINT"].presence || \
     Rails.application.config.x.git_api_endpoint.presence

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,1 @@
-Sentry.init do |config|
-  if ENV["SENTRY_DSN"].blank? && Rails.application.credentials.sentry_dsn.present?
-    config.dsn = Rails.application.credentials.sentry_dsn
-  end
-end
+Sentry.init

--- a/lib/page_speed_score.rb
+++ b/lib/page_speed_score.rb
@@ -51,7 +51,7 @@ private
 
   def service
     @service ||= Google::Apis::PagespeedonlineV5::PagespeedInsightsService.new.tap do |s|
-      s.key = Rails.application.credentials.page_speed_insights_key
+      s.key = ENV["PAGE_SPEED_INSIGHTS_KEY"]
     end
   end
 end

--- a/spec/lib/page_speed_score_spec.rb
+++ b/spec/lib/page_speed_score_spec.rb
@@ -16,8 +16,8 @@ describe PageSpeedScore do
     let(:prometheus) { Prometheus::Client.registry }
 
     before do
-      allow(Rails.application.credentials).to \
-        receive(:page_speed_insights_key).and_return("12345")
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("PAGE_SPEED_INSIGHTS_KEY").and_return("12345")
     end
 
     it "retrieves the scores for each page/strategy combination and sends them to prometheus" do


### PR DESCRIPTION
### Trello card

[Trello-1660](https://trello.com/c/eRpJcktw/1660-migrate-all-secrets-from-rails-credentials-to-the-azure-keyvaults)

### Context

We no longer use Rails credentials but some of the code will default to the Rails creds if an ENV var is not set; we no longer need to do that.

### Changes proposed in this pull request

- Remove references to Rails credentials

### Guidance to review

Also updates the page speed API key to use the ENV instead of Rails credential (this was missed in the original PR but wont be an issue until the workflow runs tonight).