### PR TITLE
Move event videos into the hero section

### DIFF
--- a/app/components/content/youtube_video_component.html.erb
+++ b/app/components/content/youtube_video_component.html.erb
@@ -1,8 +1,4 @@
-<%= tag.iframe(
-  title: title,
-  loading: "lazy",
-  src: src,
-  frameborder: 0,
-  allow: "autoplay; encrypted-media",
-  allowfullscreen: true
-) %>
+<div class="youtube-video" data-controller="youtube-video">
+  <%= preview %>
+  <%= video %>
+</div>

--- a/app/components/content/youtube_video_component.rb
+++ b/app/components/content/youtube_video_component.rb
@@ -1,19 +1,63 @@
 module Content
   class YoutubeVideoComponent < ViewComponent::Base
-    attr_reader :id, :title
+    attr_reader :id, :title, :preview_image
 
-    def initialize(id:, title:)
+    def initialize(id:, title:, preview_image: nil)
       super
 
       @id = id
       @title = title
+      @preview_image = preview_image
     end
 
     def src
-      "https://www.youtube-nocookie.com/embed/#{id}"
+      "https://www.youtube-nocookie.com/embed/#{id}?autoplay=#{autoplay}&mute=#{mute}"
+    end
+
+    def preview
+      return nil if preview_image.blank?
+
+      tag.a(**preview_link_args) do
+        image_pack_tag(preview_image, alt: helpers.image_alt(preview_image))
+      end
+    end
+
+    def video
+      tag.iframe(
+        title: title,
+        loading: "lazy",
+        src: src,
+        frameborder: 0,
+        allow: "autoplay; encrypted-media",
+        allowfullscreen: true,
+        data: {
+          "youtube-video-target": "video",
+        },
+      )
     end
 
   private
+
+    def autoplay
+      preview ? 1 : 0
+    end
+
+    def mute
+      # Modern browsers don't allow you to autoplay a video
+      # with sound enabled, so we have to mute.
+      preview ? 1 : 0
+    end
+
+    def preview_link_args
+      {
+        href: "javascript:void(0)",
+        data: {
+          action: "youtube-video#play",
+          "youtube-video-target": "preview",
+        },
+        class: "hidden",
+      }
+    end
 
     def before_render
       validate!

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -5,7 +5,7 @@
 <div class="teaching-event">
   <header class="yellow">
     <div class="heading">
-      <h1 class="heading-l heading--box-white"><%= @event.name %></h1>
+      <h1 class="heading-l heading--highlight-white"><span><%= @event.name %></span></h1>
     </div>
 
     <div class="event-details">
@@ -14,7 +14,7 @@
       <%= render(partial: 'teaching_events/show/register-button') if @event.allow_registration? %>
     </div>
 
-    <%= render(partial: 'teaching_events/show/event-image') %>
+    <%= render(partial: 'teaching_events/show/event-media') %>
     <%= render(partial: 'teaching_events/show/triangle') %>
   </header>
 

--- a/app/views/teaching_events/show/_event-image.html.erb
+++ b/app/views/teaching_events/show/_event-image.html.erb
@@ -1,8 +1,0 @@
-<% image_args = @event.image %>
-
-<%# keep an empty image div here when there's no image args to keep grid positions %>
-<div class="image">
-  <% if image_args %>
-    <%= image_pack_tag(image_args[:path], alt: image_args[:alt]) %>
-  <% end %>
-</div>

--- a/app/views/teaching_events/show/_event-media.html.erb
+++ b/app/views/teaching_events/show/_event-media.html.erb
@@ -1,0 +1,14 @@
+<% image_args = @event.image %>
+
+<%# keep an empty image div here when there's no image args to keep grid positions %>
+<div class="media">
+  <% if @event.video_id %>
+    <%= render Content::YoutubeVideoComponent.new(
+      id: @event.video_id,
+      title: "Get Into Teaching Events: Take your next step towards teaching",
+      preview_image: image_args&.dig(:path),
+    ) %>
+  <% elsif image_args %>
+    <%= image_pack_tag(image_args[:path], alt: image_args[:alt]) %>
+  <% end %>
+</div>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -5,12 +5,3 @@
 <% end %>
 
 <%= tag.div(formatted_event_description(@event.description)) %>
-
-<% if @event.video_id %>
-  <div class="teaching-event__video youtube-video-container">
-    <%= render Content::YoutubeVideoComponent.new(
-      id: @event.video_id,
-      title: "Get Into Teaching Events: Take your next step towards teaching"
-    ) %>
-  </div>
-<% end %>

