### PR TITLE
Remove bottom margin on about TTT events page

### DIFF
--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -9,7 +9,7 @@
     <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>
 
-      <section class="container main-body">
+      <section class="container main-body <%= "container--no-bottom-margin" if @no_bottom_margin %>">
         <article class="fullwidth">
           <%= yield %>
         </article>

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -1,6 +1,7 @@
 <%
   @page_title = "About train to teach events"
   @show_breadcrumbs = true
+  @no_bottom_margin = true
 %>
 
 <div class="about-ttt-events">

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -119,4 +119,12 @@ section.container {
     flex: 0 1 100%;
     @include indent-left-and-right;
   }
+
+  &--no-bottom-margin {
+    margin-bottom: 0;
+
+    > article {
+      margin-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
### Trello card

[Trello-3545](https://trello.com/c/MDO8w12I/3545-ensure-yellow-quote-block-on-about-ttt-events-page-extends-to-footer)

### Context

Add CSS class to remove bottom margin from a `container` element. Allow it to be set in the layout by views using a `no_bottom_margin` variable.

### Changes proposed in this pull request

- Remove bottom margin on about TTT events page

### Guidance to review

[Preview](https://review-get-into-teaching-app-2763.london.cloudapps.digital/events/about-train-to-teach-events)

| Mobile      | Desktop  |
| ----------- | ----------- |
|   <img width="492" alt="Screenshot 2022-08-23 at 11 27 34" src="https://user-images.githubusercontent.com/29867726/186135747-67017668-2bd8-430c-80bc-c3f02695128e.png">     |     <img width="1337" alt="Screenshot 2022-08-23 at 11 27 54" src="https://user-images.githubusercontent.com/29867726/186135823-0b611f97-37b2-49a0-8969-196fc530f78c.png">      |
