### PR TITLE
Remove providers from Engineers teach physics page

### DIFF
--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -52,17 +52,9 @@
   <section>
     <h2 class="heading-s">Engineers teach physics training programme</h2>
 
-    <p>This new teacher training programme helps engineers to become physics teachers. You can apply to study with:</p>
+    <p>This new teacher training programme helps engineers to become physics teachers.</p>
 
-      <ul>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/2H8/R576">National Mathematics and Physics School Centred Initial Teacher Training</a></li>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/B32/H546">University of Birmingham</a></li>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/E14/V473">University of East Anglia</a></li>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/M20/F3X2">University of Manchester</a></li>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/W75/P367">University of Wolverhampton</a></li>
-        <li><a href="https://www.find-postgraduate-teacher-training.service.gov.uk/course/2EV/E218">Yorkshire Wolds Teacher Training</a></li>
-      </ul>
-
+    <p>Courses starting in the 2022 to 2023 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 4 October 2022.</p>
   </section>
 
   <section class="columns">


### PR DESCRIPTION
### Trello card
https://trello.com/c/Yr7DCzuy

### Context
Now that the cycle has closed, we need to remove the list of last cycle's providers.


