### PR TITLE
Add an aria-label to the primary nav

### DIFF
--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -1,4 +1,4 @@
-<nav class="hidden-mobile" data-navigation-target="nav">
+<nav class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation">
   <%= render Header::ExtraNavigationComponent.new(classes: %w[hide-on-desktop], search_input_id: "searchbox__input--mobile") %>
   <ol class="primary" data-navigation-target="primary">
     <% all_resources.each do |resource| %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/H4N1jvTT/3130-build-new-navigation-pages

### Context and changes

When we soon add the category pages to the site we'll be introducing a second level of navigation and have two `<nav>` elements on the page.

To make the site easier to use for people with assistive technology we should label them separately so screen readers will call them by distinct names.

The main one in the header will be announced as 'Primary navigation'.

![Screenshot from 2022-04-27 11-21-38](https://user-images.githubusercontent.com/128088/165498261-9b340a87-ffe1-44cc-a0ad-99cb85aa3590.png)

