### PR TITLE
Fix TTT events banner not showing

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -56,6 +56,7 @@ class TeachingEventsController < ApplicationController
     @no_ttt_events = GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
       quantity: 1,
       type_ids: [EventType.train_to_teach_event_id, EventType.question_time_event_id],
+      start_after: Time.zone.now,
     ).blank?
 
     breadcrumb "Get into Teaching events", events_path

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -79,11 +79,13 @@ describe "teaching events", type: :request do
 
   describe "#about_ttt_events" do
     let(:events) { [GetIntoTeachingApiClient::TeachingEvent.new] }
+    let(:now) { Time.zone.now }
 
     before do
+      freeze_time
       expected_type_ids = [EventType.train_to_teach_event_id, EventType.question_time_event_id]
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events).with(type_ids: expected_type_ids, quantity: 1).and_return(events)
+        receive(:search_teaching_events).with(type_ids: expected_type_ids, quantity: 1, start_after: now).and_return(events)
       get about_ttt_events_path
     end
 


### PR DESCRIPTION
We were checking if TTT events exist but not taking into account the dates; as old events are still in the system we need to filter to those that start after the current date/time.