### PR TITLE
Ensure canonical tags match sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -5,8 +5,12 @@ class SitemapController < ApplicationController
     "/home" => "/",
   }.freeze
 
+  # http://en.wikipedia.org/wiki/URL_normalization
+  # Ensure any index route (collection) has a trailing slash (representing the semantics of a directory).
+  # This will keep it consistent with how canonical-rails behaves and ensure search engines are happy.
   OTHER_PATHS = %w[
-    /events
+    /events/
+    /blog/
     /event-categories/train-to-teach-events
     /event-categories/online-q-as
     /event-categories/school-and-university-events


### PR DESCRIPTION
### Trello card

[Trello-3138](https://trello.com/c/jZctl3us/3138-investigate-canonical-issues-with-indexing-of-the-events-page)

### Context

The canonical tags are configured to append a trailing slash to routes that represent a collection (this is semantically correct). Our sitemap (and Rails path helpers) don't append a trailing slash to collection paths, which has caused a mismatch that Google has flagged in Search Console.

Ensure all sitemap paths to index actions have a trailing slash, therefore matching the canonical tags.

### Changes proposed in this pull request

- Ensure canonical tags match sitemap

Adds missing `/blog/` path to sitemap.

### Guidance to review

I could have gone the other way and configured `canonical-rails` to omit the trailing slash on index routes, which would have made it consistent with the sitemap and how Rails path helpers work, but the other way seems more semantically correct and I don't _think_ having internal links that don't have the trailing slash will cause issues (just the sitemap being different).