### PR TITLE
Fix FastImage exception on timeout

### DIFF
--- a/lib/image_sizes.rb
+++ b/lib/image_sizes.rb
@@ -25,7 +25,7 @@ class ImageSizes
     end
 
     def cache_image_size(src)
-      @@cache[src] ||= FastImage.size(src, raise_on_failure: false, timeout: timeout)
+      @@cache[src] ||= FastImage.size(src, raise_on_failure: false, timeout: timeout.to_f)
     end
 
     def timeout

--- a/spec/lib/image_sizes_spec.rb
+++ b/spec/lib/image_sizes_spec.rb
@@ -17,8 +17,8 @@ describe ImageSizes do
     before do
       described_class.class_variable_set(:@@cache, {})
       allow(ENV).to receive(:[]).with("APP_ASSETS_URL").and_return(asset_host)
-      allow(ENV).to receive(:[]).with("FAST_IMAGE_TIMEOUT").and_return(0.25)
-      allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return(1)
+      allow(ENV).to receive(:[]).with("FAST_IMAGE_TIMEOUT").and_return("0.25")
+      allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return("1")
       allow(FastImage).to receive(:size)
         .with(fast_image_url, raise_on_failure: false, timeout: 0.25).and_return([500, 800])
     end
@@ -83,7 +83,7 @@ describe ImageSizes do
     end
 
     context "when disabled" do
-      before { allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return(0) }
+      before { allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return("0") }
 
       it "does not size the image" do
         is_expected.to include(body)

--- a/spec/requests/image_sizes_spec.rb
+++ b/spec/requests/image_sizes_spec.rb
@@ -5,7 +5,7 @@ describe "Image Sizes", type: :request do
 
   before do
     allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return(1)
+    allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return("1")
     allow(FastImage).to receive(:size).and_return([1175, 839])
     get "/content-page"
   end


### PR DESCRIPTION
The timeout will be read from the `.env` file as a String; we are seeing an error in preprod "Can't convert String to time interval", which I think is stemming from the timeout not being cast to a float. This wasn't picked up in development as FastImage loads the images from disk instead of over HTTP.
