### PR TITLE
Dependabot Ruby updates for May 2022 (part 1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ gem "loaf", ">= 0.10.0"
 
 gem "prometheus-client"
 
-gem "sentry-rails", ">= 5.2.1"
-gem "sentry-ruby", "~> 5.2.1"
+gem "sentry-rails", ">= 5.3.0"
+gem "sentry-ruby", "~> 5.3.0"
 
 gem "skylight", "~> 5.3.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ group :development, :test do
 
   # Testing framework
   gem "knapsack_pro"
-  gem "rspec-rails", "~> 5.1.1"
+  gem "rspec-rails", "~> 5.1.2"
 
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.36", ">= 3.36.0"

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "secure_headers"
 gem "canonical-rails", ">= 0.2.14"
 
 gem "front_matter_parser", github: "waiting-for-dev/front_matter_parser"
-gem "kramdown", ">= 2.3.2"
+gem "kramdown", ">= 2.4.0"
 gem "rinku"
 
 gem "addressable", "~> 2.8.0"

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "redis"
 gem "redis-session-store", ">= 0.11.4"
 
 gem "kaminari", "~> 1.2", ">= 1.2.2"
-gem "view_component", "~> 2.52.0"
+gem "view_component", "~> 2.53.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,7 +495,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.1.0)
     victor (0.3.3)
-    view_component (2.52.0)
+    view_component (2.53.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.2.0)
@@ -590,7 +590,7 @@ DEPENDENCIES
   text
   tzinfo-data
   victor
-  view_component (~> 2.52.0)
+  view_component (~> 2.53.0)
   web-console (>= 4.2.0)
   webmock (>= 3.14.0)
   webpacker (>= 5.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     kaminari-core (1.2.2)
     knapsack_pro (3.2.1)
       rake
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -552,7 +552,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (>= 2.8.0)
   kaminari (~> 1.2, >= 1.2.2)
   knapsack_pro
-  kramdown (>= 2.3.2)
+  kramdown (>= 2.4.0)
   listen (~> 3.7.1)
   loaf (>= 0.10.0)
   logger (>= 1.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.1.1)
+    rspec-rails (5.1.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -574,7 +574,7 @@ DEPENDENCIES
   redis-session-store (>= 0.11.4)
   rexml (>= 3.2.5)
   rinku
-  rspec-rails (~> 5.1.1)
+  rspec-rails (~> 5.1.2)
   rspec-retry
   rspec-sonarqube-formatter!
   rubocop-govuk (~> 4.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,13 +455,13 @@ GEM
     semantic_logger (4.10.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.2.1)
+    sentry-rails (5.3.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.2.1)
-    sentry-ruby (5.2.1)
+      sentry-ruby-core (~> 5.3.0)
+    sentry-ruby (5.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.2.1)
-    sentry-ruby-core (5.2.1)
+      sentry-ruby-core (= 5.3.0)
+    sentry-ruby-core (5.3.0)
       concurrent-ruby
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -580,8 +580,8 @@ DEPENDENCIES
   rubocop-govuk (~> 4.3.0)
   secure_headers
   selenium-webdriver (~> 3.142)
-  sentry-rails (>= 5.2.1)
-  sentry-ruby (~> 5.2.1)
+  sentry-rails (>= 5.3.0)
+  sentry-ruby (~> 5.3.0)
   shoulda-matchers
   simplecov
   skylight (~> 5.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
-    rack-attack (6.6.0)
+    rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-host-redirect (1.3.0)
       rack


### PR DESCRIPTION
### Context and changes

- Update rspec-rails to 5.1.2
- Update kramdown to 2.4.0
- Update rack-attack to 6.6.1
- Update view_component to 2.53.0
- Update sentry-ruby and sentry-rails to 5.3.0
