### PR TITLE
Pre-warm the image size cache

### DIFF
--- a/config/initializers/image_sizes.rb
+++ b/config/initializers/image_sizes.rb
@@ -1,0 +1,5 @@
+require "image_sizes"
+
+unless Rails.env.development? || Rails.env.test?
+  ImageSizes.warm_cache
+end

--- a/spec/lib/image_sizes_spec.rb
+++ b/spec/lib/image_sizes_spec.rb
@@ -16,6 +16,7 @@ describe ImageSizes do
 
     before do
       described_class.class_variable_set(:@@cache, {})
+      allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("APP_ASSETS_URL").and_return(asset_host)
       allow(ENV).to receive(:[]).with("FAST_IMAGE_TIMEOUT").and_return("0.25")
       allow(ENV).to receive(:[]).with("SIZE_IMAGES").and_return("1")
@@ -89,6 +90,21 @@ describe ImageSizes do
         is_expected.to include(body)
         expect(FastImage).not_to have_received(:size)
       end
+    end
+
+    describe "#warm_cache" do
+      before do
+        allow(FastImage).to receive(:size).and_call_original
+
+        described_class.warm_cache
+      end
+
+      subject(:cache) { described_class.cache }
+
+      it { is_expected.not_to be_empty }
+      it { expect(cache.keys).to all(start_with("/images/")) }
+      it { expect(cache.values).to include(be_a(Array)) }
+      it { expect(cache.values).to all(be_a(Array).or(eq(nil))) }
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-3704](https://trello.com/c/tT6Ai40x/3704-look-into-optimising-the-html-response-transformer-middleware)

### Context

Currently the first request for an image will have an overhead as we size it (and cache the result for later requests). We can see this having a not-insignificant impact on those first requests, taking up to ~50ms. Instead, we want to pre-fill the image size cache on boot.

### Changes proposed in this pull request

- Add ability to pre-warn the image size cache

Pre-warm the image size cache; we will do this on application boot; this commit adds the relevant method to call.

- Warm image cache on application boot

Pre-fills the image cache on application boot to avoid a slow initial request of pages.

Only performed on hosted environments to avoid slowing down the test suite/development.

### Guidance to review

