### PR TITLE
Allow blending the main content with the hero section

### DIFF
--- a/app/components/header/hero_component.rb
+++ b/app/components/header/hero_component.rb
@@ -1,6 +1,6 @@
 module Header
   class HeroComponent < ViewComponent::Base
-    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph, :title_bg_color, :hero_bg_color
+    attr_accessor :title, :subtitle, :image, :show_mailing_list, :paragraph, :title_bg_color, :hero_bg_color, :hero_blend_content
 
     def initialize(front_matter)
       return if front_matter.blank?
@@ -8,19 +8,22 @@ module Header
       super
 
       front_matter.with_indifferent_access.tap do |fm|
-        @title           = fm["heading"] || fm["title"]
-        @subtitle        = fm["subtitle"]
-        @subtitle_link   = fm["subtitle_link"]
-        @subtitle_button = fm["subtitle_button"]
-        @image           = fm["image"]
-        @paragraph       = fm["title_paragraph"]
-        @title_bg_color  = fm["title_bg_color"] || "yellow"
-        @hero_bg_color = fm["hero_bg_color"] || "grey"
+        @title              = fm["heading"] || fm["title"]
+        @subtitle           = fm["subtitle"]
+        @subtitle_link      = fm["subtitle_link"]
+        @subtitle_button    = fm["subtitle_button"]
+        @image              = fm["image"]
+        @paragraph          = fm["title_paragraph"]
+        @title_bg_color     = fm["title_bg_color"] || "yellow"
+        @hero_bg_color      = fm["hero_bg_color"] || "grey"
+        @hero_blend_content = fm["hero_blend_content"] || false
       end
     end
 
     def classes
-      %w[hero] + [hero_bg_color]
+      ["hero", hero_bg_color].tap do |c|
+        c << "blend-content" if hero_blend_content
+      end
     end
 
     def render?

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -4,7 +4,7 @@ heading: "Salaries and benefits"
 description: |-
   Teacher starting salaries are between £25,714 and £32,157, depending where you teach. Find out about teacher pay scales, pensions and benefits here.
 date: "2021-06-24"
-image: "media/images/content/hero-images/0007.jpg"
+image: "media/images/content/hero-images/0008.jpg"
 backlink: "../../"
 navigation: 40
 right_column:

--- a/app/views/content/train-to-be-a-teacher.md
+++ b/app/views/content/train-to-be-a-teacher.md
@@ -14,7 +14,7 @@ layout: "layouts/category"
 content:
     - content/train-to-be-a-teacher/questions
     - content/train-to-be-a-teacher/why-teach
-image: "media/images/content/hero-images/0008.jpg"
+image: "media/images/content/hero-images/0007.jpg"
 hero_blend_content: true
 hero_bg_color: yellow
 title_bg_color: white

--- a/app/views/content/train-to-be-a-teacher.md
+++ b/app/views/content/train-to-be-a-teacher.md
@@ -15,6 +15,9 @@ content:
     - content/train-to-be-a-teacher/questions
     - content/train-to-be-a-teacher/why-teach
 image: "media/images/content/hero-images/0008.jpg"
+hero_blend_content: true
+hero_bg_color: yellow
+title_bg_color: white
 ---
 
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -156,6 +156,18 @@ $mobile-cutoff: 800px;
     background-color: $yellow-dark;
   }
 
+  &.blend-content {
+    padding-bottom: 4em;
+
+    @include mq($from: tablet) {
+      padding-bottom: 6em;
+    }
+
+    &+ main > section {
+      margin-top: -4em;
+    }
+  }
+
   &__title {
     z-index: 20;
 

--- a/spec/components/header/hero_component_spec.rb
+++ b/spec/components/header/hero_component_spec.rb
@@ -18,6 +18,16 @@ describe Header::HeroComponent, type: "component" do
   let(:component) { described_class.new(front_matter) }
 
   describe "rendering a hero section" do
+    describe "content blending" do
+      context "when the hero is set to blend with the content" do
+        let(:extra_front_matter) { { "hero_blend_content" => true } }
+
+        specify "renders the hero with the content blended in" do
+          expect(page).to have_css(".hero.blend-content")
+        end
+      end
+    end
+
     describe "background" do
       specify "renders with a grey background" do
         expect(page).to have_css(".hero.grey")


### PR DESCRIPTION
### Trello card

[Trello-3154](https://trello.com/c/uyhjy2Sn/3154-implement-a-flexible-header-and-standardise-across-the-site)

### Context

On some pages we want to blend the main content into the hero section by having it overlap. To complicate things the background of the main section may be different to the hero, so we need to instead target the first section of 'real
content'.

### Changes proposed in this pull request

- Allow blending the main content with the hero section
- Blend content on the the train to be a teacher page

### Guidance to review

I don't think there's a nice way of doing this; the only other thing I could think of was to bring the content into the header section so that we could eliminate the negative-margin but that felt worse than targeting the siblings first child in CSS. Open to suggestions 🙈 

| Desktop      | Mobile |
| ----------- | ----------- |
| <img width="1098" alt="Screenshot 2022-05-18 at 14 47 46" src="https://user-images.githubusercontent.com/29867726/169055096-9d3de74e-5b21-496b-affb-83bafcd1e265.png">      | <img width="735" alt="Screenshot 2022-05-18 at 14 47 25" src="https://user-images.githubusercontent.com/29867726/169054970-8effdd6d-bdea-45c2-963f-e3800c092984.png">       |