### PR TITLE
Fix image sizing on about TTT events page

### DIFF
--- a/app/webpacker/styles/registration/with-side-images.scss
+++ b/app/webpacker/styles/registration/with-side-images.scss
@@ -29,6 +29,7 @@
 
         img {
           width: 100%;
+          height: auto;
         }
       }
     }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -692,6 +692,8 @@ $icon-size: 3rem;
     picture {
       img {
         max-height: 12em;
+        width: auto;
+        height: auto;
       }
     }
   }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -477,6 +477,7 @@ $icon-size: 3rem;
       padding-bottom: 1rem;
       img {
         width: 100%;
+        height: auto;
       }
 
       @include mq($from: tablet) {


### PR DESCRIPTION
We need to specify the width/height in CSS or the element width/height is used, skewing the image.