### PR TITLE
Whitelist blog tags with a centralised config file

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,11 @@ protected
     @noindex = true
   end
 
+  def add_content_error(error)
+    @content_errors ||= []
+    @content_errors << error
+  end
+
 private
 
   def declare_frontmatter

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -14,6 +14,14 @@ class BlogController < ApplicationController
   def show
     @post = ::Pages::Blog.find(request.path)
 
+    begin
+      @post.validate!
+    rescue ::Pages::ContentError => e
+      raise e unless helpers.display_content_errors?
+
+      add_content_error(e)
+    end
+
     breadcrumb "Blog", blog_index_path
     breadcrumb @post.title, request.path
 

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -4,4 +4,8 @@ module ContentHelper
       classes << "fullwidth" if front_matter["fullwidth"]
     end
   end
+
+  def display_content_errors?
+    Rails.application.config.x.display_content_errors
+  end
 end

--- a/app/models/pages/blog.rb
+++ b/app/models/pages/blog.rb
@@ -1,10 +1,12 @@
 module Pages
   class Blog
+    class InvalidTagError < RuntimeError; end
+
     class << self
       delegate :posts, :popular_tags, :similar_posts, to: :instance
 
       def find(path)
-        ::Pages::Page.find(path)
+        ::Pages::Post.find(path)
       end
 
     private

--- a/app/models/pages/content_error.rb
+++ b/app/models/pages/content_error.rb
@@ -1,0 +1,11 @@
+module Pages
+  class ContentError < RuntimeError
+    attr_reader :anchor
+
+    def initialize(message, anchor)
+      @anchor = anchor
+
+      super(message)
+    end
+  end
+end

--- a/app/models/pages/post.rb
+++ b/app/models/pages/post.rb
@@ -1,0 +1,16 @@
+module Pages
+  class Post < Page
+    def validate!
+      invalid_tags = frontmatter.tags - tags_whitelist
+
+      message = "These tags are not defined in tags.yml: #{invalid_tags.to_sentence}"
+      raise ContentError.new(message, "#tags") if invalid_tags.any?
+    end
+
+  private
+
+    def tags_whitelist
+      @tags_whitelist ||= YAML.load_file(Rails.root.join("config/tags.yml"))
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,12 +3,15 @@
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") if gtm_enabled? %>
+
     <%= render HeaderComponent.new(breadcrumbs: true) %>
 
     <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">
+        <%= render(partial: "sections/content_errors") %>
+
         <article class="markdown <%= " fullwidth" if @fullwidth %>">
           <%= yield %>
         </article>

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -12,6 +12,8 @@
 
     <main id="main-content" role="main">
       <section class="container blog main-body">
+        <%= render(partial: "sections/content_errors") %>
+
         <article class="markdown longform blog-article">
           <header>
             <%= tag.h1(@front_matter["title"], class: "heading-l heading--margin-bottom-0") %>
@@ -33,7 +35,7 @@
           <footer>
             <h2 class="heading-m">Related to this article</h2>
             <div class="blog-tags-list container ">
-              <h3>Tags</h3>
+              <h3 id="tags">Tags</h3>
               <%= render partial: "blog/tag_list", locals: { tags: @front_matter["tags"] } %>
             </div>
 

--- a/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
+++ b/app/views/layouts/campaigns/landing_page_with_hero_nav.html.erb
@@ -18,6 +18,8 @@
       <% end %>
 
       <section class="container main-body">
+        <%= render(partial: "sections/content_errors") %>
+
         <article class="markdown hero-nav">
           <%= yield %>
         </article>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -10,6 +10,8 @@
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="container main-body">
+        <%= render(partial: "sections/content_errors") %>
+
         <% if !@front_matter["image"] %>
           <header>
             <% if @front_matter["title_caption"].present? %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -10,6 +10,8 @@
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body home">
+        <%= render(partial: "sections/content_errors") %>
+
         <% @front_matter["content"]&.each do |partial| %>
           <%= render(partial) %>
         <% end %>

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -3,6 +3,7 @@
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") if gtm_enabled? %>
+    <%= render(partial: "sections/content_errors") %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -10,6 +10,8 @@
       <%= render Content::HeroComponent.new(@front_matter) %>
 
       <section class="main-body container">
