### PR TITLE
Allow hero title background color to be customised

### DIFF
--- a/app/components/header/hero_component.html.erb
+++ b/app/components/header/hero_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(class: classes) do %>
   <%= picture %>
-  <div class="hero__title">
+  <div class="hero__title <%= @title_bg_color %>">
     <h1><%= tag.span(title) %></h1>
   </div>
   <% if show_subtitle? %>

--- a/app/components/header/hero_component.rb
+++ b/app/components/header/hero_component.rb
@@ -1,6 +1,6 @@
 module Header
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph
+    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph, :title_bg_color
 
     def initialize(front_matter)
       return if front_matter.blank?
@@ -14,6 +14,7 @@ module Header
         @subtitle_button = fm["subtitle_button"]
         @image           = fm["image"]
         @paragraph       = fm["title_paragraph"]
+        @title_bg_color  = fm["title_bg_color"] || "yellow"
       end
     end
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -151,6 +151,10 @@ $mobile-cutoff: 800px;
   &__title {
     z-index: 20;
 
+    &.white h1 {
+      background-color: $white;
+    }
+
     h1 {
       background-color: $yellow-dark;
       padding: .8em .75em .8em 1.75em;

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -19,8 +19,8 @@ describe Header::HeroComponent, type: "component" do
 
   describe "rendering a hero section" do
     describe "title and subtitle" do
-      specify "renders the title in a h1 element" do
-        expect(page).to have_css(".hero__title > h1", text: front_matter["title"])
+      specify "renders the title in a h1 element with a yellow background" do
+        expect(page).to have_css(".hero__title.yellow > h1", text: front_matter["title"])
       end
 
       context "when the heading overrides the title" do
@@ -28,6 +28,14 @@ describe Header::HeroComponent, type: "component" do
 
         specify "renders the heading in a h1 element" do
           expect(page).to have_css(".hero__title > h1", text: front_matter["heading"])
+        end
+      end
+
+      context "when the title background is overriden" do
+        let(:extra_front_matter) { { "title_bg_color" => "white" } }
+
+        specify "renders the heading with the color class" do
+          expect(page).to have_css(".hero__title.white > h1", text: front_matter["heading"])
         end
       end
 


### PR DESCRIPTION
### Trello card

[Trello-3154](https://trello.com/c/uyhjy2Sn/3154-implement-a-flexible-header-and-standardise-across-the-site)

### Context

As part of the new category pages we are adding to the website we want to be able to restyle the hero section title background colour from yellow (default) to white.

Allow the hero title background colour to be customised in front matter. Default to yellow.

### Changes proposed in this pull request

- Allow hero title background color to be customised

### Guidance to review

Example (not changed in PR):

<img width="1313" alt="Screenshot 2022-05-10 at 10 48 53" src="https://user-images.githubusercontent.com/29867726/167600945-befa475d-ebc3-4822-8f9e-9c077d98d650.png">
