### PR TITLE
Fix horizontal scroll on campaign headings

### DIFF
--- a/app/webpacker/styles/components/campaign-header.scss
+++ b/app/webpacker/styles/components/campaign-header.scss
@@ -77,7 +77,11 @@
     }
 
     span:last-of-type {
-      @include font-size(xxxlarge, $adjust: 2rem);
+      @include font-size(xxxlarge, $adjust: 0.75rem);
+
+      @include mq($from: mobile) {
+        @include font-size(xxxlarge, $adjust: 2rem);
+      }
     }
   }
 


### PR DESCRIPTION
### Trello card

[Trello-3716](https://trello.com/c/ZJRxzFRR/3716-investigate-horizontal-scrolling-issue-on-explore-teaching-advisers-page)

### Context

The campaign hero section headings have an enlarged final word; on small mobile devices (iPhone 5 320px viewport) the last word can push out of the document bounds and cause horizontal scrolling.

Short of allowing break-word style word wrapping there's no perfect fix for this, but reducing the enlargement on mobile will help and fixes the particular use case highlighted in Silktide.

### Changes proposed in this pull request

- Fix horizontal scroll on campaign headings

### Guidance to review

