### PR TITLE
updating train to teach events name

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -24,7 +24,7 @@
       <span class="menu-button__text">Menu</span>
     <% end %>
   </div>
-  <%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Teacher training events", "/blog" => "Blog" }) %>
+  <%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Events", "/blog" => "Blog" }) %>
 </header>
 
 <% if breadcrumbs %>

--- a/app/views/content/a-day-in-the-life-of-a-teacher.md
+++ b/app/views/content/a-day-in-the-life-of-a-teacher.md
@@ -95,7 +95,7 @@ $q-sarah-geography-2$
 <p>To get one step closer to teaching you can:</p> 
   <ul>
     <li>get an <a href="/explore-teaching-advisers">explore teaching adviser</a> who can help you discover if teaching is for you and find classroom experience</li>
-    <li>speak to a current teacher at one of our <a href="/events/about-train-to-teach-events">Train to Teach events</a></li>
+    <li>speak to a current teacher at one of our <a href="/events/about-get-into-teaching-events">Get Into Teaching events</a></li>
     <li>find a <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">postgraduate teacher training course</a> to help you get <a href="/what-is-qts">qualified teacher status (QTS)</a></li>
     <li>learn about the <a href="/support-for-early-career-teachers">support given to early career teachers based on the early career framework</a></li>
   </ul>

--- a/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
@@ -54,4 +54,4 @@ You can have a one-to-one chat with a current teacher who can provide you with i
 
 They can also talk about why they love teaching and how rewarding it is, giving you a balanced view and insight into what the life of a teacher is really like.
 
-[Find a Get Into Teaching event near you](/events/about-train-to-teach-events).
+[Find a Get Into Teaching event near you](/events/about-get-into-teaching-events).

--- a/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-train-to-teach-event.md
@@ -1,32 +1,32 @@
 ---
-title: 5 reasons to attend a Train to Teach event
+title: 5 reasons to attend a Get Into Teaching event
 date: "2021-08-26"
 images:
   train_to_teach:
     path: "media/images/content/blog/train-to-teach.jpg"
     thumbnail_path: "media/images/content/blog/thumbnails/train-to-teach.jpg"
 description: |-
-  Whether you’re ready to apply or it’s just an idea, here are five reasons why a Train to Teach event can help you on your journey to the classroom.
+  Whether you’re ready to apply or it’s just an idea, here are five reasons why a Get Into Teaching event can help you on your journey to the classroom.
 keywords:
-  - train to teach events
+  - Get Into Teaching events
   - becoming a teacher
   - applications
   - teacher training
 tags:
   - becoming a teacher
   - teacher training advisers
-  - train to teach events
+  - Get Into Teaching events
   - applications
 closing_paragraph: enriching-the-lives-of-young-people
 ---
 
 $train_to_teach$
 
-If you’re interested in training to teach but not sure on your next steps, then our popular Train to Teach events are for you. Whether you’re ready to apply or it’s just an idea, here are five reasons why a Train to Teach event can help you on your journey to the classroom.
+If you’re interested in training to teach but not sure on your next steps, then our popular Get Into Teaching events are for you. Whether you’re ready to apply or it’s just an idea, here are five reasons why a Get Into Teaching event can help you on your journey to the classroom.
 
 ## 1. Save some time
 
-A Train to Teach event offers you a one-stop shop of information and support.  There are a number of different zones you can visit where our expert advisers will help you understand the qualifications you need and the range of different ways you can train.  
+A Get Into Teaching event offers you a one-stop shop of information and support.  There are a number of different zones you can visit where our expert advisers will help you understand the qualifications you need and the range of different ways you can train.  
 
 Whether you’ve recently graduated or you’re looking to change your career, in as little as two hours you will be able to gain clarity and confidence in your steps to becoming a teacher.
 
@@ -34,11 +34,11 @@ Whether you’ve recently graduated or you’re looking to change your career, i
 
 We understand that everyone’s journey into the classroom is different and your questions may be unique to you and your circumstances. You may have questions about your eligibility or a query about the extra financial support available if you’re a parent or a carer. 
 
