### PR TITLE
Update course publication date on Engineers teach physics page

### DIFF
--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -54,7 +54,7 @@
 
     <p>This new teacher training programme helps engineers to become physics teachers.</p>
 
-    <p>You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.</p>
+    <p>You’ll be able to find courses starting in the 2023/24 academic year from 17 October 2022.</p>
   </section>
 
   <section class="columns">

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -54,7 +54,7 @@
 
     <p>This new teacher training programme helps engineers to become physics teachers.</p>
 
-    <p>Courses starting in the 2022 to 2023 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 4 October 2022.</p>
+    <p>You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.</p>
   </section>
 
   <section class="columns">


### PR DESCRIPTION
### Trello card
https://trello.com/c/s6Mj1nAp

### Context
Providers will be able to start publishing Engineers teach physics courses from 17 October so the ETP page on GIT needs updating to reflect this.

