### PR TITLE
Ensure postcodes are not sent to Google Analytics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,4 @@ PREVIEW_PAGES=1
 VCAP_APPLICATION="{\"application_name\": \"app-name\",\"space_name\": \"space-name\",\"organization_name\": \"org-name\"}"
 GTM_ID=123-ABC
 CF_INSTANCE_INDEX=app-instance
+SECRET_KEY_BASE=d144e21816f984ea2adf984d3eadc8f93e8c71f5c05368127365b13cb840ea6e0d6822a77f3342b0913b0522dd47ea4b80a794ee2da0433f4b075337650d1170

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "faraday-encoding"
 gem "faraday-http-cache"
 gem "faraday_middleware"
 
+gem "hashids"
+
 gem "dotenv-rails", ">= 2.7.6"
 
 gem "govuk_design_system_formbuilder", ">= 2.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
+    hashids (1.0.6)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -550,6 +551,7 @@ DEPENDENCIES
   get_into_teaching_api_client_faraday!
   google-api-client (>= 0.53.0)
   govuk_design_system_formbuilder (>= 2.8.0)
+  hashids
   kaminari (~> 1.2, >= 1.2.2)
   knapsack_pro
   kramdown (>= 2.4.0)

--- a/app/components/events/search_component.html.erb
+++ b/app/components/events/search_component.html.erb
@@ -4,7 +4,7 @@
       <h2 id="searchforevents" class="colored-stripe__title purple"><%= heading %></h2>
       <div class="colored-stripe__content">
         <div class="search">
-          <%= form_for search, method: :get, url: path do |f| %>
+          <%= form_for search, method: :post, url: path do |f| %>
             <div class="search__controls" data-controller="conditional-field" data-conditional-field-mode="hide" data-conditional-field-expected="">
               <% if include_type %>
                 <%= tag.div(class: input_field_classes(:type)) do %>

--- a/app/controllers/event_categories_controller.rb
+++ b/app/controllers/event_categories_controller.rb
@@ -8,6 +8,11 @@ class EventCategoriesController < ApplicationController
 
   MAXIMUM_EVENTS_IN_CATEGORY = 1_000
 
+  def create
+    encrypted_params = Events::Search.new(event_filter_params).encrypted_attributes
+    redirect_to(event_category_path(params[:id], { events_search: encrypted_params }))
+  end
+
   def show
     @category_name = helpers.pluralised_category_name(@type.id)
     @page_title = @category_name
@@ -29,7 +34,7 @@ protected
 private
 
   def load_events(period)
-    @event_search = Events::Search.new(event_filter_params.merge(type: @type.id, period: period))
+    @event_search = Events::Search.new_decrypt(event_filter_params.merge(type: @type.id, period: period))
     events_by_type = @event_search.query_events(MAXIMUM_EVENTS_IN_CATEGORY)
     group_presenter = Events::GroupPresenter.new(
       events_by_type,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -20,6 +20,11 @@ class EventsController < ApplicationController
     render layout: "events"
   end
 
+  def perform_search
+    encrypted_params = Events::Search.new(event_search_params).encrypted_attributes
+    redirect_to search_events_path({ events_search: encrypted_params })
+  end
+
   def search
     @page_title = "Teacher training events"
     @front_matter = { "description" => "Get your questions answered at an event." }
@@ -89,7 +94,7 @@ private
   end
 
   def load_event_search
-    @event_search = Events::Search.new(event_search_params)
+    @event_search = Events::Search.new_decrypt(event_search_params)
   end
 
   def event_search_params

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,7 +7,11 @@ class PagesController < ApplicationController
   ].freeze
 
   PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}
-  DYNAMIC_PAGE_PATHS = ["/test/a", "/test/b"].freeze
+  DYNAMIC_PAGE_PATHS = [
+    "/train-to-be-a-teacher/if-you-have-a-degree", # Contains a form
+    "/train-to-be-a-teacher/if-you-dont-have-a-degree", # Contains a form
+    "/train-to-be-a-teacher/initial-teacher-training", # Contains a form
+  ].freeze
 
   before_action :set_welcome_guide_info, if: -> { request.path.start_with?("/welcome") && (params[:subject] || params[:degree_status]) }
   rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -16,6 +16,11 @@ class TeachingEventsController < ApplicationController
     "Question Time",
   ).freeze
 
