### PR TITLE
Revert changes to postcode step

### DIFF
--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -2,26 +2,15 @@ module MailingList
   module Steps
     class Postcode < ::DFEWizard::Step
       attribute :address_postcode
-      attribute :send_event_emails, :boolean
 
-      validates :send_event_emails, inclusion: { in: [true, false] }
       validates :address_postcode, postcode: true
-      validates :address_postcode, presence: true, if: -> { send_event_emails }
 
       before_validation if: :address_postcode do
         self.address_postcode = address_postcode.to_s.strip.upcase.presence
       end
 
-      def export
-        super.tap do |hash|
-          hash["address_postcode"] = postcode_in_crm unless send_event_emails
-        end
-      end
-
-    private
-
-      def postcode_in_crm
-        @store.preexisting(:address_postcode)
+      def optional?
+        true
       end
     end
   end

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -1,14 +1,12 @@
-<h1>Would you like to hear about teacher training events in your area?</h1>
-
 <%= f.govuk_error_summary %>
 
-<p>
-  We'll let you know via email about upcoming teacher training events near you
-</p>
-
-<%= f.govuk_radio_buttons_fieldset(:send_event_emails, legend: nil) do %>
-  <%= f.govuk_radio_button :send_event_emails, "true", link_errors: true do %>
-    <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", label: { text: t('helpers.label.mailing_list_steps_postcode.address_postcode') }, width: 10 %>
-  <% end %>
-  <%= f.govuk_radio_button :send_event_emails, "false" %>
+<%= f.govuk_text_field :address_postcode,
+  autocomplete: "postal-code",
+  width: 10,
+  label: {
+    tag: 'h1',
+    size: "xl",
+    text: t('helpers.label.mailing_list_steps_postcode.address_postcode'),
+  } do %>
+  <p>If you give us your postcode, we'll let you know about events happening near you.</p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,8 +403,6 @@ en:
             address_postcode:
               blank: Enter your postcode
               invalid: Enter a valid postcode
-            send_event_emails:
-              inclusion: Select if you would like to hear about teacher training events
         mailing_list/steps/privacy_policy:
           attributes:
             accept_privacy_policy:
@@ -522,10 +520,7 @@ en:
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
-        address_postcode: Your postcode
-        send_event_emails_options:
-          "true": "Yes"
-          "false": "No"
+        address_postcode: Your postcode (optional)
 
       search:
         search: Search for ...

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -31,9 +31,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "Yes"
-    fill_in "Your postcode", with: "TE57 1NG"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -78,9 +77,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "Yes"
-    fill_in "Your postcode", with: "TE57 1NG"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -119,9 +117,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "Yes"
-    fill_in "Your postcode", with: "TE57 1NG"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -159,9 +156,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "Yes"
-    fill_in "Your postcode", with: "TE57 1NG"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -214,10 +210,6 @@ RSpec.feature "Mailing list wizard", type: :feature do
       "Which subject do you want to teach?",
       selected: TeachingSubject.lookup_by_uuid(response.preferred_teaching_subject_id),
     )
-    click_on "Next step"
-
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "Yes"
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"
@@ -338,8 +330,8 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "Would you like to hear about teacher training events in your area?"
-    choose "No"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: ""
     click_on "Next step"
 
     expect(page).to have_text "Accept privacy policy"

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -6,6 +6,7 @@ describe MailingList::Steps::Postcode do
 
   it_behaves_like "a with wizard step"
 
+  it { expect(subject).to be_optional }
   it { is_expected.to respond_to :address_postcode }
 
   describe "validations for address_postcode" do
@@ -15,33 +16,6 @@ describe MailingList::Steps::Postcode do
     it { is_expected.to allow_value("").for :address_postcode }
     it { is_expected.not_to allow_value("random").for(:address_postcode).with_message(msg) }
     it { is_expected.not_to allow_value("TE57 ING").for(:address_postcode).with_message(msg) }
-
-    context "when send_event_emails is true" do
-      before { subject.send_event_emails = true }
-
-      it { is_expected.not_to allow_value(nil).for(:address_postcode) }
-    end
-  end
-
-  describe "validations for send_event_emails" do
-    it { is_expected.not_to allow_value(nil).for(:send_event_emails) }
-    it { is_expected.to allow_values(true, false).for(:send_event_emails) }
-  end
-
-  describe "#export" do
-    subject { instance.export["address_postcode"] }
-
-    let(:backingstore) { { "send_event_emails" => true, "address_postcode" => "app-postcode" } }
-    let(:crm_backingstore) { {} }
-
-    it { is_expected.to eq("app-postcode") }
-
-    context "when the postcode exists in the CRM and they select 'No'" do
-      let(:backingstore) { { "send_event_emails" => false } }
-      let(:crm_backingstore) { { "address_postcode" => "crm-postcode" } }
-
-      it { is_expected.to eq("crm-postcode") }
-    end
   end
 
   describe "data cleaning for the postcode" do


### PR DESCRIPTION
### Trello card

[Trello-2995](https://trello.com/c/1jPnQFRQ/2995-revisit-the-postcode-step-in-the-mailing-list-funnel)

### Context

We found that the new postcode step design (that places the postcode input behind a yes/no question) performed less well than our original design.

Revert back to the original design with minor copy updates.

### Changes proposed in this pull request

- Revert changes to postcode step

### Guidance to review

<img width="1212" alt="Screenshot 2022-05-25 at 09 54 22" src="https://user-images.githubusercontent.com/29867726/170223219-86ad5bdb-2f8e-4829-9ed1-1bb51dda368b.png">

