### PR TITLE
Add component for displaying inset text

### DIFF
--- a/app/components/content/inset_text_component.html.erb
+++ b/app/components/content/inset_text_component.html.erb
@@ -1,0 +1,4 @@
+<%= tag.section(class: "inset-text") do %>
+  <%= tag.h2(title) if title.present? %>
+  <%= tag.p(helpers.safe_html_format(text)) %>
+<% end %>

--- a/app/components/content/inset_text_component.rb
+++ b/app/components/content/inset_text_component.rb
@@ -1,0 +1,12 @@
+module Content
+  class InsetTextComponent < ViewComponent::Base
+    attr_reader :title, :text
+
+    def initialize(text:, title: nil)
+      super
+
+      @text = text
+      @title = title
+    end
+  end
+end

--- a/app/views/content/blog/grasp-every-opportunity.md
+++ b/app/views/content/blog/grasp-every-opportunity.md
@@ -14,9 +14,13 @@ keywords:
   - classroom
 tags:
   - career progression
+inset_text:
+  nqt-replaced-with-ect:
+    text: |-
+      Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
 ---
 
-Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
+$nqt-replaced-with-ect$
 
 I always wanted to work in an environment that was never going to be the same every day – teaching definitely provides this. Working with students from different backgrounds and preparing them to take their next steps towards success was always a huge draw to the profession.
 

--- a/app/views/content/blog/nqt-to-head-of-biology.md
+++ b/app/views/content/blog/nqt-to-head-of-biology.md
@@ -14,9 +14,13 @@ keywords:
   - classroom
 tags:
   - career progression
+inset_text:
+  nqt-replaced-with-ect:
+    text: |-
+      Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
 ---
 
-Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
+$nqt-replaced-with-ect$
 
 Two years after qualifying as a teacher, I progressed to head of biology, climbing the career ladder. I always had an inkling that teaching was the right direction.
 

--- a/app/views/content/blog/salaried-teacher-training-classroom-learning.md
+++ b/app/views/content/blog/salaried-teacher-training-classroom-learning.md
@@ -14,9 +14,13 @@ keywords:
   - classroom
 tags:
   - teacher training
+inset_text:
+  nqt-replaced-with-ect:
+    text: |-
+      Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
 ---
 
-Since this blog post was first published, the term newly qualified teacher (NQT) has been replaced with early career teacher (ECT). This describes a teacher in their first two years of teaching.
+$nqt-replaced-with-ect$
 
 Salaried teacher training offered the best option for me, earning an income while I trained towards qualified teacher status (QTS). My course also included a postgraduate certificate in education (PGCE), and Masters-level credits.
 

--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -17,6 +17,7 @@ $purple-dark: #7d58a0;
 $purple-dark-90: rgba($purple-dark, .9);
 $white: #ffffff;
 $white-90: rgba($white, .9);
+$yellow-light: #fef0cb;
 $yellow: #fbba20;
 $yellow-dark: #f9b400;
 $yellow-dark-90: rgba($yellow-dark, .9);

