### PR TITLE
removing TTT event info from promo

### DIFF
--- a/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-near-you.html.erb
@@ -1,10 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      caption: "4 July 2022",
-      heading: "Train to Teach Manchester",
-      link_target: "/events/train-to-teach-manchester-event-040722",
-      link_text: "Sign up for this event") do %>
-    <p>Hear from training providers, chat with teachers and get one-to-one advice from expert advisers.<p>
+      heading: "Teacher training events") do %>
   <% end %>
 
   <% promo.right_section(


### PR DESCRIPTION
### Trello card

https://trello.com/c/kSUdvrTW/3442-replace-events-promo-when-summer-programme-ends

### Context

Removing Train to Teach event details from events promo now that the event has passed.

### Changes proposed in this pull request

### Guidance to review

