### PR TITLE
Make completed wizard step headings h1 tags

### DIFF
--- a/app/components/content/generic_block_component.html.erb
+++ b/app/components/content/generic_block_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div(class: classes) do %>
   <%= icon %>
-  <%= tag.h3(title) %>
+  <%= tag.h2(title) %>
   <%= content %>
 <% end %>

--- a/app/components/registration/mailing_list_signup_confirmation_component.html.erb
+++ b/app/components/registration/mailing_list_signup_confirmation_component.html.erb
@@ -1,5 +1,5 @@
 <section class="text-content mailing-list__completed">
-  <%= tag.h2(heading_text, class: 'green') %>
+  <%= tag.h1(heading_text, class: 'completed') %>
 
   <p>
     We'll send your first email shortly. From teacher stories to practical

--- a/app/components/single_question_survey_component.html.erb
+++ b/app/components/single_question_survey_component.html.erb
@@ -1,5 +1,5 @@
 <div id="event_survey" data-controller="feedback">
-  <h3><%= question %></h3>
+  <h2><%= question %></h2>
   <div class="govuk-hint" data-feedback-target="text"><%= hint %></div>
   <p>
     <% answers.each do |answer| %>

--- a/app/views/callbacks/steps/completed.html.erb
+++ b/app/views/callbacks/steps/completed.html.erb
@@ -1,7 +1,7 @@
 <% @hide_page_helpful_question = true %>
 
 <section class="text-content">
-  <h2 class="green">Callback confirmed</h2>
+  <h1 class="completed">Callback confirmed</h1>
 
   <h3>What happens next</h3>
 

--- a/app/views/callbacks/steps/completed.html.erb
+++ b/app/views/callbacks/steps/completed.html.erb
@@ -3,7 +3,7 @@
 <section class="text-content">
   <h1 class="completed">Callback confirmed</h1>
 
-  <h3>What happens next</h3>
+  <h2>What happens next</h2>
 
   <p>One of our agents will call you within 30 minutes of <%= params[:date] %> at <%= params[:time] %>.</p>
 

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -1,7 +1,7 @@
 <% @hide_page_helpful_question = true %>
 
 <section class="text-content">
-  <h2 class="green">Sign up complete</h2>
+  <h1 class="completed">Sign up complete</h2>
 
   <%= tag.h3("You are signed up for #{@event.name}.") %>
 

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -3,7 +3,7 @@
 <section class="text-content">
   <h1 class="completed">Sign up complete</h2>
 
-  <%= tag.h3("You are signed up for #{@event.name}.") %>
+  <%= tag.h2("You are signed up for #{@event.name}.") %>
 
   <p><%= format_event_date @event, stacked: false %></p>
 
@@ -13,7 +13,7 @@
     <p>You're ready to receive email updates to help you get into teaching.</p>
   <%- end -%>
 
-  <h3>What happens next?</h3>
+  <h2>What happens next?</h3>
   <p>
     You will receive a confirmation email with details of the event. If there
     is an issue with the event we will contact you via phone.

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -12,7 +12,7 @@
       You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.
     </p>
 
-    <h3>Want to talk to someone?</h3>
+    <h2>Want to talk to someone?</h2>
 
     <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
 

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -6,7 +6,7 @@
   <%= render(Registration::MailingListSignupConfirmationComponent.new(mailing_list_session)) %>
 <% else %>
   <section class="text-content">
-    <h2 class="green">You've signed up</h2>
+    <h1 class="completed">You've signed up</h1>
 
     <p>
       You'll receive a welcome email shortly. If your circumstances change, you can let us know at any time.

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -8,6 +8,19 @@
     @extend h2, .green;
   }
 
+  .text-content h2 {
+    color: $black;
+    background-color: transparent;
+    display: block;
+    padding: 0;
+    @include font-size("medium");
+  }
+
+  #event_survey h2 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
   .registration__event,
   .registration__mailing-list,
   .registration__callback {

--- a/app/webpacker/styles/registration.scss
+++ b/app/webpacker/styles/registration.scss
@@ -3,6 +3,11 @@
     margin-top: 2em;
   }
 
+  h1.completed {
+    @include font-size("medium");
+    @extend h2, .green;
+  }
+
   .registration__event,
   .registration__mailing-list,
   .registration__callback {

--- a/spec/components/content/generic_block_component_spec.rb
+++ b/spec/components/content/generic_block_component_spec.rb
@@ -15,7 +15,7 @@ describe Content::GenericBlockComponent, type: "component" do
   let(:icon_size) { "30x50" }
 
   it { is_expected.to have_css("div.#{custom_class}") }
-  it { is_expected.to have_css("h3", text: title) }
+  it { is_expected.to have_css("h2", text: title) }
   it { is_expected.to have_content(content) }
   it { is_expected.to have_css(%(img[width="30"])) }
   it { is_expected.to have_css(%(img[height="50"])) }

--- a/spec/components/single_question_survey_component_spec.rb
+++ b/spec/components/single_question_survey_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SingleQuestionSurveyComponent, type: :component do
 
     describe "quesiton" do
       it "renders the question in a heading" do
-        expect(page).to have_css("h3", text: "What is your favourite colour?")
+        expect(page).to have_css("h2", text: "What is your favourite colour?")
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3241](https://trello.com/c/148ske6v/3241-dac-audit-missing-main-heading)

### Context

DAC have raised this; as there are no other headings on the page we should promote these to be `h1` tags.

### Changes proposed in this pull request

- Make completed wizard step headings h1 tags

- Correct document heading structure

As the completed page heading is how a `h1` tag (albeit styled like a `h2` tag) the subsequent headings should be `h2` tags (styled as `h3` tags!).

We need to look at the headings more widely to standardise some of this further.

### Guidance to review

Relevant pages: [mailing list completed](https://review-get-into-teaching-app-2533.london.cloudapps.digital/mailinglist/signup/completed) [callback completed](https://review-get-into-teaching-app-2533.london.cloudapps.digital/callbacks/book/completed) [event completed](https://review-get-into-teaching-app-2533.london.cloudapps.digital/events/train-to-teach-manchester-event-040922/apply/completed)