### PR TITLE
Omit page param from redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ Rails.application.routes.draw do
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|
     redirect_rules.each do |from, to|
       get from => lambda { |env|
+        request = Rack::Request.new(env)
         Rails.logger.info(redirect: { request: env["ORIGINAL_FULLPATH"], from: from, to: to })
-        redirect(path: to).call(env)
+        redirect(path: to, params: request.params.except("page")).call(env)
       }
     end
   end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 describe "Redirects", content: true, type: :request do
   before(:all) { @result = {} }
 
-  let(:query_string) { "abc=def&ghi=jkl" }
+  let(:query_string) { "#{expected_query_string}&page=5" }
+  let(:expected_query_string) { "abc=def&ghi=jkl" }
   let(:valid_results) { [200, 301, 302] }
 
   redirects = YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects")
@@ -17,7 +18,7 @@ describe "Redirects", content: true, type: :request do
         allow(Rails.logger).to receive(:info)
 
         expect(subject).to be 301
-        expect(response).to redirect_to(build_url(to, query_string))
+        expect(response).to redirect_to(build_url(to, expected_query_string))
         expect(Rails.logger).to have_received(:info).with(redirect: { request: url, from: from, to: to })
 
         target = Nokogiri.parse(response.body).at_css("a")["href"].gsub(root_url, "/")
@@ -48,7 +49,7 @@ describe "Redirects", content: true, type: :request do
           allow(Rails.logger).to receive(:info)
 
           expect(subject).to be 301
-          expect(response).to redirect_to(build_url(to, query_string))
+          expect(response).to redirect_to(build_url(to, expected_query_string))
 
           target = Nokogiri.parse(response.body).at_css("a")["href"].gsub(root_url, "/")
 


### PR DESCRIPTION
### Trello card

[Trello-3565](https://trello.com/c/lAfUB6Cg/3565-remove-query-parameters-from-event-redirects)

### Context

We occasionally see a redirect from an old set of event search results with a particular page. Often the particular page no longer exists due to events expiring over time and the user ends up with the 'no events found' page, which isn't ideal.

Ignore the `page` parameter when redirecting to provide a better user experience.

### Changes proposed in this pull request

- Omit page param from redirects

### Guidance to review

If that route gets any more complicated it would be worth splitting it out into a small module, but as it stands I've left it in the routes file for now.

[Example test redirect](https://review-get-into-teaching-app-2770.london.cloudapps.digital/event-categories/school-and-university-events?page=8)