### PR TITLE
Whitelist the staging GTM server side host

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -31,18 +31,19 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  optimize  = %w[optimize.google.com www.googleoptimize.com]
-  zendesk   = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
-  facebook  = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
-  govuk     = %w[*.gov.uk www.gov.uk]
-  hotjar    = %w[*.hotjar.com vc.hotjar.io wss://*.hotjar.com]
-  jquery    = %w[code.jquery.com]
-  pinterest = %w[*.pinterest.com *.pinterest.co.uk *.pinimg.com]
-  scribble  = %w[embed.scribblelive.com]
-  snapchat  = %w[*.snapchat.com sc-static.net]
-  twitter   = %w[t.co *.twitter.com static.ads-twitter.com analytics.twitter.com]
-  youtube   = %w[*.youtube.com *.youtube-nocookie.com i.ytimg.com www.youtube.com www.youtube-nocookie.com]
-  sentry    = %w[*.ingest.sentry.io]
+  optimize    = %w[optimize.google.com www.googleoptimize.com]
+  zendesk     = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
+  govuk       = %w[*.gov.uk www.gov.uk]
+  hotjar      = %w[*.hotjar.com vc.hotjar.io wss://*.hotjar.com]
+  jquery      = %w[code.jquery.com]
+  pinterest   = %w[*.pinterest.com *.pinterest.co.uk *.pinimg.com]
+  scribble    = %w[embed.scribblelive.com]
+  snapchat    = %w[*.snapchat.com sc-static.net]
+  twitter     = %w[t.co *.twitter.com static.ads-twitter.com analytics.twitter.com]
+  youtube     = %w[*.youtube.com *.youtube-nocookie.com i.ytimg.com www.youtube.com www.youtube-nocookie.com]
+  sentry      = %w[*.ingest.sentry.io]
+  gtm_server  = %w[get-into-teaching.nw.r.appspot.com]
 
   quoted_unsafe_inline = ["'unsafe-inline'"]
   quoted_unsafe_eval   = ["'unsafe-eval'"]
@@ -57,12 +58,12 @@ SecureHeaders::Configuration.default do |config|
     default_src: %w['none'],
     base_uri: ["'self'"],
     child_src: ["'self'"].concat(youtube, pinterest, snapchat, hotjar),
-    connect_src: ["'self'"].concat(google_apis, pinterest, hotjar, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat, sentry),
+    connect_src: ["'self'"].concat(google_apis, pinterest, hotjar, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat, sentry, gtm_server),
     font_src: ["'self'"].concat(govuk, data, %w[fonts.gstatic.com]),
     form_action: ["'self'"].concat(snapchat, facebook, govuk),
     frame_src: ["'self'"].concat(scribble, snapchat, facebook, youtube, hotjar, google_doubleclick, google_analytics, data, pinterest, optimize),
     frame_ancestors: ["'self'"],
-    img_src: ["'self'"].concat(govuk, pinterest, facebook, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, optimize, %w[cx.atdmt.com linkbam.uk]),
+    img_src: ["'self'"].concat(govuk, pinterest, facebook, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, optimize, gtm_server, %w[cx.atdmt.com linkbam.uk]),
     manifest_src: ["'self'"],
     media_src: ["'self'"].concat(zendesk),
     script_src: ["'self'"].concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, hotjar, scribble, twitter, snapchat, youtube, zendesk, optimize),


### PR DESCRIPTION
### Trello card

[Trello-3218](https://trello.com/c/wOiVsiMq/3218-facebook-conversion-api)

### Context

I have configured our UA page view event to send to our GTM server-side instance instead of directly to UA; we can use this data to fire the Facebook Conversions API tag in GTM server side, but we need to whitelist the host in our CSP first.

### Changes proposed in this pull request

- Whitelist the staging GTM server side host

### Guidance to review

We are going to stick with the default `appspot.com` GTM server side domain for our staging environment (in production we can use a custom subdomain to avoid ad-blockers stopping the analytics requests).
