### PR TITLE
Make category cards semantically correct

### DIFF
--- a/app/components/categories/card_component.html.erb
+++ b/app/components/categories/card_component.html.erb
@@ -1,9 +1,11 @@
-<%= link_to(path, class: "category__nav-card") do %>
-  <div class="category__nav-card--content">
-    <%= content_tag(heading_tag, title) %>
+<li class="category__nav-card">
+  <%= link_to(path, class: "link--black") do %>
+    <div class="category__nav-card--content">
+      <%= content_tag(heading_tag, title) %>
 
-    <%= tag.p(description) %>
-  </div>
+      <%= tag.p(description) %>
+    </div>
 
-  <div class="category__nav-card--icon"></div>
-<% end %>
+    <div class="category__nav-card--icon"></div>
+  <% end %>
+</li>

--- a/app/views/layouts/category.html.erb
+++ b/app/views/layouts/category.html.erb
@@ -11,7 +11,9 @@
 
       <section class="container category__cards main-body">
         <%= tag.nav(aria: { label: "#{@page.title} navigation" }, class: "category__nav-cards") do %>
-          <%= render(Categories::CardComponent.with_collection(ungrouped_categories(@page.path))) %>
+          <ul>
+            <%= render(Categories::CardComponent.with_collection(ungrouped_categories(@page.path))) %>
+          </ul>
         <% end %>
       </section>
 
@@ -19,7 +21,9 @@
         <section class="container category__cards main-body">
           <%= tag.h2(title, class: "heading--box-blue") %>
           <%= tag.nav(aria: { label: "#{title} category" }, class: "category__nav-cards") do %>
-            <%= render(Categories::CardComponent.with_collection(pages, heading_tag: "h3")) %>
+            <ul>
+              <%= render(Categories::CardComponent.with_collection(pages, heading_tag: "h3")) %>
+            </ul>
           <% end %>
         </section>
       <% end %>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -18,29 +18,32 @@
     }
   }
 
-  &__nav-cards {
+  &__nav-cards ul {
     display: grid;
     grid-template-columns: 1fr;
     margin-inline: 1em;
     margin-block: 2em;
+    padding: 0;
+    gap: 2em;
+    list-style: none;
 
     @include mq($from: tablet) {
       grid-template-columns: repeat(2, 1fr);
       margin-inline: 2em;
     }
-
-    gap: 2em;
-    list-style: none;
   }
 
   &__nav-card {
     background: white;
     box-shadow: 0px 6px 5px 0px rgba(0,0,0,0.15);
-    color: black;
-    text-decoration: none;
-    padding: 2em;
     display: flex;
-    gap: 1.5em;
+
+    a {
+      padding: 2em;
+      text-decoration: none;
+      display: flex;
+      gap: 1.5em;
+    }
 
     &:hover {
       box-shadow: 0px 12px 9px 0px rgba(0,0,0,0.15);

--- a/spec/components/categories/card_component_spec.rb
+++ b/spec/components/categories/card_component_spec.rb
@@ -14,9 +14,9 @@ describe Categories::CardComponent, type: "component" do
     page
   end
 
-  specify "renders a link" do
+  specify "renders a link within a list" do
     expect(subject).to have_link(item.title, href: item.path)
-    expect(subject).to have_css("a.category__nav-card")
+    expect(subject).to have_css("li.category__nav-card > a")
   end
 
   specify "the link contains a h2 title by default" do

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
 
     scenario "the child pages are represented by navigation cards" do
       Pages::Navigation.find(path).children.each do |child|
-        expect(page).to have_link(child.title, href: child.path, class: "category__nav-card")
+        expect(page).to have_link(child.title, href: child.path, class: "link--black")
         expect(page).to have_content(child.description)
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-3552](https://trello.com/c/NBhH1e8x/3552-investigate-accessibility-issue-with-navigation-cards)

### Context

The category cards are currently a `nav` element with several child anchor links. These should be part of an unordered list to be more semantically correct (according to Silktide).

### Changes proposed in this pull request

- Make category cards semantically correct

### Guidance to review

The page shouldn't change visually.