### PR TITLE
Move online event instructions to conditional

### DIFF
--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -49,6 +49,10 @@ module TeachingEvents
       event_building.present?
     end
 
+    def online?
+      is_online
+    end
+
     def location
       if show_venue_information?
         [event_building.venue,

--- a/app/views/teaching_events/show/_how-to-attend.html.erb
+++ b/app/views/teaching_events/show/_how-to-attend.html.erb
@@ -11,10 +11,15 @@
 
     <% if can_sign_up_online?(@event) %>
       <p>
-        To attend this event, you must register for a place. Once registered,
-        you will receive log-in information and joining instructions via email.
-        Please note: to access this event you will require a laptop/desktop PC
-        and be using Google Chrome as your browser.
+        You must register for a place to attend this event.
+
+        <% if @event.online? %>
+          Once registered, you will receive log-in information and joining
+          instructions via email.
+
+          Please note: to access this event you will require a laptop/desktop PC
+          and be using Google Chrome as your browser.
+        <% end %>
       </p>
 
       <%= render(partial: 'teaching_events/show/register-button') %>

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -109,8 +109,25 @@ RSpec.feature "Searching for teaching events", type: :feature do
     context "when can the event can be signed up for online" do
       let(:event) { build(:event_api) }
 
-      it { is_expected.to have_content("To attend this event, you must register for a place") }
+      it { is_expected.to have_content("You must register for a place to attend this event") }
       it { is_expected.to have_link(register_link_text) }
+    end
+
+    context "when the event is online" do
+      let(:event) { build(:event_api, :online) }
+
+      let(:expected) do
+        "Once registered, you will receive log-in information and joining instructions via email."
+      end
+
+      it { is_expected.to have_content(expected) }
+    end
+
+    context "when the event isn't online" do
+      let(:event) { build(:event_api) }
+
+      it { is_expected.not_to have_content(/you will receive log-in information/) }
+      it { is_expected.not_to have_content(/to access this event you will require a laptop/) }
     end
 
     context "when can the event can't be signed up for online" do

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -136,6 +136,20 @@ describe TeachingEvents::EventPresenter do
       end
     end
 
+    describe "#online?" do
+      context "when event is online" do
+        let(:event) { build(:event_api, :online) }
+
+        it { is_expected.to be_online }
+      end
+
+      context "when event is not online" do
+        let(:event) { build(:event_api) }
+
+        it { is_expected.not_to be_online }
+      end
+    end
+
     describe "#open?" do
       context "when event is open" do
         let(:event) { build(:event_api) }


### PR DESCRIPTION
### Trello card

https://trello.com/c/jElVr4WU

### Context and changes

When events aren't online we shouldn't be displaying the guidance on log-in instructions and hardware requirements.

Also reword the opening sentence a little.
