### PR TITLE
Removing-capital-teachers-standards

### DIFF
--- a/app/views/content/blog/top-tips-for-returning-teachers.md
+++ b/app/views/content/blog/top-tips-for-returning-teachers.md
@@ -21,7 +21,7 @@ If you’re thinking of returning to the classroom, now could be a great time. A
 
 The Department for Education are working with schools to take action in a number of areas to address issues that teachers may face. From [workload reduction](https://www.gov.uk/guidance/school-workload-reduction-toolkit), to [pupil behaviour](https://www.gov.uk/guidance/behaviour-hubs), [wellbeing](https://www.gov.uk/guidance/education-staff-wellbeing-charter) and [flexible working opportunities](https://www.gov.uk/government/collections/flexible-working-resources-for-teachers-and-schools), you may find that the classroom looks very different from when you last taught.
 
-It’s also a good idea to read up on the latest [Teachers’ Standards](https://www.gov.uk/government/publications/teachers-standards) and review changes to the [curriculum](https://www.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications).
+It’s also a good idea to read up on the latest [teachers’ standards](https://www.gov.uk/government/publications/teachers-standards) and review changes to the [curriculum](https://www.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications).
 
 ## Get free one-to-one support
 

--- a/app/views/content/returning-to-teaching.md
+++ b/app/views/content/returning-to-teaching.md
@@ -153,7 +153,7 @@ If you’re returning to teaching, you might want to re-familiarise yourself wit
 
 ### Catching up on changes
 
-* review the latest [Teachers’ Standards](https://www.gov.uk/government/publications/teachers-standards)
+* review the latest [teachers’ standards](https://www.gov.uk/government/publications/teachers-standards)
 * catch up on changes to the [national curriculum and qualifications](https://www.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications)
 * read through [current behaviour management guidelines](https://www.gov.uk/government/publications/behaviour-and-discipline-in-schools)
 * learn about how DfE have improved the [National Professional Qualifications (NPQs)](https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms) and if you may be eligible for a fully funded scholarship 


### PR DESCRIPTION
### Trello card

https://trello.com/c/gYr4bbfR/3294-remove-capitalisation-of-teachers-standards-across-the-site

### Context

Removing capitalised teachers' standards on returners and top tips for returners page. Will leave any capitalised teachers' standards on international pages to be covered by the international PRs.

### Changes proposed in this pull request

### Guidance to review

