### PR TITLE
Add GOV.UK to page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,11 +16,11 @@ module ApplicationHelper
     title || frontmatter["title"] || params[:page].to_s.humanize
   end
 
-  def prefix_title(title)
+  def suffix_title(title)
     if title
-      "#{title} | Get Into Teaching"
+      "#{title} | Get Into Teaching GOV.UK"
     else
-      "Get Into Teaching"
+      "Get Into Teaching GOV.UK"
     end
   end
 

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -1,6 +1,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title><%= prefix_title page_title(@page_title, @front_matter) %></title>
+  <title><%= suffix_title(page_title(@page_title, @front_matter)) %></title>
   <%= csp_meta_tag %>
   <%= content_for?(:canonical) ? yield(:canonical) : canonical_tag %>
   <%= tag.meta(name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no') %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,6 +11,22 @@ describe ApplicationHelper do
     it { is_expected.to have_css "body hr" }
   end
 
+  describe "#suffix_title" do
+    subject { suffix_title(title) }
+
+    context "when no title is provided" do
+      let(:title) { nil }
+
+      it { is_expected.to eq("Get Into Teaching GOV.UK") }
+    end
+
+    context "when a title is provided" do
+      let(:title) { "My Title" }
+
+      it { is_expected.to eq("My Title | Get Into Teaching GOV.UK") }
+    end
+  end
+
   describe "#new_gtm_enabled?" do
     it "returns true when GTM_ID is present" do
       allow(ENV).to receive(:[]).with("GTM_ID").and_return("ABC-123")


### PR DESCRIPTION
### Trello card

[Trello-3608](https://trello.com/c/qazPWTs5/3608-change-site-name-to-include-govuk)

### Context

We want page titles to end with "Get Into Teaching GOV.UK" instead of "Get Into Teaching".

### Changes proposed in this pull request

- Add GOV.UK to page titles

Also updates the helper name to be clearer (we are suffixing the title not prefixing it).

### Guidance to review

