### PR TITLE
Remove Question Time events

### DIFF
--- a/app/components/teaching_events/event_component.rb
+++ b/app/components/teaching_events/event_component.rb
@@ -18,7 +18,7 @@ module TeachingEvents
     delegate :provider_event?, to: :type
 
     def train_to_teach?
-      type.train_to_teach_or_question_time_event?
+      type.train_to_teach_event?
     end
 
     def online?

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -14,7 +14,6 @@ class TeachingEventsController < ApplicationController
 
   FEATURED_EVENT_TYPES = EventType.lookup_by_names(
     "Train to Teach event",
-    "Question Time",
   ).freeze
 
   def create
@@ -55,7 +54,7 @@ class TeachingEventsController < ApplicationController
   def about_ttt_events
     @no_ttt_events = GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
       quantity: 1,
-      type_ids: [EventType.train_to_teach_event_id, EventType.question_time_event_id],
+      type_ids: [EventType.train_to_teach_event_id],
       start_after: Time.zone.now,
     ).blank?
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -38,7 +38,7 @@ module EventsHelper
   end
 
   def display_event_provider_info?(event)
-    !event.type_id.in?([qt_event_type_id, ttt_event_type_id])
+    !event.type_id.in?([ttt_event_type_id])
   end
 
   def event_has_provider_info?(event)
@@ -113,9 +113,5 @@ module EventsHelper
 
   def ttt_event_type_id
     EventType.train_to_teach_event_id
-  end
-
-  def qt_event_type_id
-    EventType.question_time_event_id
   end
 end

--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -111,7 +111,7 @@ module StructuredDataHelper
   end
 
   def event_structured_data(event)
-    return unless event.type_id.in?([qt_event_type_id, ttt_event_type_id])
+    return unless event.type_id.in?([ttt_event_type_id])
 
     building_data = event_building_data(event)
     provider_data = event_provider_data(event)

--- a/app/helpers/teaching_events_helper.rb
+++ b/app/helpers/teaching_events_helper.rb
@@ -1,6 +1,6 @@
 module TeachingEventsHelper
   def is_a_train_to_teach_event?(event)
-    event.type_id.in?(EventType.lookup_by_names("Train to Teach event", "Question Time"))
+    event.type_id.in?(EventType.lookup_by_names("Train to Teach event"))
   end
 
   def event_list_id(name)

--- a/app/models/event_status.rb
+++ b/app/models/event_status.rb
@@ -50,7 +50,7 @@ class EventStatus
   end
 
   def accepts_online_registration?
-    type_ids = [EventType.question_time_event_id, EventType.train_to_teach_event_id]
+    type_ids = [EventType.train_to_teach_event_id]
 
     event.type_id.in?(type_ids) && future_dated? && open?
   end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -2,7 +2,6 @@ class EventType
   ALL =
     {
       "Train to Teach event" => 222_750_001,
-      "Question Time" => 222_750_007,
       "Online event" => 222_750_008,
       "School or University event" => 222_750_009,
     }.freeze
@@ -10,7 +9,6 @@ class EventType
   QUERY_PARAM_NAMES =
     {
       "ttt" => 222_750_001,       # Train to Teach event
-      "tttqt" => 222_750_007,     # Question Time
       "onlineqa" => 222_750_008,  # Online event
       "provider" => 222_750_009,  # School or University event
     }.freeze
@@ -22,7 +20,6 @@ class EventType
     :online_event_id,
     :school_or_university_event_id,
     :train_to_teach_event_id,
-    :question_time_event_id,
     to: :class,
   )
 
@@ -37,10 +34,6 @@ class EventType
 
     def online_event_id
       lookup_by_name("Online event")
-    end
-
-    def question_time_event_id
-      lookup_by_name("Question Time")
     end
 
     def lookup_by_name(name)
@@ -89,15 +82,7 @@ class EventType
     type_id == school_or_university_event_id
   end
 
-  def question_time_event?
-    type_id == question_time_event_id
-  end
-
   def train_to_teach_event?
     type_id == train_to_teach_event_id
-  end
-
-  def train_to_teach_or_question_time_event?
-    type_id.in?([train_to_teach_event_id, question_time_event_id])
   end
 end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -57,7 +57,7 @@ class EventType
     end
 
     def lookup_by_query_params(*names)
