### PR TITLE
Add workflow to bust docker cache

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -1,0 +1,76 @@
+name: Rebuild master docker image
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 12 * * 0'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: INFRA-KEYS
+          key: SLACK-WEBHOOK, SNYK-TOKEN
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Get Short SHA
+        id: sha
+        run: echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
+
+      - name: Login to GitHub Container Repository
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          tags: ${{ env.DOCKER_REPOSITORY }}:master
+          load: true
+          push: false
+          build-args: |
+            SHA=${{ steps.sha.outputs.short }}
+            BUILD_TYPE=release
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK-TOKEN }}
+        with:
+          image: ${{ env.DOCKER_REPOSITORY }}:master
+          args: --severity-threshold=high --file=Dockerfile
+
+      - name: Push image to registry
+        if: success()
+        run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
+
+      - name: Slack Notification
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: ${{ env.SLACK_ERROR }}
+           SLACK_MESSAGE: 'There has been a failure building the application'
+           SLACK_TITLE: 'Failure Building Application'
+           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}


### PR DESCRIPTION
### Context
Docker build layers are cached to optimise build performance but sometimes the base image is updated so we need to rebuild it.

### Changes proposed in this pull request
Add a build-no-cache work that is scheduled once a week on Sunday and can be run manually as required.

### Guidance to review
Check the new workflow runs as expected., example [here](https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/2232395955) which published image [here](https://github.com/DFE-Digital/get-into-teaching-app/pkgs/container/get-into-teaching-frontend/20741658?tag=master)

