### PR TITLE
Yet more dependabot updates (April 2022)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ group :development, :test do
 
   # Testing framework
   gem "knapsack_pro"
-  gem "rspec-rails", "~> 5.1.0"
+  gem "rspec-rails", "~> 5.1.1"
 
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.36", ">= 3.36.0"

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "secure_headers"
 gem "canonical-rails", ">= 0.2.14"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
-gem "kramdown", ">= 2.3.1"
+gem "kramdown", ">= 2.3.2"
 gem "rinku"
 
 gem "addressable", "~> 2.8.0"

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "net-smtp", require: false
 
 # Fix CVE errors
 gem "delegate", ">= 0.2.0"
-gem "logger", ">= 1.5.0"
+gem "logger", ">= 1.5.1"
 gem "matrix", ">= 0.4.2"
 gem "observer", ">= 0.1.0"
 gem "rexml", ">= 3.2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     loaf (0.10.0)
       railties (>= 3.2)
-    logger (1.5.0)
+    logger (1.5.1)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -556,7 +556,7 @@ DEPENDENCIES
   kramdown (>= 2.3.2)
   listen (~> 3.7.1)
   loaf (>= 0.10.0)
-  logger (>= 1.5.0)
+  logger (>= 1.5.1)
   matrix (>= 0.4.2)
   mdl
   net-imap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     kaminari-core (1.2.2)
     knapsack_pro (3.2.1)
       rake
-    kramdown (2.3.1)
+    kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -553,7 +553,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (>= 2.7.6)
   kaminari (~> 1.2, >= 1.2.2)
   knapsack_pro
-  kramdown (>= 2.3.1)
+  kramdown (>= 2.3.2)
   listen (~> 3.7.1)
   loaf (>= 0.10.0)
   logger (>= 1.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.1.0)
+    rspec-rails (5.1.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -575,7 +575,7 @@ DEPENDENCIES
   redis-session-store (>= 0.11.4)
   rexml (>= 3.2.5)
   rinku
-  rspec-rails (~> 5.1.0)
+  rspec-rails (~> 5.1.1)
   rspec-retry
   rspec-sonarqube-formatter!
   rubocop-govuk (~> 4.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,10 +312,10 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     observer (0.1.1)
     os (1.1.1)


### PR DESCRIPTION
### Context

- Update Nokogiri to 1.13.4
- Update kramdown to 2.3.2
- Update logger to 1.5.1
- Update rspec-rails to 5.1.1
