### PR TITLE
Restrict goal completion to live/viewable events

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -8,7 +8,7 @@ class EventStepsController < ApplicationController
   self.wizard_class = Events::Wizard
 
   before_action :noindex
-  before_action :redirect_closed_events, only: %i[show update]
+  before_action :restrict_sign_ups, only: %i[show update completed]
   before_action :set_step_page_title, only: [:show]
   before_action :set_completed_page_title, only: [:completed]
 
@@ -22,11 +22,13 @@ protected
 
 private
 
-  def redirect_closed_events
-    event_is_closed = EventStatus.new(@event).closed?
+  def restrict_sign_ups
+    event_is_viewable = EventStatus.new(@event).viewable?
     candidate_is_walk_in = wizard_store[:is_walk_in]
 
-    if event_is_closed && !candidate_is_walk_in
+    unless event_is_viewable || candidate_is_walk_in
+      # Redirecting to the main event page will either render
+      # the event in a closed state or return a 410 (Gone).
       redirect_to event_path(id: @event.readable_id)
     end
   end

--- a/app/models/event_status.rb
+++ b/app/models/event_status.rb
@@ -46,7 +46,7 @@ class EventStatus
   end
 
   def viewable?
-    !pending? && future_dated?
+    !pending? && future_dated? && open?
   end
 
   def accepts_online_registration?

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -2,6 +2,10 @@ require "attribute_filter"
 
 module Events
   class Wizard < ::DFEWizard::Base
+    ATTRIBUTES_TO_LEAVE = %w[
+      is_walk_in
+    ].freeze
+
     self.steps = [
       Steps::PersonalDetails,
       ::DFEWizard::Steps::Authenticate,
@@ -19,7 +23,8 @@ module Events
         break unless result
 
         add_attendee_to_event
-        @store.purge!
+
+        @store.prune!(leave: ATTRIBUTES_TO_LEAVE)
       end
     end
 

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
 
   subject { page }
 
-  let(:event) { GetIntoTeachingApiClient::TeachingEvent.new(status_id: 1) }
+  let(:event) { build(:event_api) }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
@@ -91,7 +91,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
   end
 
   context "when visiting the event sign up page" do
-    let(:path) { event_steps_path("123") }
+    let(:path) { event_steps_path(event.readable_id) }
 
     it { is_expected.not_to have_css(".breadcrumbs") }
   end

--- a/spec/models/event_status_spec.rb
+++ b/spec/models/event_status_spec.rb
@@ -50,44 +50,32 @@ describe EventStatus do
   end
 
   describe "viewable?" do
-    context "when closed, future-dated, not online q&a" do
-      let(:event) { build(:event_api, :closed, :school_or_university_event) }
-
-      it { is_expected.to be_viewable }
-    end
-
-    context "when closed, future-dated, online q&a" do
-      let(:event) { build(:event_api, :closed, :online_event) }
-
-      it { is_expected.to be_viewable }
-    end
-
-    context "when closed, past, not online q&a" do
-      let(:event) { build(:event_api, :closed, :train_to_teach_event, :past) }
+    context "when closed, future-dated" do
+      let(:event) { build(:event_api, :closed) }
 
       it { is_expected.not_to be_viewable }
     end
 
-    context "when pending, future-dated, online q&a" do
-      let(:event) { build(:event_api, :pending, :online_event) }
+    context "when closed, past" do
+      let(:event) { build(:event_api, :closed, :past) }
 
       it { is_expected.not_to be_viewable }
     end
 
-    context "when open, future-dated, online q&a" do
-      let(:event) { build(:event_api, :online_event) }
+    context "when pending, future-dated" do
+      let(:event) { build(:event_api, :pending) }
+
+      it { is_expected.not_to be_viewable }
+    end
+
+    context "when open, future-dated" do
+      let(:event) { build(:event_api) }
 
       it { is_expected.to be_viewable }
     end
 
-    context "when open, future-dated, not online q&a" do
-      let(:event) { build(:event_api, :train_to_teach_event) }
-
-      it { is_expected.to be_viewable }
-    end
-
-    context "when open, past, not online q&a" do
-      let(:event) { build(:event_api, :past, :school_or_university_event) }
+    context "when open, past" do
+      let(:event) { build(:event_api, :past) }
 
       it { is_expected.not_to be_viewable }
     end

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -11,6 +11,7 @@ describe Events::Wizard do
       "first_name" => "Joe",
       "last_name" => "Joseph",
       "accepted_policy_id" => "789",
+      "is_walk_in" => true,
     } }
   end
   let(:wizardstore) { DFEWizard::Store.new store[uuid], {} }
