### PR TITLE
Omit pages that are noindexed from site search results

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -72,6 +72,6 @@ private
   end
 
   def searchable_pages
-    NON_CONTENT_PAGES.merge(Pages::Frontmatter.list)
+    NON_CONTENT_PAGES.merge(Pages::Frontmatter.list).reject { |_, fm| fm[:noindex] }
   end
 end

--- a/spec/fixtures/files/markdown_content/noindex.md
+++ b/spec/fixtures/files/markdown_content/noindex.md
@@ -1,0 +1,8 @@
+---
+title: Noindexed page
+noindex: true
+keywords:
+  - noindex
+---
+
+Should not be indexed/returned in site search results

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -138,6 +138,12 @@ RSpec.describe Search do
       end
     end
 
+    describe "noindexed pages" do
+      let(:search) { "noindex" }
+
+      it { is_expected.to have_attributes length: 0 }
+    end
+
     describe "non-content pages" do
       describe "events" do
         Search::NON_CONTENT_PAGES.dig("/events", :keywords).each do |kw|


### PR DESCRIPTION
### Trello card

[Trello-3146](https://trello.com/c/BSTGiZKI/3146-add-noindex-as-filter-on-internal-search)

### Context

- Omit pages that are noindexed from site search results

### Changes proposed in this pull request

If a page has frontmatter with `noindex: true` we don't allow Google to index it, however we do still show it in the search results. We should ensure pages that are noindexed should also be omitted from our local site search.

### Guidance to review

You can test this by searching for `test` - no results should appear.