-      QUERY_PARAM_NAMES.fetch_values(*names)
+      QUERY_PARAM_NAMES.values_at(*names).compact
     end
 
     def all_ids

--- a/app/models/events/search.rb
+++ b/app/models/events/search.rb
@@ -35,10 +35,7 @@ module Events
 
     class << self
       def available_event_types
-        # We can't search for Question Time events explicitly. Instead, they
-        # are returned as Train to Teach events.
         @available_event_types ||= EventType::ALL
-          .except("Question Time")
           .map do |key, value|
             GetIntoTeachingApiClient::PickListItem.new(id: value, value: key)
           end
@@ -79,14 +76,7 @@ module Events
   private
 
     def type_ids
-      type_ids = [type]
-
-      # We combine Question Time events with Train to Teach events
-      if type == EventType.train_to_teach_event_id
-        type_ids << EventType.question_time_event_id
-      end
-
-      type_ids.compact.presence
+      [type].compact.presence
     end
 
     def month_range

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -74,7 +74,7 @@ module TeachingEvents
 
     def quote
       case event_type
-      when "Train to Teach event", "Question Time"
+      when "Train to Teach event"
         "So useful! I got answers to questions I didn't know I had yet and I'm so inspired and excited."
 
       when "Online event"
@@ -86,7 +86,7 @@ module TeachingEvents
 
     def image
       case event_type
-      when "Train to Teach event", "Question Time"
+      when "Train to Teach event"
         {
           path: "media/images/content/event-signup/birmingham-event-1.jpg",
           alt: "A bustling Train to Teach event taking place in a church, busy with stalls and visitors",
@@ -111,7 +111,7 @@ module TeachingEvents
     end
 
     def show_provider_information?
-      !type_id.in?([EventType.question_time_event_id, EventType.train_to_teach_event_id])
+      !type_id.in?([EventType.train_to_teach_event_id])
     end
 
     def show_venue_information?

--- a/app/views/teaching_events/about_ttt_events.html.erb
+++ b/app/views/teaching_events/about_ttt_events.html.erb
@@ -39,7 +39,7 @@
     </p>
 
     <p>
-    <%= link_to("Register for a Train to Teach event", events_path("teaching_events_search[type][]" => "ttt,tttqt"), class: "button") %>
+    <%= link_to("Register for a Train to Teach event", events_path("teaching_events_search[type][]" => "ttt"), class: "button") %>
     </p>
 
     <h2>What to expect on the day:</h2>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -18,7 +18,7 @@
 
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
-      <%= f.govuk_check_box :type, "ttt,tttqt", label: { text: "DfE Train to Teach" } %>
+      <%= f.govuk_check_box :type, "ttt", label: { text: "DfE Train to Teach" } %>
       <%= f.govuk_check_box :type, "onlineqa", label: { text: "DfE Online Q&A" } %>
       <%= f.govuk_check_box :type, "provider", label: { text: "Training provider" } %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,10 +263,6 @@ en:
         long: |-
           Chat online with newly qualified teachers, watch presentations on how to get into teaching, find out what your training
           will be like by hearing from schools and universities and get one-to-one advice from our teaching experts on how to apply.
-    222750007: # Question Time (displayed as Train to Teach)
-      name:
-        singular: "Train to Teach event"
-        plural: "Train to Teach events"
     222750008:
       name:
         singular: "Online Q&A"

--- a/spec/components/teaching_events/event_component_spec.rb
+++ b/spec/components/teaching_events/event_component_spec.rb
@@ -13,12 +13,6 @@ describe TeachingEvents::EventComponent, type: "component" do
         it { expect(subject.train_to_teach?).to be(true) }
       end
 
-      context "when the event is a question time event" do
-        let(:event) { build(:event_api, :question_time_event) }
-
-        it { expect(subject.train_to_teach?).to be(true) }
-      end
-
       context "when the event is not a TTT event" do
         let(:event) { build(:event_api, :school_or_university_event) }
 

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -35,10 +35,6 @@ FactoryBot.define do
       type_id { EventType.train_to_teach_event_id }
     end
 
-    trait :question_time_event do
-      type_id { EventType.question_time_event_id }
-    end
-
     trait :virtual do
       is_online { true }
       is_virtual { true }

--- a/spec/features/teaching_events/about_ttt_events_spec.rb
+++ b/spec/features/teaching_events/about_ttt_events_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature "About TTT events", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events).and_return([])
     visit about_ttt_events_path