--- a/app/webpacker/controllers/youtube_video_controller.js
+++ b/app/webpacker/controllers/youtube_video_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['preview', 'video'];
+
+  connect() {
+    if (this.hasPreviewTarget) {
+      this.showPreview();
+    }
+  }
+
+  play() {
+    this.videoTarget.classList.remove('hidden');
+    this.previewTarget.classList.add('hidden');
+  }
+
+  showPreview() {
+    this.videoTarget.classList.add('hidden');
+    this.previewTarget.classList.remove('hidden');
+  }
+}

--- a/app/webpacker/styles/components/youtube-video.scss
+++ b/app/webpacker/styles/components/youtube-video.scss
@@ -1,0 +1,37 @@
+.youtube-video {
+  position: relative;
+
+  a {
+    display: block;
+    width: 100%;
+    height: 100%;
+
+    &:before, &:after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    &:before {
+      background-color: $pink-dark;
+      width: 70px;
+      height: 70px;
+      border-radius: 3px;
+    }
+
+    &:hover::before {
+      background-color: $pink;
+    }
+
+    &::after {
+      @extend .icon-play;
+    }
+  }
+
+  iframe, img {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -59,6 +59,7 @@
 @import './components/events/signup-info';
 @import './components/turbolinks-progress-bar';
 @import './components/grouped-cards';
+@import './components/youtube-video';
 
 @import './campaigns/numbered-headings';
 

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -144,6 +144,10 @@
   @include highlight-text($yellow-dark, $black);
 }
 
+.heading--highlight-white {
+  @include highlight-text($white, $black);
+}
+
 .heading--highlight-pink {
   @include highlight-text($pink, $black);
 }

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -412,7 +412,7 @@ $icon-size: 3rem;
         grid-area: 3 / 2 / 4 / 3;
       }
 
-      .image {
+      .media {
         grid-area: 2 / 3 / 4 / 5;
       }
 
@@ -473,19 +473,22 @@ $icon-size: 3rem;
       }
     }
 
