### PR TITLE
Render event message as an InsetTextComponent

### DIFF
--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -1,9 +1,7 @@
 <h2>Event information</h2>
 
 <% if @event.message %>
-  <div class="teaching-event__message">
-    <%= tag.p(@event.message) %>
-  </div>
+  <%= render Content::InsetTextComponent.new(text: @event.message) %>
 <% end %>
 
 <%= tag.div(formatted_event_description(@event.description)) %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -538,17 +538,6 @@ $icon-size: 3rem;
     }
   }
 
-  &__message {
-    background: $purple;
-    color: $white;
-    padding: .2em 1em;
-    margin-bottom: 1em;
-
-    p {
-      @include reset;
-    }
-  }
-
   &__venue-information {
     .embedded-map {
       width: 80%;


### PR DESCRIPTION
### Trello card

[Trello-3690](https://trello.com/c/Xjx4ih15/3690-change-purple-box-to-the-inset-component-on-individual-event-pages)

### Context

We want to render the event message as an `InsetTextComponent` as we find in UR sessions that people try and interact/click on the purple notification box.

### Changes proposed in this pull request

- Render event message as an `InsetTextComponent`

### Guidance to review

[Example event](https://review-get-into-teaching-app-2831.london.cloudapps.digital/events/221012-get-into-teaching-national-event)