### PR TITLE
Fix image overlapping text on about TTT events page

### DIFF
--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -663,11 +663,11 @@ $icon-size: 3rem;
     display: grid;
     margin: 1em 2em;
 
-    grid-template-rows: min-content 1em min-content min-content;
+    grid-template-rows: min-content min-content min-content;
     grid-template-columns: auto;
 
     h1 {
-      grid-area: 1 / 1 / 3 / 2;
+      grid-area: 1 / 1 / 1 / 1;
       z-index: 1;
     }
 
@@ -677,13 +677,13 @@ $icon-size: 3rem;
 
     picture {
       transform: rotate(3deg);
-      grid-area: 1 / 1 / 3 / 2;
+      grid-area: 2 / 1 / 2 / 1;
       text-align: right;
+      margin: $indent-amount 0;
     }
 
     @include mq($from: tablet) {
       grid-template-rows: auto;
-      grid-template-columns: 2fr 3em 1fr;
 
       h1 {
         grid-area: 1 / 1 / 2 / 2;
@@ -703,8 +703,7 @@ $icon-size: 3rem;
     picture {
       img {
         max-height: 12em;
-        max-width: 100%;
-        width: auto;
+        width: 300px;
         height: auto;
       }
     }


### PR DESCRIPTION
### Trello card

[Trello-3544](https://trello.com/c/YfQrulh7/3544-fix-text-overlapping-image-on-mobile-about-ttt-events-page)

### Context

On a mobile viewport the image is obscured by the title of the page. Instead, we want to follow the welcome guide convention of dropping the image down below the text when the viewport is narrow.

### Changes proposed in this pull request

- Fix image overlapping text on about TTT events page

### Guidance to review

[Preview](https://review-get-into-teaching-app-2762.london.cloudapps.digital/events/about-train-to-teach-events)

| Mobile      | Desktop |
| ----------- | ----------- |
|   <img width="456" alt="Screenshot 2022-08-23 at 08 29 33" src="https://user-images.githubusercontent.com/29867726/186098024-72aee328-fd75-429b-b4d7-6d25a08e5a91.png">     |    <img width="1087" alt="Screenshot 2022-08-23 at 08 29 56" src="https://user-images.githubusercontent.com/29867726/186098107-20aefb3c-9a68-41dd-994b-7a38833fb99f.png">     |