-    expect(page).to have_link("Register for a Train to Teach event", href: events_path("teaching_events_search[type][]" => "ttt,tttqt"))
+    expect(page).to have_link("Register for a Train to Teach event", href: events_path("teaching_events_search[type][]" => "ttt"))
   end
 end

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -93,7 +93,6 @@ RSpec.feature "Searching for teaching events", type: :feature do
       [
         # these two types are featurable
         build(:event_api, :train_to_teach_event),
-        build(:event_api, :question_time_event),
 
         # these aren't
         build(:event_api, :online_event),
@@ -102,7 +101,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     end
 
     scenario "each event should be listed with the appropriate details" do
-      expect(page).to have_css(".event.event--train-to-teach", count: 2)
+      expect(page).to have_css(".event.event--train-to-teach", count: 1)
 
       expect(page).to have_css(".event .event__info__type", text: "DfE Online Q&A")
       expect(page).to have_css(".event .event__info__type", text: "Training provider")
@@ -157,7 +156,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for train to teach events" do
       visit events_path
 
-      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time")
+      expected_type_ids = EventType.lookup_by_names("Train to Teach event")
 
       check "DfE Train to Teach"
       click_on "Update results"
@@ -190,7 +189,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
     scenario "searching for online and train to teach events" do
       visit events_path
 
-      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "Question Time", "School or University event")
+      expected_type_ids = EventType.lookup_by_names("Train to Teach event", "School or University event")
 
       check "DfE Train to Teach"
       check "Training provider"

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -57,12 +57,6 @@ RSpec.feature "Searching for teaching events", type: :feature do
     include_examples "train-to-teach teaching event"
   end
 
-  describe "viewing a question time event" do
-    let(:event) { build(:event_api, :question_time_event, :with_provider_info) }
-
-    include_examples "train-to-teach teaching event"
-  end
-
   describe "viewing a online event" do
     let(:event) { build(:event_api, :online_event, :with_provider_info) }
 

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -138,14 +138,12 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#display_event_provider_info?" do
-    it "returns false if train to teach or question time" do
+    it "returns false if train to teach" do
       event.type_id = EventType.train_to_teach_event_id
-      expect(display_event_provider_info?(event)).to be(false)
-      event.type_id = EventType.question_time_event_id
       expect(display_event_provider_info?(event)).to be(false)
     end
 
-    it "returns true if not train to teach or question time" do
+    it "returns true if not train to teach" do
       event.type_id = EventType.online_event_id
       expect(display_event_provider_info?(event)).to be(true)
       event.type_id = EventType.school_or_university_event_id

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -294,7 +294,7 @@ describe StructuredDataHelper, type: "helper" do
       expect(script_tag).to be_nil
     end
 
-    it "returns nil when not a TTT/QT event" do
+    it "returns nil when not a TTT event" do
       event = build(:event_api, :school_or_university_event)
       expect(event_structured_data(event)).to be_nil
 
@@ -302,9 +302,6 @@ describe StructuredDataHelper, type: "helper" do
       expect(event_structured_data(event)).to be_nil
 
       event = build(:event_api, :train_to_teach_event)
-      expect(event_structured_data(event)).not_to be_nil
-
-      event = build(:event_api, :question_time_event)
       expect(event_structured_data(event)).not_to be_nil
     end
 

--- a/spec/helpers/teaching_events_helper_spec.rb
+++ b/spec/helpers/teaching_events_helper_spec.rb
@@ -80,7 +80,7 @@ describe TeachingEventsHelper, type: "helper" do
 
   describe "#is_event_type?" do
     let(:ttt) { "Train to Teach event" }
-    let(:qt) { "Question Time" }
+    let(:provider) { "School or University event" }
 
     let(:ttt_event) do
       OpenStruct.new(type_id: EventType.lookup_by_name(ttt))
@@ -91,13 +91,13 @@ describe TeachingEventsHelper, type: "helper" do
     end
 
     specify "returns false when there's no match" do
