### PR TITLE
Fixes for mobile usability issues

### DIFF
--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -1,6 +1,6 @@
 html {
-  @include mq($until: mobile) { font-size: 90%; }
-  @include mq($from: mobile, $until: tablet) { font-size: 95%; }
+  @include mq($until: mobile) { font-size: 106%; }
+  @include mq($from: mobile, $until: tablet) { font-size: 106%; }
   @include mq($from: tablet) { font-size: 100%; }
 }
 

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -119,9 +119,18 @@
     thead > tr {
       > th {
         text-align: left;
-        padding-bottom: $table-spacing;
+        padding: 0 $table-spacing $table-spacing $table-spacing;
         margin-bottom: $table-spacing;
         border-bottom: 1px solid $grey-light;
+        word-break: normal;
+
+        &:first-child {
+          padding-left: 0;
+        }
+
+        &:last-child {
+          padding-right: 0;
+        }
       }
     }
 

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -50,6 +50,14 @@ dt,
   line-height: 1.5;
 }
 
+li {
+  margin-bottom: 0.3em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
 a {
   @include font;
   color: $black;


### PR DESCRIPTION
- Increase mobile/tablet font-size

Ensures the minimum font-size of paragraphs will be 16px, which by all indications is what Google checks for when testing if text is too small to read.

- Add bottom margin to list items

We are seeing a 'clickable items too close together' usability issue; we think this may be from where we have lists of links. Adding a small bottom-margin to the list items should hopefully improve their usability.

- Prevent table headings wrapping

Table headings were wrapping mid-word and on mobile the headings were touching; this prevents word wrapping and adds a little horizontal padding.