### PR TITLE
Make flex shrink to prevent horiozontal scroll

### DIFF
--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -113,13 +113,9 @@
   border-top: 1px solid $grey-mid;
   padding-top: 3em;
   margin: 3em auto;
-
-}
-
-.promo {
   display: flex;
   flex-direction: column;
-  gap: 2em;
+  gap: 1em;
 
   @include mq($from: tablet) {
     flex-direction: row;
@@ -127,7 +123,7 @@
 
   &__left,
   &__right {
-    flex: 0 0 50%;
+    flex: 0 1 50%;
   }
 
   &__left {
@@ -172,7 +168,6 @@
 
   &__right {
     align-items: flex-start;
-    flex-basis: 50%;
     display: flex;
     flex-direction: column;
 
@@ -185,14 +180,10 @@
     p {
       margin-top: 0;
     }
-    
+
     label {
 	    font-weight: bold;
 	    display: block
-    }
-    
-    input {
-	    
     }
 
     label,
@@ -214,12 +205,9 @@
     }
 
     form {
-      width: 100%;
-
       input {
-        margin-left: 0;
-        max-width: 150px;
-        margin-right: .5em;
+        margin: 0 0 .5rem;
+        max-width: 10rem;
       }
 
       div {
@@ -254,7 +242,7 @@
   }
 
   &__content {
-    flex: 1 0 50%;
+    flex: 0 1 50%;
     margin-inline: 1em;
 
     ul {


### PR DESCRIPTION
### Trello card

https://trello.com/c/Z6YZFaz3/3187-fix-horizontal-shift-on-new-navigation-pages-on-mobile

### Context

The promo flexbox was set to `1 0` rather than `0 1` so it was maintaining its width rather than shrinking. Also tidied up the CSS a little.
