### PR TITLE
[701] Stop pinning Github actions to a minor version

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -21,7 +21,7 @@ runs:
     using: composite
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -105,7 +105,7 @@ runs:
           secret: INFRA-KEYS
           key: HTTP-USERNAME, HTTP-PASSWORD, LOGIT-API
 
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.8
 

--- a/.github/workflows/actions/owasp/action.yml
+++ b/.github/workflows/actions/owasp/action.yml
@@ -18,7 +18,7 @@ runs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - uses: Azure/login@v1
         with:
@@ -48,7 +48,7 @@ runs:
              echo ::set-output name=SCAN::$rval
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.3.0
+        uses: zaproxy/action-full-scan@v0
         with:
           token: ${{ inputs.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -38,14 +38,14 @@ jobs:
         run: echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
 
       - name: Login to GitHub Container Repository
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           context: .
           tags: ${{ env.DOCKER_REPOSITORY }}:base-master
@@ -56,7 +56,7 @@ jobs:
             BUILD_TYPE=release
 
       - name: Build release image locally
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           context: .
           tags: ${{ env.DOCKER_REPOSITORY }}:master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,14 +63,14 @@ jobs:
              echo ::set-output name=DOCKER_IMAGE::${{ env.DOCKER_REPOSITORY }}:sha-${{steps.sha.outputs.short }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           context: .
           cache-from: |
@@ -85,7 +85,7 @@ jobs:
             BUILD_TYPE=release
 
       - name: Build and push release image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           context: .
           cache-from: |
@@ -164,14 +164,14 @@ jobs:
              echo ::set-output name=DOCKER_IMAGE_TEST::${{ env.DOCKER_REPOSITORY }}:test-sha-${{ steps.sha.outputs.short }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push test image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           push: true
           context: .
@@ -406,7 +406,7 @@ jobs:
 
       - name: Add Review Label
         if: contains(github.event.pull_request.user.login, 'dependabot') == false
-        uses: actions-ecosystem/action-add-labels@v1.1.3
+        uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: Review
 
@@ -456,7 +456,7 @@ jobs:
       - name: Create a GitHub Release
         id: release
         if: steps.tag_version.outputs.pr_found == 1
-        uses: actions/create-release@v1.1.4
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -28,7 +28,7 @@ jobs:
               echo ::set-output name=pr_name::${{env.REVIEW_APPLICATION}}-${{github.event.number}}
               echo "TF_VAR_paas_app_route_name=${pr_name}"       >> $GITHUB_ENV
 
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.8
 

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@v1
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -45,7 +45,7 @@ jobs:
       - name: Slack Markdown Converter
         id: convert
         if: ${{steps.lychee.outcome}} == "failure"
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        uses: LoveToKnow/slackify-markdown-action@v1
         with:
           text: |
                 ${{ env.LYCHEE_OUTPUT }}


### PR DESCRIPTION
### Trello card
https://trello.com/c/BYSSVCNY

### Context
This creates too many distracting dependabot PRs

### Changes proposed in this pull request
Pin actions to the major version

### Guidance to review

