### PR TITLE
Enable hero background colour to be customised

### DIFF
--- a/app/components/header/hero_component.rb
+++ b/app/components/header/hero_component.rb
@@ -1,6 +1,6 @@
 module Header
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph, :title_bg_color
+    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph, :title_bg_color, :hero_bg_color
 
     def initialize(front_matter)
       return if front_matter.blank?
@@ -15,11 +15,12 @@ module Header
         @image           = fm["image"]
         @paragraph       = fm["title_paragraph"]
         @title_bg_color  = fm["title_bg_color"] || "yellow"
+        @hero_bg_color = fm["hero_bg_color"] || "grey"
       end
     end
 
     def classes
-      %w[hero]
+      %w[hero] + [hero_bg_color]
     end
 
     def render?

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -148,6 +148,14 @@ $mobile-cutoff: 800px;
   background-color: $grey;
   overflow: hidden;
 
+  &.white {
+    background-color: $white;
+  }
+
+  &.yellow {
+    background-color: $yellow-dark;
+  }
+
   &__title {
     z-index: 20;
 

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -18,6 +18,20 @@ describe Header::HeroComponent, type: "component" do
   let(:component) { described_class.new(front_matter) }
 
   describe "rendering a hero section" do
+    describe "background" do
+      specify "renders with a grey background" do
+        expect(page).to have_css(".hero.grey")
+      end
+
+      context "when the hero background is overriden" do
+        let(:extra_front_matter) { { "hero_bg_color" => "white" } }
+
+        specify "renders the hero with the color class" do
+          expect(page).to have_css(".hero.white")
+        end
+      end
+    end
+
     describe "title and subtitle" do
       specify "renders the title in a h1 element with a yellow background" do
         expect(page).to have_css(".hero__title.yellow > h1", text: front_matter["title"])


### PR DESCRIPTION
### Trello card

[Trello-3154](https://trello.com/c/uyhjy2Sn/3154-implement-a-flexible-header-and-standardise-across-the-site?filter=member:rossoliver15)

### Context

For some of the website pages we want to have a yellow or white background to
the hero section (defaulting to the current grey background).

### Changes proposed in this pull request

- Enable hero background colour to be customised

### Guidance to review

Example page:

| White Background      | Yellow Background |
| ----------- | ----------- |
| <img width="1434" alt="Screenshot 2022-05-16 at 10 09 26" src="https://user-images.githubusercontent.com/29867726/168558847-f1f165ba-0cfe-4610-9826-b877313f278b.png">      | <img width="1432" alt="Screenshot 2022-05-16 at 10 10 33" src="https://user-images.githubusercontent.com/29867726/168559049-d5462909-266f-47bd-9681-e495f45b71af.png">       |


