### PR TITLE
Make long headers on teaching-events resize better

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -406,7 +406,7 @@ $icon-size: 3rem;
     grid-template-rows: repeat(3, auto) 1em;
 
     @include mq($from: tablet) {
-      grid-template-rows: minmax(2rem, auto) 5rem minmax(2rem, auto) 2rem;
+      grid-template-rows: minmax(2rem, auto) minmax(5rem, auto) minmax(2rem, auto) 2rem;
       grid-template-columns: minmax(5rem, auto) minmax(auto, 40rem) 14rem minmax(auto, 20rem) minmax(5rem, auto);
 
       .heading {


### PR DESCRIPTION
### Trello card

https://trello.com/c/90Gk451I/3329-update-design-of-event-details-page-to-accommodate-long-event-names

### Context

Longer event names overlap the date and time content beneath. Now the title will push the content down instead.

| Small | Medium | Long |
| ------- | ------- | ------ |
| ![Screenshot from 2022-06-06 12-35-00](https://user-images.githubusercontent.com/128088/172153507-0596ec84-900a-498b-9b21-22dd9e6f88e8.png) |![Screenshot from 2022-06-06 12-35-21](https://user-images.githubusercontent.com/128088/172153504-fcb5b46e-65d9-46f8-b9ea-7075715ea428.png) | ![Screenshot from 2022-06-06 12-36-16](https://user-images.githubusercontent.com/128088/172153500-278139c4-bef2-470a-83c2-2ec89e8831ac.png) |

