### PR TITLE
Update social links on international returners page

### DIFF
--- a/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_get-ready-to-apply.md
+++ b/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_get-ready-to-apply.md
@@ -2,7 +2,8 @@ Strengthen your application and widen your net by:
 
 * networking with schools and colleagues in England (search #PrimaryRocks,
   #MFLTwitterati and #UKEdChat on Twitter)
-* following DfE on [Facebook](https://www.facebook.com/educationgovuk) and [Twitter](https://twitter.com/educationgovuk)
+* following the [Department for Education on Facebook](https://www.facebook.com/educationgovuk)
+* following the [Department for Education on Twitter](https://twitter.com/educationgovuk)
 * collecting evidence of your performance and experience overseas (this can
   include lessons recorded on video and testimonials from your headteacher)
 * getting a police clearance certificate and/or a letter of good conduct


### PR DESCRIPTION
### Trello card
https://trello.com/c/JObhwW6y

### Context
Silktide has flagged that there are two links called 'Facebook' that go to different destinations (DfE and GIT), and similarly two links called 'Twitter' that go to different destinations, which is confusing for screen reader users.

Link text updated for DfE links

