### PR TITLE
Move funding widget below first content block

### DIFF
--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -30,12 +30,6 @@ keywords:
     - Military
 ---
 
-You may be eligible for a teaching bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.
-
-Scholarships are offered by independent institutions. They set their own eligibility criteria and you’ll need to apply through the relevant scholarship body.
-
-You do not need to apply for a bursary. If you’re eligible, you’ll automatically receive it.
-
 ## Postgraduate bursaries and scholarships
 
 Postgraduate teaching bursaries and scholarships are only available for the subjects listed below. You cannot receive both a teaching bursary and a scholarship.

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -1,3 +1,9 @@
+<p>You may be eligible for a teaching bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.</p>
+
+<p>Scholarships are offered by independent institutions. They set their own eligibility criteria and you’ll need to apply through the relevant scholarship body.</p>
+
+<p>You do not need to apply for a bursary. If you’re eligible, you’ll automatically receive it.</p>
+
 <section id="funding-widget">
   <%= render FundingWidgetComponent.new(
     @funding_widget,


### PR DESCRIPTION
### Trello card

[Trello-3451](https://trello.com/c/OfMsXngK/3451-enable-funding-widget-to-be-displayed-further-down-a-page)

### Context

We want the funding widget to appear below the first block of text on the Scholarships and Bursaries page. The easiest way to do this is to put the content into the funding widget partial, which is only used on this page.

### Changes proposed in this pull request

- Move funding widget below first content block

### Guidance to review

<img width="816" alt="Screenshot 2022-07-05 at 12 43 34" src="https://user-images.githubusercontent.com/29867726/177319961-a4cc89f0-8700-4df3-939b-5194bff23aad.png">

