### PR TITLE
Fix h3 styling in grouped cards

### DIFF
--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -45,13 +45,13 @@
     &:hover {
       box-shadow: 0px 12px 9px 0px rgba(0,0,0,0.15);
 
-      h2 { text-decoration: underline; }
+      h2, h3 { text-decoration: underline; }
     }
 
     &--content {
       flex: 1 0 80%;
 
-      h2 {
+      h2, h3 {
         @extend .heading-m, .heading--margin-0;
       }
     }


### PR DESCRIPTION
### Trello card

[Trello-3522](https://trello.com/c/Sds1rCiD/3522-style-inconsistency-on-cards)

### Context

The grouped category cards have a `h3` heading tag which didn't have the necessary styles applied to underline on hover and align correctly with the arrow.

### Changes proposed in this pull request

- Fix h3 styling in grouped cards

### Guidance to review

