### PR TITLE
Fix version reference for zaproxy action

### DIFF
--- a/.github/workflows/actions/owasp/action.yml
+++ b/.github/workflows/actions/owasp/action.yml
@@ -48,7 +48,7 @@ runs:
              echo ::set-output name=SCAN::$rval
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0
+        uses: zaproxy/action-full-scan@v0.4.0
         with:
           token: ${{ inputs.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'


### PR DESCRIPTION
### Trello card
https://trello.com/c/BYSSVCNY

### Context
zaproxy version v0 does not exist. Most current is v0.4.0
https://github.com/DFE-Digital/get-into-teaching-app/pull/2885

### Changes proposed in this pull request
Update zaproxy action version

### Guidance to review

