### PR TITLE
Fix broken link checker Slack notifications

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.0
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           args: --exclude-mail --max-retries 20 app/views/content
+          fail: true
 
       - uses: Azure/login@v1
         with:
@@ -33,7 +35,7 @@ jobs:
 
       - name: Read Lychee output into var
         id: lychee-output
-        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        if: ${{steps.lychee.outcome}} == "failure"
         run: |
           DATA=$(cat  ./lychee/out.md)
           echo "LYCHEE_OUTPUT<<EOF" >> $GITHUB_ENV
@@ -42,14 +44,14 @@ jobs:
 
       - name: Slack Markdown Converter
         id: convert
-        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        if: ${{steps.lychee.outcome}} == "failure"
         uses: LoveToKnow/slackify-markdown-action@v1.0.0
         with:
           text: |
                 ${{ env.LYCHEE_OUTPUT }}
 
       - name: Slack Notification
-        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        if: ${{steps.lychee.outcome}} == "failure"
         uses: rtCamp/action-slack-notify@master
         env:
            SLACK_COLOR: ${{env.SLACK_ERROR}}


### PR DESCRIPTION
### Trello card

[Trello-3310](https://trello.com/c/MiLrSzmd/3310-fix-slack-notifications-for-broken-link-checker)

### Context

The `lychee` action we use appears to have recently changed so that the `exit_code` is only written via `exit` so that a subsequent action can read it if the `fail` argument is `true`.

In doing this I still wasn't able to read `exit_code` directly, but as the step now fails on a non-zero exit code we can use `continue-on-error: true` and then check the `outcome` of the step to achieve the same result.

### Changes proposed in this pull request

- Fix broken link checker Slack notifications

### Guidance to review

I've tested this manually and it posted to our tech channel.