### PR TITLE
Added direct link to eligibility checker

### DIFF
--- a/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
+++ b/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
@@ -1,3 +1,3 @@
 The following providers offer assessment only QTS to international teachers. You will not have to visit or train in England, but you may be assessed at your place of work by an examiner from your teaching training provider. Contact the training provider directly to ask them about entry criteria and how to apply.
 
-[Learn more about working in England if you’re a teacher from outside the UK](/non-uk-teachers/teach-in-england-if-you-trained-overseas#consider-getting-qualified-teacher-status).
+[Learn more about working in England if you’re a teacher from outside the UK](/non-uk-teachers/teach-in-england-if-you-trained-overseas#consider-getting-qualified-teacher-status-qts).

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -73,7 +73,7 @@ To teach in England you need:
 * to pass criminal and professional safeguarding checks (these will be organised by your employer)
 * to [get the right visa or status](#get-the-right-visa-or-status)
 
-It is also helpful to have a teaching qualification from your own or another non-UK country, or to get '[qualified teacher status](#consider-getting-qualified-teacher-status)'.
+It is also helpful to have a teaching qualification from your own or another non-UK country, or to get '[qualified teacher status](#consider-getting-qualified-teacher-status-qts)'.
 
 ## Get the right visa or status
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -152,7 +152,7 @@ You can get one-to-one support if you have [qualified teacher status (QTS)](http
 
 ## Find out what salary you can earn
 
-Schools have some flexibility on [salary](/salaries-and-benefits). It varies by region and your level of skill, experience and qualifications.
+Schools have some flexibility on [teachers' salaries](/salaries-and-benefits). It varies by region and your level of skill, experience and qualifications.
 
 There are [specific salary requirements for a skilled worker visa](https://www.gov.uk/government/publications/teach-in-england-if-you-qualified-outside-the-uk/teach-in-england-if-you-qualified-outside-the-uk#visas-and-immigration).
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -107,17 +107,17 @@ You can apply for QTS directly to the TRA if you meet the following 3 requiremen
 
 1. You have a teaching qualification from:
 
-* Australia
-* Canada
-* [the EEA](https://www.gov.uk/eu-eea)
-* Gibraltar
-* New Zealand
-* Switzerland
-* the USA
+	* Australia
+	* Canada
+	* [the EEA](https://www.gov.uk/eu-eea)
+	* Gibraltar
+	* New Zealand
+	* Switzerland
+	* the USA
+  
+1. You can prove you’re recognised as a teacher in the country where you qualified.
 
-2. You can prove you’re recognised as a teacher in the country where you qualified.
-
-3. You’re not prohibited or restricted from teaching by a professional sanction against you.
+1. You’re not prohibited or restricted from teaching by a professional sanction against you.
 
 You will not have to pay a fee or undergo further training. 
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -123,14 +123,14 @@ You will not have to pay a fee or undergo further training.
 
 [Check your eligibility to apply to the Teaching Regulation Agency for QTS](https://apply-for-qts-in-england.education.gov.uk/eligibility/start).
 
-### Other QTS routes
+### Other routes to QTS
 
 If you do not meet all of these requirements you may still be able to:
 
 * apply for QTS through the assessment only route
 * complete a teacher training course in England leading to QTS
 
-[Learn more about routes to QTS for teachers who trained outside the UK](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk).
+[Learn more about routes to QTS for teachers who trained or have teaching experience outside the UK](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk).
 
 ## Search for a job
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -97,7 +97,7 @@ It’s not a legal requirement in all types of schools (for example, [academy sc
 
 However, even in these schools, having QTS can help your application for a teaching job.
 
-### Understanding the different routes to QTS
+## The different routes to QTS
 
 If you decide QTS is right for you, the most appropriate route will depend on the country you’re recognised in, your qualifications and your teaching experience.
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -101,7 +101,7 @@ However, even in these schools, having QTS can help your application for a teach
 
 If you decide QTS is right for you, the most appropriate route will depend on the country you’re recognised in, your qualifications and your teaching experience.
 
-### Applying directly to England’s Teaching Regulation Agency (TRA)
+### Apply directly to England’s Teaching Regulation Agency (TRA)
 
 You can apply for QTS directly to the TRA if you meet the following 3 requirements:
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -85,15 +85,52 @@ You may also be eligible for another type of visa, or you may have a pre-existin
 
 [If you're an Irish citizen you do not need a visa](https://www.gov.uk/government/publications/common-travel-area-guidance).
 
-## Consider getting qualified teacher status
+## Consider getting qualified teacher status (QTS)
 
-[You need 'qualified teacher status' (QTS) to teach in many schools in England](https://www.gov.uk/government/publications/qualified-teacher-status-routes-to-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk).
+[Qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts) is the professional status teachers in England gain at the end of their teacher training.
 
-It's not a requirement in all [types of schools](https://www.gov.uk/types-of-school), such as academy schools, free schools, private schools and independent schools. However, having QTS can help your application.
+If you’re a qualified teacher from outside the UK, you can [work as a teacher in England for up to 4 years without QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk).
 
-If you’re a qualified teacher from outside the UK you can [work as a teacher in England for up to 4 years without QTS](https://www.gov.uk/guidance/recruit-teachers-from-overseas#employing-overseas-teachers-without-qts-the-4-year-rule).
+After that, you will need QTS to teach in many schools in England.
 
-[Apply for QTS if you trained outside the UK](https://www.gov.uk/government/publications/qualified-teacher-status-routes-to-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk).
+It’s not a legal requirement in all types of schools (for example, [academy schools, free schools and private schools](https://www.gov.uk/types-of-school)).
+
+However, even in these schools, having QTS can help your application for a teaching job.
+
+### Understanding the different routes to QTS
+
+If you decide QTS is right for you, the most appropriate route will depend on the country you’re recognised in, your qualifications and your teaching experience.
+
+### Applying directly to England’s Teaching Regulation Agency (TRA)
+
+You can apply for QTS directly to the TRA if you meet the following 3 requirements:
+
+1. You have a teaching qualification from:
+
+* Australia
+* Canada
+* [the EEA](https://www.gov.uk/eu-eea)
+* Gibraltar
+* New Zealand
+* Switzerland
+* the USA
+
+2. You can prove you’re recognised as a teacher in the country where you qualified.
+
+3. You’re not prohibited or restricted from teaching by a professional sanction against you.
+
+You will not have to pay a fee or undergo further training. 
+
+[Check your eligibility to apply to the Teaching Regulation Agency for QTS](https://apply-for-qts-in-england.education.gov.uk/eligibility/start).
+
+### Other QTS routes
+
+If you do not meet all of these requirements you may still be able to:
+
+* apply for QTS through the assessment only route
+* complete a teacher training course in England leading to QTS
+
+[Learn more about routes to QTS for teachers who trained outside the UK](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk).
 
 ## Search for a job
 


### PR DESCRIPTION
In the Teach in England page, I've added some content for users who can apply to the TRA for QTS. However before we go live I need the Apply for QTS team to improve the user journey for users who are not currently eligible (ie they did not qualify in an eligible country). 
Wes is hoping for this to happen by 6 July, will confirm when I'm in next week. 

dded direct link to eligibility checker to improve user experience for applicants eligible for QTS

### Trello card

### Context

### Changes proposed in this pull request

### Guidance to review

