### PR TITLE
Update event sign up page images

### DIFF
--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -11,7 +11,11 @@
     <%= render HeaderComponent.new %>
 
     <main role="main" id="main-content" class="main-body registration-with-image-above" role="main">
-      <%= image_pack_tag("content/event-signup/birmingham-event-1-wide.jpg", alt: "A busy train to teach event with banners and attendees chatting with advisers") %>
+      <% if @event.is_online %>
+        <%= render Content::ImageComponent.new(path: "media/images/content/event-signup/event-regional-online.jpg") %>
+      <% else %>
+        <%= render Content::ImageComponent.new(path: "media/images/content/event-signup/event-regional.jpg") %>
+      <% end %>
 
       <div class="event-info">
         <%= render Events::DesktopSignupInfo.new(@event) %>

--- a/config/images.yml
+++ b/config/images.yml
@@ -396,3 +396,7 @@
   alt: "An online Get Into Teaching event on a computer screen."
 "media/images/content/event-signup/event-regional-listing.jpg":
   alt: "A busy Get Into Teaching event with people having one-on-one conversations with expert advisers and teachers"
+"media/images/content/event-signup/event-regional-online.jpg":
+  alt: "An online Get Into Teaching event on a computer screen."
+"media/images/content/event-signup/event-regional.jpg":
+  alt: "A busy Get Into Teaching event with people having one-on-one conversations with expert advisers and teachers."


### PR DESCRIPTION
### Trello card

[Trello-3692](https://trello.com/c/cVcwMv7g/3692-replace-image-on-events-sign-up-form)

### Context

Update the images on the first event sign up page to match the online/in-person image used elsewhere.

### Changes proposed in this pull request

- Update event sign up page images

### Guidance to review