-At a Train to Teach event we can answer all your questions and maybe some you didn’t know you had!  
+At a Get Into Teaching event we can answer all your questions and maybe some you didn’t know you had!  
 
 ## 3. Make connections
 
-A Train to Teach event is a great way of making new connections. You can meet like-minded individuals on their teaching journey and stay in touch with each other through our [Aspiring Teacher Forum](https://www.facebook.com/groups/1357146377672255) or [Career Change to Teaching](https://www.facebook.com/groups/CareerChangetoTeaching) Facebook groups. 
+A Get Into Teaching event is a great way of making new connections. You can meet like-minded individuals on their teaching journey and stay in touch with each other through our [Aspiring Teacher Forum](https://www.facebook.com/groups/1357146377672255) or [Career Change to Teaching](https://www.facebook.com/groups/CareerChangetoTeaching) Facebook groups. 
 
 You can also speak to teacher training providers for advice on how to find the right course for you, as well as meeting potential future course leaders or employers. These connections could help you in your journey to a rewarding career in teaching.
 
@@ -54,4 +54,4 @@ You can have a one-to-one chat with a current teacher who can provide you with i
 
 They can also talk about why they love teaching and how rewarding it is, giving you a balanced view and insight into what the life of a teacher is really like.
 
-[Find a Train to Teach event near you](/events/about-train-to-teach-events).
+[Find a Get Into Teaching event near you](/events/about-train-to-teach-events).

--- a/app/views/content/blog/abigails-career-progression-story.md
+++ b/app/views/content/blog/abigails-career-progression-story.md
@@ -30,7 +30,7 @@ $abigail_beeley$
 
 I always enjoyed maths at school and had the opportunity to take my maths GCSE early. I went on to study Maths and Management at university, always with the idea that I would go into a leadership or management role, but with no certainty of what industry I would enter.
 
-A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Get Into Teaching event](/events) and got chatting about a career in teaching. It seemed like a great opportunity!
+A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Get Into Teaching event](/events/about-get-into-teaching-events) and got chatting about a career in teaching. It seemed like a great opportunity!
 
 I really enjoyed my teacher training. Although I had no experience in the classroom beforehand, I found I settled quite naturally into speaking to pupils at the front of the classroom. I also had a lot of support from my mentors and the maths team.
 

--- a/app/views/content/blog/abigails-career-progression-story.md
+++ b/app/views/content/blog/abigails-career-progression-story.md
@@ -30,7 +30,7 @@ $abigail_beeley$
 
 I always enjoyed maths at school and had the opportunity to take my maths GCSE early. I went on to study Maths and Management at university, always with the idea that I would go into a leadership or management role, but with no certainty of what industry I would enter.
 
-A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Train to Teach event](/events) and got chatting about a career in teaching. It seemed like a great opportunity!
+A few years after I finished university, my old school sent out a letter to former students advertising the [School Direct](/train-to-be-a-teacher/if-you-have-a-degree) route into teaching. Around the same time, I went to meet one of my friends who was working at a [Get Into Teaching event](/events) and got chatting about a career in teaching. It seemed like a great opportunity!
 
 I really enjoyed my teacher training. Although I had no experience in the classroom beforehand, I found I settled quite naturally into speaking to pupils at the front of the classroom. I also had a lot of support from my mentors and the maths team.
 

