### PR TITLE
Adjust line-height of hero text

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -172,6 +172,10 @@ $mobile-cutoff: 800px;
     z-index: 20;
   }
 
+  &__paragraph {
+    line-height: 1.5;
+  }
+
   &__subtitle {
     div {
       @include font-size("small");


### PR DESCRIPTION
### Trello card

[Trello-3434](https://trello.com/c/5oVqsi6Q/3434-make-line-height-on-category-page-intro-paragraph-consistent-with-other-content)

### Context

Bring it inline with the card components on the category pages.

### Changes proposed in this pull request

- Adjust line-height of hero text

### Guidance to review

