### PR TITLE
updating nav descriptions

### DIFF
--- a/app/views/content/funding-and-support/_nav-cards.html.erb
+++ b/app/views/content/funding-and-support/_nav-cards.html.erb
@@ -4,7 +4,7 @@
             <h2>Tuition fee and maintenance loans</h2>
 
             <p>
-                Find out how much money you could get to help pay your fees and living expenses while you train.
+                Find out which loans you could get to help pay your fees and living expenses while you train.
             </p>
             <span class="icon"></span>
         </a>
@@ -13,7 +13,7 @@
             <h2>Scholarships and bursaries</h2>
 
             <p>
-                There is extra funding available for some subject areas, find out if you are eligible.
+                Find out if you're eligible for extra funding depending on the subject you're training to teach.
             </p>
             <span class="icon"></span>
         </a>
@@ -22,7 +22,7 @@
             <h2>If you’re disabled</h2>
 
             <p>
-                If you are disabled, there is financial and practical support available to help you train.
+                Find out about the support you can get while training to teach if you're disabled.
             </p>
             <span class="icon"></span>
         </a>
@@ -30,7 +30,7 @@
         <a href="/funding-and-support/if-you-come-from-outside-england" class="category__nav-card">
             <h2>If you come from outside England</h2>
             <p>
-                There are different arrangements for getting financial support if you live outside England.
+                Find out about the different arrangements for getting financial support if you live outside England.
             </p>
             <span class="icon"></span>
         </a>
@@ -38,7 +38,7 @@
         <a href="/funding-and-support/if-youre-a-parent-or-carer" class="category__nav-card">
             <h2>If you’re a parent or carer</h2>
             <p>
-                If you have children or other caring responsibilities, you may be able to get extra financial support.
+                Find out what extra grants and schemes are available if you have children or other caring responsibilities.
             </p>
             <span class="icon"></span>
     </div>

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -2,7 +2,7 @@
 title: "Support training to teach if you're a parent or carer"
 heading: "Support training to teach if you're a parent or carer"
 description: |-
-  Find out about the extra grants and schemes you could be eligible for if you have children or other caring responsibilities.
+  Find out what extra grants and schemes are available if you have children or other caring responsibilities.
 related_content:
     Choosing the right teacher training course provider: "/blog/choosing-the-right-teacher-training-course-provider"
     Get school experience: "/train-to-be-a-teacher/get-school-experience"

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -2,7 +2,7 @@
 title: "Funding and support if you're disabled"
 heading: "Support training to teach if you're disabled"
 description: |-
-    Find out what extra support and adjustments you could be entitled to when you're training to teach if you're disabled.
+    Find out about the support you can get while training to teach if you're disabled.
 related_content:
     Who do you want to teach?: "/train-to-be-a-teacher/who-do-you-want-to-teach"
     Becoming a teacher with a hearing impairment: "/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment"

--- a/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
+++ b/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
@@ -18,7 +18,7 @@ calls_to_action:
         link_text: "Student finance calculator"
         link_target: "https://www.gov.uk/student-finance-calculator"
 navigation: 20.10
-navigation_description: Find out how much money you could get to help pay your fees and living expenses while you train.
+navigation_description: Find out which loans you could get to help pay your fees and living expenses while you train.
 keywords:
     - Tuition Fee
     - Maintenance Loan


### PR DESCRIPTION
### Trello card

https://trello.com/c/jomu3l6g/3452-look-at-nav-card-descriptions

### Context

Currently, the nav card descriptions in the nav cards file don't match those on the content pages. This PR makes sure that they match up and that the right ones are pulling through onto the live category page.

### Changes proposed in this pull request

### Guidance to review

