### PR TITLE
Ensure links have sufficient contrast on focus

### DIFF
--- a/app/components/footer/mailing_list_component.html.erb
+++ b/app/components/footer/mailing_list_component.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="mailing-list-bar__right">
       <a id="mailing-list-bar-accept" href="/mailinglist/signup/name" class="mailing-list-bar__sign-up button button--white button--nowrap" data-action="click->mailing-list#beginMailingListJourney">Sign up here</a>
-      <a id="mailing-list-bar-dismiss" href="javascript:void(0)" class="mailing-list-bar__close" data-action="click->mailing-list#dismiss" role="button">Not now</a>
+      <a id="mailing-list-bar-dismiss" href="javascript:void(0)" class="mailing-list-bar__close git-link white underline" data-action="click->mailing-list#dismiss" role="button">Not now</a>
     </div>
   </div>
 </div>

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -17,7 +17,7 @@
                 <%= tag.h2(@front_matter.dig("featured_page", "heading")) %>
                 <%= tag.span(@front_matter.dig("featured_page", "subheading"), class: "stories-feature__subheading") %>
                 <%= tag.p(@front_matter.dig("featured_page", "text")) %>
-                <%= link_to(@front_matter.dig("featured_page", "link", "text"), @front_matter.dig("featured_page", "link", "path"), class: "git-link") %>
+                <%= link_to(@front_matter.dig("featured_page", "link", "text"), @front_matter.dig("featured_page", "link", "path"), class: "git-link white") %>
               </div>
             </section>
           <% end %>

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -24,4 +24,4 @@ $red: #d4351c;
 
 // NOT PART OF THE OFFICIAL COLOUR SCHEME
 $dark-cyan: #008b8b; // used for tags
-$blue-very-dark: #0062a3; // passes accessibility contrast check on $grey
+$blue-very-dark: #003152; // passes accessibility contrast check on $grey/$yellow

--- a/app/webpacker/styles/components/chat.scss
+++ b/app/webpacker/styles/components/chat.scss
@@ -11,7 +11,6 @@
     word-break: break-all;
 
     &.button {
-      color: $white;
       margin-bottom: 0;
     }
   }

--- a/app/webpacker/styles/components/content-alert.scss
+++ b/app/webpacker/styles/components/content-alert.scss
@@ -25,7 +25,7 @@
   }
 
   a {
-    color: $white;
+    @extend .git-link, .white, .underline;
   }
 
   &__icon {

--- a/app/webpacker/styles/components/events/no-results.scss
+++ b/app/webpacker/styles/components/events/no-results.scss
@@ -6,15 +6,15 @@
   box-sizing: border-box;
   margin: 0 0 1.5em;
 
-  a {
-    color: $white;
-  }
-
   p {
     margin: 0px 0px 10px 0px;
   }
 
   .button {
     padding: 10px 1.5rem;
+  }
+
+  a:not(.button) {
+    @extend .git-link, .white, .underline;
   }
 }

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -96,7 +96,7 @@ a {
   }
 }
 
-// passes accessibility contrast check on grey background
+// passes accessibility contrast check on grey/yellow background
 @mixin dark-link {
   color: $blue-very-dark;
 }

--- a/app/webpacker/styles/mailing-list-bar.scss
+++ b/app/webpacker/styles/mailing-list-bar.scss
@@ -49,13 +49,6 @@
   &__close {
     margin-left: 1em;
     padding: .5em;
-    color: $white;
     font-weight: bold;
-    text-underline-offset: .2em;
-
-    &:hover {
-      color: $white;
-      text-decoration: none;
-    }
   }
 }

--- a/app/webpacker/styles/stories.scss
+++ b/app/webpacker/styles/stories.scss
@@ -59,10 +59,6 @@
     margin: auto $indent-amount;
     padding-bottom: 2em;
 
-    a.git-link {
-      color: $white;
-    }
-
     @include mq($from: tablet) {
       flex-shrink: 1;
       padding-left: 1em;

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -99,6 +99,27 @@ a {
     height: 19px;
     margin-left: 8px;
   }
+
+  &.white {
+    color: $white;
+
+    &:focus {
+      color: $black;
+    }
+  }
+
+  &.underline {
+    text-decoration: underline;
+    text-underline-offset: .2em;
+
+    &:hover, &:focus {
+      text-decoration: none;
+    }
+
+    &:after {
+      content: none;
+    }
+  }
 }
 
 .strong {


### PR DESCRIPTION
### Trello card

[Trello-3230](https://trello.com/c/8fA6EVmX/3230-dac-audit-colour-contrast-text)

### Context

Our links aren't standard across the site and fail on contrast checks in places.

### Changes proposed in this pull request

- Fix chat online button focus state

I'm not sure why the `color: white` was necessary here originally but its not any longer and it was overriding the focus state
causing white text on yellow background which is a contrast issue.

Remove specific text color styling to use defaults (remains white but has black on orange for focus state).

- Standardise white link focus states

We have white links op dark backgrounds in a number of places; mostly with custom CSS rules that don't correctly set the focus state to use black text (on an yellow background).

This aims to somewhat standardise the links through the `git-link` class. 

- Tweak focus dark blue color for contrast

We have a dark blue we use on some links to ensure sufficient contrast with the grey background. DAC picked up that the
contrast is still lacking when used in a focus state on a yellow background.

Darken the blue color to meet AAA accessibility contrast ratios.

### Guidance to review

More could definitely be done to clean up the links in general but I'll leave that for another day; this is primarily to fix the accessibility issues identified by DAC.