### PR TITLE
Make closed events viewable but not open for registration

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -23,10 +23,10 @@ protected
 private
 
   def restrict_sign_ups
-    event_is_viewable = EventStatus.new(@event).viewable?
+    event_is_open_for_registration = EventStatus.new(@event).accepts_online_registration?
     candidate_is_walk_in = wizard_store[:is_walk_in]
 
-    unless event_is_viewable || candidate_is_walk_in
+    unless event_is_open_for_registration || candidate_is_walk_in
       # Redirecting to the main event page will either render
       # the event in a closed state or return a 410 (Gone).
       redirect_to event_path(id: @event.readable_id)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,7 +26,7 @@ module EventsHelper
   end
 
   def can_sign_up_online?(event)
-    event.web_feed_id && EventStatus.new(event).open? && !EventType.new(event).provider_event?
+    EventStatus.new(event).accepts_online_registration?
   end
 
   def formatted_event_description(description)

--- a/app/models/event_status.rb
+++ b/app/models/event_status.rb
@@ -46,13 +46,13 @@ class EventStatus
   end
 
   def viewable?
-    !pending? && future_dated? && open?
+    future_dated? && (open? || closed?)
   end
 
   def accepts_online_registration?
     type_ids = [EventType.get_into_teaching_event_id]
 
-    event.type_id.in?(type_ids) && future_dated? && open?
+    event.type_id.in?(type_ids) && future_dated? && open? && event.web_feed_id.present?
   end
 
 private

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -79,28 +79,36 @@ describe EventsHelper, type: "helper" do
   end
 
   describe "#can_sign_up_online?" do
-    it "returns true for events with a web_feed_id that are not closed" do
-      event = GetIntoTeachingApiClient::TeachingEvent.new(
-        web_feed_id: "abc-123",
-        status_id: EventStatus.open_id,
-      )
-      expect(can_sign_up_online?(event)).to be_truthy
+    subject { can_sign_up_online?(event) }
+
+    context "when GIT (with web feed id), future-dated, open" do
+      let(:event) { build(:event_api, :get_into_teaching_event) }
+
+      it { is_expected.to be_truthy }
     end
 
-    it "returns false for events without a web_feed_id" do
-      event = GetIntoTeachingApiClient::TeachingEvent.new(
-        web_feed_id: nil,
-        status_id: EventStatus.open_id,
-      )
-      expect(can_sign_up_online?(event)).to be_falsy
+    context "when not GIT, future-dated, open" do
+      let(:event) { build(:event_api, :online_event) }
+
+      it { is_expected.to be_falsy }
     end
 
-    it "returns false for closed events" do
-      event = GetIntoTeachingApiClient::TeachingEvent.new(
-        web_feed_id: "abc-123",
-        status_id: EventStatus.closed_id,
-      )
-      expect(can_sign_up_online?(event)).to be_falsy
+    context "when GIT (with web feed id), past, open" do
+      let(:event) { build(:event_api, :get_into_teaching_event, :past) }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when GIT (with web feed id), future-dated, closed" do
+      let(:event) { build(:event_api, :get_into_teaching_event, :closed) }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "when GIT (without web feed id), future-dated, open" do
+      let(:event) { build(:event_api, :get_into_teaching_event, web_feed_id: nil) }
+
+      it { is_expected.to be_falsy }
     end
   end
 

--- a/spec/models/event_status_spec.rb
+++ b/spec/models/event_status_spec.rb
@@ -53,7 +53,7 @@ describe EventStatus do
     context "when closed, future-dated" do
       let(:event) { build(:event_api, :closed) }
 
-      it { is_expected.not_to be_viewable }
+      it { is_expected.to be_viewable }
     end
 
     context "when closed, past" do
@@ -82,7 +82,7 @@ describe EventStatus do
   end
 
   describe "#accepts_online_registration?" do
-    context "when GIT, future-dated, open" do
+    context "when GIT (with web feed id), future-dated, open" do
       let(:event) { build(:event_api, :get_into_teaching_event) }
 
       it { is_expected.to be_accepts_online_registration }
@@ -94,14 +94,20 @@ describe EventStatus do
       it { is_expected.not_to be_accepts_online_registration }
     end
 
-    context "when GIT, past, open" do
+    context "when GIT (with web feed id), past, open" do
       let(:event) { build(:event_api, :get_into_teaching_event, :past) }
 
       it { is_expected.not_to be_accepts_online_registration }
     end
 
-    context "when GIT, future-dated, closed" do
+    context "when GIT (with web feed id), future-dated, closed" do
       let(:event) { build(:event_api, :get_into_teaching_event, :closed) }
+
+      it { is_expected.not_to be_accepts_online_registration }
+    end
+
+    context "when GIT (without web feed id), future-dated, open" do
+      let(:event) { build(:event_api, :get_into_teaching_event, web_feed_id: nil) }
 
       it { is_expected.not_to be_accepts_online_registration }
     end

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -39,7 +39,7 @@ describe EventStepsController, type: :request do
     it { is_expected.to have_http_status :success }
     it { is_expected.not_to be_indexed }
 
-    context "when the event is closed" do
+    context "when the event is closed (not accepting registrations)" do
       let(:event) { build :event_api, :closed, readable_id: readable_event_id }
 
       it { is_expected.to redirect_to(event_path(id: event.readable_id)) }


### PR DESCRIPTION
### Trello card
https://trello.com/c/dW8y2mPP

We currently don't have consistent logic around when an event should be viewable but not open for registration. Going forward we are going to allow closed events to be viewable (as we already display them in search results) but _only_ allow registration to open events.

Also updates the events helper to determine if an event can be signed up to so that it is consistent with the `EventStatus` module.

We're going to take a closer look at the different scenarios in general to clean some of this up (in terms of what to do when an event is open/closed/past/future/has web feed id/etc in a follow-up ticket/PR.