### PR TITLE
Remove A/B test pages

### DIFF
--- a/app/views/content/test.md
+++ b/app/views/content/test.md
@@ -1,6 +1,0 @@
----
-title: Test Index
-noindex: true
----
-
-Test index

--- a/app/views/content/test/a.md
+++ b/app/views/content/test/a.md
@@ -1,6 +1,0 @@
----
-title: Test A
-noindex: true
----
-
-Variant A (test)

--- a/app/views/content/test/b.md
+++ b/app/views/content/test/b.md
@@ -1,6 +1,0 @@
----
-title: Test B
-noindex: true
----
-
-Variant B (test)

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -20,7 +20,7 @@ describe PagesController, type: :request do
     end
 
     context "when the page is noindexed" do
-      before { get "/test/a" }
+      before { get "/thank-you" }
 
       subject { response }
 


### PR DESCRIPTION
### Trello card

[Trello-3145](https://trello.com/c/S2hpaDVw/3145-delete-test-pages-from-production)

### Context

These were added when we were integrating Google Optimize to test it out in production and are no
longer needed.

### Changes proposed in this pull request

- Remove A/B test pages

### Guidance to review

