### PR TITLE
Add current page to breadcrumb component

### DIFF
--- a/app/components/header/breadcrumb_component.html.erb
+++ b/app/components/header/breadcrumb_component.html.erb
@@ -1,10 +1,13 @@
 <section class="container breadcrumbs">
-  <nav class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" aria-label="breadcrumbs" role="navigation">
+  <nav class="govuk-breadcrumbs" aria-label="breadcrumbs" role="navigation">
     <ol class="govuk-breadcrumbs__list">
       <% helpers.breadcrumb_trail do |crumb| %>
-        <% next if crumb.current? %>
         <li class="govuk-breadcrumbs__list-item">
-          <%= link_to(crumb.name, crumb.url, class: "govuk-breadcrumbs__link") %>
+          <% if crumb.current? %>
+            <%= tag.span(crumb.name, class: "govuk-breadcrumbs__current") %>
+          <% else %>
+            <%= link_to(crumb.name, crumb.url, class: "govuk-breadcrumbs__link") %>
+          <% end %>
         </li>
       <% end %>
     </ol>

--- a/app/controllers/blog/tag_controller.rb
+++ b/app/controllers/blog/tag_controller.rb
@@ -6,11 +6,12 @@ class Blog::TagController < ApplicationController
   POSTS_PER_PAGE = 10
 
   def show
-    breadcrumb "Blog", blog_index_path
-
     @front_matter = {
       "title" => "Blog posts about #{params[:id].tr('-', ' ')}",
     }
+
+    breadcrumb "Blog", blog_index_path
+    breadcrumb @front_matter["title"], request.path
 
     @tag = params[:id]
     @posts = paginate_posts(::Pages::Blog.posts(@tag))

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -6,13 +6,16 @@ class BlogController < ApplicationController
   def index
     @front_matter = { "title" => "Get Into Teaching Blog" }
 
+    breadcrumb "Blog", blog_index_path
+
     @posts = paginate_posts(::Pages::Blog.posts)
   end
 
   def show
-    breadcrumb "Blog", blog_index_path
-
     @post = ::Pages::Blog.find(request.path)
+
+    breadcrumb "Blog", blog_index_path
+    breadcrumb @post.title, request.path
 
     render template: @post.template, layout: "layouts/blog/post"
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,6 +10,8 @@ class EventsController < ApplicationController
   MAXIMUM_EVENTS_PER_CATEGORY = 1_000
 
   def index
+    breadcrumb "Teacher training events", request.path
+
     @page_title = "Teacher training events"
     @front_matter = {
       "description" => "Get your questions answered at an event.",
@@ -46,6 +48,7 @@ class EventsController < ApplicationController
 
     category_name = t("event_types.#{@event.type_id}.name.plural")
     breadcrumb category_name, event_category_path(category_name.parameterize)
+    breadcrumb @event.name, request.path
   end
 
   def not_available

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -96,7 +96,8 @@ private
     @page = ::Pages::Page.find content_template(path)
 
     (@page.ancestors.reverse + [@page]).each do |page|
-      breadcrumb page.title, page.path if @page.title.present?
+      title = page.heading || page.title
+      breadcrumb title, page.path if title.present?
     end
 
     render template: @page.template, layout: page_layout

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -41,9 +41,10 @@ class TeachingEventsController < ApplicationController
   end
 
   def show
-    breadcrumb "Get into Teaching events", "/teaching-events"
-
     @event = TeachingEvents::EventPresenter.new(retrieve_event)
+
+    breadcrumb "Get into Teaching events", "/teaching-events"
+    breadcrumb @event.name, request.path
 
     @page_title = @event.name
 

--- a/app/models/pages/page.rb
+++ b/app/models/pages/page.rb
@@ -7,7 +7,7 @@ module Pages
 
     attr_reader :path, :frontmatter
 
-    delegate :title, :image, to: :frontmatter
+    delegate :title, :heading, :image, to: :frontmatter
 
     class << self
       def find(path)

--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -6,6 +6,10 @@
     margin: 0;
     padding: 0 $indent-amount;
 
+    .govuk-breadcrumbs__current {
+      font-size: medium;
+    }
+
     .govuk-breadcrumbs__list .govuk-breadcrumbs__list-item {
       &:not(:first-child) {
         margin-left: 20px;
@@ -18,10 +22,7 @@
           border: none;
           transform: none;
           font-size: 0.5em;
-
-          @include mq($until: tablet) {
-            top: 9px;
-          }
+          top: 2px;
         }
       }
 

--- a/spec/components/header/breadcrumb_component_spec.rb
+++ b/spec/components/header/breadcrumb_component_spec.rb
@@ -15,13 +15,14 @@ describe Header::BreadcrumbComponent, type: "component" do
 
   it { is_expected.to have_css(".container.breadcrumbs") }
   it { is_expected.to have_css("nav.govuk-breadcrumbs") }
-  it { is_expected.not_to have_text("Current Page") }
+  it { is_expected.to have_text("Current Page") }
 
   it "links to all previous pages" do
     expect(subject).to have_css("ol") do |ol|
       expect(ol).to have_link("Page 1", href: "/page/1")
       expect(ol).to have_link("Page 2", href: "/page/2")
       expect(ol).to have_link("Page 3", href: "/page/3")
+      expect(ol).not_to have_link("Current Page")
     end
   end
 end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -27,8 +27,9 @@ RSpec.feature "Breadcrumbs", type: :feature do
 
     it { is_expected.to have_css(".breadcrumbs") }
 
-    it "links to all ancestor pages" do
+    it "links to all ancestor pages and plain text of current page" do
       page.within ".breadcrumbs" do
+        is_expected.to have_text "Nested Page Test"
         is_expected.to have_link "Subfolder", href: "/test/subfolder"
         is_expected.to have_link "Test", href: "/test"
         is_expected.to have_link "Home", href: "/"
@@ -47,9 +48,10 @@ RSpec.feature "Breadcrumbs", type: :feature do
       end
     end
 
-    it "doesn't include the current page" do
+    it "includes the current page in plain text" do
       page.within ".breadcrumbs" do
-        is_expected.not_to have_link "Ways to train"
+        is_expected.not_to have_link "Train to be a teacher"
+        is_expected.to have_text "Train to be a teacher"
       end
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-3302](https://trello.com/c/ttjy7K6l/3302-redesign-breadcrumb-to-show-current-page)

### Context

Our website structure is largely flat, which means we often have a sole 'Home' link at the top of the page. It looks out of place and it isn't clear that its a breadcrumb, so we want to always include the current page (not as a link) to make sure there's at least two breadcrumbs in the component at all times.

### Changes proposed in this pull request

- Add current page to breadcrumb component

### Guidance to review

The collapse on mobile behaviour has been dropped (otherwise the user is left with just a home link and the text for the current page, given its the last breadcrumb).