### PR TITLE
Update devcontainer base to Ruby 3.1 (Bullseye)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "2.7-buster",
+			"VARIANT": "3.1-bullseye",
 			// Options
 			"NODE_VERSION": "12"
 		}


### PR DESCRIPTION
Required for Codespaces to work on master
