### PR TITLE
Show all events on the about GiT events page

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -3,8 +3,6 @@ class TeachingEventsController < ApplicationController
 
   include CircuitBreaker
 
-  caches_page :about_git_events
-
   before_action :setup_filter, only: :index
 
   rescue_from EventNotViewableError, with: :render_gone

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -53,6 +53,7 @@ class TeachingEventsController < ApplicationController
     @git_events = GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
       type_ids: [EventType.get_into_teaching_event_id],
       start_after: Time.zone.now,
+      quantity: 20,
     )
 
     @front_matter = {

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -85,7 +85,7 @@ describe "teaching events", type: :request do
       freeze_time
       expected_type_ids = [EventType.get_into_teaching_event_id]
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
-        receive(:search_teaching_events).with(type_ids: expected_type_ids, start_after: now).and_return(events)
+        receive(:search_teaching_events).with(type_ids: expected_type_ids, start_after: now, quantity: 20).and_return(events)
       get about_git_events_path
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3664](https://trello.com/c/KjGDyeg0/3664-investigate-why-december-national-git-event-is-not-appearing-on-about-git-events-page)

### Context

The API caps the events to 10 by default and we have 11 running at the moment; increase the threshold to 20 so that we get all of the current events.

### Changes proposed in this pull request

- Show more events on the about GiT events page

- Stop caching the about events page

As we now display teaching events on this page we don't want to have it as part of the static cache (or when the event expires it won't remove until a deploy happens).

Stop caching the about events page.

### Guidance to review

