### PR TITLE
Redirect /home to root page

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -16,6 +16,7 @@ redirects:
   "/international-students": "/non-uk-teachers/train-to-teach-in-england-as-an-international-student"
   "/international-candidates": "/non-uk-teachers/train-to-teach-in-england-as-an-international-student"
   "/salaries-and-benefits-simplified": "/salaries-and-benefits"
+  "/home": "/"
 
   # Campaign landing pages
   "/helping-you-become-a-teacher": "/three-things-to-help-you-get-into-teaching"


### PR DESCRIPTION
### Trello card

[Trello-3721](https://trello.com/c/0gWcggxe/3721-fix-canonical-issue-with-home-page)

### Context

Google picked up on an issue where our home page is served on `/home` (the name of the markdown file) but its canonical should be `/` and its also set to `/home`.

To get around this we should just redirect `/home` to `/` so that its not accessible under the `/home` path at all.

### Changes proposed in this pull request

- Redirect /home to the root page

### Guidance to review