--- a/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
+++ b/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
@@ -34,7 +34,7 @@ It’s not an insurmountable obstacle if you haven’t had any experience of wor
 
 School experience is not compulsory, but it may be a good idea to try to visit a school if only to confirm that you are making the right choice before you submit your application. If you are having difficulty finding a school to visit, you might find that schools offering School Direct courses are more welcoming to an enquiry. Due to the pandemic, some schools are not currently accepting non-essential visitors, so use the [Department for Education’s Get School Experience service](https://schoolexperience.education.gov.uk/) to find details of upcoming opportunities in your area.
 
-Attending a [Get Into Teaching event](/events/about-train-to-teach-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
+Attending a [Get Into Teaching event](/events/about-get-into-teaching-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
 
 ## The personal statement
 

--- a/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
+++ b/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
@@ -34,11 +34,11 @@ It’s not an insurmountable obstacle if you haven’t had any experience of wor
 
 School experience is not compulsory, but it may be a good idea to try to visit a school if only to confirm that you are making the right choice before you submit your application. If you are having difficulty finding a school to visit, you might find that schools offering School Direct courses are more welcoming to an enquiry. Due to the pandemic, some schools are not currently accepting non-essential visitors, so use the [Department for Education’s Get School Experience service](https://schoolexperience.education.gov.uk/) to find details of upcoming opportunities in your area.
 
-Attending a [Train to Teach event](/events/about-train-to-teach-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
+Attending a [Get Into Teaching event](/events/about-train-to-teach-events) is also a good idea, as you can talk to training providers and ask them directly if they would host a visit. Remember they are there to recruit trainee teachers so may be more amenable to inviting you into their school.
 
 ## The personal statement
 
-The personal statement is your shop window. You will be asked to focus on why you have decided to train to teach and why you are suited to your chosen age group or subject. You can also talk about any relevant work experience you have had, what you learned or observed and how you might apply this to your own teaching practice.
+The personal statement is your shop window. You will be asked to focus on why you have decided to Get Into Teaching and why you are suited to your chosen age group or subject. You can also talk about any relevant work experience you have had, what you learned or observed and how you might apply this to your own teaching practice.
 
 Remember to tailor your statement to either the phase or the subject you are wanting to teach. Trying to adapt it to cover both primary and secondary, or two different subjects, is not advised.
 

--- a/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
+++ b/app/views/content/blog/application-tips-from-a-teacher-training-provider.md
@@ -38,7 +38,7 @@ Attending a [Get Into Teaching event](/events/about-get-into-teaching-events) is
 
 ## The personal statement
 
-The personal statement is your shop window. You will be asked to focus on why you have decided to Get Into Teaching and why you are suited to your chosen age group or subject. You can also talk about any relevant work experience you have had, what you learned or observed and how you might apply this to your own teaching practice.
+The personal statement is your shop window. You will be asked to focus on why you have decided to get into teaching and why you are suited to your chosen age group or subject. You can also talk about any relevant work experience you have had, what you learned or observed and how you might apply this to your own teaching practice.
 
 Remember to tailor your statement to either the phase or the subject you are wanting to teach. Trying to adapt it to cover both primary and secondary, or two different subjects, is not advised.
 

--- a/app/views/content/blog/getting-ready-to-apply.md
+++ b/app/views/content/blog/getting-ready-to-apply.md
@@ -21,7 +21,7 @@ keywords:
 tags:
   - becoming a teacher
   - teacher training advisers
-  - train to teach events
+  - Get Into Teaching events
   - applications
   - references
 ---
@@ -78,7 +78,7 @@ If a training provider offers you a place and you accept, they'll use your refer
 
 ## 7. Get some advice at an event
 
-Our Train to Teach events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Train to Teach event](/events/about-train-to-teach-events).
+Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Get Into Teaching event](/events/about-train-to-teach-events).
 
 ## 8.  Join our support networks
 

--- a/app/views/content/blog/getting-ready-to-apply.md
+++ b/app/views/content/blog/getting-ready-to-apply.md
@@ -78,7 +78,7 @@ If a training provider offers you a place and you accept, they'll use your refer
 
 ## 7. Get some advice at an event
 
-Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Get Into Teaching event](/events/about-train-to-teach-events).
+Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom. At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts. Some events are in person and others replicate the experience online. [Book your place at a Get Into Teaching event](/events/about-get-into-teaching-events).
 
 ## 8.  Join our support networks
 

--- a/app/views/content/covid-19.md
+++ b/app/views/content/covid-19.md
@@ -40,9 +40,9 @@ You may be asked to send your degree or GCSE certificates digitally too.
 
 Wait for your provider to contact you with more information.
 
-### Are Train To Teach events going ahead?
+### Are Get Into Teaching events going ahead?
 
-[Train to Teach events](/events) are going ahead.
+[Get Into Teaching events](/events) are going ahead.
 
 ### What if I’m an overseas applicant?
 

--- a/app/views/content/funding-and-support/if-you-come-from-outside-england.md
+++ b/app/views/content/funding-and-support/if-you-come-from-outside-england.md
@@ -6,7 +6,7 @@ description: |-
 related_content:
     Your initial teacher training year: "/train-to-be-a-teacher/initial-teacher-training"
     Get school experience: "/train-to-be-a-teacher/get-school-experience"
-    5 reasons to attend a Train to Teach event: "/blog/5-reasons-to-attend-a-train-to-teach-event"
+    5 reasons to attend a Get Into Teaching event: "/blog/5-reasons-to-attend-a-get-into-teaching-event"
 promo_content:
     - content/funding-and-support/promos/mailing-list-promo
 navigation: 20.35

--- a/app/views/content/help-and-advice.md
+++ b/app/views/content/help-and-advice.md
@@ -49,9 +49,9 @@ There are online, text-based sessions where you can ask a panel of specialists t
 
 You could also attend a training provider event, either online or in person, and hear directly from teacher training providers about the courses they offer and how to apply.
 
-### Train to Teach events
+### Get Into Teaching events
 
-Train to Teach events are run by the Department for Education (DfE) and are free to attend. You'll be able to:
+Get Into Teaching events are run by the Department for Education (DfE) and are free to attend. You'll be able to:
 
 - put your questions to expert advisers, teachers and training providers
 - chat with current teachers

--- a/app/views/content/help-and-advice.md
+++ b/app/views/content/help-and-advice.md
@@ -41,14 +41,6 @@ An explore teaching adviser can support you if you're an undergraduate student a
 
 Our events are a great way to meet teachers and other experts to talk about any concerns or questions you have about becoming a teacher.
 
-### Online question and answer sessions
-
-There are online, text-based sessions where you can ask a panel of specialists the questions that matter to you. These sessions, run by DfE, cover a range of different topics so you can post specific questions and receive advice tailored to your particular circumstances.
-
-### Training provider events
-
-You could also attend a training provider event, either online or in person, and hear directly from teacher training providers about the courses they offer and how to apply.
-
 ### Get Into Teaching events
 
 Get Into Teaching events are run by the Department for Education (DfE) and are free to attend. You'll be able to:
@@ -57,6 +49,14 @@ Get Into Teaching events are run by the Department for Education (DfE) and are f
 - chat with current teachers
 - find out what a career in teaching is really like
 - watch presentations which provide detailed guidance on how to get into teaching, the application process and funding your training
+
+### Online question and answer sessions
+
+There are online, text-based sessions where you can ask a panel of specialists the questions that matter to you. These sessions, run by DfE, cover a range of different topics so you can post specific questions and receive advice tailored to your particular circumstances.
+
+### Training provider events
+
+You could also attend a training provider event, either online or in person, and hear directly from teacher training providers about the courses they offer and how to apply.
 
 <a href="/events" class="button">Search for an event</a>
 

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,7 +1,7 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Attend a teacher training event",
+    title: "Attend an event",
     text: "Talk to course providers, teachers and expert advisers to get your questions answered in person or online at an event.",
     link_text: "Find an event",
     link_target: "/events",

--- a/app/views/content/three-things-to-help-you-get-into-teaching.md
+++ b/app/views/content/three-things-to-help-you-get-into-teaching.md
@@ -18,7 +18,7 @@
     - Email
     - Updates
     - Events
-    - Train To Teach
+    - Get Into Teaching
     - Advisers
     - TTAs
     - Advisor

--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -6,7 +6,7 @@ description: |-
   Get school experience to explore what life is like in the classroom before you start your initial teacher training (ITT). Discover if teaching is for you.
 related_content:
     Who do you want to teach? : "/train-to-be-a-teacher/who-do-you-want-to-teach"
-    Get Into Teachings : "/events/about-get-into-teaching-events"
+    What is a Get Into Teaching event? : "/events/about-get-into-teaching-events"
     School experience helped me change careers : "/blog/school-experience-helped-me-decide-to-switch"
 calls_to_action:
     get-school-experience:

--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -6,7 +6,7 @@ description: |-
   Get school experience to explore what life is like in the classroom before you start your initial teacher training (ITT). Discover if teaching is for you.
 related_content:
     Who do you want to teach? : "/train-to-be-a-teacher/who-do-you-want-to-teach"
-    Train to Teach events : "/events/about-train-to-teach-events"
+    Get Into Teachings : "/events/about-get-into-teaching-events"
     School experience helped me change careers : "/blog/school-experience-helped-me-decide-to-switch"
 calls_to_action:
     get-school-experience:

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -4,7 +4,7 @@ heading: "Train to be a teacher if you don't have a degree"
 description: |-
   Explore how you can train to be a teacher and gain qualified teacher status (QTS) if you don’t have a degree.
 related_content:
-    5 reasons to attend a Train to Teach event : "/blog/5-reasons-to-attend-a-train-to-teach-event"
+    5 reasons to attend a Get Into Teaching event : "/blog/5-reasons-to-attend-a-get-into-teaching-event"
     Funding your training : "/funding-and-support"
     Teach in further education without a degree : "https://www.teach-in-further-education.campaign.gov.uk"
 promo_content:

--- a/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
@@ -6,7 +6,7 @@ description: |-
 related_content:
     Career progression stories: "/blog/tag/career-progression"
     Salaries and benefits : "/salaries-and-benefits"
-    Events : "/events"
+    Attend an event : "/events"
 promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-assessment-only
 navigation: 20.10

--- a/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
@@ -6,7 +6,7 @@ description: |-
 related_content:
     Career progression stories: "/blog/tag/career-progression"
     Salaries and benefits : "/salaries-and-benefits"
-    Teacher training events : "/events"
+    Events : "/events"
 promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-assessment-only
 navigation: 20.10

--- a/app/views/content/welcome/my-journey-into-teaching/_introduction.html.erb
+++ b/app/views/content/welcome/my-journey-into-teaching/_introduction.html.erb
@@ -205,7 +205,7 @@
     <p>
       Abigail wasn’t sure what she wanted to do when she graduated with a maths
       and management degree. She knew she wanted to go into a leadership role
-      but it was after attending a Train to Teach event that she realised
+      but it was after attending a Get Into Teaching event that she realised
       teaching was right for her.
     </p>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -1,6 +1,6 @@
 <section class="teaching-events">
   <header>
-    <h1 class="heading-l heading--box-yellow">Get Into Teaching events</h1>
+    <h1 class="heading-l heading--box-yellow">Events</h1>
 
     <p>
       All events listed are designed to help you get into teacher training. They are free to attend.
@@ -11,7 +11,7 @@
 
       <dl>
         <div>
-          <dt>Train to Teach events</dt>
+          <dt>Get Into Teaching events</dt>
           <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers. Run by the Department for Education (DfE).</dd>
         </div>
 
@@ -39,20 +39,20 @@
       <div class="teaching-events__listing">
         <% if @featured_events.any? %>
           <div class="teaching-events__events teaching-events__events--featured">
-            <h2 class="heading-m">Upcoming Train to Teach events</h2>
+            <h2 class="heading-m">Upcoming Get Into Teaching events</h2>
 
             <ol><%= render TeachingEvents::EventComponent.with_collection(@featured_events) %></ol>
 
             <div class="teaching-events__about-ttt-banner">
               <div class="teaching-events__about-ttt-banner--message">
                 <p>
-                  Designed by the Department for Education, Train to Teach events
+                  Designed by the Department for Education, Get Into Teaching events
                   give you everything you need to get into teaching.
                 </p>
               </div>
 
               <div class="teaching-events__about-ttt-banner--link">
-                <%= link_to("What happens at a Train to Teach event?", about_ttt_events_path, class: "button button--white") %>
+                <%= link_to("What happens at a Get Into Teaching event?", about_ttt_events_path, class: "button button--white") %>
               </div>
             </div>
           </div>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
     <p>
-      All events listed are designed to help you get into teacher training. They are free to attend.
+      Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
 
     <details class="teaching-events__descriptions">
@@ -12,7 +12,7 @@
       <dl>
         <div>
           <dt>Get Into Teaching events</dt>
-          <dd>Watch presentations, hear from teachers, speak to advisers and meet local training providers. Run by the Department for Education (DfE).</dd>
+          <dd>Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).</dd>
         </div>
 
         <div>
@@ -46,8 +46,8 @@
             <div class="teaching-events__about-ttt-banner">
               <div class="teaching-events__about-ttt-banner--message">
                 <p>
-                  Designed by the Department for Education, Get Into Teaching events
-                  give you everything you need to get into teaching.
+                  Get Into Teaching events
+                  can answer your questions whether you're ready to start your career in teaching or just curious.
                 </p>
               </div>
 

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,7 +18,7 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "ttt,tttqt", label: { text: "DfE Train to Teach" } %>
+      <%= f.govuk_check_box :type, "ttt,tttqt", label: { text: "DfE Get Into Teaching" } %>
       <%= f.govuk_check_box :type, "onlineqa", label: { text: "DfE Online Q&A" } %>
       <%= f.govuk_check_box :type, "provider", label: { text: "Training provider" } %>
     <% end %>

--- a/config/images.yml
+++ b/config/images.yml
@@ -286,7 +286,7 @@
     - "media/images/content/blog/thumbnails/stephen.jpg"
 
 "media/images/content/blog/train-to-teach.jpg":
-  alt: "A busy Train to Teach event with attendees having conversations with Teacher Training Advisers."
+  alt: "A busy Get Into Teaching event with attendees having conversations with Teacher Training Advisers."
   variants:
     - "media/images/content/blog/thumbnails/train-to-teach.jpg"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,8 +40,8 @@ en:
   find_an_event:
     types:
       222750001: |-
-        <p>Our Train to Teach events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom.</p>
-        <p>At some of our Train to Teach events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts.
+        <p>Our Get Into Teaching events will provide you with a wealth of information and help you turn questions to confidence on your journey to the classroom.</p>
+        <p>At some of our Get Into Teaching events you can meet a whole range of local training providers; at others you’ll have the chance to put your questions to a panel of experts.
         Some events are in person and others replicate the experience online.</p>
         <p>Whichever event you choose to attend, you will have the chance to:</p>
         <ul>
@@ -50,7 +50,7 @@ en:
           <li>watch presentations which provide a step-by-step guide on how to get into teaching, the application
           process and funding your training</li>
         </ul>
-        <p>You need to register for Train to Teach events in advance, as spaces are
+        <p>You need to register for Get Into Teaching events in advance, as spaces are
         limited and fill up on a first come, first served basis.</p>
         <p>
         The presentations used at these events can be found <a href="/presentations">here</a>.

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -11,6 +11,7 @@
 - deafness
 - financial support
 - funding
+- Get Into Teaching events
 - international
 - interviews
 - life as a teacher


### PR DESCRIPTION
### Trello card

https://trello.com/c/rrrhDECs/3584-change-references-from-train-to-teach-events-to-get-into-teaching-events

### Context

Train to Teach events are being renamed Get Into Teaching events so we need to tweak the copy on the website where they are mentioned.

### Changes proposed in this pull request

### Guidance to review

