### PR TITLE
Hide mail icon from screen readers

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -2,7 +2,7 @@
   <ul class="extra-navigation__list">
     <li class="extra-navigation__link">
       <%= link_to("/mailinglist/signup/name" ) do %>
-      Register your interest <span class="icon icon-mail"></span>
+      Register your interest <span class="icon icon-mail" aria-hidden="true"></span>
       <% end %>
     </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>


### PR DESCRIPTION
### Trello card

[Trello-3260](https://trello.com/c/KpZgHkAh/3260-dac-audit-decorative-css-images)

### Context

Currently a screen reader will focus on the icon and read out 'bullet' (as its a font-based icon). This isn't very helpful and there is associated link text that gets read out so we should just be hiding this from screen readers.

### Changes proposed in this pull request

- Hide mail icon from screen readers

### Guidance to review

