### PR TITLE
Handle when event is returned as nil

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -70,7 +70,7 @@ private
     GetIntoTeachingApiClient::TeachingEventsApi.new.get_teaching_event(params[:id]).tap do |event|
       status = EventStatus.new(event)
 
-      raise ActionController::RoutingError, "Not Found" if status.pending?
+      raise ActionController::RoutingError, "Not Found" if event.nil? || status.pending?
       raise(EventNotViewableError) unless status.viewable?
     end
   end

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -33,6 +33,7 @@ redirects:
   "/event-categories/online-q-as": "/events"
   "/event-categories/school-and-university-events": "/events"
   "/teaching-events": "/events"
+  "/events/search": "/events"
 
   # Slides
   "/slides": "/presentations"

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -55,6 +55,15 @@ describe "teaching events", type: :request do
       it { is_expected.to have_http_status(:not_found) }
     end
 
+    context "when the event is nil" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+          receive(:get_teaching_event).with(readable_id).and_return(nil)
+      end
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+
     context "when the event is not viewable" do
       let(:event) { build(:event_api, :train_to_teach_event, :past) }
 


### PR DESCRIPTION
### Trello card

[Trello-3435](https://trello.com/c/CbE3Um28/3435-fix-sentry-error-on-accessing-nil-event)

### Context

When an event is not found in the API the client library is returning `nil`. I'm not sure yet when this changed as it used to throw an exception that we handle. For now, we need to handle the `nil` case and return a 404 (at the moment we get an `nil` object access error). I will look into how/when the client library changed as a separate PR.

### Changes proposed in this pull request

- Handle when event is returned as nil
- Redirect /events/search to /events

The old events form redirected the POST request to GET `/events/search` with encrypted parameters (to obfuscate the postcode/PII). The new events form also does this, however we don't have a redirect in place for people that bookmarked
the `/events/search` path and we are seeing a few errors as thats now treated as a GET event (with id of `search`), which is not found.

### Guidance to review

The two commits in this PR are related so I've bundled them together (the missing redirect is causing a number of errors and flagged the need to handle a `nil` event).