-      expect(is_event_type?(ttt_event, qt)).to be false
+      expect(is_event_type?(ttt_event, provider)).to be false
     end
   end
 
   describe "#event_type_name" do
     specify "returns the event name given a valid id" do
-      expect(event_type_name(222_750_007)).to eql("Question Time")
+      expect(event_type_name(222_750_009)).to eql("Training provider")
     end
 
     specify "returns nil when given an invalid id" do
@@ -125,13 +125,11 @@ describe TeachingEventsHelper, type: "helper" do
 
   describe "#is_a_train_to_teach_event?" do
     let(:ttt_event) { OpenStruct.new(type_id: EventType.train_to_teach_event_id) }
-    let(:qt_event) { OpenStruct.new(type_id: EventType.question_time_event_id) }
     let(:online_event) { OpenStruct.new(type_id: EventType.online_event_id) }
     let(:school_or_university_event) { OpenStruct.new(type_id: EventType.school_or_university_event_id) }
 
-    specify "returns true when the event is either Train to Teach or Question Time" do
+    specify "returns true when the event is Train to Teach" do
       expect(is_a_train_to_teach_event?(ttt_event)).to be true
-      expect(is_a_train_to_teach_event?(qt_event)).to be true
     end
 
     specify "returns false when the event is online or school and university" do

--- a/spec/models/event_status_spec.rb
+++ b/spec/models/event_status_spec.rb
@@ -82,32 +82,26 @@ describe EventStatus do
   end
 
   describe "#accepts_online_registration?" do
-    context "when QT, future-dated, open" do
-      let(:event) { build(:event_api, :question_time_event) }
-
-      it { is_expected.to be_accepts_online_registration }
-    end
-
     context "when TTT, future-dated, open" do
       let(:event) { build(:event_api, :train_to_teach_event) }
 
       it { is_expected.to be_accepts_online_registration }
     end
 
-    context "when not TTT/QT, future-dated, open" do
+    context "when not TTT, future-dated, open" do
       let(:event) { build(:event_api, :online_event) }
 
       it { is_expected.not_to be_accepts_online_registration }
     end
 
-    context "when TTT/QT, past, open" do
+    context "when TTT, past, open" do
       let(:event) { build(:event_api, :train_to_teach_event, :past) }
 
       it { is_expected.not_to be_accepts_online_registration }
     end
 
-    context "when TTT/QT, future-dated, closed" do
-      let(:event) { build(:event_api, :question_time_event, :closed) }
+    context "when TTT, future-dated, closed" do
+      let(:event) { build(:event_api, :train_to_teach_event, :closed) }
 
       it { is_expected.not_to be_accepts_online_registration }
     end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -5,7 +5,7 @@ describe EventType do
     describe ".all_ids" do
       subject { described_class.all_ids }
 
-      it { is_expected.to eq([222_750_001, 222_750_007, 222_750_008, 222_750_009]) }
+      it { is_expected.to eq([222_750_001, 222_750_008, 222_750_009]) }
     end
 
     describe ".school_or_university_event_id" do
@@ -26,15 +26,9 @@ describe EventType do
       it { is_expected.to eq(222_750_008) }
     end
 
-    describe ".question_time_event_id" do
-      subject { described_class.question_time_event_id }
-
-      it { is_expected.to eq(222_750_007) }
-    end
-
     describe ".lookup_by_name" do
       specify "returns the id given the corresponding name" do
-        expect(described_class.lookup_by_name("Question Time")).to eq(222_750_007)
+        expect(described_class.lookup_by_name("School or University event")).to eq(222_750_009)
       end
 
       specify "errors when an unrecognised name is passed in" do
@@ -44,7 +38,7 @@ describe EventType do
 
     describe ".lookup_by_names" do
       specify "returns the ids given the corresponding names" do
-        expect(described_class.lookup_by_names("Question Time", "Online event")).to eq([222_750_007, 222_750_008])
+        expect(described_class.lookup_by_names("School or University event", "Online event")).to eq([222_750_009, 222_750_008])
       end
 
       specify "errors when an unrecognised name is passed in" do
@@ -54,7 +48,7 @@ describe EventType do
 
     describe ".lookup_by_id" do
       specify "returns the id given the corresponding id" do
