### PR TITLE
Updates to ETP programme details.

### DIFF
--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -55,7 +55,7 @@
     <p>This new programme is based on the physics initial teacher training (ITT) course, and has been developed with support from the physics and engineering community. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
      </p>
      
-     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a <a href="/https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement">‘subject knowledge enhancement’ (SKE) course</a> that will provide you with the training and support for any gaps in your knowledge.
+     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">‘subject knowledge enhancement’ (SKE) course</a> that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
     <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -54,13 +54,13 @@
 
     <p>This new programme is based on the physics initial teacher training (ITT) course, and has been developed with support from the physics and engineering community. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
      </p>
-     
+
      <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">‘subject knowledge enhancement’ (SKE) course</a> that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
     <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.
      </p>
-     
+
      <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -41,7 +41,7 @@
   ) do %>
 
     <p>
-      Engineers and physicists help find solutions to some of our biggest problems. From climate change to secure energy sources, we need their problem-solving skills and creative thinking to help us survive some of the biggest challenges humanity has ever faced.
+      Engineers and physicists help find solutions to some of our biggest problems. From climate change to next generation prosthetics, we need their problem-solving skills and creative thinking to help us survive some of the biggest challenges humanity has ever faced.
     </p>
 
     <p>
@@ -52,9 +52,14 @@
   <section>
     <h2 class="heading-s">Engineers teach physics training programme</h2>
 
-    <p>This new teacher training programme helps engineers to become physics teachers.</p>
+    <p>This new programme is based on the physics initial teacher training (ITT) course. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.</p>
 
-    <p>You’ll be able to find courses starting in the 2023/24 academic year from 17 October 2022.</p>
+    <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.</p>
+
+    <p>If you’re concerned about how well you know physics as a subject, do not worry - you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.</p>
+</p>
+
+    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.</p>
   </section>
 
   <section class="columns">

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -61,7 +61,7 @@
     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
-    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.
+    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023/24 academic year from 17 October 2022.
      </p>
   </section>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -52,16 +52,19 @@
   <section>
     <h2 class="heading-s">Engineers teach physics training programme</h2>
 
-    <p>This new programme is based on the physics initial teacher training (ITT) course. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
+    <p>This new programme is based on the physics initial teacher training (ITT) course, and has been developed with support from the physics and engineering community. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
+     </p>
+     
+     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a [‘subject knowledge enhancement’ (SKE) course](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement) that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
     <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.
      </p>
-
-    <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.
+     
+     <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023/24 academic year from 17 October 2022.
+    <p>Courses starting in the 2022/23 academic year are now closed. You’ll soon be able to find courses starting in the 2023/24 academic year.
      </p>
   </section>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -58,7 +58,7 @@
     <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.
      </p>
 
-    <p>If you’re concerned about how well you know physics as a subject, do not worry - you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.
+    <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
     <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -52,14 +52,17 @@
   <section>
     <h2 class="heading-s">Engineers teach physics training programme</h2>
 
-    <p>This new programme is based on the physics initial teacher training (ITT) course. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.</p>
+    <p>This new programme is based on the physics initial teacher training (ITT) course. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
+     </p>
 
-    <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.</p>
+    <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.
+     </p>
 
-    <p>If you’re concerned about how well you know physics as a subject, do not worry - you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.</p>
-</p>
+    <p>If you’re concerned about how well you know physics as a subject, do not worry - you’ll be able to do a ‘subject knowledge enhancement’ (SKE) course that will provide you with the training and support for any gaps in your knowledge.
+     </p>
 
-    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.</p>
+    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023 to 2024 academic year from 17 October 2022.
+     </p>
   </section>
 
   <section class="columns">

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -55,7 +55,7 @@
     <p>This new programme is based on the physics initial teacher training (ITT) course, and has been developed with support from the physics and engineering community. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
      </p>
      
-     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a [‘subject knowledge enhancement’ (SKE) course](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement) that will provide you with the training and support for any gaps in your knowledge.
+     <p>If you’re concerned about how well you know physics as a subject, do not worry – you’ll be able to do a <a href="/https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement">‘subject knowledge enhancement’ (SKE) course</a> that will provide you with the training and support for any gaps in your knowledge.
      </p>
 
     <p>Your training provider may offer part-time teacher training courses and may also allow you to combine courses, for example Engineers teach physics combined with mathematics.
@@ -64,7 +64,7 @@
      <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p>Courses starting in the 2022/23 academic year are now closed. You’ll soon be able to find courses starting in the 2023/24 academic year.
+    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023/24 academic year in autumn 2022.
      </p>
   </section>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/s6Mj1nAp/3673-update-engineers-teach-physics-content-for-new-cycle

### Context

The Engineers teach physics pilot that was trialled in cycle 2021/22 is now being rolled out fully - nationally. The policy team would like to update the ETP page to reflect this ahead of the start of the new cycle.

### Changes proposed in this pull request

### Guidance to review


