### PR TITLE
Update no results page on teaching events search

### DIFF
--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -18,6 +18,17 @@ module TeachingEventsHelper
     event.type_id == EventType.lookup_by_name(type_name)
   end
 
+  def add_online_events(params)
+    params_with_online = params
+      .fetch(:teaching_events_search, {})
+      .permit!
+      .to_h
+      .merge({ online: [true, false] })
+      .deep_symbolize_keys
+
+    { teaching_events_search: params_with_online }
+  end
+
   # override:
   # * Online event               => Online forum
   # * School or University event => Training provider

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -38,15 +38,7 @@
     </div>
 
     <% if @featured_events.blank? && @events.blank? %>
-      <div class="teaching-events__none" role="alert">
-        <div class="teaching-events__none--message">
-          <h3 class="heading--margin-top-0">
-            No events found.
-          </h3>
-
-          <a class="button" href="/mailinglist/signup">Sign up to be notified about events in your area</a>
-        </div>
-      </div>
+      <%= render partial: "teaching_events/index/no_results" %>
     <% else %>
       <div class="teaching-events__listing">
         <% if @featured_events.any? %>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -11,8 +11,8 @@
 
   <div class="teaching-events__filter--group with-top-border">
     <%= f.govuk_check_boxes_fieldset(:online, legend: nil) do %>
-      <%= f.govuk_check_box :online, "false", label: { text: "In person" } %>
-      <%= f.govuk_check_box :online, "true", label: { text: "Online" } %>
+      <%= f.govuk_check_box :online, false, label: { text: "In person" } %>
+      <%= f.govuk_check_box :online, true, label: { text: "Online" } %>
     <% end %>
   </div>
 

