### PR TITLE
Embedding a GOV.UK section for School Experience

### DIFF
--- a/app/components/calls_to_action/simple_component.html.erb
+++ b/app/components/calls_to_action/simple_component.html.erb
@@ -6,14 +6,16 @@
       <%= tag.span(title, class: "call-to-action__heading") %>
     <% end %>
 
-    <% if text.present? %>
+    <% if content.present? || text.present? %>
       <p class="call-to-action__text">
-        <%= helpers.safe_html_format(text) %>
+        <%= content || helpers.safe_html_format(text) %>
       </p>
     <% end %>
 
-    <div class="call-to-action__action">
-      <%= link %>
-    </div>
+    <% if link.present? %>
+      <div class="call-to-action__action">
+        <%= link %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/calls_to_action/simple_component.rb
+++ b/app/components/calls_to_action/simple_component.rb
@@ -2,7 +2,7 @@ module CallsToAction
   class SimpleComponent < ViewComponent::Base
     attr_accessor :icon, :title, :text, :link
 
-    def initialize(icon:, link_text:, link_target:, title: nil, text: nil, hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false)
+    def initialize(icon:, link_text: nil, link_target: nil, title: nil, text: nil, hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false)
       super
 
       @icon_filename = icon
@@ -20,7 +20,7 @@ module CallsToAction
 
     def before_render
       @icon = icon_element(@icon_filename)
-      @link = link_to(@link_text, @link_target, class: "button")
+      @link = link_to(@link_text, @link_target, class: "button") if @link_text && @link_target
     end
 
   private

--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -18,53 +18,13 @@ calls_to_action:
         link_target: "https://schoolexperience.education.gov.uk/"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo
+content:
+  - content/train-to-be-a-teacher/get-school-experience/intro
+  - content/train-to-be-a-teacher/get-school-experience/what-to-expect
+  - content/train-to-be-a-teacher/get-school-experience/find-school-experience
+  - content/train-to-be-a-teacher/get-school-experience/cta
+  - content/train-to-be-a-teacher/get-school-experience/other-ways-to-get-experience
 navigation: 20.25
 navigation_description: Spending some time in a school can help you find out more about teaching and even help you decide what kind of teacher you want to be.
 ---
 
