### PR TITLE
Add border to buttons for high contrast mode

### DIFF
--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -21,6 +21,10 @@
   display: block;
   overflow-x: clip;
 
+  @media (forced-colors: active) {
+    forced-color-adjust: none;
+  }
+
   a {
     text-decoration: none;
     display: block;

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -8,6 +8,10 @@
   @include font-size("small");
   border: none;
 
+  @media (forced-colors: active) {
+    border: 2px solid transparent;
+  }
+
   &:hover {
     background: darken($bg, 5%);
     color: $fg;


### PR DESCRIPTION
### Trello card

[Trello-3254](https://trello.com/c/getLeIBt/3254-dac-audit-inverted-hit-area)

### Context

When in Windows High Contrast mode the buttons are indistinguishable from the background. To get around this we can add a transparent border that will differentiate the component in High Contrast Mode.

### Changes proposed in this pull request

- Add border to buttons for high contrast mode

### Guidance to review

We use a media query to apply this only when high contrast is enabled as it results in a minor misalignment of buttons due to the 2px border width.

![Screenshot (7)](https://user-images.githubusercontent.com/29867726/170059164-dc19fa2b-2764-4e02-bd25-5aba416cf6bf.png)

![Screenshot (8)](https://user-images.githubusercontent.com/29867726/170059180-f65f1a02-257c-48a6-8e15-071cb1a15fad.png)

