### PR TITLE
Update integration text with new postcode text

### DIFF
--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Mailing list sign up", :integration, type: :feature, js: true do
     select "Chemistry"
     click_on "Next step"
 
-    expect(page).to have_text("Would you like to hear about teacher training events in your area?")
+    expect(page).to have_text("If you give us your postcode")
     click_label "Yes"
     fill_in "Your postcode", with: "TE57 1NG"
     click_on "Next step"

--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -67,9 +67,8 @@ RSpec.feature "Mailing list sign up", :integration, type: :feature, js: true do
     select "Chemistry"
     click_on "Next step"
 
-    expect(page).to have_text("If you give us your postcode")
-    click_label "Yes"
-    fill_in "Your postcode", with: "TE57 1NG"
+    expect(page).to have_text "If you give us your postcode"
+    fill_in "Your postcode (optional)", with: "TE57 1NG"
     click_on "Next step"
 
     expect(page).to have_text("Accept privacy policy")


### PR DESCRIPTION
### Trello card

N/A

### Context

Some text changes look like they're causing the integration tests to fail. 

### Guidance to review

Running the integration tests locally was causing errors when dismissing the cookie banner - not sure why, need to investigate further. This is being submitted to try and get the releases flowing again.
