### PR TITLE
Update wizard to use new repo/gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem "actionpack-cloudfront", ">= 1.2.0"
 # HTML-aware ERB parsing
 gem "better_html", ">= 1.0.16"
 
-gem "dfe_wizard", github: "DFE-Digital/dfe_wizard"
+gem "git_wizard", github: "DFE-Digital/get-into-teaching-wizard"
 
 gem "rack-host-redirect"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/DFE-Digital/dfe_wizard.git
-  revision: 08a2dda2de41b67ea28dfa3513f59245ea6dcc6a
-  specs:
-    dfe_wizard (1.0.1)
-      activemodel (>= 6.0.3.4)
-      activesupport (>= 6.0.3.4)
-
-GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
   revision: cf858eb830316acbb9a7cb1f2991a7eb89f17f36
   specs:
@@ -20,6 +12,14 @@ GIT
       faraday_middleware
       faraday_middleware-circuit_breaker
       get_into_teaching_api_client
+
+GIT
+  remote: https://github.com/DFE-Digital/get-into-teaching-wizard.git
+  revision: 3d35745683526ee015f1a1de06cade6ab76119bb
+  specs:
+    git_wizard (2.0.0)
+      activemodel (>= 6.0.3.4)
+      activesupport (>= 6.0.3.4)
 
 GIT
   remote: https://github.com/bfoz/geometry.git
@@ -257,7 +257,7 @@ GEM
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jwt (2.2.3)
     kaminari (1.2.2)
@@ -497,7 +497,7 @@ GEM
     timeout (0.2.0)
     tomlrb (2.0.1)
     trailblazer-option (0.1.1)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.2.0)
@@ -542,7 +542,6 @@ DEPENDENCIES
   canonical-rails (>= 0.2.14)
   capybara (~> 3.37)
   delegate (>= 0.2.0)
-  dfe_wizard!
   dotenv-rails (>= 2.7.6)
   erb_lint (>= 0.1.1)
   factory_bot_rails (>= 6.2.0)
@@ -554,6 +553,7 @@ DEPENDENCIES
   front_matter_parser!
   geometry!
   get_into_teaching_api_client_faraday!
+  git_wizard!
   google-api-client (>= 0.53.0)
   govuk_design_system_formbuilder (>= 2.8.0)
   hashids

--- a/app/controllers/callbacks/steps_controller.rb
+++ b/app/controllers/callbacks/steps_controller.rb
@@ -2,7 +2,7 @@ module Callbacks
   class StepsController < ApplicationController
     include CircuitBreaker
 
-    include DFEWizard::Controller
+    include GITWizard::Controller
     self.wizard_class = Callbacks::Wizard
 
     before_action :noindex
@@ -46,7 +46,7 @@ module Callbacks
     helper_method :step_path
 
     def wizard_store
-      ::DFEWizard::Store.new app_store, crm_store
+      ::GITWizard::Store.new app_store, crm_store
     end
 
     def app_store

--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -4,7 +4,7 @@ class EventStepsController < ApplicationController
   before_action :set_is_walk_in, only: %i[show update]
   before_action :load_event
 
-  include DFEWizard::Controller
+  include GITWizard::Controller
   self.wizard_class = Events::Wizard
 
   before_action :noindex
@@ -47,7 +47,7 @@ private
   end
 
   def wizard_store
-    ::DFEWizard::Store.new app_store, crm_store
+    ::GITWizard::Store.new app_store, crm_store
   end
 
   def app_store

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -2,7 +2,7 @@ module MailingList
   class StepsController < ApplicationController
     include CircuitBreaker
 
-    include DFEWizard::Controller
+    include GITWizard::Controller
     self.wizard_class = MailingList::Wizard
 
     before_action :noindex, unless: -> { request.path.include?("/name") }
@@ -29,7 +29,7 @@ module MailingList
     helper_method :step_path
 
     def wizard_store
-      ::DFEWizard::Store.new app_store, crm_store
+      ::GITWizard::Store.new app_store, crm_store
     end
 
     def app_store

--- a/app/models/callbacks/steps/callback.rb
+++ b/app/models/callbacks/steps/callback.rb
@@ -1,6 +1,6 @@
 module Callbacks
   module Steps
-    class Callback < ::DFEWizard::Step
+    class Callback < ::GITWizard::Step
       extend CallbackBookingQuotas
 
       attribute :address_telephone, :string

