### PR TITLE
Fix mobile usability issues

### DIFF
--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -8,8 +8,8 @@
       display: flex;
       flex-wrap: wrap;
       box-sizing: border-box;
-      padding: .5rem $indent-amount;
-      margin: 2em 0 0;
+      padding: 0.4em $indent-amount;
+      margin: 2em 0 0 -1em;
       list-style: none;
 
       * {
@@ -23,18 +23,20 @@
           margin-right: .8em;
           color: $black;
           font-size: .842em;
-          @include mq($until: tablet) {
-            font-size: .737em;
-          }
+          font-size: 1em;
+          padding: 1em;
 
           &:after {
             content: "";
             display: inline-block;
+            position: absolute;
+            top: 50%;
+            left: 100%;
             width: .5em;
             height: .5em;
             border: 2px solid $black;
             border-width: 2px 2px 0 0;
-            margin-left: 6px;
+            margin-top: -4px;
             transform: rotate(45deg);
           }
         }
@@ -42,7 +44,6 @@
         &:last-child {
           a {
             margin-right: 0;
-            padding-right: 0;
 
             &:after {
               display: none;
@@ -50,6 +51,18 @@
           }
         }
       }
+    }
+  }
+}
+
+@include mq($from: desktop) {
+  .breadcrumbs .breadcrumb ol {
+    margin-left: 0;
+    padding: 0.5rem $indent-amount;
+
+    li a {
+      font-size: 0.9em;
+      padding: 0.2em 0.4em;
     }
   }
 }

--- a/app/webpacker/styles/header/menu-button.scss
+++ b/app/webpacker/styles/header/menu-button.scss
@@ -36,6 +36,7 @@
     display: inline-block;
     margin-left: .6em;
     color: $black;
+    font-size: 0.9rem;
   }
 
   .menu-button__icon {


### PR DESCRIPTION
### Trello card

[Trello-3139](https://trello.com/c/vrtGDHcJ/3139-investigate-mobile-usability-issues-flagged-in-google-search-console)

### Context

We are seeing errors on the Google Mobile Usability checker. Strangely I can't replicate them; if I boot up a review instance running master and check it then it passes. We think its likely due to the breadcrumb and/or mobile menu button text/clickable area being small on mobile, so increasing those may resolve the issues.

### Changes proposed in this pull request

- Increase breadcrumb clickable area on mobile

The breadcrumb font size and clickable area on mobile is too small; increasing it to improve usability.

- Tweak font-size of menu button to match list items

The font-size of the menu button is marginally smaller than the menu items on the expanded navigation; this tweaks it to match.

### Guidance to review

