### PR TITLE
Ensure a pointer cursor is used on all buttons

### DIFF
--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -21,6 +21,10 @@ input {
   padding-right: .4em;
 }
 
+button, input[type=submit] {
+  cursor: pointer;
+}
+
 form {
   .govuk-label,
   h3.govuk-fieldset__heading {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -41,6 +41,7 @@ a {
   @include button;
   @include chevron;
   display: inline-block;
+  cursor: pointer;
 
   &:disabled {
     opacity: 0.7;


### PR DESCRIPTION
### Trello card

[Trello-3242](https://trello.com/c/wbt0nJbu/3242-dac-audit-missing-mouse-pointer)

### Context

DAC suggest that a pointer type cursor is used on all buttons to indicate to users that they are clickable.

### Changes proposed in this pull request

- Ensure a pointer cursor is used on all buttons

### Guidance to review

It's worth noting that this goes against the CSS recommendations/standard, which suggests a cursor type pointer
should only be used for "clickable links". Buttons have a high affordance and therefore the pointer cursor is not necessary
(i.e. its obvious you can click on it because it looks like a button).