### PR TITLE
Fix accessibility issue on events list

### DIFF
--- a/app/views/event_categories/show.html.erb
+++ b/app/views/event_categories/show.html.erb
@@ -14,9 +14,9 @@
 <% if @events.any? %>
 <section id="event-category-list" class="types-of-event">
   <div class="events-featured">
-    <div class="events-featured__list">
+    <ul class="events-featured__list">
       <%= render partial: "events/event", collection: @events %>
-    </div>
+    </ul>
   </div>
 </section>
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,3 +1,5 @@
-<%= link_to event_path(id: event.readable_id), class: "events-featured__list__item" do %>
-  <%= render(Events::EventBoxComponent.new(event)) %>
-<% end %>
+<li>
+  <%= link_to event_path(id: event.readable_id), class: "events-featured__list__item" do %>
+    <%= render(Events::EventBoxComponent.new(event)) %>
+  <% end %>
+</li>

--- a/app/views/events/_event_group.html.erb
+++ b/app/views/events/_event_group.html.erb
@@ -16,9 +16,9 @@
     </div>
 
     <% if events.any? %>
-      <div class="events-featured__list">
+      <ul class="events-featured__list">
         <%= render partial: "event", collection: events %>
-      </div>
+      </ul>
     <% else %>
       <% if type_id == ttt_event_type_id %>
         <%= render(Events::NoResultsComponent.new) do %>

--- a/app/views/internal/events/index.html.erb
+++ b/app/views/internal/events/index.html.erb
@@ -46,9 +46,9 @@
     <div class="events container">
       <section class="types-of-event">
         <div class="events-featured">
-          <div class="events-featured__list">
+          <ul class="events-featured__list">
             <%= render partial: "event", collection: @events %>
-          </div>
+          </ul>
         </div>
         <%= paginate @events %>
       </section>

--- a/app/webpacker/styles/events.scss
+++ b/app/webpacker/styles/events.scss
@@ -77,6 +77,7 @@
     }
 
     &__list {
+      list-style: none;
       padding: 0;
       @include cards-grid;
 


### PR DESCRIPTION
### Trello card

[Trello-3127](https://trello.com/c/5sTO2dNB/3127-investigate-accessibility-issue-with-lists-on-returning-from-overseas-page)

### Context

Silktide is flagging the events list as a navigation component and therefore should be in `ul/li` tags. I think its probably inferred this from the class name (which contains `list`) and the fact it's multiple adjacent anchor tags. This feels a bit like a false positive but its worth fixing just to placate Silktide.

### Changes proposed in this pull request

- Fix accessibility issue with events listing

### Guidance to review

