### PR TITLE
Add original request to redirect logs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
     redirect_rules.each do |from, to|
       get from => lambda { |env|
-        Rails.logger.info(redirect: { from: from, to: to })
+        Rails.logger.info(redirect: { request: env["ORIGINAL_FULLPATH"], from: from, to: to })
         redirect(path: to).call(env)
       }
     end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -9,14 +9,16 @@ describe "Redirects", content: true, type: :request do
   redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")
   redirects.each do |from, to|
     describe "'#{from}' redirects to '#{to}'" do
-      subject { get(build_url(from, query_string)) }
+      let(:url) { build_url(from, query_string) }
+
+      subject { get(url) }
 
       specify "redirects successfully" do
         allow(Rails.logger).to receive(:info)
 
         expect(subject).to be 301
         expect(response).to redirect_to(build_url(to, query_string))
-        expect(Rails.logger).to have_received(:info).with(redirect: { from: from, to: to })
+        expect(Rails.logger).to have_received(:info).with(redirect: { request: url, from: from, to: to })
 
         target = Nokogiri.parse(response.body).at_css("a")["href"].gsub(root_url, "/")
 


### PR DESCRIPTION
### Trello card

[Trello-3414](https://trello.com/c/sdcYUyVi/3414-investigate-high-traffic-to-legacy-urls)

### Context

We are seeing a large number of redirects for certain patterns; to help debug where the traffic is coming from we want to log the original request URL as well as the redirect information.

### Changes proposed in this pull request

- Add original request to redirect logs

### Guidance to review

