### PR TITLE
Update images in train to be a teacher sections

### DIFF
--- a/app/components/calls_to_action/promo/left_section.html.erb
+++ b/app/components/calls_to_action/promo/left_section.html.erb
@@ -1,4 +1,4 @@
-<div class="promo__left">
+<div class="<%= wrapper_classes %>">
   <div>
     <h2>
       <% if caption %>

--- a/app/components/calls_to_action/promo/left_section.rb
+++ b/app/components/calls_to_action/promo/left_section.rb
@@ -1,12 +1,17 @@
 class CallsToAction::Promo::LeftSection < ViewComponent::Base
-  attr_reader :caption, :heading, :link_text, :link_target
+  attr_reader :caption, :heading, :link_text, :link_target, :classes
 
-  def initialize(heading:, caption: nil, link_text: nil, link_target: nil)
+  def initialize(heading:, caption: nil, link_text: nil, link_target: nil, classes: [])
     @caption = caption
     @heading = heading
     @link_text = link_text
     @link_target = link_target
+    @classes = classes
 
     super
+  end
+
+  def wrapper_classes
+    (classes + %w[promo__left]).join(" ")
   end
 end

--- a/app/views/content/train-to-be-a-teacher/promos/_get-adviser-promo.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_get-adviser-promo.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Get an adviser") do %>
+      heading: "Get an adviser", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(

--- a/app/views/content/train-to-be-a-teacher/promos/_learn-adviser-promo.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_learn-adviser-promo.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Teacher training advisers") do %>
+      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Advice and support in your inbox") do %>
+      heading: "Advice and support in your inbox", classes: %w[ml-background]) do %>
   <% end %>
 
   <% promo.right_section(

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -135,6 +135,16 @@
     gap: .5em;
     padding-block: 2em;
 
+    &.tta-background {
+      background-image: url("../images/content/homepage/teacher-training-adviser.jpg");
+      background-position-y: 20%;
+    }
+
+    &.ml-background {
+      background-image: url("../images/content/hero-images/0015.jpg");
+      background-position-y: 20%;
+    }
+
     > div {
       padding: 0 1em .3em 1em;
       max-width: 60%;

--- a/spec/components/calls_to_action/promo/promo_component_spec.rb
+++ b/spec/components/calls_to_action/promo/promo_component_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe CallsToAction::Promo::PromoComponent, type: :component do
 
       it { is_expected.not_to have_css(".promo__left a") }
     end
+
+    context "when classes are provided" do
+      let(:left_args) { { heading: "heading", classes: %w[one two three] } }
+
+      it {
+        is_expected.to have_css(".promo__left.one.two.three")
+      }
+    end
   end
 
   describe "right side" do


### PR DESCRIPTION
### Trello card

[Trello-3184](https://trello.com/c/nyaNmwad/3184-update-images-on-the-new-nav-promo-sections)

### Context

The events promos had the correct images, however the adviser and mailing list promos should have alternate background images.

### Changes proposed in this pull request

- Update images in train to be a teacher sections

### Guidance to review