--- a/app/models/callbacks/steps/matchback_failed.rb
+++ b/app/models/callbacks/steps/matchback_failed.rb
@@ -1,6 +1,6 @@
 module Callbacks
   module Steps
-    class MatchbackFailed < ::DFEWizard::Step
+    class MatchbackFailed < ::GITWizard::Step
       def skipped?
         @store["authenticate"]
       end

--- a/app/models/callbacks/steps/personal_details.rb
+++ b/app/models/callbacks/steps/personal_details.rb
@@ -1,7 +1,7 @@
 module Callbacks
   module Steps
-    class PersonalDetails < ::DFEWizard::Step
-      include ::DFEWizard::IssueVerificationCode
+    class PersonalDetails < ::GITWizard::Step
+      include ::GITWizard::IssueVerificationCode
 
       attribute :email
       attribute :first_name

--- a/app/models/callbacks/steps/privacy_policy.rb
+++ b/app/models/callbacks/steps/privacy_policy.rb
@@ -1,6 +1,6 @@
 module Callbacks
   module Steps
-    class PrivacyPolicy < ::DFEWizard::Step
+    class PrivacyPolicy < ::GITWizard::Step
       attribute :accept_privacy_policy, :boolean
       attribute :accepted_policy_id
 

--- a/app/models/callbacks/steps/talking_points.rb
+++ b/app/models/callbacks/steps/talking_points.rb
@@ -1,6 +1,6 @@
 module Callbacks
   module Steps
