### PR TITLE
Perform full page load on search selection

### DIFF
--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -135,7 +135,7 @@ export default class extends Controller {
     if (chosen && chosen.link) {
       if (this.analyticsSubmitter) this.sendToAnalytics();
 
-      Turbolinks.visit(chosen.link);
+      window.location = chosen.link;
     }
   }
 


### PR DESCRIPTION
### Trello card

[Trello-3140](https://trello.com/c/l1nMZXW7/3140-investigate-cumulative-layout-shift-cls-issues-on-desktop-core-web-vitals)

### Context

Currently if a user searches then clicks on a result we use Turbolinks to transition to the page. This is an issue on mobile because when a user taps into the search input the browser zooms into it for easier typing; when the page transitions via Turbolinks the viewport is not reset and so the subsequent page appears to have horizontal scroll issues (when in fact they
just need to zoom back out).

### Changes proposed in this pull request

- Perform full page load on search selection

### Guidance to review

I can't find a clean way of resetting the viewport with Javascript, so it feels like the simplest solution here is to just let the browser load the page that's selected instead of transitioning with Turbolinks.