### PR TITLE
Standardise videos with a view component

### DIFF
--- a/app/components/content/youtube_video_component.html.erb
+++ b/app/components/content/youtube_video_component.html.erb
@@ -1,0 +1,8 @@
+<%= tag.iframe(
+  title: title,
+  loading: "lazy",
+  src: src,
+  frameborder: 0,
+  allow: "autoplay; encrypted-media",
+  allowfullscreen: true
+) %>

--- a/app/components/content/youtube_video_component.rb
+++ b/app/components/content/youtube_video_component.rb
@@ -1,0 +1,29 @@
+module Content
+  class YoutubeVideoComponent < ViewComponent::Base
+    attr_reader :id, :title
+
+    def initialize(id:, title:)
+      super
+
+      @id = id
+      @title = title
+    end
+
+    def src
+      "https://www.youtube-nocookie.com/embed/#{id}"
+    end
+
+  private
+
+    def before_render
+      validate!
+    end
+
+    def validate!
+      %i[id title].each do |required_attr|
+        error_message = "#{required_attr} must be present"
+        fail(ArgumentError, error_message) if send(required_attr).blank?
+      end
+    end
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -29,10 +29,6 @@ module EventsHelper
     event.web_feed_id && EventStatus.new(event).open? && !EventType.new(event).provider_event?
   end
 
-  def embed_event_video_url(video_url)
-    video_url&.sub("watch?v=", "embed/")
-  end
-
   def formatted_event_description(description)
     if strip_tags(description) != description
       safe_html_format(description)

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -27,10 +27,15 @@ module TeachingEvents
       :summary,
       :type_id,
       :status_id,
-      :video_url,
       :web_feed_id,
       to: :event,
     )
+
+    def video_id
+      return nil if event.video_url.blank?
+
+      event.video_url[/(v=|embed\/)(.{11})/, 2]
+    end
 
     def venue_address
       return if event_building.blank?

--- a/app/views/content/blog/top-tips-for-returning-teachers.md
+++ b/app/views/content/blog/top-tips-for-returning-teachers.md
@@ -11,6 +11,10 @@ keywords:
   - returning to teaching
 tags:
   - returning to teaching
+youtube_video:
+  return-to-teaching-advisers-video:
+    id: 2NrLm_XId4k
+    title: A video about what Return to Teaching Advisers do
 ---
 
 $calculator$
