### PR TITLE
Make pagination component accessible

### DIFF
--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,5 +8,6 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
+  <span class="visually-hidden"><%= page.current? ? "Current page" : "Page" %>:</span>
   <%= link_to_unless page.current?, page, url, { remote: remote, rel: page.rel } %>
 </span>


### PR DESCRIPTION
### Trello card

[Trello-429](https://trello.com/c/QHcrgFN3/429-dac-audit-current-page-location)

### Context

Screen readers only read out the page number when they get to the pagination component which doesn't provide enough context. Instead, we should prefix the number with "Page" or "Current page".

### Changes proposed in this pull request

- Make pagination component accessible

### Guidance to review

