### PR TITLE
Log when we perform a redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,12 @@ Rails.application.routes.draw do
   get "/sitemap.xml", to: "sitemap#show", via: :all
 
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
-    redirect_rules.each { |from, to| get from, to: redirect(path: to) }
+    redirect_rules.each do |from, to|
+      get from => lambda { |env|
+        Rails.logger.info(redirect: { from: from, to: to })
+        redirect(path: to).call(env)
+      }
+    end
   end
 
   if Rails.env.rolling? || Rails.env.preprod? || Rails.env.production? || Rails.env.pagespeed?

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -11,8 +11,11 @@ describe "Redirects", content: true, type: :request do
       subject { get(build_url(from, query_string)) }
 
       specify "redirects successfully" do
+        allow(Rails.logger).to receive(:info)
+
         expect(subject).to be 301
         expect(response).to redirect_to(build_url(to, query_string))
+        expect(Rails.logger).to have_received(:info).with(redirect: { from: from, to: to })
 
         target = Nokogiri.parse(response.body).at_css("a")["href"].gsub(root_url, "/")
 


### PR DESCRIPTION
### Trello card

[Trello-3349](https://trello.com/c/5g14tyJ3/3349-look-into-how-many-redirects-are-still-used-which-ones-we-can-get-rid-of)

### Context

We want to be able to track which of our custom redirects are still being used (so that we can remove them when we find no traffic going through them any longer).

Update redirect route to log out the details, which we can then pull into a Kibana visualisation.

### Changes proposed in this pull request

- Log when we perform a redirect

### Guidance to review

Initially I was going to do this as a metric but as it would likely end up with low cardinality and infrequent data points it didn't feel like a good fit. Kibana also has a longer retention period than our metrics so should prove to be a more reliable data store.