-        expect(described_class.lookup_by_id(222_750_007)).to eq("Question Time")
+        expect(described_class.lookup_by_id(222_750_009)).to eq("School or University event")
       end
 
       specify "errors when an unrecognised id is passed in" do
@@ -64,7 +58,7 @@ describe EventType do
 
     describe ".lookup_by_ids" do
       specify "returns the ids given the corresponding class names" do
-        expect(described_class.lookup_by_ids(222_750_007, 222_750_008)).to eq(["Question Time", "Online event"])
+        expect(described_class.lookup_by_ids(222_750_009, 222_750_008)).to eq(["School or University event", "Online event"])
       end
 
       specify "errors when an unrecognised name is passed in" do
@@ -74,7 +68,7 @@ describe EventType do
 
     describe ".lookup_by_query_param" do
       specify "returns the id given the corresponding query param" do
-        expect(described_class.lookup_by_query_param("tttqt")).to eq(222_750_007)
+        expect(described_class.lookup_by_query_param("ttt")).to eq(222_750_001)
       end
 
       specify "errors when an unrecognised name is passed in" do
@@ -84,7 +78,7 @@ describe EventType do
 
     describe ".lookup_by_query_params" do
       specify "returns the id given the corresponding query params" do
-        expect(described_class.lookup_by_query_params("tttqt", "onlineqa")).to eq([222_750_007, 222_750_008])
+        expect(described_class.lookup_by_query_params("ttt", "onlineqa")).to eq([222_750_001, 222_750_008])
       end
 
       specify "errors when an unrecognised name are passed in" do
@@ -97,7 +91,7 @@ describe EventType do
 
   it { is_expected.to respond_to(:type_id) }
 
-  %i[lookup_by_id online_event_id school_or_university_event_id train_to_teach_event_id question_time_event_id]
+  %i[lookup_by_id online_event_id school_or_university_event_id train_to_teach_event_id]
     .each do |delegated_method|
       it { is_expected.to delegate_method(delegated_method).to(:class).as(delegated_method) }
     end
@@ -108,7 +102,6 @@ describe EventType do
     it { is_expected.to be_a_online_qa_event }
 
     it { is_expected.not_to be_a_provider_event }
-    it { is_expected.not_to be_a_question_time_event }
     it { is_expected.not_to be_a_train_to_teach_event }
   end
 
@@ -118,7 +111,6 @@ describe EventType do
     it { is_expected.to be_a_train_to_teach_event }
 
     it { is_expected.not_to be_a_provider_event }
-    it { is_expected.not_to be_a_question_time_event }
     it { is_expected.not_to be_a_online_qa_event }
   end
 
@@ -127,32 +119,7 @@ describe EventType do
 
     it { is_expected.to be_a_provider_event }
 
-    it { is_expected.not_to be_a_question_time_event }
     it { is_expected.not_to be_a_online_qa_event }
     it { is_expected.not_to be_a_train_to_teach_event }
-  end
-
-  describe "#question_time_event?" do
-    subject { described_class.new(build(:event_api, :question_time_event)) }
-
-    it { is_expected.to be_a_question_time_event }
-
-    it { is_expected.not_to be_a_online_qa_event }
-    it { is_expected.not_to be_a_train_to_teach_event }
-    it { is_expected.not_to be_a_provider_event }
-  end
-
-  describe "#train_to_teach_or_question_time_event?" do
-    context "when train_to_teach_event" do
-      subject { described_class.new(build(:event_api, :train_to_teach_event)) }
-
-      it { is_expected.to be_a_train_to_teach_or_question_time_event }
-    end
-
-    context "when question_time_event" do
-      subject { described_class.new(build(:event_api, :question_time_event)) }
-
-      it { is_expected.to be_a_train_to_teach_or_question_time_event }
-    end
   end
 end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -81,8 +81,8 @@ describe EventType do
         expect(described_class.lookup_by_query_params("ttt", "onlineqa")).to eq([222_750_001, 222_750_008])
       end
 
-      specify "errors when an unrecognised name are passed in" do
-        expect { described_class.lookup_by_query_params("onlineqa", "other") }.to raise_error(KeyError)
+      specify "ignores unrecognised values" do
+        expect(described_class.lookup_by_query_params("onlineqa", "other")).to eq([222_750_008])
       end
     end
   end