@@ -38,7 +39,7 @@ describe Events::Wizard do
   describe "#complete!" do
     let(:request) do
       GetIntoTeachingApiClient::TeachingEventAddAttendee.new(
-        { event_id: "abc123", email: "email@address.com", first_name: "Joe", last_name: "Joseph", accepted_policy_id: "789" },
+        { event_id: "abc123", email: "email@address.com", first_name: "Joe", last_name: "Joseph", accepted_policy_id: "789", is_walk_in: true },
       )
     end
 
@@ -47,11 +48,18 @@ describe Events::Wizard do
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:add_teaching_event_attendee).with(request)
       allow(Rails.logger).to receive(:info)
+      allow(wizardstore).to receive(:prune!).and_call_original
       subject.complete!
     end
 
     it { is_expected.to have_received(:valid?) }
-    it { expect(store[uuid]).to eql({}) }
+
+    it "prunes the store, retaining certain attributes" do
+      expect(store[uuid]).to eql({
+        "is_walk_in" => wizardstore[:is_walk_in],
+      })
+      expect(wizardstore).to have_received(:prune!).with({ leave: described_class::ATTRIBUTES_TO_LEAVE }).once
+    end
 
     it "logs the request model (filtering sensitive attributes)" do
       filtered_json = {
@@ -67,6 +75,7 @@ describe Events::Wizard do
         "lastName" => "[FILTERED]",
         "addressPostcode" => nil,
         "addressTelephone" => "[FILTERED]",
+        "isWalkIn" => true,
       }.to_json
       expect(Rails.logger).to have_received(:info).with("Events::Wizard#add_attendee_to_event: #{filtered_json}")
     end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -185,5 +185,17 @@ describe EventStepsController, type: :request do
     end
 
     it { is_expected.to have_http_status :success }
+
+    context "when the event is in the past" do
+      let(:event) { build :event_api, :past, readable_id: readable_event_id }
+
+      it { is_expected.to redirect_to(event_path(id: event.readable_id)) }
+
+      context "when the candidate is a 'walk-in'" do
+        before { get event_step_path(readable_event_id, :personal_details, walk_in: true) }
+
+        it { is_expected.to have_http_status :success }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-3433](https://trello.com/c/3wu6pGzV/3433-investigate-why-historic-events-are-showing-up-in-ga-goal-completions)

### Context

At the moment its possible to reach the sign up `/completed` page for an event that is in the past/closed. As we have our goal completions setup to look for requests to this path its possible for a completion event to register in UA after the event
date (if a user has bookmarked the page or has left it open and reloads).

To prevent this we can redirect to the root event path, which will render a `410 gone` response (no longer registering as a goal completion). If the event is still 'live' but registrations are closed, the user will be presented with the event and closure message.

A 'walk in' can still technically sign up for a closed event (as this happensat the time of the event, so potenitally shortly after the start_at date). We need to make sure this is still possible by retaining the `is_walk_in`attribute in the store after sign up (otherwise the completion step will not know the sign up was a walk in and redirect them). 

### Changes proposed in this pull request

- Restrict goal completion to live/viewable events

- Use event factory in tests

As the controller action now inspects the date as well as the status of the event it needs to be present on our mock; we can do this easily by swapping it out to use the factory.

### Guidance to review

This PR also simplifies/changes the logic around determining if an event is 'viewable'. Previously we checked it was future dated and not pending. We should be safe to include closed in that conditional now as we no longer have a way of viewing past/archived events (previously you could view a past online Q&A event).

[Example completed page of past event](https://review-get-into-teaching-app-2644.london.cloudapps.digital/events/train-to-teach-london-event-050322/apply/completed)