@@ -30,14 +34,7 @@ If you have [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualifi
 From helping you to brush up on your subject knowledge to preparing for interviews, our advisers will be with you every step of the way and help you get back in the classroom.
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
-  <iframe 
-    title="A video about what Return to Teaching Advisers do"
-    loading="lazy"
-    src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
-    frameborder="0" 
-    allow="autoplay; encrypted-media" 
-    allowfullscreen
-  ></iframe>
+$return-to-teaching-advisers-video$
 </div>
 
 > Kathryn [RTTA] has been central in my engagement in the programme. She made it incredibly easy to find all the information needed and is always on hand with first class advice.

--- a/app/views/content/returning-to-teaching.md
+++ b/app/views/content/returning-to-teaching.md
@@ -62,6 +62,10 @@ quote:
     text: "Don’t necessarily expect to get the first job you apply for and don’t get disheartened if you’re not successful."
     name: "Helen"
     job_title: "Returning teacher"
+youtube_video:
+  return-to-teaching-advisers-video:
+    id: 2NrLm_XId4k
+    title: A video about what Return to Teaching Advisers do
 ---
 
 Returning to teaching can be easier than you expect.
@@ -98,14 +102,7 @@ A return to teaching adviser can give you free one-to-one support with:
 * finding teaching vacancies
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
-  <iframe 
-    title="A video about what Return to Teaching Advisers do"
-    loading="lazy"
-    src="https://www.youtube-nocookie.com/embed/2NrLm_XId4k" 
-    frameborder="0" 
-    allow="autoplay; encrypted-media" 
-    allowfullscreen
-  ></iframe>
+$return-to-teaching-advisers-video$
 </div>
 
 Return to teaching advisers also run [events to support returners](/events).

--- a/app/views/content/teacher-training-advisers.md
+++ b/app/views/content/teacher-training-advisers.md
@@ -42,6 +42,13 @@ calls_to_action:
       link_text: "Get a teacher training adviser"
       link_target: "/tta-service"
       icon: "icon-person"
+youtube_video:
+  about-teacher-training-advisers-video:
+    id: ZaGL8c4FkLA
+    title: A video about what Teacher Training Advisers do
+  about-teacher-training-advisers-experience-video:
+    id: T9Bhcaa6LJ4
+    title: A video about what teaching experience our Teacher Training Advisers have
 ---
 Teacher training advisers give you free, one-to-one help and support. 
 
@@ -65,14 +72,7 @@ Our advisers can help you at any time, even if you're a year or more away from a
 ## Meet Emma, a teacher training adviser
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
-  <iframe 
-    title="A video about what Teacher Training Advisers do"
-    loading="lazy"
-    src="https://www.youtube-nocookie.com/embed/ZaGL8c4FkLA" 
-    frameborder="0" 
-    allow="autoplay; encrypted-media" 
-    allowfullscreen
-  ></iframe>
+$about-teacher-training-advisers-video$
 </div>
 
 ## Helping you decide if teaching is right for you
@@ -86,14 +86,7 @@ Your adviser can help you navigate your path into teaching, and make sure you ge
 ## Meet Simon, a teacher training adviser
 
 <div data-controller="aspect-ratio" data-aspect-ratio-width-value="560" data-aspect-ratio-height-value="290">
-  <iframe 
-    title="A video about what teaching experience our Teacher Training Advisers have"
-    loading="lazy"
-    src="https://www.youtube-nocookie.com/embed/T9Bhcaa6LJ4" 
-    frameborder="0" 
-    allow="autoplay; encrypted-media" 
-    allowfullscreen
-  ></iframe>
+$about-teacher-training-advisers-experience-video$
 </div>
 
 ## Already applied and been unsuccessful?

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -55,7 +55,10 @@
     <p>See the <a href="/presentations">presentations used at Train to Teach events</a>.</p>
 
     <div class="youtube-video-container">
-      <iframe src="https://www.youtube.com/embed/eAWwqLLEINI" frameborder="0" allowfullscreen title="Train to Teach Events: Take your next step towards teaching"></iframe>
+      <%= render Content::YoutubeVideoComponent.new(
+        id: "eAWwqLLEINI",
+        title: "Train to Teach Events: Take your next step towards teaching"
+      ) %>
     </div>
   </article>
 

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -8,8 +8,11 @@
 
 <%= tag.div(formatted_event_description(@event.description)) %>
 
-<% if @event.video_url %>
+<% if @event.video_id %>
   <div class="teaching-event__video youtube-video-container">
-    <%= tag.iframe(src: embed_event_video_url(@event.video_url), frameborder: "0", allowfullscreen: true, title: "Train to Teach Events: Take your next step towards teaching") %>
+    <%= render Content::YoutubeVideoComponent.new(
+      id: @event.video_id,
+      title: "Train to Teach Events: Take your next step towards teaching"
+    ) %>
   </div>
 <% end %>

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -7,7 +7,7 @@ module TemplateHandlers
     DEFAULTS = {}.freeze
     GLOBAL_FRONT_MATTER = Rails.root.join("config/frontmatter.yml").freeze
     COMPONENT_PLACEHOLDER_REGEX = /\$([A-z0-9-]+)\$/
-    COMPONENT_TYPES = %w[quote inset_text].freeze
+    COMPONENT_TYPES = %w[quote inset_text youtube_video].freeze
 
     class << self
       def call(template, source = nil)

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Content::YoutubeVideoComponent, type: :component do
+  let(:id) { "abc123" }
+  let(:title) { "Title" }
+  let(:component) { described_class.new(id: id, title: title) }
+
+  subject(:render) do
+    render_inline(component)
+    page
+  end
+
+  it { is_expected.to have_css("iframe[src='https://www.youtube-nocookie.com/embed/#{id}']") }
+  it { is_expected.to have_css("iframe[title=#{title}]") }
+  it { is_expected.to have_css("iframe[loading=lazy]") }
+  it { is_expected.to have_css("iframe[frameborder=0]") }
+  it { is_expected.to have_css("iframe[allow='autoplay; encrypted-media']") }
+  it { is_expected.to have_css("iframe[allowfullscreen]") }
+
+  describe "validation" do
+    context "when the id is not set" do
+      let(:id) { nil }
+
+      it { expect { render }.to raise_error(ArgumentError, "id must be present") }
+    end
+
+    context "when the title is not set" do
+      let(:title) { nil }
+
+      it { expect { render }.to raise_error(ArgumentError, "title must be present") }
+    end
+  end
+end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -165,23 +165,6 @@ describe EventsHelper, type: "helper" do
     end
   end
 
-  describe "#embed_event_video_url" do
-    it "returns nil if the event video is nil" do
-      expect(embed_event_video_url(nil)).to be_nil
-    end
-
-    it "returns an embedded url when given an embedded url" do
-      standard_url = "https://www.youtube.com/watch?v=BelJ2AjtHoQ"
-      embed_url = "https://www.youtube.com/embed/BelJ2AjtHoQ"
-      expect(embed_event_video_url(standard_url)).to eq(embed_url)
-    end
-
-    it "returns an embedded url when given a standard url" do
-      embed_url = "https://www.youtube.com/embed/BelJ2AjtHoQ"
-      expect(embed_event_video_url(embed_url)).to eq(embed_url)
-    end
-  end
-
   describe "#pluralised_category_name" do
     {
       222_750_001 => "Train to Teach events",

--- a/spec/lib/template_handlers/markdown_spec.rb
+++ b/spec/lib/template_handlers/markdown_spec.rb
@@ -237,6 +237,9 @@ describe TemplateHandlers::Markdown, type: :view do
           "inset-text-1" => { "text" => "text 1" },
           "inset-text-2" => { "text" => "text 2" },
         },
+        "youtube_video" => {
+          "video-1" => { "id" => "abc123", "title" => "Video title" },
+        },
       }
     end
 
