### PR TITLE
removing (honours) from copy

### DIFF
--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -22,7 +22,7 @@ keywords:
   - qts
 ---
 
-You need a bachelor's degree (honours) to teach in primary, secondary and special schools in England. This does not have to be a bachelor's degree in teaching.
+You need a bachelor's degree to teach in primary, secondary and special schools in England. This does not have to be a bachelor's degree in teaching.
 
 You also need to gain qualified teacher status (QTS) to teach in most schools which you get through teacher training.
 


### PR DESCRIPTION
### Trello card

### Context

Tom Crookes Smith pointed out that you don't need a bachelor's degree **(honours)** to be a teacher - confirmed by Phoebe in policy. So we're removing the **(honours)** from the copy.

### Changes proposed in this pull request

### Guidance to review

