### PR TITLE
Various Ruby updates June 2022 (part 1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,7 @@ RSpec/InstanceVariable:
   Exclude:
     - spec/features/content_pages_spec.rb
     - spec/requests/redirects_spec.rb
+    - spec/components/**/*.rb
 
 RSpec/NamedSubject:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem "redis"
 gem "redis-session-store", ">= 0.11.4"
 
 gem "kaminari", "~> 1.2", ">= 1.2.2"
-gem "view_component", "~> 2.54.1"
+gem "view_component", "~> 2.56.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,8 @@ gem "loaf", ">= 0.10.0"
 
 gem "prometheus-client"
 
-gem "sentry-rails", ">= 5.3.0"
-gem "sentry-ruby", "~> 5.3.0"
+gem "sentry-rails", ">= 5.3.1"
+gem "sentry-ruby", "~> 5.3.1"
 
 gem "skylight", "~> 5.3.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "webpacker", ">= 5.4.3"
 # gem 'mini_magick', '~> 4.8'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.11.1", require: false
+gem "bootsnap", ">= 1.12.0", require: false
 
 # Temporarily adding as part of Ruby 3.1 upgrade, we should be able
 # to remove them once we're on Rails 7.0.1+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bindex (0.8.1)
-    bootsnap (1.11.1)
+    bootsnap (1.12.0)
       msgpack (~> 1.2)
     brakeman (5.2.3)
     builder (3.2.4)
@@ -301,7 +301,7 @@ GEM
       tomlrb
     mixlib-shellout (3.2.5)
       chef-utils
-    msgpack (1.5.1)
+    msgpack (1.5.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     net-imap (0.2.3)
@@ -531,7 +531,7 @@ DEPENDENCIES
   addressable (~> 2.8.0)
   amazing_print
   better_html (>= 1.0.16)
-  bootsnap (>= 1.11.1)
+  bootsnap (>= 1.12.0)
   brakeman (~> 5.2.3)
   byebug
   canonical-rails (>= 0.2.14)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,13 +456,13 @@ GEM
     semantic_logger (4.10.0)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.3.0)
+    sentry-rails (5.3.1)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.3.0)
-    sentry-ruby (5.3.0)
+      sentry-ruby-core (~> 5.3.1)
+    sentry-ruby (5.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.3.0)
-    sentry-ruby-core (5.3.0)
+      sentry-ruby-core (= 5.3.1)
+    sentry-ruby-core (5.3.1)
       concurrent-ruby
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -582,8 +582,8 @@ DEPENDENCIES
   rubocop-govuk (~> 4.3.0)
   secure_headers
   selenium-webdriver (~> 3.142)
-  sentry-rails (>= 5.3.0)
-  sentry-ruby (~> 5.3.0)
+  sentry-rails (>= 5.3.1)
+  sentry-ruby (~> 5.3.1)
   shoulda-matchers
   simplecov
   skylight (~> 5.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -496,7 +496,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.1.0)
     victor (0.3.3)
-    view_component (2.54.1)
+    view_component (2.56.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.2.0)
@@ -592,7 +592,7 @@ DEPENDENCIES
   text
   tzinfo-data
   victor
-  view_component (~> 2.54.1)
+  view_component (~> 2.56.0)
   web-console (>= 4.2.0)
   webmock (>= 3.14.0)
   webpacker (>= 5.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     faraday-encoding (0.0.5)
       faraday
     faraday-excon (1.1.0)
-    faraday-http-cache (2.2.0)
+    faraday-http-cache (2.3.0)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-host-redirect (1.3.0)

--- a/app/components/registration/mailing_list_signup_confirmation_component.rb
+++ b/app/components/registration/mailing_list_signup_confirmation_component.rb
@@ -2,9 +2,9 @@ class Registration::MailingListSignupConfirmationComponent < ViewComponent::Base
   attr_reader :mailing_list_session
 
   def initialize(mailing_list_session)
-    super
-
     @first_name = mailing_list_session["first_name"]
+
+    super
   end
 
   def heading_text

--- a/spec/components/content/hero_component_spec.rb
+++ b/spec/components/content/hero_component_spec.rb
@@ -93,14 +93,14 @@ describe Content::HeroComponent, type: "component" do
         let(:component) { described_class.new(front_matter.merge("image" => nil)) }
 
         specify "nothing is rendered" do
-          expect(rendered_component).to be_empty
+          expect(@rendered_content).to be_empty
         end
       end
 
       context "when an image is present in the front matter" do
         specify "the hero renders it" do
           expect(page).to have_css("img[data-lazy-disable=true]")
-          expect(rendered_component).to match(/images\/.*[0-9a-f]+\.jpg/)
+          expect(@rendered_content).to match(/images\/.*[0-9a-f]+\.jpg/)
         end
       end
     end

--- a/spec/components/content/image_component_spec.rb
+++ b/spec/components/content/image_component_spec.rb
@@ -7,7 +7,7 @@ describe Content::ImageComponent, type: "component" do
   before { render_inline(described_class.new(**example_args)) }
 
   specify "image has the right path" do
-    expect(rendered_component).to match(%r{src="/packs-test/v1/media/images/#{image_name}-.*.jpg"})
+    expect(@rendered_content).to match(%r{src="/packs-test/v1/media/images/#{image_name}-.*.jpg"})
   end
 
   specify "image has the right alt text" do

--- a/spec/components/footer/cookie_acceptance_component_spec.rb
+++ b/spec/components/footer/cookie_acceptance_component_spec.rb
@@ -29,7 +29,7 @@ describe Footer::CookieAcceptanceComponent, type: "component" do
     end
 
     specify "nothing is rendered" do
-      expect(rendered_component).to be_empty
+      expect(@rendered_content).to be_empty
     end
   end
 end

--- a/spec/components/registration/mailing_list_signup_confirmation_component_spec.rb
+++ b/spec/components/registration/mailing_list_signup_confirmation_component_spec.rb
@@ -8,7 +8,7 @@ describe Registration::MailingListSignupConfirmationComponent, type: :component 
   let(:component) { described_class.new(mailing_list_session) }
 
   specify "renders a button-style link to the welcome guide" do
-    expect(Capybara.string(rendered_component)).to have_link("Continue your journey", href: "/welcome")
+    expect(Capybara.string(@rendered_content)).to have_link("Continue your journey", href: "/welcome")
   end
 
   describe "#heading_text" do


### PR DESCRIPTION
### Context and changes

- Update rack to 2.2.3.1
- Update bootsnap to 1.12.0
- Update view_component to 2.56.0
- Update sentry-ruby and sentry-rails to 5.3.1
- Update faraday-http-cache to 2.3.0