-    .image {
+    .media {
       padding-bottom: 1rem;
-      img {
+      > * img {
         width: 100%;
         height: auto;
       }
 
       @include mq($from: tablet) {
-        img {
+        > * {
           margin: 1em;
-          max-height: 14em;
-          object-position: center;
-          object-fit: cover;
+
+          img {
+            max-height: 14em;
+            object-position: center;
+            object-fit: cover;
+          }
         }
         padding-bottom: 0;
       }
@@ -569,10 +572,6 @@ $icon-size: 3rem;
   &__scribble {
     margin: 4em 1em;
     flex-grow: 1;
-  }
-
-  &__video {
-    margin-block: 2em;
   }
 
   &__provider-information a {
@@ -706,11 +705,6 @@ $icon-size: 3rem;
     .button {
       margin-block: 2em;
     }
-  }
-
-  .youtube-video-container {
-    max-width: 40em;
-    margin-block: 2em;
   }
 }
 

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -123,23 +123,3 @@ hr {
   border: 0;
   margin: $indent-amount 0;
 }
-
-// responsively resize youtube videos by surrounding
-// the iframe in a .youtube-video-container wrapper
-//
-// approach lifted from https://embedresponsively.com/
-.youtube-video-container {
-  position: relative;
-  padding-bottom: 56.25%;
-  height: 0;
-  overflow: hidden;
-  max-width: 100%;
-
-  iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-}

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -3,19 +3,33 @@ require "rails_helper"
 describe Content::YoutubeVideoComponent, type: :component do
   let(:id) { "abc123" }
   let(:title) { "Title" }
-  let(:component) { described_class.new(id: id, title: title) }
+  let(:preview_image) { nil }
+  let(:component) { described_class.new(id: id, title: title, preview_image: preview_image) }
 
   subject(:render) do
     render_inline(component)
     page
   end
 
-  it { is_expected.to have_css("iframe[src='https://www.youtube-nocookie.com/embed/#{id}']") }
+  it { is_expected.to have_css("iframe[data-youtube-video-target=video]") }
+  it { is_expected.to have_css("iframe[src='https://www.youtube-nocookie.com/embed/#{id}?autoplay=0&mute=0']") }
   it { is_expected.to have_css("iframe[title=#{title}]") }
   it { is_expected.to have_css("iframe[loading=lazy]") }
   it { is_expected.to have_css("iframe[frameborder=0]") }
   it { is_expected.to have_css("iframe[allow='autoplay; encrypted-media']") }
   it { is_expected.to have_css("iframe[allowfullscreen]") }
+  it { is_expected.not_to have_css("a") }
+  it { is_expected.not_to have_css("img") }
+
+  context "when a preview_image is specified" do
+    let(:preview_image) { "media/images/content/blog/bedfordshire.jpg" }
+
+    it { is_expected.to have_css("a.hidden") }
+    it { is_expected.to have_css("a[data-action='youtube-video#play']") }
+    it { is_expected.to have_css("a[data-youtube-video-target=preview]") }
+    it { is_expected.to have_css("a img[src*='packs-test/v1/media/images/content/blog/bedfordshire']") }
+    it { is_expected.to have_css("iframe[src='https://www.youtube-nocookie.com/embed/#{id}?autoplay=1&mute=1']") }
+  end
 
   describe "validation" do
     context "when the id is not set" do

--- a/spec/javascript/controllers/youtube_video_controller_spec.js
+++ b/spec/javascript/controllers/youtube_video_controller_spec.js
@@ -1,0 +1,68 @@
+import { Application } from 'stimulus';
+import YoutubeVideoController from 'youtube_video_controller.js';
+
+describe('YoutubeVideoController', () => {
+  beforeAll(() => registerController());
+
+  const setBody = (preview) => {
+    document.body.innerHTML = `
+      <div data-controller="youtube-video">
+        ${preview}
+        <iframe id="video" data-youtube-video-target="video"></iframe>
+      </div>
+    `;
+  }
+
+  const registerController = () => {
+    const application = Application.start();
+    application.register('youtube-video', YoutubeVideoController);
+  }
+
+  describe('when there is no preview image', () => {
+    beforeEach(() => {
+      setBody();
+    });
+
+    it('displays the video', () => {
+      expect(document.getElementById("video").classList).not.toContain('hidden');
+    });
+  })
+
+  describe('when there is a preview image', () => {
+    beforeEach(() => {
+      const preview = `
+        <a
+          href="javascript:void(0)"
+          id="preview"
+          data-youtube-video-target="preview"
+          data-action="youtube-video#play"
+          class="hidden">
+            <img src="a/preview/image.png">
+        </a>
+      `;
+      setBody(preview);
+    });
+
+    it('displays the preview image', () => {
+      expect(document.getElementById("preview").classList).not.toContain('hidden');
+    });
+
+    it('does not display the video', () => {
+      expect(document.getElementById("video").classList).toContain('hidden');
+    });
+
+    describe('when clicking on the preview image', () => {
+      beforeEach(() => {
+        document.getElementById("preview").click();
+      });
+
+      it('hides the preview image', () => {
+        expect(document.getElementById("preview").classList).toContain('hidden');
+      });
+
+      it('displays the video', () => {
+        expect(document.getElementById("video").classList).not.toContain('hidden');
+      });
+    });
+  })
+});

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -159,7 +159,7 @@ describe Internal::EventsController, type: :request do
         it "shows pending events" do
           assert_response :success
           expect(response.body).to include("This is a pending event")
-          expect(response.body).to match(%r{<h1.*>Pending provider event</h1>})
+          expect(response.body).to match(%r{<h1.*><span>Pending provider event</span></h1>})
         end
       end
 


### PR DESCRIPTION
### Trello card

[Trello-3693](https://trello.com/c/glJcgHDP/3693-consider-adding-video-to-individual-event-pages)

### Context

The events team have requested videos to be added to the Get Into Teaching events at thee top of the page. We want to render the event images as a thumbnail preview for the videos and then play the video on click.

### Changes proposed in this pull request

- Move event videos into hero section

We are assigning YouTube videos to the Get Into Teaching events on the website; currently they display under the event summary information quite a way down the page. Instead, we want to indicate that the event image in the hero section is clickable and, when clicked, will transition to play the YouTube video.

### Guidance to review

A limitation with modern browsers is that they will not let videos auto-play with sound enabled, this means the only way (short of using something other than youtube video embedding) we can play the videos on clicking the preview image is if it is muted.

We should check the other YouTube videos on the website still look fine after this change.

[Example event with a video/preview](https://review-get-into-teaching-app-2852.london.cloudapps.digital/events/221101-get-into-teaching-south-west-event)