--- a/app/webpacker/styles/components/inset-text.scss
+++ b/app/webpacker/styles/components/inset-text.scss
@@ -1,0 +1,15 @@
+.inset-text {
+  margin-top: $indent-amount;
+  margin-bottom: $indent-amount;
+  padding: $indent-amount;
+  background-color: $yellow-light;
+  border-left: 6px solid $black;
+
+  h2, p {
+    @include font-size("small");
+  }
+
+  a {
+    @extend .link--black;
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -49,6 +49,7 @@
 @import './components/content-cta';
 @import './components/content-alert';
 @import './components/feature-table';
+@import './components/inset-text';
 @import './components/link-block';
 @import './components/pagination';
 @import './components/quote';

--- a/docs/content.md
+++ b/docs/content.md
@@ -16,6 +16,7 @@ This documentation aims to be a reference for content editors that want to make 
 		* [Sidebar](#sidebar)
   * [Accessibility](#accessibility)
     * [iframe](#iframe)
+  * [Inset text](#inset-text)
 3. [Creating a Blog Post](#creating-a-blog-post)
 	* [Images](#images)
 	* [Footers](#footers)
@@ -232,6 +233,23 @@ When adding an iFrame elemet as part of Markdown content or a HTML page we shoul
   title="A video about returning to teaching"
   ...
 ></iframe>
+```
+
+### Inset text
+
+If you need to call-out something important in an article and differentiate it from the surrounding text, you can use the inset text component. Specify the component in the frontmatter and then include it anywhere in the page:
+
+```yaml
+---
+inset_text:
+  important-content:
+    title: Optional title
+    text: Text that can contain <a href="#">links</a>
+---
+
+# My page
+
+$important-content$
 ```
 
 ## Creating a Blog Post

--- a/spec/components/content/inset_text_component_spec.rb
+++ b/spec/components/content/inset_text_component_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe Content::InsetTextComponent, type: :component do
+  let(:title) { "Title" }
+  let(:text) { "Text" }
+  let(:component) { described_class.new(text: text, title: title) }
+
+  subject do
+    render_inline(component)
+    page
+  end
+
+  it { is_expected.to have_css("section.inset-text") }
+  it { is_expected.to have_css(".inset-text p", text: text) }
+  it { is_expected.to have_css(".inset-text h2", text: title) }
+
+  context "when there is no title" do
+    let(:title) { nil }
+
+    it { is_expected.not_to have_css(".inset-text h2") }
+  end
+
+  context "when the text contains HTML" do
+    let(:text) { %(text with a <a href="#">link</a>) }
+
+    it { is_expected.to have_css(".inset-text a", text: "link") }
+  end
+
+  context "when the text contains malicious HTML" do
+    let(:text) { %{<script>alert();</script>} }
+
+    it { is_expected.not_to have_css("script") }
+  end
+end

--- a/spec/components/previews/content/inset_text_component_preview.rb
+++ b/spec/components/previews/content/inset_text_component_preview.rb
@@ -1,0 +1,28 @@
+class Content::InsetTextComponentPreview < ViewComponent::Preview
+  def default
+    component = Content::InsetTextComponent.new(**text)
+    render(component)
+  end
+
+  def with_title
+    component = Content::InsetTextComponent.new(**text.merge(title))
+    render(component)
+  end
+
+private
+
+  def text
+    {
+      text: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. "\
+      "Praesent a nisl semper, efficitur velit ac, tincidunt arcu.</p>"\
+      "<p>Morbi non nisl eu arcu molestie lacinia <a href=\"#\">quis quis</a> libero.</p>"\
+      "<p><a href=\"#\">Link</a></p>",
+    }
+  end
+
+  def title
+    {
+      title: "Optional title",
+    }
+  end
+end

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -181,10 +181,10 @@ describe TemplateHandlers::Markdown, type: :view do
     it { is_expected.to have_css "abbr[title=\"Pay as you earn\"]", text: "PAYE" }
   end
 
-  describe "injecting rich content" do
+  describe "injecting CTAs" do
     let(:front_matter_with_calls_to_action) do
       {
-        "title": "Page with rich content (calls to action)",
+        "title": "Page with calls to action",
         "calls_to_action" => {
           "big-warning" => {
             "name" => "simple",
@@ -287,6 +287,51 @@ describe TemplateHandlers::Markdown, type: :view do
         key = Image.new.alt("media/images/content/hero-images/#{photo}.jpg")
         expect(rendered).to have_css(%(img[alt="#{key}"]))
       end
+    end
+  end
+
+  describe "injecting content view components" do
+    let(:front_matter_with_images) do
+      {
+        "title": "Page with view components",
+        "quote" => {
+          "quote-1" => { "text" => "quote 1", "name" => "name", "job_title" => "job title", "inline" => "left" },
+        },
+        "inset_text" => {
+          "inset-text-1" => { "text" => "text 1" },
+          "inset-text-2" => { "text" => "text 2" },
+        },
+      }
+    end
+
+    let :markdown do
+      <<~MARKDOWN
+        # Some page
+
+        $quote-1$
+
+        Some text
+
+        $inset-text-1$
+
+        Some more text
+
+        $inset-text-2$
+      MARKDOWN
+    end
+
+    before do
+      allow(described_class).to receive(:global_front_matter).and_return(front_matter_with_images)
+      stub_template "page_with_rich_content.md" => markdown
+      render template: "page_with_rich_content"
+    end
+
+    subject { rendered }
+
+    it "contains the specified view components" do
+      is_expected.to have_css(".quote", text: "quote 1")
+      is_expected.to have_css(".inset-text", text: "text 1")
+      is_expected.to have_css(".inset-text", text: "text 2")
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-3352](https://trello.com/c/bqdPpvtD/3352-highlight-that-a-blog-post-contains-old-terminology)

### Context

Now that we have moved some of the old stories into the blog, we need to highlight that some of them have old content/terminology. To do this we will call it out at the top of the blog article in an inset component.

### Changes proposed in this pull request

- Add component for displaying inset text

Add an `InsetTextComponent` that can be used to highlight a portion of text within an article. It optionally takes a title and can render safe HTML so it is possible to include inline links.

- Render inset text in markdown handler

Update the markdown handler to support rendering `InsetText` view components specified by the `inset_text` key within the frontmatter.

Clean up the component rendering logic so that we can easily whitelist new components to be rendered in the future.

- Update blog articles with inset text

We want to call out the first paragraph of these blog articles as inset text on the page to make it clearer to the user that the terminology has changed.

### Guidance to review

<img width="748" alt="Screenshot 2022-07-05 at 09 10 53" src="https://user-images.githubusercontent.com/29867726/177281483-9df22877-e834-4f7b-83d3-6c70acc0ce91.png">