@@ -253,6 +256,10 @@ describe TemplateHandlers::Markdown, type: :view do
         Some more text
 
         $inset-text-2$
+
+        Some more text
+
+        $video-1$
       MARKDOWN
     end
 
@@ -268,6 +275,7 @@ describe TemplateHandlers::Markdown, type: :view do
       is_expected.to have_css(".quote", text: "quote 1")
       is_expected.to have_css(".inset-text", text: "text 1")
       is_expected.to have_css(".inset-text", text: "text 2")
+      is_expected.to have_css("iframe[title='Video title']")
     end
   end
 end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -27,7 +27,6 @@ describe TeachingEvents::EventPresenter do
       summary
       type_id
       status_id
-      video_url
       web_feed_id
     ].each { |attribute| it { is_expected.to delegate_method(attribute).to(:event) } }
   end
@@ -60,6 +59,34 @@ describe TeachingEvents::EventPresenter do
         let(:event) { build(:event_api) }
 
         it { is_expected.to have_location }
+      end
+    end
+
+    describe "#video_id" do
+      let(:video_id) { "BelJ2AjtHoQ" }
+
+      context "when the video_url is nil" do
+        let(:event) { build(:event_api, video_url: nil) }
+
+        it { expect(subject.video_id).to be_nil }
+      end
+
+      context "when the video_url is not a valid YouTube URL" do
+        let(:event) { build(:event_api, video_url: "http://youtube.com/#{video_id}") }
+
+        it { expect(subject.video_id).to be_nil }
+      end
+
+      context "when the video_url is an embedded URL" do
+        let(:event) { build(:event_api, video_url: "https://www.youtube.com/embed/#{video_id}") }
+
+        it { expect(subject.video_id).to eq(video_id) }
+      end
+
+      context "when the video_url is a watch URL" do
+        let(:event) { build(:event_api, video_url: "https://www.youtube.com/watch?v=#{video_id}") }
+
+        it { expect(subject.video_id).to eq(video_id) }
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3571](https://trello.com/c/X0GN6kxS/3571-create-a-video-component)

### Context

We are currently including custom HTML for YouTube videos at each occasion that we want to render a video on a page. This leads to inconsistencies between the various snippets of HTML.

Add `YoutubeVideoComponent` to standardise how we render YouTube videos and whitelist the compnent in the Markdown template handler so that we can use it in our content pages.

### Changes proposed in this pull request

- Standardise videos with a view component

### Guidance to review

This may inadvertently fix an issue flagged in Google Search Console whereby only some of our videos are being correctly indexed. I've take the HTML snippet for the standard iframe from one of the indexed videos.

If this doesn't fix the issue (Google are vague about what constitutes a 'prominent' video) it may be worth removing the `loading: lazy` attribute as it could be that videos above the fold are being indexed and videos further down are not because they don't get loaded immediately.

Pages with videos on them:

[Blog - Top Tips for Returning Teachers](https://review-get-into-teaching-app-2772.london.cloudapps.digital/blog/top-tips-for-returning-teachers)
[Returning to Teaching](https://review-get-into-teaching-app-2772.london.cloudapps.digital/returning-to-teaching)
[Teacher Training Advisers x 2](https://review-get-into-teaching-app-2772.london.cloudapps.digital/teacher-training-advisers)
[About TTT Events](https://review-get-into-teaching-app-2772.london.cloudapps.digital/events/about-train-to-teach-events)