### PR TITLE
Use h2 tag for next steps heading

### DIFF
--- a/app/components/calls_to_action/next_steps_component.html.erb
+++ b/app/components/calls_to_action/next_steps_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(class: %w[call-to-action call-to-action--next-steps]) do %>
 
   <div class="call-to-action__content">
-    <%= tag.span("Get support from an adviser", class: "call-to-action__heading") %>
+    <%= tag.h2("Get support from an adviser", class: "call-to-action__heading") %>
 
     <div class="call-to-action__action">
       <p class="call-to-action__text">


### PR DESCRIPTION
### Trello card

[Trello-3236](https://trello.com/c/QCEXtbCm/3236-dac-audit-visual-headings-get-support-from-an-adviser)

### Context

The DAC report picked up on this; we should be using `h2` tag here to be semantically correct.

### Changes proposed in this pull request

- Use h2 tag for next steps heading

### Guidance to review

Test on [this page](https://review-get-into-teaching-app-2531.london.cloudapps.digital/steps-to-become-a-teacher) and [this page](https://review-get-into-teaching-app-2531.london.cloudapps.digital/presentations)