### PR TITLE
Require an address city for all buildings

### DIFF
--- a/app/models/internal/event_building.rb
+++ b/app/models/internal/event_building.rb
@@ -17,7 +17,7 @@ module Internal
     validates :address_line1, length: { maximum: 255 }
     validates :address_line2, length: { maximum: 255 }
     validates :address_line3, length: { maximum: 255 }
-    validates :address_city, length: { maximum: 100 }
+    validates :address_city, presence: true, length: { maximum: 100 }
     validates :address_postcode, presence: true, postcode: true, allow_blank: false, length: { maximum: 100 }
 
     def self.initialize_with_api_building(building)

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -24,5 +24,6 @@
   </main>
 
   <%= render "components/videoplayer" %>
+  <%= javascript_pack_tag 'govuk/frontend', 'data-turbolinks-track': 'reload', async: true %>
 <% end %>
 </html>

--- a/app/webpacker/packs/internal.js
+++ b/app/webpacker/packs/internal.js
@@ -1,21 +1,10 @@
-import { initAll } from 'govuk-frontend';
 import { enhanceSelectElement } from 'accessible-autocomplete';
 import flatpickr from 'flatpickr';
 import 'trix';
 import '../styles/internal.scss';
 
-initialiseGovUk();
 initialiseSelectElement();
 initialiseFlatpickr();
-
-function initialiseGovUk() {
-  initAll();
-
-  // Needed for GovUK JavaScript
-  document.body.className = document.body.className
-    ? document.body.className + ' js-enabled'
-    : 'js-enabled';
-}
 
 function initialiseSelectElement() {
   const selectId = document.querySelector('#internal-event-building-id-field');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,6 +469,8 @@ en:
           attributes:
             venue:
               blank: Enter a venue name
+            address_city:
+              blank: Enter a city
             address_postcode:
               blank: Enter a postcode
 

--- a/spec/models/internal/event_building_spec.rb
+++ b/spec/models/internal/event_building_spec.rb
@@ -33,6 +33,7 @@ describe Internal::EventBuilding do
 
     describe "#address_city" do
       it { is_expected.to validate_length_of(:address_city).is_at_most(100) }
+      it { is_expected.to validate_presence_of(:address_city) }
     end
 
     describe "#address_postcode" do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -369,6 +369,7 @@ describe Internal::EventsController, type: :request do
           context "when \"add a building\" is selected" do
             let(:expected_venue) { "New venue" }
             let(:expected_postcode) { "M1 7AX" }
+            let(:expected_city) { "Manchester" }
             let(:params) do
               attributes_for :internal_event,
                              :provider_event,
@@ -376,6 +377,7 @@ describe Internal::EventsController, type: :request do
                                "building":
                                  { "id": building_id,
                                    "venue": expected_venue,
+                                   "address_city": expected_city,
                                    "address_postcode": expected_postcode } }
             end
 
@@ -387,7 +389,7 @@ describe Internal::EventsController, type: :request do
                   address_line1: nil,
                   address_line2: nil,
                   address_line3: nil,
-                  address_city: nil,
+                  address_city: expected_city,
                   address_postcode: expected_postcode,
                   image_url: nil,
                 })


### PR DESCRIPTION
> :warning: pending sign-off from events team before we merge

### Trello card

[Trello-2963](https://trello.com/c/l0Yw3U53/2963-investigate-why-some-provider-events-are-missing-location-in-new-events-listing-design)

### Context

We want to ensure all buildings are entered with an address city as we use this on the listings page to indicate where the event is (even if its an online event as it may be location-relevant).

### Changes proposed in this pull request

- Require a city address for all buildings
- Fix GOV.UK JS not loading in internal event pages

### Guidance to review

It looks like the JS needs to be evaluated after the page has loaded and it hasn't been working on the internal events pages. Switch to using the `frontend.js` pack that only pulls in the parts we actually use (radio buttons in the internal events form).