### PR TITLE
Change docker caching from gha to registry

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -57,7 +57,6 @@ runs:
                  echo ::set-output name=key::${pr_name}
                  echo "TF_VAR_paas_app_application_name=${pr_name}" >> $GITHUB_ENV
                  echo "TF_VAR_paas_app_route_name=${pr_name}"       >> $GITHUB_ENV
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:review-${{steps.sha.outputs.short}}
              fi
 
              if [ "${{inputs.environment }}" == "Development" ]
@@ -65,7 +64,6 @@ runs:
                  echo ::set-output name=control::$(echo "dev" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-dev" )
                  echo ::set-output name=key::"app.dev.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{inputs.environment }}" == "Test" ]
@@ -73,7 +71,6 @@ runs:
                  echo ::set-output name=control::$(echo "test" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-test" )
                  echo ::set-output name=key::"app.test.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{inputs.environment }}" == "Speed" ]
@@ -82,7 +79,6 @@ runs:
                  echo ::set-output name=control::$(echo "pagespeed" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-pagespeed" )
                  echo ::set-output name=key::"app.pagespeed.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{inputs.environment }}" == "UR" ]
@@ -91,7 +87,6 @@ runs:
                  echo ::set-output name=control::$(echo "ur" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-UR" )
                  echo ::set-output name=key::"app.ur.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
 
              if [ "${{inputs.environment }}" == "Production" ]
@@ -99,8 +94,9 @@ runs:
                  echo ::set-output name=control::$(echo "production" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-prod" )
                  echo ::set-output name=key::"app.production.terraform"
-                 echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
+
+             echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
 
       - uses: DfE-Digital/keyvault-yaml-secret@v1
         id:  keyvault-yaml-secret

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -44,12 +44,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker image
+      - name: Build and push base image
         uses: docker/build-push-action@v3.1.1
         with:
+          context: .
+          tags: ${{ env.DOCKER_REPOSITORY }}:base-master
+          push: true
+          target: base
+          build-args: |
+            SHA=${{ steps.sha.outputs.short }}
+            BUILD_TYPE=release
+
+      - name: Build release image locally
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: .
           tags: ${{ env.DOCKER_REPOSITORY }}:master
-          load: true
           push: false
+          load: true
           build-args: |
             SHA=${{ steps.sha.outputs.short }}
             BUILD_TYPE=release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,14 @@ jobs:
         run: |
              if [ "${{github.ref}}" == "refs/heads/master" ]
              then
-                echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_EVENT::${{ env.DOCKER_REPOSITORY }}:master
+                GIT_BRANCH=master
              else
-                echo ::set-output name=DOCKER_SHA::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:review-${{steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_EVENT::${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}
+                GIT_REF=${{ github.head_ref }}
+                GIT_BRANCH=${GIT_REF##*/}
              fi
+
+             echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+             echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:sha-${{steps.sha.outputs.short }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2.0.0
@@ -68,18 +69,36 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push to Docker Hub
+      - name: Build and push base
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:base-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_REPOSITORY}}:base-master
+          tags: ${{ env.DOCKER_REPOSITORY }}:base-${{ env.BRANCH_TAG }}
+          push: true
+          target: base
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            SHA=${{ steps.sha.outputs.short }}
+            BUILD_TYPE=release
+
+      - name: Build and push release image
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: .
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:master
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:base-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:base-master
           tags: |
             ${{ steps.docker.outputs.DOCKER_IMAGE }}
-            ${{ steps.docker.outputs.DOCKER_SHA }}
-            ${{ steps.docker.outputs.DOCKER_EVENT }}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
           push: true
           build-args: |
+            BUILDKIT_INLINE_CACHE=1
             SHA=${{ steps.sha.outputs.short }}
             BUILD_TYPE=release
 
@@ -135,12 +154,14 @@ jobs:
         run: |
              if [ "${{github.ref}}" == "refs/heads/master" ]
              then
-                echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:sha-${{ steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_EVENT_TEST::${{ env.DOCKER_REPOSITORY }}:master
+                GIT_BRANCH=master
              else
-                echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:review-${{steps.sha.outputs.short }}
-                echo ::set-output name=DOCKER_EVENT_TEST::${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}
+                GIT_REF=${{ github.head_ref }}
+                GIT_BRANCH=${GIT_REF##*/}
              fi
+
+             echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+             echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:test-sha-${{ steps.sha.outputs.short }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2.0.0
@@ -149,25 +170,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and output locally
+      - name: Build and push test image
         uses: docker/build-push-action@v3.1.1
         with:
-          outputs: type=docker,dest=/tmp/image.tar
+          push: true
           context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:test-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:test-master
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:base-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:base-master
           tags: |
             ${{ steps.docker.outputs.DOCKER_IMAGE_TEST }}
-            ${{ steps.docker.outputs.DOCKER_EVENT_TEST }}
+            ${{ env.DOCKER_REPOSITORY }}:test-${{ env.BRANCH_TAG }}
           build-args: |
+            BUILDKIT_INLINE_CACHE=1
             SHA=${{ steps.sha.outputs.short }}
             BUILD_TYPE=test
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: app_test
-          path: /tmp/image.tar
 
       - name: Slack Notification
         if: failure() && github.ref == 'refs/heads/master'
@@ -189,12 +208,6 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Load Docker Image
-        run: docker load --input app_test/image.tar
 
       - name: Lint Ruby
         run: |-
@@ -226,12 +239,6 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Load Docker Image
-        run: docker load --input app_test/image.tar
 
       - name: ESLint - JavaScript linting
         run: |-
@@ -269,12 +276,6 @@ jobs:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
           key: SLACK-WEBHOOK, KNAPSACK-PRO-TEST-SUITE-TOKEN-RSPEC
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Load Docker Image
-        run: docker load --input app_test/image.tar
 
       - name: Run Specs
         run: |-
@@ -336,9 +337,6 @@ jobs:
 
       - name: Download Artifacts
         uses: actions/download-artifact@v3
-
-      - name: Load Docker Image
-        run: docker load --input app_test/image.tar
 
       - name: Combine Coverage Reports
         run: |-
@@ -560,12 +558,6 @@ jobs:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: INFRA-KEYS
           key: HTTP-USERNAME, HTTP-PASSWORD, MAILSAC-API-KEY
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Load Docker Image
-        run: docker load --input app_test/image.tar
 
       - name: Run Integration Tests
         run: |-


### PR DESCRIPTION
### Trello card

https://trello.com/c/96RrOmzk/667-change-caching-from-gha-to-registry

### Context

The build workflow is currently using type=gha for docker image caching.
Our preferred method is registry, which gives more control over the caching, and also maintains a common standard between repositories.

Also removing the tar file for the test image, and pushing to ghcr to use caching instead.

### Changes proposed in this pull request

Update build-and-deploy workflow
Update build-no-cache workflow

### Guidance to review

Check build logs to make sure it's working as expected
- https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/2977982281 

Check run time to confirm it's not slower than the previous method
Check image tags in ghcr

