### PR TITLE
Add meta descriptions for event pages

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -22,7 +22,10 @@ class TeachingEventsController < ApplicationController
   end
 
   def index
-    @page_title = "Find an event near you"
+    @front_matter = {
+      title: "Find an event near you",
+      description: "Find out more about getting into teaching at a free event where you can get all your questions answered by teachers, advisers and training providers.",
+    }.with_indifferent_access
 
     setup_results
 
@@ -46,7 +49,10 @@ class TeachingEventsController < ApplicationController
     breadcrumb "Events", events_path
     breadcrumb @event.name, request.path
 
-    @page_title = @event.name
+    @front_matter = {
+      title: @event.name,
+      description: @event.summary,
+    }.with_indifferent_access
 
     render layout: "teaching_event"
   end

--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -4,7 +4,7 @@
   <%= analytics_body_tag class: "govuk-template__body govuk-body", data: { controller: "video link table", "link-target": "content" }, id: "body" do %>
     <%= render(partial: "sections/gtm_fallback") if gtm_enabled? %>
 
-    <%= render HeaderComponent.new(breadcrumbs: @show_breadcrumbs) %>
+    <%= render HeaderComponent.new %>
 
     <main id="main-content" role="main">
       <%= render Content::HeroComponent.new(@front_matter) %>


### PR DESCRIPTION
### Trello card

[Trello-3652](https://trello.com/c/vEXuQ8Yg/3652-add-meta-descriptions-to-the-events-listing-and-about-git-events-pages)

### Context

Add meta descriptions to the event and event listings pages.

### Changes proposed in this pull request

- Add meta descriptions for event pages

### Guidance to review

Also removes redundant `show_breadcrumbs` reference in events layout.