### PR TITLE
Change adviser link on food for thought page

### DIFF
--- a/app/views/content/food-for-thought/_promo.html.erb
+++ b/app/views/content/food-for-thought/_promo.html.erb
@@ -8,6 +8,6 @@
   ) do %>
       <p>Talk to an experienced former teacher who can help you find school experience, learn what it's like to be in the classroom and answer all your questions about getting into teaching.</p>
 
-      <%= link_to("Find out more about advisers", "/tta-service", class: "button") %>
+      <%= link_to("Find out more about advisers", "/explore-teaching-advisers", class: "button") %>
   <% end %>
 <% end %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/PwiBz9If

### Context
Updated adviser link to go to Explore teaching advisers page rather than TTA funnel start page

