### PR TITLE
Use h2 tag for funding heading

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -1,6 +1,6 @@
 <div class="call-to-action call-to-action--funding-widget">
   <div class="call-to-action__content">
-    <span class="call-to-action__heading">What funding could I get for teacher training?</span>
+    <h2 class="call-to-action__heading">What funding could I get for teacher training?</h2>
 
     <div class="call-to-action__text">
       <div class="call-to-action__form">

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -260,6 +260,7 @@
       padding: 0.5em 1.25em;
       margin-left: -22px;
       margin-bottom: 1.5em;
+      max-width: none;
     }
     .call-to-action__content {
       background-color: $grey;


### PR DESCRIPTION
### Trello card

[Trello-3235](https://trello.com/c/3pgULjYn/3235-dac-audit-visual-headings-funding-widget)

### Context

This was picked up in the DAC report; it makes sense semantically for it to be a `h2` tag.

### Changes proposed in this pull request

- Use h2 tag for funding heading

### Guidance to review

[See funding page](https://review-get-into-teaching-app-2530.london.cloudapps.digital/funding-your-training)