### PR TITLE
Make event search params more analytics friendly

### DIFF
--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -9,10 +9,10 @@ class EventType
 
   QUERY_PARAM_NAMES =
     {
-      "train_to_teach_event" => 222_750_001,
-      "question_time" => 222_750_007,
-      "online_event" => 222_750_008,
-      "school_or_university_event" => 222_750_009,
+      "ttt" => 222_750_001,       # Train to Teach event
+      "tttqt" => 222_750_007,     # Question Time
+      "onlineqa" => 222_750_008,  # Online event
+      "provider" => 222_750_009,  # School or University event
     }.freeze
 
   attr_accessor :type_id

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -7,6 +7,14 @@ class EventType
       "School or University event" => 222_750_009,
     }.freeze
 
+  QUERY_PARAM_NAMES =
+    {
+      "train_to_teach_event" => 222_750_001,
+      "question_time" => 222_750_007,
+      "online_event" => 222_750_008,
+      "school_or_university_event" => 222_750_009,
+    }.freeze
+
   attr_accessor :type_id
 
   delegate(
@@ -49,6 +57,14 @@ class EventType
 
     def lookup_by_ids(*ids)
       ALL.invert.fetch_values(*ids)
+    end
+
+    def lookup_by_query_param(name)
+      QUERY_PARAM_NAMES.fetch(name)
+    end
+
+    def lookup_by_query_params(*names)
+      QUERY_PARAM_NAMES.fetch_values(*names)
     end
 
     def all_ids

--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -91,7 +91,9 @@ module TeachingEvents
     def type_condition
       return nil if type.blank?
 
-      type.reject(&:blank?).flat_map { |t| t.split(",") }.map(&:to_i).presence
+      event_type_params = type.reject(&:blank?).flat_map { |t| t.split(",") }
+
+      EventType.lookup_by_query_params(*event_type_params).presence
     end
   end
 end

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -34,7 +34,7 @@
     </p>
 
     <p>
-    <%= link_to("Register for a Train to Teach event", events_path("teaching_events_search[type][]" => "222_750_001,222_750_007"), class: "button") %>
+    <%= link_to("Register for a Train to Teach event", events_path("teaching_events_search[type][]" => "ttt,tttqt"), class: "button") %>
     </p>
 
     <h2>What to expect on the day:</h2>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,9 +18,9 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "222_750_001,222_750_007", label: { text: "DfE Train to Teach" } %>
-      <%= f.govuk_check_box :type, "222_750_008", label: { text: "DfE Online Q&A" } %>
-      <%= f.govuk_check_box :type, "222_750_009", label: { text: "Training provider" } %>
+      <%= f.govuk_check_box :type, "train_to_teach_event,question_time", label: { text: "DfE Train to Teach" } %>
+      <%= f.govuk_check_box :type, "online_event", label: { text: "DfE Online Q&A" } %>
+      <%= f.govuk_check_box :type, "school_or_university_event", label: { text: "Training provider" } %>
     <% end %>
   </div>
 

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,9 +18,9 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "train_to_teach_event,question_time", label: { text: "DfE Train to Teach" } %>
-      <%= f.govuk_check_box :type, "online_event", label: { text: "DfE Online Q&A" } %>
-      <%= f.govuk_check_box :type, "school_or_university_event", label: { text: "Training provider" } %>
+      <%= f.govuk_check_box :type, "ttt,tttqt", label: { text: "DfE Train to Teach" } %>
+      <%= f.govuk_check_box :type, "onlineqa", label: { text: "DfE Online Q&A" } %>
+      <%= f.govuk_check_box :type, "provider", label: { text: "Training provider" } %>
     <% end %>
   </div>
 

--- a/spec/features/teaching_events/about_ttt_events_spec.rb
+++ b/spec/features/teaching_events/about_ttt_events_spec.rb
@@ -3,6 +3,6 @@ require "rails_helper"
 RSpec.feature "About TTT events", type: :feature do
   scenario "there is a link to a pre-filtered page" do
     visit about_ttt_events_path
-    expect(page).to have_link("Register for a Train to Teach event", href: events_path("teaching_events_search[type][]" => "222_750_001,222_750_007"))
+    expect(page).to have_link("Register for a Train to Teach event", href: events_path("teaching_events_search[type][]" => "ttt,tttqt"))
   end
 end

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -6,6 +6,24 @@ RSpec.feature "Searching for teaching events", type: :feature do
   let(:event_count) { 5 }
   let(:events) { build_list(:event_api, event_count) }
 
+  describe "filter contents" do
+    before do
+      allow_any_instance_of(TeachingEvents::Search).to receive(:results).and_return(events)
+      visit events_path
+    end
+
+    specify "the events filter contains valid event query params" do
+      html = Nokogiri.parse(page.html)
+
+      params = html
+        .css(%(input[type='checkbox'][name='teaching_events_search[type][]']))
+        .map { |e| e.attr("value") }
+        .flat_map { |qp| qp.split(",") }
+
+      expect(params).to match_array(EventType::QUERY_PARAM_NAMES.keys)
+    end
+  end
+
   describe "event lists" do
     before do
       allow_any_instance_of(TeachingEvents::Search).to receive(:results).and_return(events)

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -74,21 +74,21 @@ describe EventType do
 
     describe ".lookup_by_query_param" do
       specify "returns the id given the corresponding query param" do
-        expect(described_class.lookup_by_query_param("question_time")).to eq(222_750_007)
+        expect(described_class.lookup_by_query_param("tttqt")).to eq(222_750_007)
       end
 
       specify "errors when an unrecognised name is passed in" do
-        expect { described_class.lookup_by_query_param("some_networking_event") }.to raise_error(KeyError)
+        expect { described_class.lookup_by_query_param("other") }.to raise_error(KeyError)
       end
     end
 
     describe ".lookup_by_query_params" do
       specify "returns the id given the corresponding query params" do
-        expect(described_class.lookup_by_query_params("question_time", "online_event")).to eq([222_750_007, 222_750_008])
+        expect(described_class.lookup_by_query_params("tttqt", "onlineqa")).to eq([222_750_007, 222_750_008])
       end
 
       specify "errors when an unrecognised name are passed in" do
-        expect { described_class.lookup_by_query_params("online_event", "some_networking_event") }.to raise_error(KeyError)
+        expect { described_class.lookup_by_query_params("onlineqa", "other") }.to raise_error(KeyError)
       end
     end
   end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -71,6 +71,26 @@ describe EventType do
         expect { described_class.lookup_by_ids(999_888_777) }.to raise_error(KeyError)
       end
     end
+
+    describe ".lookup_by_query_param" do
+      specify "returns the id given the corresponding query param" do
+        expect(described_class.lookup_by_query_param("question_time")).to eq(222_750_007)
+      end
+
+      specify "errors when an unrecognised name is passed in" do
+        expect { described_class.lookup_by_query_param("some_networking_event") }.to raise_error(KeyError)
+      end
+    end
+
+    describe ".lookup_by_query_params" do
+      specify "returns the id given the corresponding query params" do
+        expect(described_class.lookup_by_query_params("question_time", "online_event")).to eq([222_750_007, 222_750_008])
+      end
+
+      specify "errors when an unrecognised name are passed in" do
+        expect { described_class.lookup_by_query_params("online_event", "some_networking_event") }.to raise_error(KeyError)
+      end
+    end
   end
 
   subject { described_class.new(build(:event_api)) }

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -92,10 +92,10 @@ describe TeachingEvents::Search do
   end
 
   describe "#results" do
-    ttt           = "train_to_teach_event"
-    qt            = "question_time"
-    online        = "online_event"
-    school_or_uni = "school_or_university_event"
+    ttt           = "ttt"
+    qt            = "tttqt"
+    online        = "onlineqa"
+    school_or_uni = "provider"
 
     let(:fake_api) do
       instance_double(

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -92,10 +92,10 @@ describe TeachingEvents::Search do
   end
 
   describe "#results" do
-    ttt           = EventType.train_to_teach_event_id
-    qt            = EventType.question_time_event_id
-    online        = EventType.online_event_id
-    school_or_uni = EventType.school_or_university_event_id
+    ttt           = "train_to_teach_event"
+    qt            = "question_time"
+    online        = "online_event"
+    school_or_uni = "school_or_university_event"
 
     let(:fake_api) do
       instance_double(
@@ -169,19 +169,19 @@ describe TeachingEvents::Search do
       OpenStruct.new(
         description: "Train to Teach and Online",
         input: { type: [ttt, online].map(&:to_s) },
-        expected_conditions: { type_ids: [ttt, online] },
+        expected_conditions: { type_ids: EventType.lookup_by_query_params(ttt, online) },
       ),
 
       OpenStruct.new(
         description: "School or University or Question Time",
         input: { type: [qt, school_or_uni].map(&:to_s) },
-        expected_conditions: { type_ids: [qt, school_or_uni] },
+        expected_conditions: { type_ids: EventType.lookup_by_query_params(qt, school_or_uni) },
       ),
 
       OpenStruct.new(
         description: "All types",
         input: { type: [qt, school_or_uni, ttt, online].map(&:to_s) },
-        expected_conditions: { type_ids: [qt, school_or_uni, ttt, online] },
+        expected_conditions: { type_ids: EventType.lookup_by_query_params(qt, school_or_uni, ttt, online) },
       ),
     ].each do |query|
       context "#{query.description} (#{query.input})" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/doE2bUqu/2701-set-up-redirects-to-make-pre-filtered-event-links-easier-to-use

### Context

This is the first step in making the event search query string easier to read. Here we're replacing the Dynamics-generated IDs (eg 222_750_008) with a readable string:

#### Before

```
&teaching_events_search[type][]=222_750_008&teaching_events_search[type][]=222_750_009
```

#### After

```
&teaching_events_search[type][]=online_event&teaching_events_search[type][]=school_or_university_event
```

The query string is complex because we're binding the search form to an object (which makes it easier for us to show errors, etc), but in doing so it means we're using Rails' conventions for query params.

We could simplify more so it's more like:

```
?event_types=online_event,school_or_university_event
```

But we'd need to make bigger changes to the way the filter and form works, re-implementing a lot of what Rails gives us from scratch.

### Changes proposed in this pull request

- Add lookup_by_query_params methods to EventType
- Change the search over to use named event params