--- a/app/views/teaching_events/index/_no_results.html.erb
+++ b/app/views/teaching_events/index/_no_results.html.erb
@@ -1,0 +1,17 @@
+<div class="teaching-events__none" role="alert">
+  <h3 class="heading--margin-top-0">
+    0 events found
+  </h3>
+
+  <p><strong>Why not try:</strong></p>
+  <ul>
+    <% if @event_search.distance.present? %>
+      <li>expanding your search area</li>
+    <% end %>
+    <% if @event_search.in_person_only? %>
+      <li>changing event type - <%= link_to("online events", teaching_events_path(add_online_events(params))) %> may be available</li>
+    <% end %>
+
+    <li><%= link_to("clearing your filters", teaching_events_path) %> to start again</li>
+  </ul>
+</div>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -112,9 +112,15 @@ $icon-size: 3rem;
   }
 
   &__none {
-    &--message {
-      padding: 1rem 1rem 2rem;
-      background: $grey;
+    margin: 1rem;
+
+    @include mq($from: tablet) {
+      border-left: 1px solid $slightly-darker-grey;
+      padding-left: 3rem;
+    }
+
+    ul {
+      list-style-type: square;
     }
   }
 

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -183,12 +183,39 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
     context "when no events are found" do
       let(:event_count) { 0 }
+      let(:params) { nil }
 
-      scenario "a useful message is shown" do
-        visit teaching_events_path
+      before { visit teaching_events_path(params) }
 
-        expect(page).to have_css(".teaching-events__none", text: "No events found")
-        expect(page).to have_link("Sign up to be notified about events in your area", href: "/mailinglist/signup")
+      scenario "a useful message and options are shown" do
+        within(".teaching-events__none") do
+          expect(page).to have_css("h3", text: "0 events found")
+          expect(page).to have_css("p", text: "Why not try:")
+          expect(page).to have_link(text: "clearing your filters", href: teaching_events_path)
+        end
+      end
+
+      context "when the candidate has filtered by distance" do
+        let(:params) { { teaching_events_search: { distance: 5 } } }
+
+        scenario "an alternate option is shown" do
+          within(".teaching-events__none") do
+            expect(page).to have_css("li", text: "expanding your search area")
+          end
+        end
+      end
+
+      context "when the candidate has filtered by in-person only" do
+        let(:params) { { teaching_events_search: { distance: 5, online: [false] } } }
+
+        scenario "an alternate option is shown" do
+          within(".teaching-events__none") do
+            add_online_events_path = teaching_events_path(
+              params.deep_merge({ teaching_events_search: { online: [true, false] } }),
+            )
+            expect(page).to have_link(text: "online events", href: add_online_events_path)
+          end
+        end
       end
     end
   end

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -7,6 +7,29 @@ describe TeachingEventsHelper, type: "helper" do
     end
   end
 
+  describe "#add_online_events" do
+    let(:online) { [false] }
+    let(:params) do
+      ActionController::Parameters.new({
+        teaching_events_search: {
+          distance: 20,
+          online: online,
+        },
+        other: "param",
+      })
+    end
+
+    subject { add_online_events(params) }
+
+    it { is_expected.to eq({ teaching_events_search: { distance: 20, online: [true, false] } }) }
+
+    context "when online is nil" do
+      let(:online) { nil }
+
+      it { is_expected.to eq({ teaching_events_search: { distance: 20, online: [true, false] } }) }
+    end
+  end
+
   describe "#event_format" do
     [
       {

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -61,6 +61,36 @@ describe TeachingEvents::Search do
     end
   end
 
+  describe "online/in-person toggling" do
+    let(:online) { nil }
+
+    subject { described_class.new(online: online) }
+
+    it { is_expected.not_to be_online_only }
+    it { is_expected.not_to be_in_person_only }
+
+    context "when online only" do
+      let(:online) { ["true", ""] }
+
+      it { is_expected.to be_online_only }
+      it { is_expected.not_to be_in_person_only }
+    end
+
+    context "when in-person only" do
+      let(:online) { ["false", ""] }
+
+      it { is_expected.not_to be_online_only }
+      it { is_expected.to be_in_person_only }
+    end
+
+    context "when online and in-person" do
+      let(:online) { ["true", "false", ""] }
+
+      it { is_expected.not_to be_online_only }
+      it { is_expected.not_to be_in_person_only }
+    end
+  end
+
   describe "#results" do
     ttt           = EventType.train_to_teach_event_id
     qt            = EventType.question_time_event_id


### PR DESCRIPTION
### Trello card

[Trello-2835](https://trello.com/c/FkYV0eZV/2835-improve-no-results-message-to-signpost-people-to-online-events)

### Context

Currently if there are no results when searching for teaching events we get a not very helpful no results message and are sign posted to the mailing list.

Instead, we want to offer users actions they could take to potentially expand their search results.

If a user filters by postcode/distance then we want to prompt them to expand their search area. If they filter by in-person
only then we can prompt them to include online events. As a last resort we can provide a quick link to enable users to clear their filters and return all results (start again).

### Changes proposed in this pull request

- Update no results page on teaching events search

### Guidance to review

| Link      | Screenshot |
| ----------- | ----------- |
| [Expand search results](https://review-get-into-teaching-app-2612.london.cloudapps.digital/teaching-events?teaching_events_search%5Bdistance%5D=5&teaching_events_search%5Bonline%5D%5B%5D=&teaching_events_search%5Bpostcode%5D=BZ9cGQFObhjxhBEs1ehqZ&teaching_events_search%5Btype%5D%5B%5D=)      | <img width="817" alt="Screenshot 2022-06-10 at 10 39 10" src="https://user-images.githubusercontent.com/29867726/173037758-cb59dc6f-272d-4e95-8d6c-4f92ffd422ee.png">       |
| [Include online events](https://review-get-into-teaching-app-2612.london.cloudapps.digital/teaching-events?teaching_events_search%5Bdistance%5D=&teaching_events_search%5Bonline%5D%5B%5D=&teaching_events_search%5Bonline%5D%5B%5D=false&teaching_events_search%5Bpostcode%5D=BZ9cGQFObhjxhBEs1ehqZ&teaching_events_search%5Btype%5D%5B%5D=&teaching_events_search%5Btype%5D%5B%5D=222_750_008)   | <img width="896" alt="Screenshot 2022-06-10 at 10 39 34" src="https://user-images.githubusercontent.com/29867726/173037827-afb16b24-88e8-42e8-b7b4-95cff3f44102.png">        |
| [Clear your filters](https://review-get-into-teaching-app-2612.london.cloudapps.digital/teaching-events?teaching_events_search%5Bdistance%5D=&teaching_events_search%5Bonline%5D%5B%5D=&teaching_events_search%5Bonline%5D%5B%5D=false&teaching_events_search%5Bonline%5D%5B%5D=true&teaching_events_search%5Bpostcode%5D=BZ9cGQFObhjxhBEs1ehqZ&teaching_events_search%5Btype%5D%5B%5D=&teaching_events_search%5Btype%5D%5B%5D=222_750_008)   | <img width="809" alt="Screenshot 2022-06-10 at 10 40 04" src="https://user-images.githubusercontent.com/29867726/173037930-11dfc0fa-0e83-4964-8482-2a925e38ed55.png">        |
| [All options](https://review-get-into-teaching-app-2612.london.cloudapps.digital/teaching-events?teaching_events_search%5Bdistance%5D=5&teaching_events_search%5Bonline%5D%5B%5D=&teaching_events_search%5Bonline%5D%5B%5D=false&teaching_events_search%5Bpostcode%5D=BZ9cGQFObhjxhBEs1ehqZ&teaching_events_search%5Btype%5D%5B%5D=&teaching_events_search%5Btype%5D%5B%5D=222_750_008)   | <img width="882" alt="Screenshot 2022-06-10 at 10 40 27" src="https://user-images.githubusercontent.com/29867726/173038010-a2a116ed-5e13-4964-bdca-acb7ae509eeb.png">        |






