### PR TITLE
Disable Google Optimize on events pages

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -6,8 +6,4 @@
 #   - /events
 #   - /
 
-paths:
-  - /test/a
-  - /test/b
-  - /events
-  - /teaching-events
+paths: []

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -205,7 +205,7 @@ describe ApplicationHelper do
   describe "#google_optimize_config" do
     subject { google_optimize_config }
 
-    it { is_expected.to eq({ paths: ["/test/a", "/test/b", "/events", "/teaching-events"] }) }
+    it { is_expected.to eq({ paths: [] }) }
   end
 
   describe "#sentry_dsn" do


### PR DESCRIPTION
### Trello card

[Trello-3252](https://trello.com/c/oLyDgnKx/3252-remove-optimize-script-from-events-page)

### Context

We are no longer running the Google Optimize experiment, however we are still loading the script on the events landing pages. As Google Optimize has an anti-flicker behaviour built in this is resulting in a short flash of a white page that blocks the event page momentarily.

Remove Google Optimize from events page so that they load faster/without a minor delay.

### Changes proposed in this pull request

- Disable Google Optimize on events page

### Guidance to review

Both variants of the events pages should still be accessible directly (and it should default to the original design).