### PR TITLE
[647] Fix review apps concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,7 +368,7 @@ jobs:
     needs: [ build_release ]
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
-    concurrency: Review_${{github.event.inputs.pr}}
+    concurrency: Review_${{github.event.number}}
     environment:
        name: Review
     steps:


### PR DESCRIPTION
### Trello card
https://trello.com/c/mtHKEcHM

### Context
Review app deployment failures including:
- https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/2772614004
- https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/2772610842

### Changes proposed in this pull request
Fix the string used for review app deployment concurrency

### Guidance to review
Check on school experience: https://github.com/DFE-Digital/schools-experience/blob/master/.github/workflows/build.yml#L390