### PR TITLE
Break-word on long event links

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -584,6 +584,10 @@ $icon-size: 3rem;
   &__video {
     margin-block: 2em;
   }
+
+  &__provider-information a {
+    word-wrap: break-word;
+  }
 }
 
 .teaching-events__about-ttt-banner {


### PR DESCRIPTION
### Trello card

[Trello-3453](https://trello.com/c/K29WZFh1/3453-fix-horizontal-scrolling-on-new-event-detail-pages)

### Context

Providers occasionally enter long event links that don't wrap, causing horizontal scroll issues on mobile.

Ensure provider links word break and wrap instead of causing horizontal scroll.

### Changes proposed in this pull request

- Break-word on long event links

### Guidance to review

| Before      | After |
| ----------- | ----------- |
| <img width="312" alt="Screenshot 2022-07-05 at 09 49 29" src="https://user-images.githubusercontent.com/29867726/177289574-26a4b695-fcf0-4c86-a78b-33855e820f8d.png">      | <img width="318" alt="Screenshot 2022-07-05 at 09 49 00" src="https://user-images.githubusercontent.com/29867726/177289538-d1ffefed-9d56-4cde-8e41-7f9ba88331a4.png">       |