### PR TITLE
Remove space between autocomplete result items

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -56,6 +56,7 @@
 
 .autocomplete__option {
   padding-left: 1em;
+  margin-bottom: 0;
 
   h3 {
     @extend .heading-s, .heading--margin-0;


### PR DESCRIPTION
### Context and changes

The margin-bottom on accessible-autocomplete was pushing our autocomplete items apart when they should have been flush.

Thanks to @mylesjarvis for the heads up!

| Before | After |
| ------ | ------- |
| ![Screenshot from 2022-06-01 11-58-22](https://user-images.githubusercontent.com/128088/171389409-ed09a4b6-6e4a-4300-a5d6-eb298ee1974a.png) | ![Screenshot from 2022-06-01 11-58-44](https://user-images.githubusercontent.com/128088/171389423-b31ce0af-261d-4c3a-b5cc-9d5ebbd7573a.png) |
