### PR TITLE
Improve cookie dialog tabbing behaviour for screen readers

### DIFF
--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -23,8 +23,8 @@ export default class extends Controller {
     const cookiePrefs = new CookiePreferences();
     cookiePrefs.allowAll();
 
-    this.overlayTarget.classList.remove('visible');
     this.stopInterceptingTabKeydown();
+    this.overlayTarget.classList.remove('visible');
     this.resetFocus();
   }
 
@@ -37,22 +37,31 @@ export default class extends Controller {
     // focus then blur on the first link to prevent
     // the next element being tabbed to after accepting
     // being in the footer (which is where the cookie acceptance
-    // HTML is placed)
-    document.querySelector('a').focus();
-    document.querySelector('a').blur();
+    // HTML is placed). A small delay is required or Chromevox
+    // misses the re-focus and heads to the footer.
+    setTimeout(() => {
+      document.querySelector('a').focus();
+      document.querySelector('a').blur();
+    }, 150);
   }
 
   startInterceptingTabKeydown() {
     // by default these have a -1 tab index which
     // prevents the keydown event triggering on tab
-    this.agreeTarget.tabIndex = 1;
-    this.infoTarget.tabIndex = 2;
+    this.infoTarget.tabIndex = 1;
+    this.agreeTarget.tabIndex = 2;
     this.disagreeTarget.tabIndex = 3;
 
     this.keydownHandler = this.handleKeydown.bind(this);
     this.agreeTarget.addEventListener('keydown', this.keydownHandler);
     this.infoTarget.addEventListener('keydown', this.keydownHandler);
     this.disagreeTarget.addEventListener('keydown', this.keydownHandler);
+
+    // focus on info target to begin with; a small delay is required
+    // or Chromevox misses the focus call.
+    setTimeout(() => {
+      this.infoTarget.focus();
+    }, 150);
   }
 
   stopInterceptingTabKeydown() {
@@ -82,26 +91,26 @@ export default class extends Controller {
   focusOnNext(e) {
     switch (e.target) {
       case this.agreeTarget:
-        this.infoTarget.focus();
-        break;
-      case this.infoTarget:
         this.disagreeTarget.focus();
         break;
-      default:
+      case this.infoTarget:
         this.agreeTarget.focus();
+        break;
+      default:
+        this.infoTarget.focus();
     }
   }
 
   focusOnPrevious(e) {
     switch (e.target) {
       case this.agreeTarget:
-        this.disagreeTarget.focus();
-        break;
-      case this.disagreeTarget:
         this.infoTarget.focus();
         break;
-      default:
+      case this.disagreeTarget:
         this.agreeTarget.focus();
+        break;
+      default:
+        this.disagreeTarget.focus();
     }
   }
 

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -64,39 +64,39 @@ describe('CookieAcceptanceController', () => {
     });
 
     it('updates the tab indexes', () => {
-      expect(acceptButton.tabIndex).toEqual(1)
-      expect(infoButton.tabIndex).toEqual(2)
+      expect(infoButton.tabIndex).toEqual(1)
+      expect(acceptButton.tabIndex).toEqual(2)
       expect(disagreeButton.tabIndex).toEqual(3)
     })
 
     describe('tabbing behaviour', () => {
       describe('when the accept button has focus', () => {
-        it('tabs to the info link and from the disagree button', () => {
+        it('tabs to the disagree button and from the info button', () => {
           acceptButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
-          expect(infoButton).toEqual(document.activeElement);
+          expect(disagreeButton).toEqual(document.activeElement);
 
           acceptButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
-          expect(disagreeButton).toEqual(document.activeElement);
+          expect(infoButton).toEqual(document.activeElement);
         })
       });
 
       describe('when the info link has focus', () => {
-        it('tabs to the disagree button and from the agree button', () => {
+        it('tabs to the agree button and from the disagree button', () => {
           infoButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
-          expect(disagreeButton).toEqual(document.activeElement);
+          expect(acceptButton).toEqual(document.activeElement);
 
           infoButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
-          expect(acceptButton).toEqual(document.activeElement);
+          expect(disagreeButton).toEqual(document.activeElement);
         })
       });
 
       describe('when the disagree link has focus', () => {
-        it('tabs to the accept button and from the info button', () => {
+        it('tabs to the info button and from the agree button', () => {
           disagreeButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
-          expect(acceptButton).toEqual(document.activeElement);
+          expect(infoButton).toEqual(document.activeElement);
 
           disagreeButton.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, shiftKey: true }));
-          expect(infoButton).toEqual(document.activeElement);
+          expect(acceptButton).toEqual(document.activeElement);
         })
       });
     });


### PR DESCRIPTION
### Trello card

[Trello-3223](https://trello.com/c/opOhwZxQ/3223-dac-audit-focus-order-cookie-pop-up)

### Context

Our current tabbing behaviour is accept button -> cookie link -> preferences button.

The DAC accessibility audit suggests a better tabbing order to be cookie link -> accept button -> preferences button.

### Changes proposed in this pull request

- Improve cookie dialog tabbing behaviour for screen readers

### Guidance to review

I also noticed while testing with Chromevox that it often misses the programatic re-focus made on initially showing the modal and dismissing it.

Adding a small delay before we do this after opening/closing the dialog seems to make it more reliable.
