### PR TITLE
Removing still time to apply messaging

### DIFF
--- a/app/views/content/blog/7-things-to-include-in-your-teacher-training-application.md
+++ b/app/views/content/blog/7-things-to-include-in-your-teacher-training-application.md
@@ -16,16 +16,9 @@ tags:
   - becoming a teacher
   - teacher training
   - personal statements
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/apply-for-teacher-training">Start your teacher training application now</a>.</p>
 ---
 
 $bedfordshire$
-
-$still-time-to-apply$
 
 Not sure what to include in your teacher training application? Just think of the word TEACHER! Juliet Fern, Mieka Harris and Kate Hudson-Glynn from the University of Bedfordshire explain all.
 

--- a/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
+++ b/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
@@ -16,16 +16,9 @@ tags:
   - becoming a teacher
   - teacher training
   - personal statements
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
 
 $rocket$
-
-$still-time-to-apply$
 
 It’s important to make an excellent first impression if you want to secure that interview, and time spent on a well-thought-out application is never wasted.
 

--- a/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
+++ b/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
@@ -16,16 +16,9 @@ tags:
   - becoming a teacher
   - teacher training advisers
   - applications
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
 
 $right_provider$
-
-$still-time-to-apply$
 
 When choosing a course provider for your teacher training, it’s important to consider what will suit your individual circumstances. The course you choose needs to offer you the right support and be a good fit for you. When looking for a course, you may wish to research and explore a potential provider’s values, how they structure their courses, and what kinds of support and fun-filled opportunities they offer.
 

--- a/app/views/content/blog/getting-ready-to-apply.md
+++ b/app/views/content/blog/getting-ready-to-apply.md
@@ -24,16 +24,9 @@ tags:
   - train to teach events
   - applications
   - references
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
 
 $notepad$
-
-$still-time-to-apply$
 
 Applications for teacher training courses starting in 2022 open on 12 October, but there is plenty you can be doing right now to get ready.
 

--- a/app/views/content/blog/how-to-apply-for-teacher-training.md
+++ b/app/views/content/blog/how-to-apply-for-teacher-training.md
@@ -25,16 +25,9 @@ tags:
   - personal statements
   - qualifications
   - applications
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
 
 $header_image$
-
-$still-time-to-apply$
 
 From effective preparation, to submitting your application, we’ve broken down the whole process into manageable steps, so you can see exactly what’s involved.
 

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -58,14 +58,7 @@ keywords:
   - Settlement Scheme
   - Statement
   - Comparability
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
-
-$still-time-to-apply$
 
 Citizens of every country in the world can apply to train to teach in England.
 

--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -36,14 +36,7 @@ keywords:
   - European
   - Statement
   - Comparability
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
-
-$still-time-to-apply$
 
 Overseas teachers enrich the lives of students and add value to schools and the wider community. The [Department for Education (DfE)](https://www.gov.uk/government/organisations/department-for-education) wishes to assist Ukrainian refugees in any way we can, and we support and encourage schools and training providers to recruit Ukrainian teachers and teacher trainees. 
 

--- a/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
@@ -32,14 +32,7 @@ promo_content:
 navigation: 20.25
 navigation_title: How to apply
 navigation_description: Discover tips on preparing your teacher training application, from choosing your referees, to writing your personal statement.
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk//apply-for-teacher-training/get-school-experience">Start your teacher training application now</a>.</p>
 ---
-
-$still-time-to-apply$
 
 Give yourself the best chance of getting on the course you want.
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -14,14 +14,7 @@ promo_content:
 navigation: 20.05
 navigation_title: If you have or are studying for a degree
 navigation_description: Find out how to get qualified teacher status (QTS) through postgraduate teacher training if you have a degree or you’re studying for one. 
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
-
-$still-time-to-apply$
 
 If you have a degree, or you’re currently studying for one, there are different routes you can take to getting [qualified teacher status](/what-is-qts) (QTS). You need QTS to work in the majority of schools in England including state maintained primary, secondary and special schools.
 

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -10,14 +10,7 @@ related_content:
     Training and support for early career teachers : "/support-for-early-career-teachers"
 promo_content:
     - content/train-to-be-a-teacher/promos/events-promo-itt
-inset_text:
-  still-time-to-apply:
-    text: |-
-      <p>There's still time to apply and start teacher training this September.</p>
-      <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find your postgraduate teacher training course now</a>.</p>
 ---
-
-$still-time-to-apply$
 
 Your initial teacher training (ITT) will vary depending on your course provider and the qualifications you're working towards.
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/fpHmIADy/3572-remove-still-time-to-apply-messaging

### Context

Once the deadline for applications passes, we need to remove the 'still time to apply' messaging from the site.

### Changes proposed in this pull request

### Guidance to review

