### PR TITLE
Fix focus style on assessment only provider links

### DIFF
--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -18,16 +18,17 @@
   .group__cards {
     @include cards-grid;
 
-    a {
-      @extend .link;
-    }
-
     .group__card {
       box-sizing: border-box;
       padding: 1em;
       background: $white;
 
       &__heading {
+        a {
+          @extend .link;
+          display: inline-block;
+        }
+
         h4 {
           @extend .heading--margin-0;
         }


### PR DESCRIPTION
### Trello card

[Trello-3591](https://trello.com/c/OrNbRpE0/3591-fix-styling-bug-on-assessment-only-page)

### Context

The background color of the focus state for the link was not being applied as the anchor was not a block element.

### Changes proposed in this pull request

- Fix focus style on assessment only provider links

### Guidance to review

