### PR TITLE
Add spacing between blog title and image on listings page

### DIFF
--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -2,6 +2,7 @@
   @include mq($from: tablet) {
     > div {
       display: flex;
+      gap: $indent-amount;
 
       header {
         flex-grow: 1;


### PR DESCRIPTION
### Trello card

[Trello-3346](https://trello.com/c/fJPNphOx/3346-add-gap-between-long-blog-titles-and-image-on-blog-listings-page?filter=member:rossoliver15)

### Context

Certain blog titles wrapped too close to the image on the listings page; adding a gap to the flexbox layout means there will always be space between the elements.

### Changes proposed in this pull request

- Add spacing between blog title and image on listings page

### Guidance to review

| Before      | After |
| ----------- | ----------- |
|     <img width="733" alt="Screenshot 2022-06-09 at 08 35 10" src="https://user-images.githubusercontent.com/29867726/172791181-76c4bdd8-c834-43b3-a7a8-6446a3c61100.png">  |  <img width="724" alt="Screenshot 2022-06-09 at 08 34 36" src="https://user-images.githubusercontent.com/29867726/172791087-923140da-0a2c-4e5c-ac19-0da3177bd0c1.png">       |


