### PR TITLE
Unwind homepage changes supporting events comms burst

### DIFF
--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,6 +1,7 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
     <%= tag.div(icon, class: "call-to-action__icon__container") %>
     <%= tag.div(class: "call-to-action__content") do %>
+      <%= tag.div(caption, class: "caption-m caption--purple caption--bold") if caption %>
       <%= tag.h2(title, class: "call-to-action__heading") %>
       <%= tag.p(text) if text.present? %>
     <% end %>

--- a/app/components/calls_to_action/homepage_component.rb
+++ b/app/components/calls_to_action/homepage_component.rb
@@ -1,13 +1,15 @@
 module CallsToAction
   class HomepageComponent < ViewComponent::Base
-    attr_accessor :icon, :image, :title, :text, :link
+    attr_accessor :icon, :image, :title, :text, :link, :caption, :badge_text
 
-    def initialize(icon:, link_text:, link_target:, image:, title: nil, text: nil)
+    def initialize(icon:, link_text:, link_target:, image:, title: nil, caption: nil, text: nil, badge_text: nil)
       super
 
-      @title         = title
-      @text          = text
-      @image         = image
+      @title = title
+      @badge_text = badge_text
+      @caption = caption
+      @text = text
+      @image = image
       @icon_filename = icon
 
       @link_target = link_target
@@ -22,7 +24,9 @@ module CallsToAction
   private
 
     def image_element(image)
-      tag.div(style: %[background-image: url('#{asset_pack_path(image)}')], class: "call-to-action__image")
+      tag.div(style: %[background-image: url('#{asset_pack_path(image)}')], class: "call-to-action__image") do
+        tag.div(tag.span(helpers.safe_html_format(badge_text)), class: "badge badge--bordered badge--fixed-80") if badge_text.present?
+      end
     end
 
     def icon_element(icon)

--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,12 +1,10 @@
 <%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }, role: "navigation") do %>
   <ul class="extra-navigation__list">
-    <li class="extra-navigation__link">
-      <%= link_to(about_git_events_path, class: "link--black") do %>
-      <i
-        class="badge"
-        data-controller="badge"
-        data-badge-path-value="<%= git_statistics_events_path %>"
-        data-badge-json-key-value="open_events_count"></i>Get Into Teaching events
+    <li class="extra-navigation__link extra-navigation__mail">
+      <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
+      Register your interest
+      <span class="icon icon-mail" aria-hidden="true"></span>
+      <span class="icon icon-mail-white" aria-hidden="true"></span>
       <% end %>
     </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -5,8 +5,8 @@
     Read official Department for Education information to help you become a teacher. Learn about funding, teacher training, and steps to become a teacher. 
   date: "2021-06-16"
   fullwidth: true
-  subtitle: "Get information and support to help you become a teacher."
-  subtitle_button: "Register for updates"
+  subtitle: "Whether you're just thinking about teaching or you're ready to apply, get tailored advice and insights sent straight to your inbox."
+  subtitle_button: "Get advice in your inbox"
   subtitle_link: "/mailinglist/signup/name"
   image: "media/images/content/hero-images/0012.jpg"
   navigation_title: "Home"

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -5,7 +5,7 @@
     Read official Department for Education information to help you become a teacher. Learn about funding, teacher training, and steps to become a teacher. 
   date: "2021-06-16"
   fullwidth: true
-  subtitle: "Whether you're just thinking about teaching or you're ready to apply, get tailored advice and insights sent straight to your inbox."
+  subtitle: "Whether you're just thinking about teaching or you're ready to apply, get tailored advice sent straight to your email."
   subtitle_button: "Get advice in your inbox"
   subtitle_link: "/mailinglist/signup/name"
   image: "media/images/content/hero-images/0012.jpg"

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -5,10 +5,10 @@
     Read official Department for Education information to help you become a teacher. Learn about funding, teacher training, and steps to become a teacher. 
   date: "2021-06-16"
   fullwidth: true