+        <%= render(partial: "sections/content_errors") %>
+
         <% if !@front_matter["image"] %>
           <header>
             <% if @front_matter["title_caption"].present? %>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -3,6 +3,7 @@
   <%= render "sections/head" %>
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content", "link-assets-url-value": ENV["APP_ASSETS_URL"] }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") if gtm_enabled? %>
+    <%= render(partial: "sections/content_errors") %>
 
     <%= render HeaderComponent.new %>
 

--- a/app/views/sections/_content_errors.html.erb
+++ b/app/views/sections/_content_errors.html.erb
@@ -1,0 +1,12 @@
+<% if @content_errors && display_content_errors? %>
+  <div class="govuk-error-summary govuk-!-width-full govuk-!-margin-5" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem with the content of this page
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <%= safe_join(@content_errors.map { |e| tag.a(tag.li(e.message), href: e.anchor) }) %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -7,4 +7,6 @@ Rails.application.configure do
     "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
 
   config.view_component.show_previews = true
+
+  config.x.display_content_errors = true
 end

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -1,0 +1,32 @@
+- applications
+- autism
+- becoming a teacher
+- behaviour
+- benefits
+- bursaries
+- career change to teaching
+- career progression
+- changing career to teaching
+- classroom concerns
+- deafness
+- financial support
+- funding
+- international
+- interviews
+- life as a teacher
+- maintenance loans
+- mentors
+- neurodiversity
+- non-UK teachers
+- pensions
+- personal statements
+- qualifications
+- references
+- returning to teaching
+- salaries
+- school experience
+- support
+- teacher training
+- teacher training advisers
+- teaching internships
+- train to teach events

--- a/docs/content.md
+++ b/docs/content.md
@@ -296,3 +296,7 @@ To add a new generic variant, copy and paste an existing one, give it an appropr
 ```yaml
 closing_paragraph: my-new-closing-paragraph
 ```
+
+### Tags
+
+We have a whitelist of available blog tags in `/config/tags.yml` - if you try to add a tag not contained within this list you will receive an error message on the blog post page and our test suite will fail (preventing you from deploying your blog post). If you need a tag not already in the whitelist, add it to the `tags.yml` before referencing it in your blog post.

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -50,4 +50,21 @@ describe "reading the blog", type: :feature do
     # ensure we're pulling in and including the generic closing paragraph named in the front matter
     expect(page).to have_css("article > p:last-of-type", text: "enriching the lives of young people")
   end
+
+  context "when a blog post has invalid tags" do
+    scenario "viewing - do not display content errors" do
+      allow(Rails.application.config.x).to receive(:display_content_errors).and_return(false)
+
+      expect { visit blog_path("post_invalid_tag") }.to raise_error(Pages::ContentError)
+    end
+
+    scenario "viewing - display content errors" do
+      allow(Rails.application.config.x).to receive(:display_content_errors).and_return(true)
+
+      visit blog_path("post_invalid_tag")
+
+      expect(page).to have_http_status(:success)
+      expect(page).to have_text("These tags are not defined in tags.yml: invalid tag")
+    end
+  end
 end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -13,7 +13,7 @@ end
 RSpec.feature "content pages check", type: :feature, content: true do
   include_context "with stubbed types api"
 
-  let(:other_paths) { %w[/ /blog /search /tta-service /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }
+  let(:other_paths) { %w[/ /blog /blog/post_invalid_tag /search /tta-service /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }
   let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}, %r{/test}] }
 
   before do

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -29,4 +29,18 @@ describe ContentHelper, type: :helper do
       end
     end
   end
