### PR TITLE
updating events module

### DIFF
--- a/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
@@ -1,8 +1,8 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      caption: "11 June 2022",
-      heading: "Train to Teach London",
-      link_target: "/events/train-to-teach-london-event-110622",
+      caption: "4 July 2022",
+      heading: "Train to Teach Manchester",
+      link_target: "/events/train-to-teach-manchester-event-040722",
       link_text: "Sign up for this event") do %>
     <p>Hear from training providers, chat with teachers and get one-to-one advice from expert advisers.<p>
   <% end %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/EZP65J4C/3355-update-event-promo-module-to-promote-manchester-train-to-teach-event

### Context

Changing to train to teach manchester event on 4 July 2022.

### Changes proposed in this pull request

### Guidance to review

