### PR TITLE
Tweak padding on highlighted headings

### DIFF
--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -15,7 +15,7 @@
 
   span {
     box-decoration-break: clone;
-    padding: 0.15em 0;
+    padding: 0.1em 0;
     background: $backgroundColor;
     box-shadow: 1rem 0 0 $backgroundColor, -1rem 0 0 $backgroundColor;
   }

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -10,14 +10,16 @@
 @mixin highlight-text($backgroundColor, $color) {
   // Multi-line padded highlight effect without horizontal
   // gabs between lines.
-  margin: 0 1rem;
   color: $color;
+  line-height: 1.4;
 
   span {
+    background-color: $backgroundColor;
+    display: inline;
+    padding: 0.45rem 1rem;
+
     box-decoration-break: clone;
-    padding: 0.1em 0;
-    background: $backgroundColor;
-    box-shadow: 1rem 0 0 $backgroundColor, -1rem 0 0 $backgroundColor;
+    -webkit-box-decoration-break: clone;
   }
 }
 


### PR DESCRIPTION
### Trello card

[Trello-3348](https://trello.com/c/Ulmo5Ytv/3348-small-bug-fix-on-blog-headings)

### Context

These headings have a highlight/background over multi-line text; we're finding on some browsers the highlighting of the next line overlaps the text of the previous. Tweaking the padding to be slightly less should improve this.

### Changes proposed in this pull request

- Tweak padding on highlighted headings

### Guidance to review