+
+  describe "#display_content_errors?" do
+    before { allow(Rails.application.config.x).to receive(:display_content_errors).and_return(false) }
+
+    subject { display_content_errors? }
+
+    it { is_expected.to be(false) }
+
+    context "when config is set to true" do
+      before { allow(Rails.application.config.x).to receive(:display_content_errors).and_return(true) }
+
+      it { is_expected.to be(true) }
+    end
+  end
 end

--- a/spec/models/pages/blog_spec.rb
+++ b/spec/models/pages/blog_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Pages::Blog do
   describe ".find" do
     subject { described_class }
 
-    before { allow(::Pages::Page).to receive(:find).with("/some/template").and_return("/some_template.md") }
+    before { allow(::Pages::Post).to receive(:find).with("/some/template").and_return("/some_template.md") }
 
     specify "calls the other method" do
       described_class.find("/some/template")
 
-      expect(::Pages::Page).to have_received(:find).with("/some/template").once
+      expect(::Pages::Post).to have_received(:find).with("/some/template").once
     end
   end
 

--- a/spec/models/pages/post_spec.rb
+++ b/spec/models/pages/post_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ::Pages::Post do
+  let(:instance) { described_class.new("/blog/post", frontmatter) }
+
+  describe "#validate!" do
+    let(:frontmatter) { { tags: %w[benefits] } }
+
+    subject(:validate) { instance.validate! }
+
+    it { expect { validate }.not_to raise_error }
+
+    context "when the post has invalid tags" do
+      let(:frontmatter) { { tags: %w[invalid] } }
+
+      it "raises an error" do
+        expected_attrs = { message: "These tags are not defined in tags.yml: invalid", anchor: "#tags" }
+        expect { validate }.to raise_error(
+          an_instance_of(Pages::ContentError).and(having_attributes(expected_attrs)),
+        )
+      end
+    end
+  end
+end

--- a/spec/support/views/content/blog/post_invalid_tag.md
+++ b/spec/support/views/content/blog/post_invalid_tag.md
@@ -1,0 +1,9 @@
+---
+title: A blog post with invalid tag
+subtitle: A blog post with invalid tag
+date: "2022-05-17"
+tags:
+  - invalid tag
+---
+
+A blog post with invalid tag


### PR DESCRIPTION
### Trello card

[Trello-3164](https://trello.com/c/ikHA33tm/3164-control-the-creation-of-blog-tags-centrally-to-enable-better-curation-of-blog-posts)

### Context

We want to stop new tags being added ad-hoc to blog posts; instead, they must be part of the centralised `tags.yml` file before they can be used.

If a new tag is used without being declared we will raise an exception, which will be flagged by our existing content specs that ensure all content on the website can be rendered successfully.

If a blog post has an invalid tag (such that its not declared in the whitelist of available tags) we want to raise this as a problem. The difficulty here is that its often going to be a content editor that runs into this, so whilst we want a test to fail to prevent a deployment we also want to make it clear to content editors that there is an issue/what the issue is (and delving into the CI to find out wouldn't be a great experience for them).

To achieve this, we can surface the content errors on the `rolling` environment (which is used for review apps) within the page being edited. The tests will still fail to prevent a deployment and the content editor will be able to resolve the issue without developer assistance.

### Changes proposed in this pull request

- Raise an error when an invalid blog tag is used
- Surface content errors on rolling
- Update content documentation around blog tags

### Guidance to review

I've made this a somewhat generic solution with a view that we could potentially use `ContentError` elsewhere (to prevent large image files from being added, for example).

I opted to render the errors inline with the article being edited, but if we expand this it may make sense to `rescue_from` in the `ApplicationController` and render a generic 'there are content errors on this page' template (to avoid rescuing in individual actions).

<img width="1066" alt="Screenshot 2022-06-15 at 11 22 30" src="https://user-images.githubusercontent.com/29867726/173805100-c63922cf-626c-437b-ad70-14259a278766.png">
