### PR TITLE
Fix lack of padding on about GiT events page

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -55,7 +55,7 @@
       </section>
     </section>
 
-    <section class="fullwidth grey-bg no-margin no-padding">
+    <section class="fullwidth grey-bg no-margin no-padding-top">
       <section class="container no-margin bottom-padding">
         <div>
           <h2 class="heading-s">Can't find what you're looking for?</h2>

--- a/app/webpacker/styles/subject-specific/_article.scss
+++ b/app/webpacker/styles/subject-specific/_article.scss
@@ -90,6 +90,10 @@ article {
     padding: 0;
   }
 
+  .no-padding-top {
+    padding-top: 0;
+  }
+
   .bottom-padding {
     padding-bottom: 4em;
   }


### PR DESCRIPTION
### Trello card

[Trello-3667](https://trello.com/c/ENHGt6VG/3667-fix-padding-on-about-git-events-page-on-mobile)

### Context

The 'can't find what you're looking for' text and link lack left-padding for the mobile viewport on the [about GiT events page]().

### Changes proposed in this pull request

- Fix lack of padding on about GiT events page

Not an ideal fix but we will tackle this as part of the wider subject-specific layout cleanup work later on.

### Guidance to review