-You can visit schools to get unpaid experience in the classroom before you start your initial teacher training (ITT).
-
-It can help you:
-
-- decide if you want to train to be a teacher
-- discover which setting you’d like to teach in (primary or secondary)
-- build a relationship with a school you might want to work for later
-
-## What to expect
-
-Your experience will either be in a school or joining classes and meeting teachers online. Placements usually last one or 2 days, but some can last up to 3 weeks.
-
-During your experience, you’ll get to do things like:
-
-- observe lessons
-- see how teachers manage a classroom
-- find out how specific subjects are taught
-- speak to teachers and interact with pupils
-- learn more about teacher training - including the application and interview process
-
-## Find school experience
-
-You can search for and request [school experience](https://schoolexperience.education.gov.uk/) in England.
-
-If you can’t find what you’re looking for, you can call a school directly. You can [find schools near you](https://get-information-schools.service.gov.uk/) and ask who to talk to about getting school experience.
-
-They may ask you to have a DBS check before attending.
-
-Use our Get school experience service to search for and request experience in England.
-
-$get-school-experience$
-
-## Other ways to get experience of the classroom
-
-### Teaching internships
-
-You could apply for a [paid teaching internship](/teaching-internship-providers) if you’re currently doing an undergraduate degree and are interested in teaching:
-
-- maths
-- physics
-- computing
-- modern languages
-
-### Watch pre-recorded lessons
-
-You can [observe teachers’ lessons](https://teachers.thenational.academy/lessons-for-itt) on the Oak National Academy website to help you get to know teaching better, before or alongside your ITT.

--- a/app/views/content/train-to-be-a-teacher/get-school-experience/_cta.html.erb
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience/_cta.html.erb
@@ -1,9 +1,54 @@
 <%=
   render CallsToAction::SimpleComponent.new(
     icon: "icon-arrow",
-    link_text: "Search for experience",
-    link_target: "/",
-    title: "Find school experience",
-    text: "Use our service to search for and organise a placement in England"
-  )
+    title: "Real classroom experience",
+  ) do
 %>
+  <p>Use our service to search for and organise a placement in England.</p>
+
+  <div class="embedded-govuk">
+
+    <header>
+      <div class="embedded-govuk--crown">
+        <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+          <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+        </svg>
+
+        <span class="govuk-heading-m">GOV.UK</span>
+      </div>
+
+      <h2 class="govuk-heading-l">Get school experience</h2>
+    </header>
+
+    <p class="govuk-body">
+      Use this service if you want to request school experience in a primary or
+      secondary school in England.
+    </p>
+
+    <p class="govuk-body">
+      School experience allows you to find out more about teaching by visting
+      schools.
+    </p>
+
+    <p class="govuk-body">You'll need:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the right to work in the UK</li>
+      <li>a degree (or to be studying for one)</li>
+      <li>to be aged 18 or over</li>
+    </ul>
+
+    <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button" aria-labelledby="start-button-label">
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+
+    <p id="start-button-label" class="govuk-hint">
+      <span class="govuk-visually-hidden">Start now</span>
+
+      Link opens in new tab.
+    </p>
+  </div>
+<% end %>

--- a/app/views/content/train-to-be-a-teacher/get-school-experience/_find-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience/_find-school-experience.md
@@ -1,0 +1,9 @@
+## Find school experience
+
+You can search for and request [school experience](https://schoolexperience.education.gov.uk/) in England.
+
+If you can’t find what you’re looking for, you can call a school directly. You can [find schools near you](https://get-information-schools.service.gov.uk/) and ask who to talk to about getting school experience.
+
+They may ask you to have a DBS check before attending.
+
+Use our Get school experience service to search for and request experience in England.

--- a/app/views/content/train-to-be-a-teacher/get-school-experience/_intro.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience/_intro.md
@@ -1,0 +1,7 @@
+You can visit schools to get unpaid experience in the classroom before you start your initial teacher training (ITT).
+
+It can help you:
+
+- decide if you want to train to be a teacher
+- discover which setting you’d like to teach in (primary or secondary)
+- build a relationship with a school you might want to work for later

--- a/app/views/content/train-to-be-a-teacher/get-school-experience/_other-ways-to-get-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience/_other-ways-to-get-experience.md
@@ -1,0 +1,14 @@
+## Other ways to get experience of the classroom
+
+### Watch pre-recorded lessons
+
+You can [observe teachers’ lessons](https://teachers.thenational.academy/lessons-for-itt) on the Oak National Academy website to help you get to know teaching better, before or alongside your ITT.
+
+### Teaching internships
+
+You could apply for a [paid teaching internship](/teaching-internship-providers) if you’re currently doing an undergraduate degree and are interested in teaching:
+
+- maths
+- physics
+- computing
+- modern languages

--- a/app/views/content/train-to-be-a-teacher/get-school-experience/_what-to-expect.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience/_what-to-expect.md
@@ -1,0 +1,11 @@
+## What to expect
+
+Your experience will either be in a school or joining classes and meeting teachers online. Placements usually last one or 2 days, but some can last up to 3 weeks.
+
+During your experience, you’ll get to do things like:
+
+- observe lessons
+- see how teachers manage a classroom
+- find out how specific subjects are taught
+- speak to teachers and interact with pupils
+- learn more about teacher training - including the application and interview process

--- a/app/webpacker/styles/embedded-govuk.scss
+++ b/app/webpacker/styles/embedded-govuk.scss
@@ -1,0 +1,27 @@
+.embedded-govuk {
+  background: white;
+  padding: 1.5em;
+  border-radius: 5px;
+
+  * {
+    font-family: 'Arial', sans-serif !important;
+  }
+
+  // add a margin on tablet and above to space the
+  // embedded content more nicely within the bigger
+  // CTA
+  @include mq($from: tablet) {
+    margin: 0 1em 1em 0;
+  }
+
+  a.govuk-button { color: white };
+
+  &--crown {
+    display: flex;
+    gap: .5em;
+    align-items: center;
+    margin-bottom: 1em;
+
+    span { margin-bottom: 0 };
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -33,6 +33,7 @@
 @import 'welcome-guide';
 @import 'urgent-call-for-qualified-teachers';
 @import 'category';
+@import 'embedded-govuk';
 
 @import 'subject-specific';
 

--- a/spec/components/calls_to_action/simple_component_spec.rb
+++ b/spec/components/calls_to_action/simple_component_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe CallsToAction::SimpleComponent, type: :component do
       end
     end
 
+    context "when no link is present" do
+      let(:kwargs) { { icon: icon, title: title } }
+
+      specify "no paragraph tag should be rendered" do
+        expect(page).not_to have_css("a")
+      end
+    end
+
+    context "when a block is passed in instead of text" do
+      let(:custom_content) { "Custom content" }
+
+      before { render_inline(described_class.new(**kwargs)) { custom_content } }
+
+      specify "the custom content is rendered in the CTA" do
+        expect(page).to have_css(".call-to-action__text", text: custom_content)
+      end
+    end
+
     describe "utility classes" do
       %w[mobile tablet desktop].each do |size|
         context "hiding on #{size}" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/WHNPHSff/3276-design-embedding-govuk-start-pages-into-git

### Context and changes

Currently going from GIT to GOV.UK-style pages (like School Experince) can be a bit jarring for users. This is an attempt to ease the transition by showing that they're about to go to a more-official looking site.

- Split up get-school-experience page into partials
- Make SimpleComponent more flexible
- Add a 'GOV.UK' like embedded section for SE

| Desktop | Mobile |
| -------- | --------- |
| ![Screenshot from 2022-06-07 12-02-25](https://user-images.githubusercontent.com/128088/172364273-e938d6b8-442b-4e49-89d1-15619ae3b81d.png) | ![Screenshot from 2022-06-07 12-02-37](https://user-images.githubusercontent.com/128088/172364285-3f905526-97d3-4710-8059-0ae300051f97.png) |

### Limitations

The GOV.UK Transport font is not used here because getting it to play nicely with our styles is would involve lots of additional work. We'd need to load it separately (so all users aren't impacted by the font download) and style things individually because the Design System is very all-or-nothing. If we think it's needed I'm happy to revisit, but in my opinion it looks ok as-is.


