### PR TITLE
Update logo alt text for accessibility

### DIFF
--- a/app/components/header/logo_component.html.erb
+++ b/app/components/header/logo_component.html.erb
@@ -1,7 +1,7 @@
 <div class="logo-wrapper">
   <div class="logo">
     <a href="/" class="logo__image">
-      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to Home page", size: "180x62", data: { "lazy-disable": true } %>
+      <%= image_pack_tag 'media/images/getintoteachinglogo.svg', alt: "Go to the Get Into Teaching homepage, Teaching Every Lesson Shapes a Life logo", size: "180x62", data: { "lazy-disable": true } %>
     </a>
   </div>
 </div>


### PR DESCRIPTION
### Trello card

[Trello-3343](https://trello.com/c/d1Iw9gNG/3343-dac-audit-label-in-name-logo?filter=member:rossoliver15)

### Context

It was picked up in the DAC report that the logo alt text is "Go to home page" even though the image has the text "Teaching
Every Lesson Shapes a Life". The user using voice assist expected "Click teaching every lesson shapes a life" to take
them to the homepage. The recommendation was to add alt text that covers both scenarios.

Update the alt text to include "Teaching every lesson shapes a life" and "Go to the Get Into Teaching homeage" (the former
being what DAC expect and the latter being what other GOV.UK services appear to use).

### Changes proposed in this pull request

- Update logo alt text for accessibility

### Guidance to review

I couldn't replicate the DAC report for this; using 'Tap teaching every lesson shapes a life' on mobile safari doesn't work (but 'tap <visible link>' does). I also couldn't replicate it in Chrome with various voice assist extensions, so we're just going by the suggested solution in the DAC report (that having both separated by a pipe will work).