### PR TITLE
Fix page titles on error

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -9,8 +9,8 @@ class EventStepsController < ApplicationController
 
   before_action :noindex
   before_action :restrict_sign_ups, only: %i[show update completed]
-  before_action :set_step_page_title, only: [:show]
-  before_action :set_completed_page_title, only: [:completed]
+  before_action :set_step_page_title, only: %i[show update]
+  before_action :set_completed_page_title, only: %i[completed]
 
   layout :resolve_layout
 

--- a/lib/error_title.rb
+++ b/lib/error_title.rb
@@ -1,0 +1,21 @@
+class ErrorTitle
+  def initialize(page)
+    @page = page
+  end
+
+  def html
+    doc = Nokogiri::HTML(@page)
+    error = doc.at_css(".govuk-error-summary")
+
+    prefix_title(doc) if error.present?
+
+    doc.to_html(encoding: "UTF-8", indent: 2)
+  end
+
+private
+
+  def prefix_title(doc)
+    title = doc.at_css("title")
+    title.content = "Error: #{title.text}"
+  end
+end

--- a/lib/middleware/html_response_transformer.rb
+++ b/lib/middleware/html_response_transformer.rb
@@ -3,6 +3,7 @@ require "lazy_load_images"
 require "responsive_images"
 require "external_links"
 require "image_sizes"
+require "error_title"
 
 module Middleware
   class HtmlResponseTransformer
@@ -32,6 +33,7 @@ module Middleware
       response_body = ResponsiveImages.new(response_body).html
       response_body = LazyLoadImages.new(response_body).html
       response_body = ExternalLinks.new(response_body).html
+      response_body = ErrorTitle.new(response_body).html
 
       # <source> has no content so should be self-closing; configuring Nokogiri
       # to remove the closing tags results in breakages elsewhere in the document,

--- a/spec/lib/error_title_spec.rb
+++ b/spec/lib/error_title_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+require "error_title"
+
+describe ErrorTitle do
+  describe "#html" do
+    subject { instance.html }
+
+    let(:document) do
+      <<~HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>#{document_title}</title>
+          </head>
+          <body>#{body}</body>
+        </html>
+      HTML
+    end
+    let(:document_title) { "Title of the document" }
+    let(:body) do
+      <<~HTML
+        <div class="govuk-error-summary"></div>
+      HTML
+    end
+    let(:instance) { described_class.new(document) }
+
+    it { is_expected.to include("<title>Error: #{document_title}</title>") }
+
+    context "when there are no errors on the page" do
+      let(:body) do
+        <<~HTML
+          <div>No errors here!</div>
+        HTML
+      end
+
+      it { is_expected.to include("<title>#{document_title}</title>") }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-3660](https://trello.com/c/BBZSmQaq/3660-fix-title-missing-on-validation-errors)

### Context

When the event sign up form is submitted with errors the subsequent page doesn't render a correct page title. We should also be prefixing page titles with `Error:` to be inline with the GOV.UK guidance.

### Changes proposed in this pull request

- Ensure page title is set on validation errors

When the event forum is submitted with validation errors the `before_action` wasn't running to se the page title.

- Prefix page title if the page contains errors

Inline with the GOV.UK guidance we should prefix page titles that contain an error message with `Error: `.

Add middleware to prefix page titles if the GOV.UK error summary element is found within the page.

### Guidance to review

Go to sign up for an event; cause a validation error (leave a field blank, for example) and check the title has `Error: <page title> | Get Into Teaching GOV.UK`.

The other way of doing this would be to modify the `page_title` helper to check for a `422` status code and prefix the title. As Rails doesn't render a `422` by default for validation errors this felt more robust and is also inline with a pattern we have in place for transforming HTML responses.