### PR TITLE
Make the scribble box grow to fill the space

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -35,11 +35,11 @@ $icon-size: 3rem;
       color: $blue;
       cursor: pointer;
       text-decoration: underline;
-      
+
       &:hover {
 	      text-decoration: none;
       }
-      
+
       &::marker {
 	      padding-right: 2em;
       }
@@ -571,7 +571,8 @@ $icon-size: 3rem;
   }
 
   &__scribble {
-    margin: 0 1em;
+    margin: 4em 1em;
+    flex-grow: 1;
   }
 
   &__video {


### PR DESCRIPTION
### Trello card



### Context

The iframe that contains the scribble event didn't grow to fill the box. Now it's set to explicitely grow via flexbox.


| Desktop | Mobile |
| ------ | -------- |
| ![Screenshot from 2022-06-09 11-12-48](https://user-images.githubusercontent.com/128088/172824691-b1d9eabb-1466-4234-84e3-074e6a164da2.png) | ![Screenshot from 2022-06-09 11-13-35](https://user-images.githubusercontent.com/128088/172824721-51afecc6-9089-4674-964b-42d04fad10e5.png) |

Again no events locally to test with _but_ you can see the changes in the browser tools in the screenshot above and they match the PR, so 🤞🏽 