### PR TITLE
adding meta description and keywords

### DIFF
--- a/app/views/content/subjects/maths.md
+++ b/app/views/content/subjects/maths.md
@@ -10,6 +10,7 @@ keywords:
   - maths
   - teaching maths
   - teacher training
+
 content:
   - "content/subjects/maths/header"
   - "content/subjects/maths/article"

--- a/app/views/content/subjects/maths.md
+++ b/app/views/content/subjects/maths.md
@@ -1,9 +1,15 @@
 ---
 title: Get into teaching maths
+description: |-
+    Find out about becoming a maths teacher, including what you’ll be teaching and what funding you could be eligible for to help you train.
 layout: "layouts/minimal"
 main_class: "subject-specific"
 colour: "yellow"
 image: "media/images/content/hero-images/0004.jpg"
+keywords:
+  - maths
+  - teaching maths
+  - teacher training
 content:
   - "content/subjects/maths/header"
   - "content/subjects/maths/article"


### PR DESCRIPTION
### Trello card
https://trello.com/c/YmLl4Y1D

### Context

Noticed that the maths page doesn't currently have a meta description or keywords tags. Thought I'd quickly open up a PR to add these in.

### Changes proposed in this pull request

### Guidance to review

