### PR TITLE
Ensure dialog cannot be accessed by screen readers when dismissed

### DIFF
--- a/app/webpacker/styles/dialog.scss
+++ b/app/webpacker/styles/dialog.scss
@@ -8,7 +8,7 @@
 }
 
 .dialog {
-  display: flex;
+  display: none;
   position: fixed;
   left: 0;
   top: 0;
@@ -17,10 +17,9 @@
   z-index: 1000;
   justify-content: center;
   align-items: center;
-  transform: translateY(110vh);
 
   &.visible {
-    animation: slide-up 0s forwards;
+    display: flex;
   }
 
   &__background {


### PR DESCRIPTION
### Trello card

[Trello-3232](https://trello.com/c/JmquPZQn/3232-dac-audit-bleed-through)

### Context

Currently the dialog is 'hidden' by pushing it out of the browser viewport. This hides it from the page but not from screen readers, which are still able to access it via tabbing (even though the `tabindex` is `-1` - I couldn't replicate the issue but it was reported by DAC so may be another screen reader).

To fix this we can ensure the element is hidden with `display: none;`.

### Changes proposed in this pull request

- Ensure dialog cannot be accessed by screen readers when dismissed

### Guidance to review

