### PR TITLE
replacing train to teach with get into teaching events

### DIFF
--- a/app/components/teaching_events/event_component.html.erb
+++ b/app/components/teaching_events/event_component.html.erb
@@ -32,7 +32,7 @@
 
     <div class="event__meta">
       <div class="event-image">
-        <%= image_pack_tag("media/images/content/event-signup/birmingham-event-2.jpg", alt: "A popular train to teach event in a hall with stalls and banners" ) %>
+        <%= image_pack_tag("media/images/content/event-signup/birmingham-event-2.jpg", alt: "A popular Get Into Teaching event in a hall with stalls and banners" ) %>
       </div>
 
       <div class="dfelogo">

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -13,7 +13,7 @@ class TeachingEventsController < ApplicationController
   EVENT_COUNT = 15 # 15 regular ones per page
 
   FEATURED_EVENT_TYPES = EventType.lookup_by_names(
-    "Train to Teach event",
+    "Get Into Teaching event",
     "Question Time",
   ).freeze
 

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -1,6 +1,6 @@
 module TeachingEventsHelper
   def is_a_train_to_teach_event?(event)
-    event.type_id.in?(EventType.lookup_by_names("Train to Teach event", "Question Time"))
+    event.type_id.in?(EventType.lookup_by_names("Get Into Teaching event", "Question Time"))
   end
 
   def event_list_id(name)

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,7 +1,7 @@
 class EventType
   ALL =
     {
-      "Train to Teach event" => 222_750_001,
+      "Get Into Teaching event" => 222_750_001,
       "Question Time" => 222_750_007,
       "Online event" => 222_750_008,
       "School or University event" => 222_750_009,
@@ -9,7 +9,7 @@ class EventType
 
   QUERY_PARAM_NAMES =
     {
-      "ttt" => 222_750_001,       # Train to Teach event
+      "ttt" => 222_750_001,       # Get Into Teaching event
       "tttqt" => 222_750_007,     # Question Time
       "onlineqa" => 222_750_008,  # Online event
       "provider" => 222_750_009,  # School or University event
@@ -32,7 +32,7 @@ class EventType
     end
 
     def train_to_teach_event_id
-      lookup_by_name("Train to Teach event")
+      lookup_by_name("Get Into Teaching event")
     end
 
     def online_event_id

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -36,7 +36,7 @@ module Events
     class << self
       def available_event_types
         # We can't search for Question Time events explicitly. Instead, they
-        # are returned as Train to Teach events.
+        # are returned as Get Into Teaching events.
         @available_event_types ||= EventType::ALL
           .except("Question Time")
           .map do |key, value|
@@ -81,7 +81,7 @@ module Events
     def type_ids
       type_ids = [type]
 
-      # We combine Question Time events with Train to Teach events
+      # We combine Question Time events with Get Into Teaching events
       if type == EventType.train_to_teach_event_id
         type_ids << EventType.question_time_event_id
       end

--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -42,7 +42,7 @@ module TeachingEvents
     end
 
     def train_to_teach?
-      EventType.lookup_by_name("Train to Teach event").in?(type_condition || [])
+      EventType.lookup_by_name("Get Into Teaching event").in?(type_condition || [])
     end
 
     def online

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -74,7 +74,7 @@ module TeachingEvents
 
     def quote
       case event_type
-      when "Train to Teach event", "Question Time"
+      when "Get Into Teaching event", "Question Time"
         "So useful! I got answers to questions I didn't know I had yet and I'm so inspired and excited."
 
       when "Online event"
@@ -86,10 +86,10 @@ module TeachingEvents
 
     def image
       case event_type
-      when "Train to Teach event", "Question Time"
+      when "Get Into Teaching event", "Question Time"
         {
           path: "media/images/content/event-signup/birmingham-event-1.jpg",
-          alt: "A bustling Train to Teach event taking place in a church, busy with stalls and visitors",
+          alt: "A bustling Get Into Teaching event taking place in a church, busy with stalls and visitors",
         }
       when "Online event"
         nil

--- a/app/views/content/a-day-in-the-life-of-a-teacher.md
+++ b/app/views/content/a-day-in-the-life-of-a-teacher.md
@@ -94,7 +94,7 @@ $q-sarah-geography-2$
 
 <p>To get one step closer to teaching you can:</p> 
   <ul>
-    <li>speak to a current teacher at one of our <a href="/events/about-train-to-teach-events">Train to Teach events</a></li>
+    <li>speak to a current teacher at one of our <a href="/events/about-train-to-teach-events">Get Into Teaching events</a></li>
     <li>find a <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">postgraduate teacher training course</a> to help you get <a href="/what-is-qts">qualified teacher status (QTS)</a></li>
     <li>find a <a href="https://teaching-vacancies.service.gov.uk/">teaching job</a></li>
     <li>learn about the <a href="/support-for-early-career-teachers">support given to early career teachers based on the early career framework</a></li>

--- a/app/views/content/blog/5-reasons-to-attend-a-get-into-teaching-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-get-into-teaching-event.md
@@ -1,33 +1,33 @@
 ---
-title: 5 reasons to attend a Train to Teach event
+title: 5 reasons to attend a Get Into Teaching event
 date: "2021-08-26"
 images:
   train_to_teach:
     path: "media/images/content/blog/train-to-teach.jpg"
     thumbnail_path: "media/images/content/blog/thumbnails/train-to-teach.jpg"
 description: |-
-  Whether you’re ready to apply or it’s just an idea, here are five reasons why a Train to Teach event can help you on your journey to the classroom.
+  Whether you’re ready to apply or it’s just an idea, here are five reasons why a Get Into Teaching event can help you on your journey to the classroom.
     
 keywords:
-  - train to teach events
+  - Get Into Teaching events
   - becoming a teacher
   - applications
   - teacher training
 tags:
   - becoming a teacher
   - teacher training advisers
-  - train to teach events
+  - Get Into Teaching events
   - applications
 closing_paragraph: enriching-the-lives-of-young-people
 ---
 
 $train_to_teach$
 
-If you’re interested in training to teach but not sure on your next steps, then our popular Train to Teach events are for you. Whether you’re ready to apply or it’s just an idea, here are five reasons why a Train to Teach event can help you on your journey to the classroom.
+If you’re interested in training to teach but not sure on your next steps, then our popular Get Into Teaching events are for you. Whether you’re ready to apply or it’s just an idea, here are five reasons why a Get Into Teaching event can help you on your journey to the classroom.
 
 ## 1. Save some time
 
-A Train to Teach event offers you a one-stop shop of information and support.  There are a number of different zones you can visit where our expert advisers will help you understand the qualifications you need and the range of different ways you can train.  
+A Get Into Teaching event offers you a one-stop shop of information and support.  There are a number of different zones you can visit where our expert advisers will help you understand the qualifications you need and the range of different ways you can train.  
 
 Whether you’ve recently graduated or you’re looking to change your career, in as little as two hours you will be able to gain clarity and confidence in your steps to becoming a teacher.
 
@@ -35,11 +35,11 @@ Whether you’ve recently graduated or you’re looking to change your career, i
 
 We understand that everyone’s journey into the classroom is different and your questions may be unique to you and your circumstances. You may have questions about your eligibility or a query about the extra financial support available if you’re a parent or a carer. 
 
-At a Train to Teach event we can answer all your questions and maybe some you didn’t know you had!  
+At a Get Into Teaching event we can answer all your questions and maybe some you didn’t know you had!  
 
 ## 3. Make connections
 
-A Train to Teach event is a great way of making new connections. You can meet like-minded individuals on their teaching journey and stay in touch with each other through our [Aspiring Teacher Forum](https://www.facebook.com/groups/1357146377672255) or [Career Change to Teaching](https://www.facebook.com/groups/CareerChangetoTeaching) Facebook groups. 
+A Get Into Teaching event is a great way of making new connections. You can meet like-minded individuals on their teaching journey and stay in touch with each other through our [Aspiring Teacher Forum](https://www.facebook.com/groups/1357146377672255) or [Career Change to Teaching](https://www.facebook.com/groups/CareerChangetoTeaching) Facebook groups. 
 
 You can also speak to teacher training providers for advice on how to find the right course for you, as well as meeting potential future course leaders or employers. These connections could help you in your journey to a rewarding career in teaching.
 
@@ -55,4 +55,4 @@ You can have a one-to-one chat with a current teacher who can provide you with i
 
 They can also talk about why they love teaching and how rewarding it is, giving you a balanced view and insight into what the life of a teacher is really like.
 
-[Find a Train to Teach event near you](/events/about-train-to-teach-events).
+[Find a Get Into Teaching event near you](/events/about-train-to-teach-events).

--- a/app/views/content/blog/abigails-career-progression-story.md
+++ b/app/views/content/blog/abigails-career-progression-story.md
@@ -30,7 +30,7 @@ $abigail_beeley$
 
 I always enjoyed maths at school and had the opportunity to take my maths GCSE early. I went on to study Maths and Management at university, always with the idea that I would go into a leadership or management role, but with no certainty of what industry I would enter.
 
-A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Train to Teach event](/events) and got chatting about a career in teaching. It seemed like a great opportunity!
+A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Get Into Teaching event](/events) and got chatting about a career in teaching. It seemed like a great opportunity!
 
 I really enjoyed my teacher training. Although I had no experience in the classroom beforehand, I found I settled quite naturally into speaking to pupils at the front of the classroom. I also had a lot of support from my mentors and the maths team.
 

--- a/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
+++ b/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
@@ -34,7 +34,7 @@ It’s not an insurmountable obstacle if you haven’t had any experience of wor
 
 School experience is not compulsory, but it may be a good idea to try to visit a school if only to confirm that you are making the right choice before you submit your application. If you are having difficulty finding a school to visit, you might find that schools offering School Direct courses are more welcoming to an enquiry. Due to the pandemic, some schools are not currently accepting non-essential visitors, so use the [Department for Education’s Get School Experience service](https://schoolexperience.education.gov.uk/) to find details of upcoming opportunities in your area.
 
-Attending a [Train to Teach event](/events/about-train-to-teach-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
+Attending a [Get Into Teaching event](/events/about-train-to-teach-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
 
 ## The personal statement
 

--- a/app/views/content/blog/getting-ready-to-apply.md
+++ b/app/views/content/blog/getting-ready-to-apply.md
@@ -21,7 +21,7 @@ keywords:
 tags:
   - becoming a teacher
   - teacher training advisers
-  - train to teach events
+  - Get Into Teaching events
   - applications
   - references
 ---
@@ -78,7 +78,7 @@ If a training provider offers you a place and you accept, they'll use your refer
 
 ## 7. Get some advice at an event
 
-Our Train to Teach events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Train to Teach event](/events/about-train-to-teach-events).
+Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Get Into Teaching event](/events/about-train-to-teach-events).
 
 ## 8.  Join our support networks
 

--- a/app/views/content/covid-19.md
+++ b/app/views/content/covid-19.md
@@ -40,9 +40,9 @@ You may be asked to send your degree or GCSE certificates digitally too.
 
 Wait for your provider to contact you with more information.
 
-### Are Train To Teach events going ahead?
+### Are Get Into Teaching events going ahead?
 
-[Train to Teach events](/events) are going ahead.
+[Get Into Teaching events](/events) are going ahead.
 
 ### What if I’m an overseas applicant?
 

--- a/app/views/content/funding-and-support/if-you-come-from-outside-england.md
+++ b/app/views/content/funding-and-support/if-you-come-from-outside-england.md
@@ -6,7 +6,7 @@ description: |-
 related_content:
     Your initial teacher training year: "/train-to-be-a-teacher/initial-teacher-training"
     Get school experience: "/train-to-be-a-teacher/get-school-experience"
-    5 reasons to attend a Train to Teach event: "/blog/5-reasons-to-attend-a-train-to-teach-event"
+    5 reasons to attend a Get Into Teaching event: "/blog/5-reasons-to-attend-a-train-to-teach-event"
 promo_content:
     - content/funding-and-support/promos/mailing-list-promo
 navigation: 20.35

--- a/app/views/content/help-and-advice.md
+++ b/app/views/content/help-and-advice.md
@@ -40,9 +40,9 @@ There are online, text-based sessions where you can ask a panel of specialists t
 
 You could also attend a training provider event, either online or in person, and hear directly from teacher training providers about the courses they offer and how to apply.
 
-### Train to Teach events
+### Get Into Teaching events
 
-Train to Teach events are run by the Department for Education (DfE) and are free to attend. You'll be able to:
+Get Into Teaching events are run by the Department for Education (DfE) and are free to attend. You'll be able to:
 
 - put your questions to expert advisers, teachers and training providers
 - chat with current teachers

--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -6,7 +6,7 @@ description: |-
   Get school experience to explore what life is like in the classroom before you start your initial teacher training (ITT). Discover if teaching is for you.
 related_content:
     Who do you want to teach? : "/train-to-be-a-teacher/who-do-you-want-to-teach"
-    Train to Teach events : "/events/about-train-to-teach-events"
+    Get Into Teaching events : "/events/about-train-to-teach-events"
     School experience helped me change careers : "/blog/school-experience-helped-me-decide-to-switch"
 calls_to_action:
     get-school-experience:

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -4,7 +4,7 @@ heading: "Train to be a teacher if you don't have a degree"
 description: |-
   Explore how you can train to be a teacher and gain qualified teacher status (QTS) if you don’t have a degree.
 related_content:
-    5 reasons to attend a Train to Teach event : "/blog/5-reasons-to-attend-a-train-to-teach-event"
+    5 reasons to attend a Get Into Teaching event : "/blog/5-reasons-to-attend-a-get-into-teaching-event"
     Funding your training : "/funding-and-support"
     Teach in further education without a degree : "https://www.teach-in-further-education.campaign.gov.uk"
 promo_content:

--- a/app/views/content/welcome/my-journey-into-teaching/_introduction.html.erb
+++ b/app/views/content/welcome/my-journey-into-teaching/_introduction.html.erb
@@ -205,7 +205,7 @@
     <p>
       Abigail wasn’t sure what she wanted to do when she graduated with a maths
       and management degree. She knew she wanted to go into a leadership role
-      but it was after attending a Train to Teach event that she realised
+      but it was after attending a Get Into Teaching event that she realised
       teaching was right for her.
     </p>
 

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -11,7 +11,7 @@
     <%= render HeaderComponent.new %>
 
     <main role="main" id="main-content" class="main-body registration-with-image-above" role="main">
-      <%= image_pack_tag("content/event-signup/birmingham-event-1-wide.jpg", alt: "A busy train to teach event with banners and attendees chatting with advisers") %>
+      <%= image_pack_tag("content/event-signup/birmingham-event-1-wide.jpg", alt: "A busy Get Into Teaching event with banners and attendees chatting with advisers") %>
 
       <div class="event-info">
         <%= render Events::DesktopSignupInfo.new(@event) %>

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -1,5 +1,5 @@
 <%
-  @page_title = "About train to teach events"
+  @page_title = "About Get Into Teaching events"
   @show_breadcrumbs = true
   @no_bottom_margin = true
 %>
@@ -9,19 +9,19 @@
     <h1 class="heading--highlight-pink">
       <span>What happens at a</span>
       <br>
-      <span>Train to Teach event?</span>
+      <span>Get Into Teaching event?</span>
     </h1>
 
     <% if @no_ttt_events %>
-      <%= render Content::InsetTextComponent.new(text: "The summer programme of Train to Teach events has now ended. Train to Teach events will start again in November and you'll be able to book your place from the end of September. You can also search for #{link_to('more events', events_path)}." ) %>
+      <%= render Content::InsetTextComponent.new(text: "The summer programme of Get Into Teaching events has now ended. Get Into Teaching events will start again in November and you'll be able to book your place from the end of September. You can also search for #{link_to('more events', events_path)}." ) %>
     <% end %>
 
-    <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg", alt: "A popular train to teach event in a hall with stalls and banners" %>
+    <%= image_pack_tag "media/images/content/event-signup/birmingham-event-3.jpg", alt: "A popular Get Into Teaching event in a hall with stalls and banners" %>
   </header>
 
   <article>
     <p>
-      Train to Teach events are designed to give you an insight into what it’s
+      Get Into Teaching events are designed to give you an insight into what it’s
       like to be a teacher, as well as the practical information you need to get
       onto a teacher training course.
     </p>
@@ -39,7 +39,7 @@
     </p>
 
     <p>
-    <%= link_to("Register for a Train to Teach event", events_path("teaching_events_search[type][]" => "ttt,tttqt"), class: "button") %>
+    <%= link_to("Register for a Get Into Teaching event", events_path("teaching_events_search[type][]" => "ttt,tttqt"), class: "button") %>
     </p>
 
     <h2>What to expect on the day:</h2>
@@ -55,7 +55,7 @@
     <div class="youtube-video-container">
       <%= render Content::YoutubeVideoComponent.new(
         id: "eAWwqLLEINI",
-        title: "Train to Teach Events: Take your next step towards teaching"
+        title: "Get Into Teaching events: Take your next step towards teaching"
       ) %>
     </div>
   </article>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -11,7 +11,7 @@
 
       <dl>
         <div>
-          <dt>Train to Teach events</dt>
+          <dt>Get Into Teaching events</dt>
           <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers. Run by the Department for Education (DfE).</dd>
         </div>
 
@@ -39,20 +39,20 @@
       <div class="teaching-events__listing">
         <% if @featured_events.any? %>
           <div class="teaching-events__events teaching-events__events--featured">
-            <h2 class="heading-m">Upcoming Train to Teach events</h2>
+            <h2 class="heading-m">Upcoming Get Into Teaching events</h2>
 
             <ol><%= render TeachingEvents::EventComponent.with_collection(@featured_events) %></ol>
 
             <div class="teaching-events__about-ttt-banner">
               <div class="teaching-events__about-ttt-banner--message">
                 <p>
-                  Designed by the Department for Education, Train to Teach events
+                  Designed by the Department for Education, Get Into Teaching events
                   give you everything you need to get into teaching.
                 </p>
               </div>
 
               <div class="teaching-events__about-ttt-banner--link">
-                <%= link_to("What happens at a Train to Teach event?", about_ttt_events_path, class: "button button--white") %>
+                <%= link_to("What happens at a Get Into Teaching event?", about_ttt_events_path, class: "button button--white") %>
               </div>
             </div>
           </div>

--- a/app/views/teaching_events/index/_no_results.html.erb
+++ b/app/views/teaching_events/index/_no_results.html.erb
@@ -4,9 +4,9 @@
   </h3>
 
   <% if @event_search.train_to_teach? %>
-    <p><strong>The summer programme of Train to Teach events has now ended. You can:</strong></p>
+    <p><strong>The summer programme of Get Into Teaching events has now ended. You can:</strong></p>
     <ul>
-      <li>look again in late September and book your place on a November Train to Teach event</li>
+      <li>look again in late September and book your place on a November Get Into Teaching event</li>
       <li><%= link_to("attend an Online Q&A", events_path(teaching_events_search: { type: %w[onlineqa] })) %> to ask your questions to a panel of experts</li>
     </ul>
   <% else %>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -12,7 +12,7 @@
   <div class="teaching-event__video youtube-video-container">
     <%= render Content::YoutubeVideoComponent.new(
       id: @event.video_id,
-      title: "Train to Teach Events: Take your next step towards teaching"
+      title: "Get Into Teaching events: Take your next step towards teaching"
     ) %>
   </div>
 <% end %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -8,7 +8,7 @@ $icon-size: 3rem;
   &::after {
     @include font-size(small);
     position: absolute;
-    content: "Train to Teach event";
+    content: "Get Into Teaching event";
     right: 5%;
     top: -1em;
     background: $pink url(../images/icon-ttt-white.svg) no-repeat left center;

--- a/config/images.yml
+++ b/config/images.yml
@@ -283,7 +283,7 @@
     - "media/images/content/blog/thumbnails/stephen.jpg"
 
 "media/images/content/blog/train-to-teach.jpg":
-  alt: "A busy Train to Teach event with attendees having conversations with Teacher Training Advisers."
+  alt: "A busy Get Into Teaching event with attendees having conversations with Teacher Training Advisers."
   variants:
     - "media/images/content/blog/thumbnails/train-to-teach.jpg"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,8 +40,8 @@ en:
   find_an_event:
     types:
       222750001: |-
-        <p>Our Train to Teach events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom.</p>
-        <p>At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts.
+        <p>Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom.</p>
+        <p>At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts.
         Some events are in person and others replicate the experience online.</p>
         <p>Whichever event you choose to attend, you will have the chance to:</p>
         <ul>
@@ -50,7 +50,7 @@ en:
           <li>watch presentations which provide a step-by-step guide on how to get into teaching, the application
           process and funding your training</li>
         </ul>
-        <p>You need to register for Train to Teach events in advance, as spaces are
+        <p>You need to register for Get Into Teaching events in advance, as spaces are
         limited and fill up on a first come, first served basis.</p>
         <p>
         The presentations used at these events can be found <a href="/presentations">here</a>.
@@ -256,8 +256,8 @@ en:
   event_types:
     222750001:
       name:
-        singular: "Train to Teach event"
-        plural: "Train to Teach events"
+        singular: "Get Into Teaching event"
+        plural: "Get Into Teaching events"
       description:
         short: The main event - hear from teachers, training providers and our expert advisers. Get answers to your questions and learn more about ways to train and funding.
         long: |-
@@ -265,8 +265,8 @@ en:
           will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
     222750007: # Question Time (displayed as Train to Teach)
       name:
-        singular: "Train to Teach event"
-        plural: "Train to Teach events"
+        singular: "Get Into Teaching event"
+        plural: "Get Into Teaching events"
     222750008:
       name:
         singular: "Online Q&A"

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -29,5 +29,5 @@
 - teacher training
 - teacher training advisers
 - teaching internships
-- train to teach events
+- Get Into Teaching events
 - veterans

--- a/docs/event-flow.md
+++ b/docs/event-flow.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 graph TD;
-  chooses_event[/Chooses a Train to Teach event/] --> sign_up_for_this_event
+  chooses_event[/Chooses a Get Into Teaching event/] --> sign_up_for_this_event
   sign_up_for_this_event[Sign up for this event] -- Doesn't exist in CRM --> telephone_number[What is your telephone number?] --> accept_privacy_policy[Accept privacy policy]
 
   sign_up_for_this_event -- Exists in CRM --> already_registered[You've already registered with us]

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -65,7 +65,7 @@ describe Events::EventBoxComponent, type: "component" do
     let(:event) { build :event_api, :train_to_teach_event }
 
     specify %(the event type name should be displayed) do
-      expect(page).to have_content("Train to Teach event")
+      expect(page).to have_content("Get Into Teaching event")
     end
 
     specify %(the box should have the right type of divider) do
@@ -97,7 +97,7 @@ describe Events::EventBoxComponent, type: "component" do
     let(:event) { build :event_api, :train_to_teach_event, :virtual }
 
     specify %(the event type name should be displayed) do
-      expect(page).to have_content("Train to Teach event")
+      expect(page).to have_content("Get Into Teaching event")
     end
 
     specify %(the event should also be described as a 'Event has moved online') do

--- a/spec/components/teaching_events/event_component_spec.rb
+++ b/spec/components/teaching_events/event_component_spec.rb
@@ -33,7 +33,7 @@ describe TeachingEvents::EventComponent, type: "component" do
         it { expect(subject.provider_event?).to be(true) }
       end
 
-      context "when the event is a train to teach event" do
+      context "when the event is a Get Into Teaching event" do
         let(:event) { build(:event_api) }
 
         it { expect(subject.provider_event?).to be(false) }
@@ -113,7 +113,7 @@ describe TeachingEvents::EventComponent, type: "component" do
       expect(subject).to have_css("li.event")
     end
 
-    context "when a train to teach event" do
+    context "when a Get Into Teaching event" do
       it { expect(subject).to have_css("li.event.event--train-to-teach") }
 
       specify "contains the event name as a link" do

--- a/spec/features/teaching_events/about_ttt_events_spec.rb
+++ b/spec/features/teaching_events/about_ttt_events_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature "About TTT events", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events).and_return([])
     visit about_ttt_events_path
-    expect(page).to have_link("Register for a Train to Teach event", href: events_path("teaching_events_search[type][]" => "ttt,tttqt"))
+    expect(page).to have_link("Register for a Get Into Teaching event", href: events_path("teaching_events_search[type][]" => "ttt,tttqt"))
   end
 end

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
       allow_any_instance_of(TeachingEvents::Search).to receive(:results).and_return(events)
     end
 
-    scenario "The first two train to teach events are 'featured'" do
+    scenario "The first two Get Into Teaching events are 'featured'" do
       visit events_path
 
       expect(page).to have_current_path("/events")
@@ -154,10 +154,10 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(online: false)).once
     end
 
-    scenario "searching for train to teach events" do
+    scenario "searching for Get Into Teaching events" do
       visit events_path
 
-      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time")
+      expected_type_ids = EventType.lookup_by_names("Get Into Teaching event", "Question Time")
 
       check "DfE Train to Teach"
       click_on "Update results"
@@ -187,10 +187,10 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(fake_api).to have_received(:search_teaching_events_grouped_by_type).with(hash_including(type_ids: expected_type_ids)).once
     end
 
-    scenario "searching for online and train to teach events" do
+    scenario "searching for online and Get Into Teaching events" do
       visit events_path
 
-      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time", "School or University event")
+      expected_type_ids = EventType.lookup_by_names("Get Into Teaching event", "Question Time", "School or University event")
 
       check "DfE Train to Teach"
       check "Training provider"
@@ -236,7 +236,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
         end
       end
 
-      context "when the candidate has filtered by Train to Teach events" do
+      context "when the candidate has filtered by Get Into Teaching events" do
         let(:params) { { teaching_events_search: { type: %w[ttt] } } }
 
         scenario "specific Train to Teach options are shown" do

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     end
   end
 
-  describe "viewing a train to teach event" do
+  describe "viewing a Get Into Teaching event" do
     let(:event) { build(:event_api, :with_provider_info) }
 
     include_examples "train-to-teach teaching event"

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -105,11 +105,11 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#event_type_color" do
-    it "returns purple for train to teach events" do
+    it "returns purple for Get Into Teaching events" do
       expect(event_type_color(EventType.train_to_teach_event_id)).to eq("purple")
     end
 
-    it "returns blue for non-train to teach events" do
+    it "returns blue for non-Get Into Teaching events" do
       expect(event_type_color(EventType.online_event_id)).to eq("blue")
       expect(event_type_color(EventType.school_or_university_event_id)).to eq("blue")
     end
@@ -167,7 +167,7 @@ describe EventsHelper, type: "helper" do
 
   describe "#pluralised_category_name" do
     {
-      222_750_001 => "Train to Teach events",
+      222_750_001 => "Get Into Teaching events",
       222_750_008 => "Online Q&As",
       222_750_009 => "School and University events",
     }.each do |type_id, name|
@@ -183,7 +183,7 @@ describe EventsHelper, type: "helper" do
     end
 
     it "returns the category name with 'Past' prepended if the category name does not contain 'online'" do
-      expect(past_category_name(222_750_001)).to eql("Past Train to Teach events")
+      expect(past_category_name(222_750_001)).to eql("Past Get Into Teaching events")
     end
   end
 

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -79,7 +79,7 @@ describe TeachingEventsHelper, type: "helper" do
   end
 
   describe "#is_event_type?" do
-    let(:ttt) { "Train to Teach event" }
+    let(:ttt) { "Get Into Teaching event" }
     let(:qt) { "Question Time" }
 
     let(:ttt_event) do

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -183,13 +183,13 @@ describe Events::Search do
         end
       end
 
-      context "when searching Train to Teach events" do
+      context "when searching Get Into Teaching events" do
         before do
           subject.type = EventType.train_to_teach_event_id
           expected_attributes[:type_ids] << EventType.question_time_event_id
         end
 
-        it "queries Question Time and Train to Teach events" do
+        it "queries Question Time and Get Into Teaching events" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
             receive(:search_teaching_events_grouped_by_type).with(**expected_attributes)
         end

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -47,11 +47,11 @@ describe Events::GroupPresenter do
         expect(type_ids).to include(online_event_type_id)
       end
 
-      context "when there are Question Time or Train to Teach events" do
+      context "when there are Question Time or Get Into Teaching events" do
         let(:train_to_teach_events) { [] }
         let(:question_time_events) { [] }
 
-        it "still contains a key for Train to Teach events" do
+        it "still contains a key for Get Into Teaching events" do
           expect(type_ids).to include(EventType.train_to_teach_event_id)
         end
 
@@ -152,7 +152,7 @@ describe Events::GroupPresenter do
       expect(subject.sorted_events_of_type(type)).to eq(online_events)
     end
 
-    context "when type is Train to Teach event" do
+    context "when type is Get Into Teaching event" do
       let(:type) { EventType.train_to_teach_event_id }
 
       it "returns the Train to Teach and Question Time events" do

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -108,7 +108,7 @@ describe TeachingEvents::EventPresenter do
     describe "#quote" do
       subject { described_class.new(event).quote }
 
-      context "when event is a Train to Teach event" do
+      context "when event is a Get Into Teaching event" do
         let(:event) { build(:event_api, :train_to_teach_event) }
 
         specify { expect(subject).to match(/I got answers to questions/) }
@@ -136,7 +136,7 @@ describe TeachingEvents::EventPresenter do
     describe "#image" do
       subject { described_class.new(event).image }
 
-      context "when event is a Train to Teach event" do
+      context "when event is a Get Into Teaching event" do
         let(:event) { build(:event_api, :train_to_teach_event) }
 
         specify { expect(subject[:path]).to end_with(".jpg") }
@@ -208,7 +208,7 @@ describe TeachingEvents::EventPresenter do
     describe "#show_provider_information?" do
       subject { described_class.new(event).show_provider_information? }
 
-      context "when event is a Train to Teach event" do
+      context "when event is a Get Into Teaching event" do
         let(:event) { build(:event_api, :train_to_teach_event) }
 
         specify { expect(subject).to be false }
@@ -264,7 +264,7 @@ describe TeachingEvents::EventPresenter do
     describe "#allow_registration?" do
       subject { described_class.new(event).allow_registration? }
 
-      context "when event is a future Train to Teach event" do
+      context "when event is a future Get Into Teaching event" do
         let(:event) { build(:event_api, :train_to_teach_event) }
 
         specify { expect(subject).to be true }
@@ -276,13 +276,13 @@ describe TeachingEvents::EventPresenter do
         specify { expect(subject).to be true }
       end
 
-      context "when event is a past Train to Teach event" do
+      context "when event is a past Get Into Teaching event" do
         let(:event) { build(:event_api, :past, :question_time_event) }
 
         specify { expect(subject).to be false }
       end
 
-      context "when event is a future non-Train to Teach event" do
+      context "when event is a future non-Get Into Teaching event" do
         let(:event) { build(:event_api, :school_or_university_event) }
 
         specify { expect(subject).to be false }

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -92,12 +92,12 @@ describe "teaching events", type: :request do
     subject { response.body }
 
     it { expect(response).to have_http_status(:success) }
-    it { is_expected.not_to include("The summer programme of Train to Teach events has now ended.") }
+    it { is_expected.not_to include("The summer programme of Get Into Teaching events has now ended.") }
 
-    context "when there are no train to teach events" do
+    context "when there are no Get Into Teaching events" do
       let(:events) { [] }
 
-      it { is_expected.to include("The summer programme of Train to Teach events has now ended.") }
+      it { is_expected.to include("The summer programme of Get Into Teaching events has now ended.") }
     end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/rrrhDECs/3584-change-references-from-train-to-teach-events-to-get-into-teaching-events

### Context

Now that Train to Teach events are being renamed Get Into Teaching events, we need to change all references to these on the website.

### Changes proposed in this pull request

### Guidance to review

