### PR TITLE
Minor fixes to image size processing

### DIFF
--- a/app/webpacker/styles/welcome-guide.scss
+++ b/app/webpacker/styles/welcome-guide.scss
@@ -53,6 +53,7 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
   margin: 0 auto;
 
   img {
+    height: auto;
     display: block;
   }
 

--- a/lib/image_sizes.rb
+++ b/lib/image_sizes.rb
@@ -25,11 +25,11 @@ class ImageSizes
     end
 
     def cache_image_size(src)
-      @@cache[src] ||= FastImage.size(src, raise_on_failure: false, timeout: timeout.to_f)
+      @@cache[src] ||= FastImage.size(src, raise_on_failure: false, timeout: timeout)
     end
 
     def timeout
-      ENV["FAST_IMAGE_TIMEOUT"]
+      ENV["FAST_IMAGE_TIMEOUT"].to_f
     end
   end
 


### PR DESCRIPTION
- Shift to_f into timeout method

This way it will be consistent across calls to `timeout`.

- Fix image heights in welcome guide

As images always have an explicit height in their `img` element we need to override it in CSS to avoid
skewing when we have a fixed width. 