### PR TITLE
Fix semantics on steps to become a teacher list

### DIFF
--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -30,19 +30,17 @@
 
             <ol class="steps">
               <% steps_fm.each.with_index(1) do |(title, contents), i| %>
-                <%= tag.section(class: "step", id: "step-#{i}") do %>
-                  <li>
-                    <header class="step__header">
-                      <div class="step__number">
-                        <%= i %>
-                      </div>
-                      <%= tag.h2(title, class: "heading-m") %>
-                    </header>
-
-                    <div class="step__content">
-                      <%= render(partial: contents["partial"]) %>
+                <%= tag.li(class: "step", id: "step-#{i}") do %>
+                  <header class="step__header">
+                    <div class="step__number">
+                      <%= i %>
                     </div>
-                  </li>
+                    <%= tag.h2(title, class: "heading-m") %>
+                  </header>
+
+                  <div class="step__content">
+                    <%= render(partial: contents["partial"]) %>
+                  </div>
                 <% end %>
               <% end %>
             </ol>


### PR DESCRIPTION
### Trello card

[Trello-3551](https://trello.com/c/9Y9OUH29/3551-investigate-accessibility-issue-with-lists-on-steps)

### Context

It was flagged by Silktide that we are nesting a `section` immediately within an `ol` element which is not semantic. Remove the `section` and apply the classes on the `li` element instead.

### Changes proposed in this pull request

- Fix semantics on steps to become a teacher list

### Guidance to review

It should look no different visually. [Preview page](https://review-get-into-teaching-app-2767.london.cloudapps.digital/steps-to-become-a-teacher).