### PR TITLE
Add landmark roles to improve document structure

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -13,7 +13,7 @@
 <%= render Footer::VideoPlayerComponent.new %>
 <%= render Footer::CookieAcceptanceComponent.new %>
 
-<footer class="site-footer">
+<footer class="site-footer" role="contentinfo">
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">

--- a/app/components/header/breadcrumb_component.html.erb
+++ b/app/components/header/breadcrumb_component.html.erb
@@ -1,5 +1,5 @@
 <section class="container breadcrumbs">
-  <nav class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" aria-label="breadcrumbs">
+  <nav class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" aria-label="breadcrumbs" role="navigation">
     <ol class="govuk-breadcrumbs__list">
       <% helpers.breadcrumb_trail do |crumb| %>
         <% next if crumb.current? %>

--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }) do %>
+<%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }, role: "navigation") do %>
   <ul class="extra-navigation__list">
     <li class="extra-navigation__link">
       <%= link_to("/mailinglist/signup/name" ) do %>
@@ -13,5 +13,5 @@
       <% end %>
     <% end %>
   </ul>
-  <div class="searchbar" data-searchbox-target="searchbar"></div>
+  <div class="searchbar" data-searchbox-target="searchbar" role="search"></div>
 <% end %>

--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -1,4 +1,4 @@
-<nav class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation">
+<nav class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation" role="navigation">
   <ol class="primary" data-navigation-target="primary">
     <% all_resources.each do |resource| %>
       <%= nav_link(resource.title, resource.path) %>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -15,7 +15,7 @@
 </div>
 <% end %>
 
-<header class="limit-content-width" data-controller="navigation">
+<header class="limit-content-width" data-controller="navigation" role="banner">
   <%= render Header::ExtraNavigationComponent.new(search_input_id: "searchbox__input--desktop") %>
   <%= render Header::LogoComponent.new %>
   <div class="menu-button" id="mobile-navigation-menu-button">

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -23,7 +23,7 @@
 
 <section>
   <h3>Explore the site<h3>
-  <aside class="blocks blocks--no-top-margin">
+  <aside class="blocks blocks--no-top-margin" role="complementary">
     <%= render Content::GenericBlockComponent.new(
       title: "Life as a teacher",
       icon_image: "icon-school-black.svg",

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination" aria-label="pager">
+  <nav class="pagination" aria-label="pager" role="navigation">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= render(partial: "sections/gtm_fallback") if gtm_enabled? %>
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -6,14 +6,14 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <section class="container blog main-body">
         <%= render(partial: "blog/header", locals: { mobile: true }) %>
         <article class="text-content longform<%= " with-aside" if content_for?(:aside) %>">
           <%= render(partial: "blog/header", locals: { mobile: false }) %>
           <%= yield %>
         </article>
-        <aside>
+        <aside role="complementary">
           <%= yield :aside %>
         </aside>
       </section>

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -10,7 +10,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <section class="container blog main-body">
         <article class="markdown longform blog-article">
           <header>

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) do %>
         <% if @front_matter["hero_nav"].any? %>
           <ol class="hero__nav">

--- a/app/views/layouts/category.html.erb
+++ b/app/views/layouts/category.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main class="category" id="main-content">
+    <main class="category" id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container category__cards main-body">

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">
@@ -65,7 +65,7 @@
 
         <% if @front_matter["fullwidth"].blank? %>
           <% if @front_matter["related_content"].present? %>
-            <aside class="link-block link-block--related">
+            <aside class="link-block link-block--related" role="complementary">
               <h2 class="link-block__header">Related content</h2>
               <ul class="link-block__list">
                 <% @front_matter["related_content"].each do |item, anchor| %>
@@ -76,7 +76,7 @@
           <% end %>
 
           <% if @front_matter["right_column"].present? %>
-            <aside>
+            <aside role="complementary">
               <%= render partial: "layouts/shared/narrow_call_to_action" %>
             </aside>
           <% end %>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <section class="container main-body">
         <article class="markdown disclaimer fullwidth">
           <% if !@front_matter["image"] %>

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -9,7 +9,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body">

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body home">

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <main id="main-content" class="<%= class_names("internal", action_name ) %>">
+  <main id="main-content" class="<%= class_names("internal", action_name ) %>" role="main">
     <section class="container internal-container">
       <article class="fullwidth">
         <%= yield %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -10,7 +10,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main id="main-content" class="main-body">
+    <main id="main-content" class="main-body" role="main">
       <section class="feature registration container">
         <%= yield %>
       </section>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -10,7 +10,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main role="main" id="main-content" class="main-body registration-with-image-above">
+    <main role="main" id="main-content" class="main-body registration-with-image-above" role="main">
       <%= image_pack_tag("content/event-signup/birmingham-event-1.jpg", alt: "A busy train to teach event with banners and attendees chatting with advisers") %>
 
       <div class="event-info">

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -10,7 +10,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main id="main-content" class="main-body registration-with-side-images">
+    <main id="main-content" class="main-body registration-with-side-images" role="main">
       <section class="signup-container">
         <%= image_pack_tag 'content/mailing-list-signup/left.jpg', class: 'left-img hide-on-mobile hide-on-tablet', alt: "" %>
         <div class="signup-form">

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body container">

--- a/app/views/layouts/stories/landing.html.erb
+++ b/app/views/layouts/stories/landing.html.erb
@@ -6,7 +6,7 @@
 
       <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-      <main class="story-landing" id="main-content">
+      <main class="story-landing" id="main-content" role="main">
         <%= render Content::HeroComponent.new(@front_matter) %>
 
         <section class="container main-body">

--- a/app/views/layouts/stories/list.html.erb
+++ b/app/views/layouts/stories/list.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">

--- a/app/views/layouts/stories/story.html.erb
+++ b/app/views/layouts/stories/story.html.erb
@@ -6,7 +6,7 @@
 
       <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-      <main id="main-content" class="main-body">
+      <main id="main-content" class="main-body" role="main">
         <%= render Stories::StoryComponent.new(@front_matter, @page.data) do %>
           <%= yield %>
         <% end %>

--- a/app/views/layouts/teaching_event.html.erb
+++ b/app/views/layouts/teaching_event.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body">

--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new(breadcrumbs: @show_breadcrumbs) %>
 
-    <main id="main-content">
+    <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -6,7 +6,7 @@
 
     <%= render HeaderComponent.new %>
 
-    <main class="welcome-guide main-body" id="main-content">
+    <main class="welcome-guide main-body" id="main-content" role="main">
       <%= yield %>
 
       <% @front_matter["content"]&.each do |partial| %>

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -27,7 +27,7 @@
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
     </article>
 
-    <aside>
+    <aside role="complementary">
       <%= render(partial: "teaching_events/show/venue-information") if @event.show_venue_information? %>
     </aside>
   </div>


### PR DESCRIPTION
### Trello card

[Trello-3309](https://trello.com/c/mTd3SLZe/3309-review-labelling-of-landmarks-and-sections)

### Context

As we use semantic HTML elements in the majority of places adding the `role` attribute isn't strictly necessary but it is advisable:

> It is also good practice to include the role redundantly with the associated semantic element.

Add `role` landmark for banner, complementary, main, contentinfo, navigation and search.

I've avoided adding `region` landmarks as these will be inferred from where we use `section` elements as long as a heading exists and there are a lot of them so it would be a maintenance burden IMO.

### Changes proposed in this pull request

- Add landmark roles to improve document structure

### Guidance to review

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role