### PR TITLE
Fix low contrast on list summary

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -32,13 +32,9 @@ $icon-size: 3rem;
 
   &__descriptions {
     &--summary {
-      color: $blue;
+      @extend .link;
       cursor: pointer;
       text-decoration: underline;
-
-      &:hover {
-	      text-decoration: none;
-      }
 
       &::marker {
 	      padding-right: 2em;


### PR DESCRIPTION
### Trello card

[Trello-3446](https://trello.com/c/iYxpoeqx/3446-fix-colour-contrast-in-description-summary-on-event-landing-page)

### Context

We manually specified a `$blue` color here which doesn't meet the minimum contrast ratios for accessibility. Pull in our `link` class to get our usual darker blue and the black focus state.

### Changes proposed in this pull request

- Fix low contrast on list summary

### Guidance to review

I looked for other places we use the lighter blue colour and only found it being used as a background color rather than text color elsewhere, so this should be the only occurrence with contrast issues.