-  subtitle: "Whether you're ready to start your career in teaching or just curious, we can answer your questions at a Get Into Teaching event this November."
-  subtitle_button: "Get Into Teaching events"
-  subtitle_link: "/events/about-get-into-teaching-events"
-  image: "media/images/content/hero-images/event-image.jpg"
+  subtitle: "Get information and support to help you become a teacher."
+  subtitle_button: "Register for updates"
+  subtitle_link: "/mailinglist/signup/name"
+  image: "media/images/content/hero-images/0012.jpg"
   navigation_title: "Home"
   navigation_path: "/"
   hero_content_width: wide

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,11 +1,13 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    title: "Get personalised guidance in your inbox",
-    text: "Answer just a few questions and we'll send you helpful advice and insights relevant to you.",
-    link_text: "Get advice in your inbox",
-    link_target: "/mailinglist/signup",
-    image: "media/images/content/hero-images/0012.jpg")
+    badge_text: "Updated<br>events",
+    caption: "Events are amazing",
+    title: "New teacher training events",
+    text: "Whether you are ready to start or just curious, events are a great place to get information about Teaching.",
+    link_text: "Showcase page",
+    link_target: "/events/about-get-into-teaching-events",
+    image: "media/images/content/homepage/here-to-help.jpg")
   %>
 
   <%= render CallsToAction::HomepageComponent.new(

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,19 +1,17 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-calendar",
-    badge_text: "Updated<br>events",
-    caption: "Events are amazing",
-    title: "New teacher training events",
-    text: "Whether you are ready to start or just curious, events are a great place to get information about Teaching.",
-    link_text: "Showcase page",
-    link_target: "/events/about-get-into-teaching-events",
+    title: "Online and in-person events",
+    text: "Talk to teachers, expert advisers and teacher training providers at an event to find out more about getting into teaching.",
+    link_text: "Find an event",
+    link_target: "/events",
     image: "media/images/content/homepage/here-to-help.jpg")
   %>
 
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-person",
     title: "Get one-to-one support",
-    text: "Whether you’re just considering teaching or you’re ready to apply, talk to an experienced teacher for support and advice.",
+    text: "Talk to an experienced former teacher to find out if teaching is for you and how to take your next steps towards the classroom.",
     link_text: "Get an adviser",
     link_target: "/tta-service",
     image: "media/images/content/homepage/teacher-training-adviser.jpg")

--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -11,7 +11,7 @@
   <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-person",
     title: "Get one-to-one support",
-    text: "Talk to an experienced former teacher to find out if teaching is for you and how to take your next steps towards the classroom.",
+    text: "Talk to an adviser with years of teaching experience to find out if teaching is for you and how to take your next steps.",
     link_text: "Get an adviser",
     link_target: "/tta-service",
     image: "media/images/content/homepage/teacher-training-adviser.jpg")

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -123,10 +123,14 @@
 
     grid-template-rows: 1em 1fr 2fr .8fr 1em;
     grid-template-columns: 1.2fr .8fr;
-    overflow: hidden;
+    overflow: visible;
 
     &:first-child .call-to-action__image {
       background-position: 70%;
+    }
+
+    .badge{
+      transform: translate(-50%, -50%);
     }
 
     .call-to-action__icon__container {
@@ -134,7 +138,7 @@
 
       grid-area: 1 / 1 / 3 / 2;
 
-      margin: 1em auto auto -.2em;
+      margin: 1em auto auto 0;
       padding-left: .2em;
       background-color: $yellow;
       display: inline-block;
@@ -170,6 +174,7 @@
       grid-area: 2 / 2 / 5 / 3;
       background-position: center;
       background-size: cover;
+      margin: 30px 0;
     }
 
     @include mq($until: tablet) {
@@ -204,7 +209,10 @@
         }
       }
 
-      .call-to-action__image { grid-area: 1 / 2 / 2 / 3; }
+      .call-to-action__image {
+        grid-area: 1 / 2 / 2 / 3;
+        margin: 0;
+      }
     }
   }
 

