### PR TITLE
Enforce a `margin-bottom` on main

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -53,6 +53,10 @@ body {
 
 $content-max-width: 1200px;
 
+main {
+  margin-bottom: 4em;
+}
+
 .main-body {
   margin-bottom: 3em;
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/qqt2wPhx

### Context

The footer overhangs upwards so whenever there's no margin at the bottom of main there's a danger of overlap.