-    class TalkingPoints < ::DFEWizard::Step
+    class TalkingPoints < ::GITWizard::Step
       OPTIONS = [
         "Eligibility to become a teacher",
         "Routes into teaching",

--- a/app/models/callbacks/wizard.rb
+++ b/app/models/callbacks/wizard.rb
@@ -1,11 +1,11 @@
 require "attribute_filter"
 
 module Callbacks
-  class Wizard < ::DFEWizard::Base
+  class Wizard < ::GITWizard::Base
     self.steps = [
       Steps::PersonalDetails,
       Steps::MatchbackFailed,
-      ::DFEWizard::Steps::Authenticate,
+      ::GITWizard::Steps::Authenticate,
       Steps::Callback,
       Steps::TalkingPoints,
       Steps::PrivacyPolicy,

--- a/app/models/events/steps/contact_details.rb
+++ b/app/models/events/steps/contact_details.rb
@@ -1,6 +1,6 @@
 module Events
   module Steps
-    class ContactDetails < ::DFEWizard::Step
+    class ContactDetails < ::GITWizard::Step
       attribute :address_telephone
       validates :address_telephone, telephone: true, allow_blank: true
 

--- a/app/models/events/steps/further_details.rb
+++ b/app/models/events/steps/further_details.rb
@@ -1,6 +1,6 @@
 module Events
   module Steps
-    class FurtherDetails < ::DFEWizard::Step
+    class FurtherDetails < ::GITWizard::Step
       attribute :event_id
       attribute :privacy_policy, :boolean
       attribute :subscribe_to_mailing_list, :boolean

--- a/app/models/events/steps/personal_details.rb
+++ b/app/models/events/steps/personal_details.rb
@@ -1,7 +1,7 @@
 module Events
   module Steps
-    class PersonalDetails < ::DFEWizard::Step
-      include ::DFEWizard::IssueVerificationCode
+    class PersonalDetails < ::GITWizard::Step
+      include ::GITWizard::IssueVerificationCode
 
       attribute :email
       attribute :first_name

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -1,6 +1,6 @@
 module Events
   module Steps
-    class PersonalisedUpdates < ::DFEWizard::Step
+    class PersonalisedUpdates < ::GITWizard::Step
       attribute :degree_status_id, :integer
       attribute :consideration_journey_stage_id, :integer
       attribute :address_postcode

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -1,14 +1,14 @@
 require "attribute_filter"
 
 module Events
-  class Wizard < ::DFEWizard::Base
+  class Wizard < ::GITWizard::Base
     ATTRIBUTES_TO_LEAVE = %w[
       is_walk_in
     ].freeze
 
     self.steps = [
       Steps::PersonalDetails,
-      ::DFEWizard::Steps::Authenticate,
+      ::GITWizard::Steps::Authenticate,
       Steps::ContactDetails,
       Steps::FurtherDetails,
       Steps::PersonalisedUpdates,

--- a/app/models/mailing_list/steps/already_subscribed.rb
+++ b/app/models/mailing_list/steps/already_subscribed.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class AlreadySubscribed < ::DFEWizard::Step
+    class AlreadySubscribed < ::GITWizard::Step
       def skipped?
         !subscribed_to_mailing_list?
       end

--- a/app/models/mailing_list/steps/degree_status.rb
+++ b/app/models/mailing_list/steps/degree_status.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class DegreeStatus < ::DFEWizard::Step
+    class DegreeStatus < ::GITWizard::Step
       attribute :degree_status_id, :integer
 
       validates :degree_status_id,

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -1,7 +1,7 @@
 module MailingList
   module Steps
-    class Name < ::DFEWizard::Step
-      include ::DFEWizard::IssueVerificationCode
+    class Name < ::GITWizard::Step
+      include ::GITWizard::IssueVerificationCode
 
       attribute :first_name
       attribute :last_name

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class Postcode < ::DFEWizard::Step
+    class Postcode < ::GITWizard::Step
       attribute :address_postcode
 
       validates :address_postcode, postcode: true

--- a/app/models/mailing_list/steps/privacy_policy.rb
+++ b/app/models/mailing_list/steps/privacy_policy.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class PrivacyPolicy < ::DFEWizard::Step
+    class PrivacyPolicy < ::GITWizard::Step
       attribute :accept_privacy_policy, :boolean
       attribute :accepted_policy_id
 

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class Subject < ::DFEWizard::Step
+    class Subject < ::GITWizard::Step
       attribute :preferred_teaching_subject_id
       validates :preferred_teaching_subject_id,
                 presence: true,

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -1,6 +1,6 @@
 module MailingList
   module Steps
-    class TeacherTraining < ::DFEWizard::Step
+    class TeacherTraining < ::GITWizard::Step
       attribute :consideration_journey_stage_id, :integer
       validates :consideration_journey_stage_id,
                 presence: true,

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -1,7 +1,7 @@
 require "attribute_filter"
 
 module MailingList
-  class Wizard < ::DFEWizard::Base
+  class Wizard < ::GITWizard::Base
     ATTRIBUTES_TO_LEAVE = %w[
       first_name
       last_name
@@ -13,7 +13,7 @@ module MailingList
 
     self.steps = [
       Steps::Name,
-      ::DFEWizard::Steps::Authenticate,
+      ::GITWizard::Steps::Authenticate,
       Steps::AlreadySubscribed,
       Steps::DegreeStatus,
       Steps::TeacherTraining,

--- a/spec/models/callbacks/steps/personal_details_spec.rb
+++ b/spec/models/callbacks/steps/personal_details_spec.rb
@@ -4,7 +4,7 @@ describe Callbacks::Steps::PersonalDetails do
   include_context "with wizard step"
   it_behaves_like "a with wizard step"
 
-  it { expect(described_class).to include(::DFEWizard::IssueVerificationCode) }
+  it { expect(described_class).to include(::GITWizard::IssueVerificationCode) }
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/callbacks/wizard_spec.rb
+++ b/spec/models/callbacks/wizard_spec.rb
@@ -14,7 +14,7 @@ describe Callbacks::Wizard do
       },
     }
   end
-  let(:wizardstore) { DFEWizard::Store.new store[uuid], {} }
+  let(:wizardstore) { GITWizard::Store.new store[uuid], {} }
 
   describe ".steps" do
     subject { described_class.steps }
@@ -23,7 +23,7 @@ describe Callbacks::Wizard do
       is_expected.to eql [
         Callbacks::Steps::PersonalDetails,
         Callbacks::Steps::MatchbackFailed,
-        ::DFEWizard::Steps::Authenticate,
+        ::GITWizard::Steps::Authenticate,
         Callbacks::Steps::Callback,
         Callbacks::Steps::TalkingPoints,
         Callbacks::Steps::PrivacyPolicy,

--- a/spec/models/events/steps/personal_details_spec.rb
+++ b/spec/models/events/steps/personal_details_spec.rb
@@ -4,7 +4,7 @@ describe Events::Steps::PersonalDetails do
   include_context "with wizard step"
   it_behaves_like "a with wizard step"
 
-  it { expect(described_class).to include(::DFEWizard::IssueVerificationCode) }
+  it { expect(described_class).to include(::GITWizard::IssueVerificationCode) }
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -14,7 +14,7 @@ describe Events::Wizard do
       "is_walk_in" => true,
     } }
   end
-  let(:wizardstore) { DFEWizard::Store.new store[uuid], {} }
+  let(:wizardstore) { GITWizard::Store.new store[uuid], {} }
 
   describe ".steps" do
     subject { described_class.steps }
@@ -22,7 +22,7 @@ describe Events::Wizard do
     it do
       is_expected.to eql [
         Events::Steps::PersonalDetails,
-        ::DFEWizard::Steps::Authenticate,
+        ::GITWizard::Steps::Authenticate,
         Events::Steps::ContactDetails,
         Events::Steps::FurtherDetails,
         Events::Steps::PersonalisedUpdates,
@@ -117,7 +117,7 @@ describe Events::Wizard do
       before { wizardstore[:is_walk_in] = false }
 
       it "raises an exception" do
-        expect { subject.exchange_unverified_request(request) }.to raise_error(DFEWizard::ContinueUnverifiedNotSupportedError)
+        expect { subject.exchange_unverified_request(request) }.to raise_error(GITWizard::ContinueUnverifiedNotSupportedError)
       end
     end
 

--- a/spec/models/mailing_list/steps/degree_status_spec.rb
+++ b/spec/models/mailing_list/steps/degree_status_spec.rb
@@ -37,7 +37,7 @@ describe MailingList::Steps::DegreeStatus do
     it { is_expected.not_to be_magic_link_token_used }
 
     context "when magic link token was used" do
-      before { wizardstore["auth_method"] = DFEWizard::Base::Auth::MAGIC_LINK_TOKEN }
+      before { wizardstore["auth_method"] = GITWizard::Base::Auth::MAGIC_LINK_TOKEN }
 
       it { is_expected.to be_magic_link_token_used }
     end

--- a/spec/models/mailing_list/steps/name_spec.rb
+++ b/spec/models/mailing_list/steps/name_spec.rb
@@ -16,7 +16,7 @@ describe MailingList::Steps::Name do
 
   it_behaves_like "a with wizard step"
 
-  it { expect(described_class).to include(::DFEWizard::IssueVerificationCode) }
+  it { expect(described_class).to include(::GITWizard::IssueVerificationCode) }
 
   it { is_expected.to respond_to :first_name }
   it { is_expected.to respond_to :last_name }

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -16,7 +16,7 @@ describe MailingList::Wizard do
       "accepted_policy_id" => "789",
     } }
   end
-  let(:wizardstore) { DFEWizard::Store.new store[uuid], {} }
+  let(:wizardstore) { GITWizard::Store.new store[uuid], {} }
 
   describe ".steps" do
     subject { described_class.steps }
@@ -24,7 +24,7 @@ describe MailingList::Wizard do
     it do
       is_expected.to eql [
         MailingList::Steps::Name,
-        ::DFEWizard::Steps::Authenticate,
+        ::GITWizard::Steps::Authenticate,
         MailingList::Steps::AlreadySubscribed,
         MailingList::Steps::DegreeStatus,
         MailingList::Steps::TeacherTraining,

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -84,7 +84,7 @@ describe EventStepsController, type: :request do
     before do
       allow_any_instance_of(Events::Steps::PersonalDetails).to \
         receive(:is_walk_in?).and_return(true)
-      allow_any_instance_of(DFEWizard::Steps::Authenticate).to \
+      allow_any_instance_of(GITWizard::Steps::Authenticate).to \
         receive(:candidate_identity_data) { identity_data }
     end
 
@@ -147,7 +147,7 @@ describe EventStepsController, type: :request do
           allow_any_instance_of(Events::Steps::PersonalDetails).to \
             receive(:valid?).and_return true
 
-          allow_any_instance_of(::DFEWizard::Steps::Authenticate).to \
+          allow_any_instance_of(::GITWizard::Steps::Authenticate).to \
             receive(:valid?).and_return true
 
           allow_any_instance_of(Events::Steps::ContactDetails).to \

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -1,11 +1,11 @@
 shared_context "with wizard store" do
   let(:backingstore) { { "name" => "Joe", "age" => 35 } }
   let(:crm_backingstore) { {} }
-  let(:wizardstore) { DFEWizard::Store.new backingstore, crm_backingstore }
+  let(:wizardstore) { GITWizard::Store.new backingstore, crm_backingstore }
 end
 
-class TestWizard < DFEWizard::Base
-  class Name < DFEWizard::Step
+class TestWizard < GITWizard::Base
+  class Name < GITWizard::Step
     attribute :name
     validates :name, presence: true
   end


### PR DESCRIPTION
We have renamed the repository of the `dfe_wizard` to something more git-specific and updated the gem name.

Update the Gemfile to use the new repository/name and update module references.

The functionality of the gem has not changed.