### PR TITLE
Make the teaching-event quote flush with footer

### DIFF
--- a/app/views/layouts/teaching_event.html.erb
+++ b/app/views/layouts/teaching_event.html.erb
@@ -9,7 +9,7 @@
     <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
-      <section class="main-body">
+      <section class="main-body main-body--no-bottom-margin">
         <%= yield %>
       </section>
     </main>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -120,6 +120,10 @@
     flex-direction: row;
   }
 
+  &:last-of-type {
+    margin-bottom: 6em;
+  }
+
   &__left,
   &__right {
     flex: 0 1 50%;

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -53,10 +53,6 @@ body {
 
 $content-max-width: 1200px;
 
-main {
-  margin-bottom: 4em;
-}
-
 .main-body {
   margin-bottom: 3em;
 

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -708,6 +708,7 @@ $icon-size: 3rem;
 
 .what-theyre-saying {
   margin-top: 4em;
+  padding-bottom: 2em;
   display: grid;
   background: $yellow;
 


### PR DESCRIPTION
### Trello card

N/A

### Context

The bottom of the teaching event page looks a bit odd. This change removes the forced `margin-bottom` from the `.main-content` so it's flush. The `margin-bottom` of the bottom bits of most pages means it looks fine. It does look a bit broken on the stories page but that will soon be gone so shouldn't be a worry.

* [ ] Remove stories pages before merging this

| Before | After |
| ------ | ------- |
| ![Screenshot from 2022-06-07 14-55-39](https://user-images.githubusercontent.com/128088/172399930-58ca1528-8857-4ab4-ad9e-9fb6d4872a88.png) | ![Screenshot from 2022-06-07 14-55-23](https://user-images.githubusercontent.com/128088/172399958-d2c3c87c-ea64-4513-a083-6a2de7b91d9b.png) | 