--- a/spec/models/events/search_spec.rb
+++ b/spec/models/events/search_spec.rb
@@ -32,7 +32,7 @@ describe Events::Search do
   describe ".available_event_type_ids" do
     subject { described_class.new.available_event_type_ids }
 
-    it { is_expected.to eq(EventType.all_ids - [EventType.question_time_event_id]) }
+    it { is_expected.to eq(EventType.all_ids) }
   end
 
   describe "#future?" do
@@ -180,18 +180,6 @@ describe Events::Search do
         it "the whitespace is stripped before querying the API" do
           expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
             receive(:search_teaching_events_grouped_by_type).with(**expected_attributes.merge(postcode: "TE57 1NG"))
-        end
-      end
-
-      context "when searching Train to Teach events" do
-        before do
-          subject.type = EventType.train_to_teach_event_id
-          expected_attributes[:type_ids] << EventType.question_time_event_id
-        end
-
-        it "queries Question Time and Train to Teach events" do
-          expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-            receive(:search_teaching_events_grouped_by_type).with(**expected_attributes)
         end
       end
 

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -113,7 +113,6 @@ describe TeachingEvents::Search do
 
   describe "#results" do
     ttt           = "ttt"
-    qt            = "tttqt"
     online        = "onlineqa"
     school_or_uni = "provider"
 
@@ -193,15 +192,15 @@ describe TeachingEvents::Search do
       ),
 
       OpenStruct.new(
-        description: "School or University or Question Time",
-        input: { type: [qt, school_or_uni].map(&:to_s) },
-        expected_conditions: { type_ids: EventType.lookup_by_query_params(qt, school_or_uni) },
+        description: "School or University or Train to Teach",
+        input: { type: [ttt, school_or_uni].map(&:to_s) },
+        expected_conditions: { type_ids: EventType.lookup_by_query_params(ttt, school_or_uni) },
       ),
 
       OpenStruct.new(
         description: "All types",
-        input: { type: [qt, school_or_uni, ttt, online].map(&:to_s) },
-        expected_conditions: { type_ids: EventType.lookup_by_query_params(qt, school_or_uni, ttt, online) },
+        input: { type: [school_or_uni, ttt, online].map(&:to_s) },
+        expected_conditions: { type_ids: EventType.lookup_by_query_params(school_or_uni, ttt, online) },
       ),
     ].each do |query|
       context "#{query.description} (#{query.input})" do

--- a/spec/presenters/events/group_presenter_spec.rb
+++ b/spec/presenters/events/group_presenter_spec.rb
@@ -4,10 +4,9 @@ describe Events::GroupPresenter do
   subject { described_class.new(events_by_type, display_empty: display_empty_types) }
 
   let(:train_to_teach_events) { build_list(:event_api, 5, :train_to_teach_event) }
-  let(:question_time_events) { build_list(:event_api, 5, :question_time_event) }
   let(:online_events) { build_list(:event_api, 2, :online_event) }
   let(:school_and_university_events) { build_list(:event_api, 15, :school_or_university_event) }
-  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events, question_time_events].flatten }
+  let(:all_events) { [train_to_teach_events, online_events, school_and_university_events].flatten }
   let(:events_by_type) { group_events_by_type(all_events) }
   let(:display_empty_types) { false }
 
@@ -15,9 +14,9 @@ describe Events::GroupPresenter do
     let(:type_ids) { subject.sorted_events_by_type.map(&:first) }
     let(:online_event_type_id) { EventType.online_event_id }
 
-    it "returns events_by_type as an array of [type_id, events] tuples (with TTT and QT events combined)" do
+    it "returns events_by_type as an array of [type_id, events] tuples" do
       expect(subject.sorted_events_by_type).to eq([
-        [EventType.train_to_teach_event_id, train_to_teach_events + question_time_events],
+        [EventType.train_to_teach_event_id, train_to_teach_events],
         [EventType.online_event_id, online_events],
         [EventType.school_or_university_event_id, school_and_university_events],
       ])
@@ -47,16 +46,11 @@ describe Events::GroupPresenter do
         expect(type_ids).to include(online_event_type_id)
       end
 
