### PR TITLE
Fix issues with internal events form

### DIFF
--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -3,7 +3,7 @@
 <% content_for :head do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'internal', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', async: true %>
+  <%= javascript_pack_tag 'internal', 'data-turbolinks-track': 'reload', defer: true %>
 <% end %>
 
 <%= render "sections/head" %>

--- a/app/webpacker/packs/internal.js
+++ b/app/webpacker/packs/internal.js
@@ -10,11 +10,6 @@ initialiseFlatpickr();
 
 function initialiseGovUk() {
   initAll();
-
-  // Needed for GovUK JavaScript
-  document.body.className = document.body.className
-    ? document.body.className + ' js-enabled'
-    : 'js-enabled';
 }
 
 function initialiseSelectElement() {

--- a/app/webpacker/packs/js_enabled.js
+++ b/app/webpacker/packs/js_enabled.js
@@ -1,1 +1,2 @@
 document.documentElement.classList.toggle('js-enabled');
+document.body.classList.toggle('js-enabled');

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -62,7 +62,7 @@ module Rack
       end
 
       # Throttle event upsert by IP (5rpm)
-      throttle("event upsert", limit: 5, period: 1.minute) do |req|
+      throttle("event upsert", limit: 10, period: 20.seconds) do |req|
         event_upsert_paths = [
           %r{/internal/events},
           %r{/internal/approve},

--- a/spec/javascript/js_enabled_spec.js
+++ b/spec/javascript/js_enabled_spec.js
@@ -1,7 +1,11 @@
 import 'js_enabled';
 
 describe('js_enabled', () => {
-  it('includes the css js_enabled class in the html element', () => {
+  it('includes the js-enabled class in the html element', () => {
     expect(document.documentElement.classList).toContain('js-enabled');
+  });
+
+  it('includes the js-enabled class in the body element', () => {
+    expect(document.body.classList).toContain('js-enabled');
   });
 });

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -91,7 +91,7 @@ describe "Rate limiting", type: :request do
       end
     end
 
-    it_behaves_like "an IP-based rate limited endpoint", "POST /internal/events", 5, 1.minute do
+    it_behaves_like "an IP-based rate limited endpoint", "POST /internal/events", 10, 20.seconds do
       def perform_request
         post internal_events_path,
              headers: { "REMOTE_ADDR" => ip }.merge(generate_auth_headers(:author)),
@@ -99,7 +99,7 @@ describe "Rate limiting", type: :request do
       end
     end
 
-    it_behaves_like "an IP-based rate limited endpoint", "PUT /internal/approve", 5, 1.minute do
+    it_behaves_like "an IP-based rate limited endpoint", "PUT /internal/approve", 10, 20.seconds do
       let(:params) { { "id": event[:id] } }
 
       def perform_request


### PR DESCRIPTION
### Trello card

[Trello-3657](https://trello.com/c/r0jdzIGZ/3657-investigate-issues-with-internal-provider-events-form?filter=member:rossoliver15)

### Context

We have had reports from users of the internal events form that the building selection is not always working and the rate limiting has occasionally been hit when adding new events.

### Changes proposed in this pull request

- Fix internal events JS not loading

The internal events Javascript was set to load `async`, which meant it would often execute before the page document was ready and the `js-enabled` class was not present on the document body, resulting in it not running.

Change the JS load method to `defer` so it will always execute after page load and consolidate the logic to add a `js-enabled` class so we're doing it consistently.

- Increase internal events rate limiting thresholds

A provider has notified us that they have hit the 'too many requests' error reasonably often on the internal events form; increasing the rate limit threshold to avoid false positives.

### Guidance to review

You can check it works by navigating to the [internal events portal](https://review-get-into-teaching-app-2824.london.cloudapps.digital/internal/events) and signing in as a publisher to add a new event.