### PR TITLE
Remove alert before provider update

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -10,17 +10,4 @@ instances                 = 4
 basic_auth                = 0
 azure_key_vault           = "s146p01-kv"
 azure_resource_group      = "s146p01-rg"
-alerts = {
-  GiT_App_Production_Healthcheck = {
-    website_name  = "Get Into Teaching Website (Production)"
-    website_url   = "https://getintoteaching.education.gov.uk/healthcheck.json"
-    test_type     = "HTTP"
-    check_rate    = 60
-    contact_group = [185037]
-    trigger_rate  = 0
-    confirmations = 1
-    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
-
-  }
-}
+alerts = {}


### PR DESCRIPTION
### Trello card

### Context
Remove the production StatusCake alert before we recreate it using the new Terraform provider.

### Changes proposed in this pull request

### Guidance to review