-      context "when there are Question Time or Train to Teach events" do
+      context "when there are no Train to Teach events" do
         let(:train_to_teach_events) { [] }
-        let(:question_time_events) { [] }
 
         it "still contains a key for Train to Teach events" do
           expect(type_ids).to include(EventType.train_to_teach_event_id)
-        end
-
-        it "does not contain a key for Question Time events" do
-          expect(type_ids).not_to include(EventType.question_time_event_id)
         end
       end
     end
@@ -155,8 +149,8 @@ describe Events::GroupPresenter do
     context "when type is Train to Teach event" do
       let(:type) { EventType.train_to_teach_event_id }
 
-      it "returns the Train to Teach and Question Time events" do
-        expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events + question_time_events)
+      it "returns the Train to Teach events" do
+        expect(subject.sorted_events_of_type(type)).to eq(train_to_teach_events)
       end
     end
   end

--- a/spec/presenters/teaching_events/event_presenter_spec.rb
+++ b/spec/presenters/teaching_events/event_presenter_spec.rb
@@ -114,12 +114,6 @@ describe TeachingEvents::EventPresenter do
         specify { expect(subject).to match(/I got answers to questions/) }
       end
 
-      context "when event is a Question Time event" do
-        let(:event) { build(:event_api, :question_time_event) }
-
-        specify { expect(subject).to match(/I got answers to questions/) }
-      end
-
       context "when event is a School or University event" do
         let(:event) { build(:event_api, :school_or_university_event) }
 
@@ -138,13 +132,6 @@ describe TeachingEvents::EventPresenter do
 
       context "when event is a Train to Teach event" do
         let(:event) { build(:event_api, :train_to_teach_event) }
-
-        specify { expect(subject[:path]).to end_with(".jpg") }
-        specify { expect(subject).to have_key(:alt) }
-      end
-
-      context "when event is a Question Time event" do
-        let(:event) { build(:event_api, :question_time_event) }
 
         specify { expect(subject[:path]).to end_with(".jpg") }
         specify { expect(subject).to have_key(:alt) }
@@ -214,12 +201,6 @@ describe TeachingEvents::EventPresenter do
         specify { expect(subject).to be false }
       end
 
-      context "when event is a Question Time event" do
-        let(:event) { build(:event_api, :question_time_event) }
-
-        specify { expect(subject).to be false }
-      end
-
       context "when event is a School or University event" do
         let(:event) { build(:event_api, :school_or_university_event) }
 
@@ -270,14 +251,8 @@ describe TeachingEvents::EventPresenter do
         specify { expect(subject).to be true }
       end
 
-      context "when event is a future Question Time event" do
-        let(:event) { build(:event_api, :question_time_event) }
-
-        specify { expect(subject).to be true }
-      end
-
       context "when event is a past Train to Teach event" do
-        let(:event) { build(:event_api, :past, :question_time_event) }
+        let(:event) { build(:event_api, :past, :train_to_teach_event) }
 
         specify { expect(subject).to be false }
       end

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -83,7 +83,7 @@ describe "teaching events", type: :request do
 
     before do
       freeze_time
-      expected_type_ids = [EventType.train_to_teach_event_id, EventType.question_time_event_id]
+      expected_type_ids = [EventType.train_to_teach_event_id]
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events).with(type_ids: expected_type_ids, quantity: 1, start_after: now).and_return(events)
       get about_ttt_events_path


### PR DESCRIPTION
### Trello card

[Trello-3649](https://trello.com/c/543WVKAS/3649-update-api-to-support-get-into-teaching-events)

### Context

We are migrating away from the Train to Teach/Question Time events to a new 'Get Into Teaching event' type. The Question Time events have always complicated things because we merge them and treat them as Train to Teach events.

Remove Question Time events to simplify the Train to Teach events before we migrate them over to Get Into Teaching events.

### Changes proposed in this pull request

- Remove Question Time events

- Ignore unrecognised query parameters

We currently raise an unhandled exception if an unrecognised query parameter is used on the event search page. As we are removing Question Time events its likely we will get requests that contain the corresponding query parameter still.

Handle unrecognised query parameters more gracefully by ignoring them and returning the search results.

### Guidance to review

Nothing should appear different as far as the user is concerned; we have no Question Time events in production and they were always masked as Train to Teach events anyway.