### PR TITLE
Move the details descriptions to an expandable box

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -6,12 +6,12 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Get Into Teaching events</h1>
 
+    <p>
+      All events listed here are designed to help you get into teacher training. They are all free to attend.
+    </p>
+
     <details class="teaching-events__descriptions">
       <summary class="teaching-events__descriptions--summary">What are the event types?</summary>
-
-      <p>
-        All events listed here are designed to help you get into teacher training. They are all free to attend.
-      </p>
 
       <dl>
         <div>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -6,26 +6,30 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Get Into Teaching events</h1>
 
-    <p>
-      All events listed here are designed to help you get into teacher training. They are all free to attend.
-    </p>
+    <details class="teaching-events__descriptions">
+      <summary class="teaching-events__descriptions--summary">What are the event types?</summary>
 
-    <dl>
-      <div>
-        <dt>DfE Train to Teach events</dt>
-        <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers.</dd>
-      </div>
+      <p>
+        All events listed here are designed to help you get into teacher training. They are all free to attend.
+      </p>
 
-      <div>
-        <dt>DfE Online Q&amp;As</dt>
-        <dd>Get answers to your specific questions from an online panel of teacher training advisers.</dd>
-      </div>
+      <dl>
+        <div>
+          <dt>DfE Train to Teach events</dt>
+          <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers.</dd>
+        </div>
 
-      <div>
-        <dt>Training provider events</dt>
-        <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-      </div>
-    </dl>
+        <div>
+          <dt>DfE Online Q&amp;As</dt>
+          <dd>Get answers to your specific questions from an online panel of teacher training advisers.</dd>
+        </div>
+
+        <div>
+          <dt>Training provider events</dt>
+          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
+        </div>
+      </dl>
+    </details>
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -7,11 +7,11 @@
     <h1 class="heading-l heading--box-yellow">Get Into Teaching events</h1>
 
     <p>
-      All events listed here are designed to help you get into teacher training. They are all free to attend.
+      All events listed are designed to help you get into teacher training. They are free to attend.
     </p>
 
     <details class="teaching-events__descriptions">
-      <summary class="teaching-events__descriptions--summary">What are the event types?</summary>
+      <summary class="teaching-events__descriptions--summary">Explore the different types of events</summary>
 
       <dl>
         <div>

--- a/app/webpacker/images/content/icons/icon-building.svg
+++ b/app/webpacker/images/content/icons/icon-building.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <clipPath id="clip-icon-building">
+      <rect width="64" height="64"/>
+    </clipPath>
+  </defs>
+  <g id="icon-building" clip-path="url(#clip-icon-building)">
+    <g id="Group_941" data-name="Group 941" transform="translate(12.28 15.234)">
+      <path id="Path_1306" data-name="Path 1306" d="M355.024,401.366V388.6l-12.552-4.912L329.92,388.6v12.77h-7.64v16.263h40.384V401.366Zm-25.1,12.989h-4.366V404.64h4.366Zm21.829,0h-5.457v-8.3h-7.64v8.3h-5.457V390.888l9.277-3.6,9.278,3.6v23.467Zm7.64,0h-4.366V404.64h4.366Z" transform="translate(-322.28 -383.684)"/>
+    </g>
+  </g>
+</svg>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -34,6 +34,15 @@ $icon-size: 3rem;
     &--summary {
       color: $blue;
       cursor: pointer;
+      text-decoration: underline;
+      
+      &:hover {
+	      text-decoration: none;
+      }
+      
+      &::marker {
+	      padding-right: 2em;
+      }
     }
 
     dl {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -28,46 +28,28 @@ $icon-size: 3rem;
         padding: 0 1rem;
       }
     }
+  }
+
+  &__descriptions {
+    &--summary {
+      color: $blue;
+      cursor: pointer;
+    }
 
     dl {
-      margin: 2em 0 1em;
+      padding: 0 1rem;
 
       div {
-        display: flex;
-        flex-direction: column;
-
-        @include mq($from: tablet) {
-          flex-direction: row;
-          gap: 1rem;
-          padding-inline: 1rem;
-        }
-      }
-
-      div + div {
-        margin-top: 2em;
+        margin-bottom: .5em;
       }
 
       dt {
         font-weight: bold;
-
-        flex: 0 1 25%;
+        margin-block: .2em;
       }
 
       dd {
         margin-left: 0;
-
-        flex: 1 0 75%;
-      }
-
-      dd + dt {
-        margin-top: 1em;
-      }
-
-      @include mq($from: tablet) {
-        dt,
-        dd {
-          display: inline-block;
-        }
       }
     }
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -326,8 +326,8 @@ $icon-size: 3rem;
             }
 
             &.in-person {
-              background: url(../images/icon-building.svg) no-repeat left center;
-              background-size: 2em; // using 2em because it's an old icon and is bigger than the others
+              background: url(../images/content/icons/icon-building.svg) no-repeat left center;
+              background-size: $icon-size;
             }
           }
         }


### PR DESCRIPTION
### Trello card

https://trello.com/c/ENQrIOP1/2897-improve-events-page-redesign-of-where-definitions-should-be-placed

### Context

The details descriptions at the top of the teaching events list take up a lot of room and are quite ugly. This reformats them so they take up more vertical space but places them inside a `<details>` element so they're hidden by default.

|            | Desktop | Mobile |
| -------- | -------- | ----------|
| Collapsed | ![Screenshot from 2022-06-07 13-54-03](https://user-images.githubusercontent.com/128088/172384703-fe1ecafb-87d6-4e2c-be67-61e03f6c3683.png) | ![Screenshot from 2022-06-07 13-54-20](https://user-images.githubusercontent.com/128088/172384775-7bdbb601-4f8e-415f-b51b-db6768ea61de.png) |
| Expanded | ![Screenshot from 2022-06-07 13-54-07](https://user-images.githubusercontent.com/128088/172384607-bdc7f446-ee5d-4791-9837-a828b69a7c2a.png) | ![Screenshot from 2022-06-07 13-54-25](https://user-images.githubusercontent.com/128088/172384640-f9ce6a66-e4bf-471f-adaa-255e625ef7ae.png) |

