### PR TITLE
Build permissions for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,17 @@
 name: Build and Deploy
+
 on:
   workflow_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
   push:
     branches: [ master ]
+
+permissions:
+  contents: write
+  deployments: write
+  issues: write
+  pull-requests: write
 
 jobs:
   build_release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   deployments: write
   issues: write
+  packages: write
   pull-requests: write
 
 jobs:
@@ -36,9 +37,9 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: SLACK-WEBHOOK
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -67,7 +68,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to Docker Hub
         uses: docker/build-push-action@v2.10.0
@@ -115,9 +116,9 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: SLACK-WEBHOOK
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@master
@@ -150,7 +151,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and output locally
         uses: docker/build-push-action@v2.10.0


### PR DESCRIPTION
### Context
Dependabot by default has readonly permissions, some steps in the workflow require write permissions.

### Changes proposed in this pull request
This change sets workflow permissions for Actions and Dependabot.

### Guidance to review
Check that workflow is running as expected

