### PR TITLE
Convert steps to be an ordered list

### DIFF
--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -26,22 +26,24 @@
 
           <% @front_matter.key?("steps") && @front_matter["steps"].tap do |steps_fm| %>
 
-            <div class="steps">
+            <ol class="steps">
               <% steps_fm.each.with_index(1) do |(title, contents), i| %>
                 <%= tag.section(class: "step", id: "step-#{i}") do %>
-                  <header class="step__header">
-                    <div class="step__number">
-                      <%= i %>
-                    </div>
-                    <%= tag.h2(title) %>
-                  </header>
+                  <li>
+                    <header class="step__header">
+                      <div class="step__number">
+                        <%= i %>
+                      </div>
+                      <%= tag.h2(title) %>
+                    </header>
 
-                  <div class="step__content">
-                    <%= render(partial: contents["partial"]) %>
-                  </div>
+                    <div class="step__content">
+                      <%= render(partial: contents["partial"]) %>
+                    </div>
+                  </li>
                 <% end %>
               <% end %>
-            </div>
+            </ol>
 
           <% end %>
 

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -2,6 +2,8 @@
   position: relative;
   margin: 0;
   box-sizing: border-box;
+  list-style: none;
+  padding: 0;
 
   &:before {
     content: "";
@@ -14,6 +16,10 @@
     @include mq($until: tablet) {
       left: 27px;
     }
+  }
+
+  ul {
+    list-style: disc;
   }
 
   * {


### PR DESCRIPTION
### Trello card

[Trello-3222](https://trello.com/c/dh1lZwnR/3222-dac-audit-no-list)

### Context

This was picked up on the DAC audit; they recommend this as an ordered list rather than sections.

### Changes proposed in this pull request

- Convert steps to be an ordered list

### Guidance to review

