### PR TITLE
Fix the sitemap for the new event structure

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -11,9 +11,7 @@ class SitemapController < ApplicationController
   OTHER_PATHS = %w[
     /events/
     /blog/
-    /event-categories/train-to-teach-events
-    /event-categories/online-q-as
-    /event-categories/school-and-university-events
+    /events/about-train-to-teach-events
     /mailinglist/signup/name
   ].freeze
 

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -9,8 +9,8 @@ class SitemapController < ApplicationController
   # Ensure any index route (collection) has a trailing slash (representing the semantics of a directory).
   # This will keep it consistent with how canonical-rails behaves and ensure search engines are happy.
   OTHER_PATHS = %w[
-    /events/
-    /blog/
+    /events
+    /blog
     /events/about-train-to-teach-events
     /mailinglist/signup/name
   ].freeze


### PR DESCRIPTION
### Trello card

https://trello.com/c/cCltcNPa/3418-add-core-events-pages-to-the-sitemap

### Context and changes

#### Remove event category pages from sitemap

The old event categories page no longer exist and have been removed. In their place the 'about-train-to-teach-events' page has been added.

#### Remove trailing slashes from events and blog

It appears that Google isn't too worried about the presence (or absence) of the trailing slash but it does treat both variations as separate pages.

As we link to `/events` and `/blog` in most places (via the `events_path` and `blog_path` helpers) it makes sense to drop them from `OTHER_PATHS`.
