### PR TITLE
Include GiT/Online Q&A events in sitemap

### DIFF
--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -25,9 +25,21 @@ RSpec.describe SitemapController, type: :request do
       },
     }
   end
-  let(:sitemap_pages) { content_pages.except("/test/a") }
+  let(:event_pages) do
+    events.map { |e| event_path(e.readable_id) }.index_with({})
+  end
+  let(:all_sitemap_pages) { content_sitemap_pages.merge(event_pages) }
+  let(:content_sitemap_pages) { content_pages.except("/test/a") }
+  let(:events) { build_list(:event_api, 3) }
 
   before do
+    freeze_time
+    allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
+      receive(:search_teaching_events).with(
+        start_after: Time.zone.now,
+        quantity: 100,
+        type_ids: [EventType.get_into_teaching_event_id, EventType.online_event_id],
+      ).and_return(events)
     allow(Pages::Frontmatter).to receive(:list) { content_pages }
     get("/sitemap.xml")
   end
@@ -39,15 +51,15 @@ RSpec.describe SitemapController, type: :request do
       expect(subject.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
     end
 
-    describe "content_pages" do
-      let(:expected) { SitemapController::OTHER_PATHS.count + sitemap_pages.count }
-      let(:paths) { sitemap_pages.keys.concat(SitemapController::OTHER_PATHS) }
+    describe "sitemap pages" do
+      let(:expected) { SitemapController::OTHER_PATHS.count + all_sitemap_pages.count }
+      let(:paths) { all_sitemap_pages.keys.concat(SitemapController::OTHER_PATHS) }
 
-      specify "should have the right number of content_pages" do
+      specify "should have the right number of pages" do
         expect(expected).to eql(subject.xpath("/xmlns:urlset/xmlns:url").size)
       end
 
-      specify "the content_pages should have the correct paths" do
+      specify "the pages should have the correct paths" do
         expect(
           subject
             .xpath("xmlns:urlset/xmlns:url/xmlns:loc")
@@ -58,7 +70,7 @@ RSpec.describe SitemapController, type: :request do
 
     describe "priority" do
       specify "priority should be assinged from frontmatter" do
-        sitemap_pages.each do |path, data|
+        content_sitemap_pages.each do |path, data|
           importance = subject.at_xpath(
             %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:priority),
           ).text
@@ -70,7 +82,7 @@ RSpec.describe SitemapController, type: :request do
 
     describe "lastmod" do
       specify "last modified date should be assinged from frontmatter" do
-        sitemap_pages.each do |path, data|
+        content_sitemap_pages.each do |path, data|
           last_modified = subject.at_xpath(
             %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:lastmod),
           ).text


### PR DESCRIPTION
### Trello card

[Trello-3706](https://trello.com/c/7Qp3pHO9/3706-add-git-events-and-online-qas-to-sitemap)

### Context

We want to include GiT events and Online Q&A events in the sitemap.xml so that Google hopefully does a better job of keeping our indexed pages up to date.

### Changes proposed in this pull request

- Include GiT/Online Q&A events in sitemap

Add Get into Teaching events and Online Q&A events to the `sitemap.xml`.

We only include future events and limit to 100 (which should be plenty to cover all active events at any given time).

### Guidance to review

The sitemap can be viewed [here](https://review-get-into-teaching-app-2830.london.cloudapps.digital/sitemap.xml).

It uses the global default `lastmod` for the entries; we don't expose a 'created at' date from the API and from what I've ready Google ignores the `lastmod` anyway so its probably not worth doing so.