### PR TITLE
Fix duplicate text issues on international pages

### DIFF
--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -296,7 +296,7 @@ Alternatively, you may be eligible for a different type of visa which allows you
 
 ### 6. Plan your move to the UK
 
-Visit the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/Information--Advice) for advice about immigration, finding a place to live and opening a bank account. Their [Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
+Visit the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/) for advice about immigration, finding a place to live and opening a bank account. Their [Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
 
 Your teacher training provider may also be able to help you plan your move to the UK  – contact them directly to ask.
 

--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -228,7 +228,7 @@ To get advice about training to teach, you can:
 
 ### Get help with international qualifications
 
-If your qualifications come from a non-UK institution, your teacher training provider may want to see a [statement of comparability](https://enic.org.uk/Qualifications/SOC/Default.aspx) from UK ENIC. A statement of comparability proves that your school and university qualifications are the same standard as UK GCSEs and a UK undergraduate degree.
+If your qualifications come from a non-UK institution, your teacher training provider may want to see a [statement of comparability](https://www.enic.org.uk/Qualifications/SOC/Default.aspx) from UK ENIC. A statement of comparability proves that your school and university qualifications are the same standard as UK GCSEs and a UK undergraduate degree.
 
 Call us on +44 (0) 800 389 2500 for:
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/h3cdtF0r

### Context
Silktide has identified issues on two international pages where the same link text is used for different destinations. This is not good practice in terms of accessibility as it can be particularly confusing for screen reader users.
