### PR TITLE
Remove empty <aside> element when not fullwidth

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,9 +9,6 @@
 
     <main id="main-content">
       <section class="container">
-        <% unless @fullwidth %>
-          <aside></aside>
-        <% end %>
         <article class="markdown <%= " fullwidth" if @fullwidth %>">
           <%= yield %>
         </article>


### PR DESCRIPTION
The empty aside element is pushing content to the right with the new simplified flex ordering. It's no longer needed so let's drop it.