--- a/app/webpacker/styles/components/badge.scss
+++ b/app/webpacker/styles/components/badge.scss
@@ -13,6 +13,7 @@ html:not(.js-enabled) {
   font-weight: bold;
   font-size: 0.8em;
   margin-right: $indent-amount / 4;
+  text-align: center;
 
   span {
     display: inline-block;
@@ -20,5 +21,18 @@ html:not(.js-enabled) {
     padding-bottom: 50%;
     margin-left: 7px;
     margin-right: 7px;
+  }
+
+  &--bordered {
+    border: 1px solid $white;
+  }
+
+  &--fixed-80 {
+    line-height: normal;
+    width: 80px;
+    height: 80px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 }

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -27,6 +27,20 @@
     }
   }
 
+  &__mail a {
+    &:not(:focus) {
+      .icon-mail-white {
+        display: none;
+      }
+    }
+
+    &:focus {
+      .icon-mail {
+        display: none;
+      }
+    }
+  }
+
   &__search a {
     background-color: $pink;
     padding: 0.6em $indent-amount / 2;

--- a/spec/components/calls_to_action/homepage_component_spec.rb
+++ b/spec/components/calls_to_action/homepage_component_spec.rb
@@ -6,10 +6,23 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
   let(:title) { "Joey" }
   let(:link_text) { "Click here" }
   let(:link_target) { "/some-dir/some-page" }
+  let(:caption) { "Caption text" }
+  let(:badge_text) { "Badge text" }
   let(:text) { nil }
 
   describe "rendering the component" do
-    let(:kwargs) { { icon: icon, title: title, link_text: link_text, link_target: link_target, image: image, text: text } }
+    let(:kwargs) do
+      {
+        icon: icon,
+        title: title,
+        link_text: link_text,
+        link_target: link_target,
+        image: image,
+        text: text,
+        caption: caption,
+        badge_text: badge_text,
+      }
+    end
 
     let(:component) { described_class.new(**kwargs) }
 
@@ -29,6 +42,10 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
       expect(page).to have_css(".call-to-action__heading", text: title)
     end
 
+    specify "the caption is present" do
+      expect(page).to have_css(".caption-m", text: caption)
+    end
+
     specify "the link is present" do
       expect(page).to have_link(link_text, href: link_target)
     end
@@ -37,12 +54,28 @@ RSpec.describe CallsToAction::HomepageComponent, type: :component do
       expect(page.find(".call-to-action__image")["style"]).to include("packs-test/v1/media/images/dfelogo")
     end
 
+    specify "the badge_text is present" do
+      expect(page).to have_css(".call-to-action__image .badge", text: badge_text)
+    end
+
     context "when text is present" do
       let(:text) { "some text" }
 
       it "renders the text" do
         expect(page).to have_css(".call-to-action__content p", text: text)
       end
+    end
+
+    context "when caption is not present" do
+      let(:caption) { nil }
+
+      it { expect(page).not_to have_css(".caption-m") }
+    end
+
+    context "when badge_text is not present" do
+      let(:badge_text) { nil }
+
+      it { expect(page).not_to have_css(".badge") }
     end
   end
 end


### PR DESCRIPTION
> :warning: Not to be merged until November.

### Trello card

[Trello-782](https://trello.com/c/RkUrPiwZ/782-unwind-changes-supporting-event-comms-burst-on-home-page)

### Context

We changed the home page to support the GiT events comms burst; once that has ended we want to re-instate the original home page design with some minor tweaks to the events CTA.

### Changes proposed in this pull request

- Revert to register for interest header link

We want to restore the mailing list sign up link in the header; events will be called out further down in a CTA.

- Update homepage component for badge/caption

We want to add a purple caption and badge (containing text) to the homepage component. Update component with attributes and tweak CSS of badge to support fixed-width for multi-line text content.

- Update homepage CTA for events

Update the left homepage CTA to call out events.

### Guidance to review

