### PR TITLE
Add heading to upcoming non-TTT events

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -60,6 +60,7 @@
 
         <% if @events.any? %>
           <div class="teaching-events__events teaching-events__events--regular">
+            <h2 class="heading-m">Events coming up soon</h2>
             <ol><%= render TeachingEvents::EventComponent.with_collection(@events) %></ol>
 
             <div class="teaching-events__pagination">

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -146,7 +146,9 @@ $icon-size: 3rem;
       background: $grey;
       padding: 2rem 1rem 2rem;
       margin-bottom: 1rem;
+    }
 
+    &--featured, &--regular {
       h2 {
         margin-block: 1rem 2rem;
         padding-inline: 1rem;


### PR DESCRIPTION
### Trello card

[Trello-3357](https://trello.com/c/ytaV8syp/3357-add-context-above-event-listings-to-indicate-they-are-sorted-by-date)

### Context

We want to add a heading above the 'regular' (not featured Train to Teach) events to make it clearer that they are ordered by date.

### Changes proposed in this pull request

- Add heading to upcoming non-TTT events

### Guidance to review

