### PR TITLE
Make the Scribble box wider

### DIFF
--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -22,7 +22,6 @@
     <article>
       <%= render(partial: "teaching_events/show/event-summary") %>
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
-      <%= render(partial: "teaching_events/show/scribble") if @event.scribble_id.present? %>
       <%= render(partial: "teaching_events/show/how-to-attend") %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
     </article>
@@ -31,6 +30,12 @@
       <%= render(partial: "teaching_events/show/venue-information") if @event.show_venue_information? %>
     </aside>
   </div>
+
+  <% if @event.scribble_id.present? %>
+    <div class="container teaching-event__info">
+      <%= render(partial: "teaching_events/show/scribble") %>
+    </div>
+  <% end %>
 
   <%= render(partial: "teaching_events/show/what-theyre-saying") %>
 </div>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -579,6 +579,10 @@ $icon-size: 3rem;
     margin-top: 2em;
   }
 
+  &__scribble {
+    margin: 0 1em;
+  }
+
   &__video {
     margin-block: 2em;
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/hC7dfoiJ/2829-address-width-issue-re-scribble-confirmation-message

### Context and changes

Scribble is an embeddable 'event' iframe placed on the page. When it's in the article element which occupies 66% of the width it gets cramped and isn't very responsive.

Here we're moving it outside of the `<article>` element and placing it below so it can occupy 100% of the width. A small margin is applied so it will line up with the content above.

### Testing

Tricky to test locally as there are no events but it should now appear where this "lorem ipsum" paragraph is 😅 

![Screenshot from 2022-06-07 14-19-03](https://user-images.githubusercontent.com/128088/172391624-6d9a3bdc-a1c3-4e81-9f71-b9235784da71.png)

