### PR TITLE
Allow new staging GTM server in CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -43,7 +43,7 @@ SecureHeaders::Configuration.default do |config|
   twitter     = %w[t.co *.twitter.com static.ads-twitter.com analytics.twitter.com]
   youtube     = %w[*.youtube.com *.youtube-nocookie.com i.ytimg.com www.youtube.com www.youtube-nocookie.com]
   sentry      = %w[*.ingest.sentry.io]
-  gtm_server  = %w[get-into-teaching.nw.r.appspot.com]
+  gtm_server  = %w[get-into-teaching-staging-gtm.nw.r.appspot.com]
   reddit      = %w[www.redditstatic.com alb.reddit.com]
 
   quoted_unsafe_inline = ["'unsafe-inline'"]


### PR DESCRIPTION
We've got a new server-side container for GTM staging and need to whitelist it in the CSP before it can be used.
