### PR TITLE
Use Rails 7 defaults

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -74,7 +74,7 @@ class PagesController < ApplicationController
       url += "?#{session[:utm].to_param}"
     end
 
-    redirect_to(url, turbolinks: false, status: :moved_permanently)
+    redirect_to(url, turbolinks: false, status: :moved_permanently, allow_other_host: true)
   end
 
 protected

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ Bundler.require(*Rails.groups)
 module GetIntoTeachingWebsite
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Switching to Rails 7 defaults means we need to tell `#redirect_to` that we're intentionally linking to another site using `allow_other_host: true`
