### PR TITLE
Make contact option titles heading tags

### DIFF
--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -8,12 +8,12 @@
             <div class="options">
               <% unless helpers.privacy_page?(request.path) %>
               <div class="live-chat">
-                <p>Live chat</p>
+                <h3>Live chat</h3>
                 <%= render ChatComponent.new %>
               </div>
               <% end %>
               <div>
-                <p>Call us</p>
+                <h3>Call us</h3>
                 <p class="telephone">0800 389 2500</p>
               </div>
             </div>

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -36,6 +36,10 @@
           > div {
             flex: 1 0;
 
+            h3 {
+              font-weight: normal;
+            }
+
             &.live-chat {
               word-break: break-all;
               border-bottom: 1px solid $purple;


### PR DESCRIPTION
### Trello card

[Trello-3239](https://trello.com/c/DBpGdmX7/3239-dac-audit-section-missing-heading-talk-to-us)

### Context

DAC have raised that the titles in the contact section for 'live chat' and 'call us' should be heading tags; `h3` makes
sense here. 

### Changes proposed in this pull request

- Make contact option title heading tags

### Guidance to review

