### PR TITLE
Update homepage promo sections

### DIFF
--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,6 +1,9 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
     <%= tag.div(icon, class: "call-to-action__icon__container") %>
-    <%= tag.span(title, class: "call-to-action__heading") %>
+    <%= tag.div(class: "call-to-action__content") do %>
+      <%= tag.span(title, class: "call-to-action__heading") %>
+      <%= tag.p(text) if text.present? %>
+    <% end %>
     <div class="call-to-action__action">
       <%= link %>
     </div>

--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
     <%= tag.div(icon, class: "call-to-action__icon__container") %>
     <%= tag.div(class: "call-to-action__content") do %>
-      <%= tag.span(title, class: "call-to-action__heading") %>
+      <%= tag.h2(title, class: "call-to-action__heading") %>
       <%= tag.p(text) if text.present? %>
     <% end %>
     <div class="call-to-action__action">

--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -1,11 +1,12 @@
 module CallsToAction
   class HomepageComponent < ViewComponent::Base
-    attr_accessor :icon, :image, :title, :link
+    attr_accessor :icon, :image, :title, :text, :link
 
-    def initialize(icon:, link_text:, link_target:, image:, title: nil)
+    def initialize(icon:, link_text:, link_target:, image:, title: nil, text: nil)
       super
 
       @title         = title
+      @text          = text
       @image         = image
       @icon_filename = icon
 

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,15 +1,17 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Have your questions answered at a teacher training event.",
-    link_text: "Find events",
+    title: "Attend a teacher training event",
+    text: "Talk to course providers, teachers and expert advisers to get your questions answered in person or online at an event.",
+    link_text: "Find an event",
     link_target: "/events",
     image: "media/images/content/homepage/here-to-help.jpg")
   %>
 
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-person",
-    title: "Get started with a teacher training adviser.",
+    title: "Get one-to-one support",
+    text: "Whether you’re just considering teaching or you’re ready to apply, talk to an experienced teacher for support and advice.",
     link_text: "Get an adviser",
     link_target: "/tta-service",
     image: "media/images/content/homepage/teacher-training-adviser.jpg")

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -144,6 +144,10 @@
       }
     }
 
+    .call-to-action__heading {
+      margin-top: 0;
+    }
+
     .call-to-action__content {
       grid-area: 3 / 1 / 4 / 2;
       padding: 0 1.5em;

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -144,15 +144,9 @@
       }
     }
 
-    .call-to-action__heading {
-      @include reset;
-      align-self: center;
-      padding: 0 1em;
-      @include font-size(medium);
-      line-height: 1.3em;
-      text-decoration-thickness: .12em;
-
+    .call-to-action__content {
       grid-area: 3 / 1 / 4 / 2;
+      padding: 0 1.5em;
     }
 
     .call-to-action__action {
@@ -189,10 +183,13 @@
         }
       }
 
-      .call-to-action__heading {
+      .call-to-action__content {
         grid-area: 2 / 1 / 3 / 3;
-        margin: 1em auto .5em 0;
-        @include font-size('small');
+        margin: 1em auto 0 0;
+
+        .call-to-action__heading {
+          @include font-size('small');
+        }
       }
 
       .call-to-action__action {

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
   let(:title) { "Joey" }
   let(:link_text) { "Click here" }
   let(:link_target) { "/some-dir/some-page" }
+  let(:text) { nil }
 
   describe "rendering the component" do
-    let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target, image: image } }
+    let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target, image: image, text: text } }
 
     let(:component) { described_class.new(**kwargs) }
 
@@ -34,6 +35,14 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
 
     specify "the image is present" do
       expect(page.find(".call-to-action__image")["style"]).to include("packs-test/v1/media/images/dfelogo")
+    end
+
+    context "when text is present" do
+      let(:text) { "some text" }
+
+      it "renders the text" do
+        expect(page).to have_css(".call-to-action__content p", text: text)
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-3274](https://trello.com/c/vgTBkBwc/3274-change-home-page-promo-blocks-for-events-and-tta-to-allow-for-more-copy)

### Context

Change the heading text and add a paragraph of new copy to each section.

### Changes proposed in this pull request

- Update homepage promo section

### Guidance to review

| Desktop      | Mobile |
| ----------- | ----------- |
| <img width="1214" alt="Screenshot 2022-05-26 at 15 30 50" src="https://user-images.githubusercontent.com/29867726/170509278-dad20e65-d47f-4f58-83ad-69eb29910603.png">      | <img width="606" alt="Screenshot 2022-05-26 at 15 31 07" src="https://user-images.githubusercontent.com/29867726/170509335-8a1d2083-4995-47bd-a071-5f1337388a24.png">       |



It's a bit tricky to tweak the HTML of the component to support text due to the homepage component using a grid layout and sharing CSS with other `call-to-action` components that don't use a grid layout. I added a surrounding `__content` container for ease of laying this out, but we may want to look at consolidating the CTA styles in the future.