### PR TITLE
Small subject-specific page tweaks

### DIFF
--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -162,9 +162,11 @@
       course.
     </p>
 
-    <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">
-      Find out about subject knowledge enhancement courses.
-    </a>
+    <p>
+      <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">
+        Find out about subject knowledge enhancement courses.
+      </a>
+    </p>
   </section>
 
   <section>

--- a/app/webpacker/styles/subject-specific/_article.scss
+++ b/app/webpacker/styles/subject-specific/_article.scss
@@ -57,6 +57,10 @@ article {
         }
       }
     }
+
+    &:last-child {
+      margin-bottom: 4em;
+    }
   }
 
   > section + section {


### PR DESCRIPTION
### Context

A couple of very minor visual tweaks on the subject-specific page styles.

#### Ensure there's a bottom margin on last section

| Before | After |
| -------- | -------- |
| ![Screenshot from 2022-06-13 09-55-11](https://user-images.githubusercontent.com/128088/173317663-abde05b7-e973-4268-a38a-db9195599244.png) | ![Screenshot from 2022-06-13 09-55-32](https://user-images.githubusercontent.com/128088/173317687-18704777-59c7-4526-908d-cc700c24eab8.png) |

#### Wrap hyperlink in a paragraph so it inherits style

| Before | After |
| -------- | -------- |
| ![Screenshot from 2022-06-13 09-56-34](https://user-images.githubusercontent.com/128088/173317795-fe094178-b556-45c6-b12b-25cfba6cd8e6.png) | ![Screenshot from 2022-06-13 09-56-44](https://user-images.githubusercontent.com/128088/173317827-aee9c29c-d88a-48b9-bf20-ba169127ac55.png) |