### PR TITLE
Make integration tests more resilient

### DIFF
--- a/spec/integration/events_spec.rb
+++ b/spec/integration/events_spec.rb
@@ -8,9 +8,12 @@ RSpec.feature "Event sign up", :integration, type: :feature, js: true do
     navigate_to_events
   end
 
-  around do |example|
+  around do |example| # rubocop:disable RSpec/AroundBlock
     WebMock.enable_net_connect!
-    example.run
+    # The integration tests fail occasionally; I think this is in part due
+    # to our mail provider being flakey (for TOTP confirmation emails). Allow
+    # integration tests to be retried to make them more resilient.
+    example.run_with_retry retry: 3
     WebMock.disable_net_connect!(allow_localhost: true)
   end
 

--- a/spec/support/spec_helpers/integration.rb
+++ b/spec/support/spec_helpers/integration.rb
@@ -4,6 +4,7 @@ module SpecHelpers
       host = Rails.application.config.x.integration_host
       creds = Rails.application.config.x.integration_credentials
       Capybara.run_server = false
+      Capybara.default_max_wait_time = 5
       Capybara.app_host = "https://#{creds[:username]}:#{creds[:password]}@#{host}"
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3665](https://trello.com/c/IkZqmhoO/3665-fix-flakey-event-sign-up-integration-tests)

### Context

The integration tests run against our test environment and occasionally fail for no clear reason. I believe its either due to the requests taking longer than the default Capybara wait time (2s) or our mail provider being slow/flakey (for TOTP confirmation emails).

### Changes proposed in this pull request

- Make integration tests more resilient

Increase the default Capybara wait time on integration tests and allow integration tests to be retried up to 3 times.

### Guidance to review