+  def create
+    encrypted_params = TeachingEvents::Search.new(search_params).encrypted_attributes
+    redirect_to teaching_events_path({ teaching_events_search: encrypted_params })
+  end
+
   def index
     @page_title = "Find an event near you"
 
@@ -73,7 +78,7 @@ private
   end
 
   def setup_results
-    @event_search = TeachingEvents::Search.new(search_params)
+    @event_search = TeachingEvents::Search.new_decrypt(search_params)
   end
 
   def set_front_matter

--- a/app/models/concerns/encrypted_attributes.rb
+++ b/app/models/concerns/encrypted_attributes.rb
@@ -1,0 +1,34 @@
+require "encryptor"
+
+module EncryptedAttributes
+  extend ActiveSupport::Concern
+
+  included do |_base|
+    delegate :encrypt?, to: :class
+    class_attribute :encrypted_attributes
+
+    def self.new_decrypt(attributes)
+      decrypted_attributes = attributes.to_h.each_with_object({}) do |(k, v), hash|
+        hash[k] = encrypt?(k) ? ::Encryptor.decrypt(v) : v
+      end
+
+      new(decrypted_attributes)
+    end
+
+    def encrypted_attributes
+      attributes.each_with_object({}) do |(k, v), hash|
+        hash[k] = encrypt?(k) ? ::Encryptor.encrypt(v) : v
+      end
+    end
+  end
+
+  class_methods do
+    def encrypt_attributes(*attributes)
+      self.encrypted_attributes = attributes.map(&:to_s)
+    end
+
+    def encrypt?(key)
+      key.to_s.in?(encrypted_attributes)
+    end
+  end
+end

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -3,6 +3,8 @@ module Events
     include ActiveModel::Model
     include ActiveModel::Attributes
     include ActiveModel::Validations::Callbacks
+    include EncryptedAttributes
+    encrypt_attributes :postcode
 
     RESULTS_PER_TYPE = 9
     FUTURE_MONTHS = 24

--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -3,6 +3,8 @@ module TeachingEvents
     include ActiveModel::Model
     include ActiveModel::Attributes
     include ActiveModel::Validations::Callbacks
+    include EncryptedAttributes
+    encrypt_attributes :postcode
 
     FUTURE_MONTHS = 6
 
@@ -14,8 +16,8 @@ module TeachingEvents
       "50 miles" => 50,
     }.freeze
 
-    attr_accessor :online, :type
-
+    attribute :online
+    attribute :type
     attribute :postcode, :string
     attribute :distance, :integer
 

--- a/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
@@ -12,7 +12,7 @@
         heading: "Events are a great place to ask questions") do %>
       <p>Events are one of the best ways to speak to people and ask the questions you need to get into teaching.</p>
 
-      <%= form_for Events::Search.new, method: :get, url: search_events_path do |f| %>
+      <%= form_for Events::Search.new, method: :post, url: search_events_path do |f| %>
         <%= f.hidden_field :distance, value: 10 %>
         <%= f.label :postcode, "Enter postcode" %>
         <%= f.text_field :postcode, autocomplete: "postal-code" %>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_form_for(@event_search, method: :get, url: "/teaching-events") do |f| %>
+<%= govuk_form_for(@event_search, method: :post, url: "/teaching-events") do |f| %>
   <h2>Filters</h2>
 
   <div class="teaching-events__filter--group">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
   resources "events", path: "/events", only: %i[index show search] do
     collection do
       get "search"
+      post "search", to: "events#perform_search"
     end
     resources "steps",
               path: "/apply",
@@ -115,7 +116,7 @@ Rails.application.routes.draw do
 
   resources :event_categories, only: %i[show], path: "event-categories" do
     member do
-      get "archive", to: "event_categories#show_archive"
+      post "", to: "event_categories#create"
     end
   end
   # The event category pages used to exist here - once we're sure no traffic is

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -1,0 +1,32 @@
+class Encryptor
+  delegate :encrypt_and_sign, :decrypt_and_verify, to: :crypt
+
+  class << self
+    def encrypt(value)
+      return nil if value.blank?
+
+      new.encrpyt_string(value)
+    end
+
+    def decrypt(value)
+      return nil if value.blank?
+
+      new.decrypt_string(value)
+    end
+  end
+
+  def encrpyt_string(value)
+    hashids.encode(value.chars.map(&:ord))
+  end
+
+  def decrypt_string(value)
+    hashids.decode(value).map(&:chr).join
+  end
+
+private
+
+  def hashids
+    salt = ENV["SECRET_KEY_BASE"][0..31]
+    Hashids.new(salt)
+  end
+end

