### PR TITLE
Return focus after minimizing chat window

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -32,6 +32,7 @@ export default class extends Controller {
   }
 
   start(e) {
+    this.previousTarget = e.target;
     e.preventDefault();
     this.loadChat();
   }
@@ -87,6 +88,14 @@ export default class extends Controller {
 
   showWebWidget() {
     window.$zopim.livechat.window.show();
+    window.$zopim.livechat.window.onHide(() => {
+      // Return focus back to where it was before opening
+      // the chat widget.
+      if (this.previousTarget) {
+        this.previousTarget.focus();
+        this.previousTarget.blur();
+      }
+    });
   }
 
   get zendeskScriptLoaded() {

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -7,6 +7,7 @@ describe('ChatController', () => {
   afterEach(() => jest.useRealTimers());
 
   let chatShowSpy;
+  let chatOnHideSpy;
 
   const setBody = () => {
     document.body.innerHTML = `
@@ -41,7 +42,8 @@ describe('ChatController', () => {
   describe('when the chat is online', () => {
     beforeEach(() => {
       chatShowSpy = jest.fn();
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy } } } }));
+      chatOnHideSpy = jest.fn();
+      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy, onHide: chatOnHideSpy } } } }));
 
       setBody();
       setCurrentTime('2021-01-01 10:00');


### PR DESCRIPTION
### Trello card

[Trello-3231](https://trello.com/c/iYuu9qip/3231-dac-audit-focus-order-webchat)

### Context

Currently if you open the Zendesk chat and minimize it the focus returns to the top of the page. Instead, we should remember the position of the focus prior to opening the chat (most likely the 'Chat online' button) and return focus there
when the user hides the chat session.

### Changes proposed in this pull request

- Return focus after minimizing chat window

### Guidance to review

