### PR TITLE
Fixing accessibility issue on return to England after teaching overseas page

### DIFF
--- a/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_after-accordion.md
+++ b/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_after-accordion.md
@@ -29,10 +29,10 @@ learn more.
 
 ### Contact
 
-Sign up for an [online Q&A for returners](/events).
+To find out more about returning to England to teach, you can:
 
-Email us at teach.inengland@education.gov.uk.
-
-Join us on [Facebook](https://www.facebook.com/getintoteaching),
-[Instagram](https://www.instagram.com/get_into_teaching/) and
-[Twitter](https://twitter.com/getintoteaching).
+* sign up for an [online Q&A for returners](/events)
+* email us at teach.inengland@education.gov.uk
+* [find us on Facebook](https://www.facebook.com/getintoteaching)
+* [discover us on Instagram](https://www.instagram.com/get_into_teaching/)
+* [follow us on Twitter](https://twitter.com/getintoteaching)


### PR DESCRIPTION
### Trello card

https://trello.com/c/9QJKfhVH/3746-mark-navigation-as-list-on-return-to-teaching-from-overseas-page

### Context

Silktide has identified a section on the Return to England after teaching overseas page that should be marked as a list for accessibility best practice.

This is most likely the Contact section at the bottom of the page. This needs styling as an unordered list.

### Changes proposed in this pull request

### Guidance to review

