### PR TITLE
Update promo section on steps to go to mailing list

### DIFF
--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -46,14 +46,22 @@
             </ol>
 
           <% end %>
+        <% end %>
+      </section>
 
-          <div class="supplementary steps-cta">
-            <%= render CallsToAction::NextStepsComponent.new %>
-          </div>
-
+      <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
+        <% promo.left_section(
+            heading: "Advice and support", classes: %w[ml-background]) do %>
         <% end %>
 
-      </section>
+        <% promo.right_section(
+          heading: "Find out more about getting into teaching"
+        ) do %>
+            <p>Explore how you can get into teaching primary or secondary and find top tips on making a successful application.</p>
+
+            <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
+        <% end %>
+      <% end %>
     </main>
 
     <%= render FooterComponent.new %>


### PR DESCRIPTION
### Trello card

[Trello-3645](https://trello.com/c/nhP962u5/3645-change-cta-on-steps-page-from-tta-to-mailing-list)

### Context

We want the steps page to have a CTA for the mailing list sign up as we find most users are at the start of their journey and usually opt to sign up for the mailing list rather than talk to an adviser anyway.

Swap out CTA with the new promo section component that directs the user to the mailing list.

### Changes proposed in this pull request

- Update promo section on steps to go to mailing list

### Guidance to review

[Steps to become a teacher page](https://review-get-into-teaching-app-2821.london.cloudapps.digital/steps-to-become-a-teacher)