--- a/spec/components/events/search_component_spec.rb
+++ b/spec/components/events/search_component_spec.rb
@@ -11,7 +11,7 @@ describe Events::SearchComponent, type: "component" do
   before { freeze_time }
 
   specify "builds a search form" do
-    expect(page).to have_css("form[action='#{path}'][method='get']")
+    expect(page).to have_css("form[action='#{path}'][method='post']")
   end
 
   describe "heading" do

--- a/spec/factories/events/search_factory.rb
+++ b/spec/factories/events/search_factory.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
       distance { 20 }
       postcode { nil }
     end
+
+    trait :with_encrypted_postcode do
+      postcode { Encryptor.encrypt("TE57 1NG") }
+    end
   end
 end

--- a/spec/features/event_near_you_promo_spec.rb
+++ b/spec/features/event_near_you_promo_spec.rb
@@ -23,6 +23,9 @@ RSpec.feature "Events near you promo", type: :feature do
     fill_in "Enter postcode", with: "M1"
     click_on "event-search"
 
-    expect(page).to have_current_path("/events/search?events_search[distance]=#{distance}&events_search[postcode]=#{postcode}")
+    current_url = CGI.unescape(page.current_url)
+    expect(current_url).to include("/events/search")
+    expect(current_url).to include("events_search[distance]=#{distance}")
+    expect(current_url).to include("events_search[postcode]=#{Encryptor.encrypt(postcode)}")
   end
 end

--- a/spec/features/find_an_event_spec.rb
+++ b/spec/features/find_an_event_spec.rb
@@ -36,12 +36,13 @@ RSpec.feature "Finding an event", type: :feature do
 
     click_on "Update results"
 
-    expect(page.current_url).to include("/events/search")
+    current_url = CGI.unescape(page.current_url)
+    expect(current_url).to include("/events/search")
 
-    expect(page.current_url).to include("events_search[type]=")
-    expect(page.current_url).to include("events_search[distance]=")
-    expect(page.current_url).to include("events_search[postcode]=")
-    expect(page.current_url).to include("events_search[month]=")
+    expect(current_url).to include("events_search[type]=")
+    expect(current_url).to include("events_search[distance]=")
+    expect(current_url).to include("events_search[postcode]=")
+    expect(current_url).to include("events_search[month]=")
   end
 
   scenario "Finding an event by the list of featured events" do

--- a/spec/lib/encryptor_spec.rb
+++ b/spec/lib/encryptor_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "encryptor"
+
+RSpec.describe Encryptor do
+  let(:value) { "value" }
+
+  describe ".encrypt" do
+    subject { described_class.encrypt(value) }
+
+    it { is_expected.to eq("Nx6SYGs2QI1VtbD") }
+
+    context "when nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe ".decrypt_hash" do
+    let(:encrypted_value) { described_class.encrypt(value) }
+
+    subject { described_class.decrypt(encrypted_value) }
+
+    it { is_expected.to eq(value) }
+
+    context "when nil" do
+      let(:encrypted_value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/concerns/encrypted_attributes_spec.rb
+++ b/spec/models/concerns/encrypted_attributes_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe EncryptedAttributes do
+  let(:test_model) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include EncryptedAttributes
+      encrypt_attributes :name, :email
+
+      attribute :name
+      attribute :email
+      attribute :height
+      attribute :age
+    end
+  end
+  let(:instance) do
+    test_model.new(name: "Name", email: "email@address.com", height: nil, age: 20)
+  end
+
+  describe "#encrypted_attributes" do
+    subject { instance.encrypted_attributes }
+
+    it "encrypts attributes flagged for encryption" do
+      is_expected.to include({
+        "name" => "7XDiV3FmPhl3",
+        "email" => "94PseMsmBtgesaDs9VTMquj0TQzhw6TRvcWOfjYfqNIwVUG6hxY",
+        "height" => nil,
+        "age" => 20,
+      })
+    end
+  end
+
+  describe ".new_decrypt" do
+    let(:encrypted_attributes) { instance.encrypted_attributes }
+
+    subject { test_model.new_decrypt(encrypted_attributes).attributes }
+
+    it { is_expected.to eq(instance.attributes) }
+
+    context "when passed permitted ActionController::Parameters" do
+      let(:encrypted_attributes) { ActionController::Parameters.new(instance.encrypted_attributes).permit! }
+
+      it { is_expected.to eq(instance.attributes) }
+    end
+
+    context "when passed a malformed value that cannot be decrypted" do
+      let(:encrypted_attributes) { { name: "malformed" } }
+
+      it { is_expected.to include({ "height" => nil }) }
+    end
+  end
+end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -11,6 +11,12 @@ describe Events::Search do
     it { is_expected.to respond_to :period }
   end
 
+  describe ".encrypted_attributes" do
+    subject { described_class.encrypted_attributes }
+
+    it { is_expected.to eq(%w[postcode]) }
+  end
+
   describe "#period" do
     subject { described_class.new.period }
 

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -10,6 +10,12 @@ describe TeachingEvents::Search do
     it { is_expected.to respond_to(:distance) }
   end
 
+  describe ".encrypted_attributes" do
+    subject { described_class.encrypted_attributes }
+
+    it { is_expected.to eq(%w[postcode]) }
+  end
+
   describe "validation" do
     describe "postcode" do
       describe "before_validation" do

--- a/spec/requests/events_by_category_spec.rb
+++ b/spec/requests/events_by_category_spec.rb
@@ -78,7 +78,7 @@ describe "View events by category", type: :request do
       type_id = EventType.school_or_university_event_id
       expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type).with(filter.merge(type_ids: [type_id], quantity_per_type: expected_limit))
