### PR TITLE
Surface national Get Into Teaching events on no results

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -85,7 +85,7 @@ class TeachingEventsController < ApplicationController
 private
 
   def git_events
-    TeachingEvents::Search.new(type: %w[git]).results
+    @git_events ||= TeachingEvents::Search.new(type: %w[git]).results
   end
 
   def not_available_path
@@ -111,6 +111,7 @@ private
 
   def setup_results
     @event_search = TeachingEvents::Search.new_decrypt(search_params)
+    @national_git_events = git_events.select(&:is_online) if @event_search.results.empty?
   end
 
   def render_gone

--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -30,7 +30,7 @@ module TeachingEvents
     before_validation { self.postcode = postcode.to_s.strip.upcase.presence }
 
     def results
-      query.flat_map(&:teaching_events).sort_by(&:start_at)
+      @results ||= query.flat_map(&:teaching_events).sort_by(&:start_at)
     end
 
     def in_person_only?

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -33,42 +33,42 @@
       <%= render partial: "teaching_events/index/filter" %>
     </div>
 
-    <% if @featured_events.blank? && @events.blank? %>
-      <%= render partial: "teaching_events/index/no_results" %>
-    <% else %>
-      <div class="teaching-events__listing">
-        <% if @featured_events.any? %>
-          <div class="teaching-events__events teaching-events__events--featured">
-            <h2 class="heading-m">Upcoming Get Into Teaching events</h2>
+    <div class="teaching-events__listing">
+      <% if @featured_events.blank? && @events.blank? %>
+        <%= render partial: "teaching_events/index/no_results" %>
+      <% end %>
 
-            <ol><%= render TeachingEvents::EventComponent.with_collection(@featured_events) %></ol>
+      <% if @featured_events.any? %>
+        <div class="teaching-events__events teaching-events__events--featured">
+          <h2 class="heading-m">Upcoming Get Into Teaching events</h2>
 
-            <div class="teaching-events__about-git-banner">
-              <div class="teaching-events__about-git-banner--message">
-                <p>
-                  Get Into Teaching events can answer your questions whether you're ready to start your career in teaching or just curious.
-                </p>
-              </div>
+          <ol><%= render TeachingEvents::EventComponent.with_collection(@featured_events) %></ol>
 
-              <div class="teaching-events__about-git-banner--link">
-                <%= link_to("What happens at a Get Into Teaching event?", about_git_events_path, class: "button button--white") %>
-              </div>
+          <div class="teaching-events__about-git-banner">
+            <div class="teaching-events__about-git-banner--message">
+              <p>
+                Get Into Teaching events can answer your questions whether you're ready to start your career in teaching or just curious.
+              </p>
+            </div>
+
+            <div class="teaching-events__about-git-banner--link">
+              <%= link_to("What happens at a Get Into Teaching event?", about_git_events_path, class: "button button--white") %>
             </div>
           </div>
-        <% end %>
+        </div>
+      <% end %>
 
-        <% if @events.any? %>
-          <div class="teaching-events__events teaching-events__events--regular">
-            <h2 class="heading-m">Events coming up soon</h2>
-            <ol><%= render TeachingEvents::EventComponent.with_collection(@events) %></ol>
+      <% if @events.any? %>
+        <div class="teaching-events__events teaching-events__events--regular">
+          <h2 class="heading-m">Events coming up soon</h2>
+          <ol><%= render TeachingEvents::EventComponent.with_collection(@events) %></ol>
 
-            <div class="teaching-events__pagination">
-              <%= paginate @events %>
-            </div>
+          <div class="teaching-events__pagination">
+            <%= paginate @events %>
           </div>
-        <% end %>
-      </div>
-    <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </section>
 

--- a/app/views/teaching_events/index/_no_results.html.erb
+++ b/app/views/teaching_events/index/_no_results.html.erb
@@ -1,7 +1,7 @@
-<div class="teaching-events__none" role="alert">
-  <h3 class="heading--margin-top-0">
+<div class="teaching-events__events teaching-events__events--none" role="alert">
+  <h2 class="heading-m">
     0 events found
-  </h3>
+  </h2>
 
   <p><strong>Why not try:</strong></p>
   <ul>
@@ -15,3 +15,10 @@
     <li><%= link_to("clearing your filters", events_path) %> to start again</li>
   </ul>
 </div>
+
+<% if @national_git_events&.any? %>
+<div class="teaching-events__events teaching-events__events--regular">
+  <h2 class="heading-m">Other events you may be interested in</h2>
+  <ol><%= render TeachingEvents::EventComponent.with_collection(@national_git_events) %></ol>
+</div>
+<% end %>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -107,19 +107,6 @@ $icon-size: 3rem;
     }
   }
 
-  &__none {
-    margin: 1rem;
-
-    @include mq($from: tablet) {
-      border-left: 1px solid $slightly-darker-grey;
-      padding-left: 3rem;
-    }
-
-    ul {
-      list-style-type: square;
-    }
-  }
-
   &__events {
     @include reset;
 
@@ -144,10 +131,15 @@ $icon-size: 3rem;
       margin-bottom: 1rem;
     }
 
-    &--featured, &--regular {
+    &--featured, &--regular, &--none {
       h2 {
         margin-block: 1rem 2rem;
-        padding-inline: 1rem;
+      }
+    }
+
+    &--none {
+      ul {
+        list-style-type: square;
       }
     }
   }


### PR DESCRIPTION
### Trello card

[Trello-3736](https://trello.com/c/H0GuHUHZ/3736-consider-displaying-next-national-online-get-into-teaching-event-on-events-no-results-page)

### Context

- Display upcoming national GiT events on no results view

When a candidate has performed a search and there are no results we want to surface the national Get Into Teaching events as a potential point of interest for them.

### Changes proposed in this pull request

- Display upcoming national GiT events on no results view

Memoize the `TeachingEvent::Search#results` so that we can check for empty and query national GiT events without triggering a further API call.

Add national GiT events to no results page and tidy up the CSS/HTML a bit.

### Guidance to review