-      get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: postcode })
+      get event_category_path("school-and-university-events", events_search: { distance: radius, postcode: Encryptor.encrypt(postcode) })
     end
   end
 

--- a/spec/requests/events_controller_spec.rb
+++ b/spec/requests/events_controller_spec.rb
@@ -63,6 +63,7 @@ describe EventsController, type: :request do
       let(:search_params) do
         attributes_for(
           :events_search,
+          :with_encrypted_postcode,
           type: event_type,
           month: search_month,
           distance: "",

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -19,7 +19,7 @@ describe "teaching events", type: :request do
 
     context "when searching" do
       subject do
-        params = { postcode: "KY11 9YU", distance: 20, online: false }
+        params = { postcode: Encryptor.encrypt("KY11 9YU"), distance: 20, online: false }
         get teaching_events_path(params: { teaching_events_search: params })
         response
       end


### PR DESCRIPTION
### Trello card

[Trello-416](https://trello.com/c/YxfD4ndn/416-investigate-alternatives-to-passing-postcode-in-urls)

### Context

A UK postcode is considered Personally Identifiable Information (PII) and therefore should not be sent to external services such as Google Analytics or output in URL/made available in the browser history.

We want to avoid this happening by encrypting postcodes before they are rendered in the URL of a GET request.

### Changes proposed in this pull request

- Add simple Encryptor lib

Add a simple `Encryptor` library that can encrypt/decrypt string values. We are using [Hashids](https://hashids.org/) which is intended for obfuscating your database ids when used in URLs and results in a short hash when given a postcode (mapped to character integer values).

This isn't going to be as secure as something like `ActiveSupport::MessageEncryptor` but I think for the purpose of obfuscating PII it should be sufficient and results in a much shorter hash.

The solution should be easily transferrable to other services as we need to do similar in other projects.

- Add concern to encrypt ActiveModel attributes

We plan on encrypting the attributes of a form model when rendering the GET request that contains PII in the URL query string. In order to do this we need to be able to query the encrypted attributes of a model (to construct the URL) and then be able to instantiate the same model using the encrypted attributes (decrypting the fields into the model attributes).

The usage will be along the lines of:

```
model = Model.new(attributes_from_post_request)
url = model_path(model.encrypted_attributes)
redirect_to url
model = Model.new_decrypt(attributes_from_get_request)
```

- Encrypt postcode in event search URL

Encrypt the postcode in the event search URL so as not to expose it to Google Analytics/the browser history.

In order to do this we include the `EncryptedAttributes` concern into the `Events::Search` model and change the form method from `get` to `post`. This ensures the postcode is transmitted securely to the controller action, whereby we can encrypt it and redirect to the `GET` search endpoint, decrypt it and display the relevant results to the user. This method ensures the postcode is not leaked to the URL and yet the search results URL can be copied/bookmarked.

Removes a redundant route for event archives.

- Encrypt postcode in teaching event search URL

Ditto with respect to the previous commit.

### Guidance to review

I've given the various search forms (events, event categories and teaching events) a good click about with various filter combinations and it seems fine, but it would be worth others doing some exploratory testing.