### PR TITLE
Add site name to home page structured data

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -70,8 +70,9 @@ module StructuredDataHelper
     structured_data("HowTo", data)
   end
 
-  def search_structured_data
+  def home_structured_data
     data = {
+      name: suffix_title(nil),
       url: root_url,
       potentialAction: {
         "@type": "SearchAction",

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -20,7 +20,7 @@
   <%= yield :head %>
   <%= breadcrumbs_structured_data(breadcrumb_trail) %>
   <%= logo_structured_data %>
-  <%= search_structured_data if current_page?(root_path) %>
+  <%= home_structured_data if current_page?(root_path) %>
   <%= how_to_structured_data(@page) if @page.present? && @front_matter.key?("how_to") %>
 
   <% if @front_matter["noindex"] || @noindex %>

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe StructuredDataHelper, type: "helper" do
   include ERB::Util
   include EventsHelper
+  include ApplicationHelper
 
   let(:image_path) { "media/images/getintoteachinglogo.svg" }
 
@@ -169,10 +170,10 @@ describe StructuredDataHelper, type: "helper" do
     end
   end
 
-  describe ".search_structured_data" do
+  describe ".home_structured_data" do
     subject(:data) { JSON.parse(script_tag.content, symbolize_names: true) }
 
-    let(:html) { search_structured_data }
+    let(:html) { home_structured_data }
     let(:script_tag) { Nokogiri::HTML.parse(html).at_css("script") }
 
     before { enable_structured_data(:web_site) }
@@ -182,10 +183,16 @@ describe StructuredDataHelper, type: "helper" do
       expect(script_tag).to be_nil
     end
 
-    it "includes search information" do
+    it "includes site information" do
       expect(data).to include({
         "@type": "WebSite",
         url: root_url,
+        name: "Get Into Teaching GOV.UK",
+      })
+    end
+
+    it "includes search information" do
+      expect(data).to include({
         potentialAction: {
           "@type": "SearchAction",
           "target": {


### PR DESCRIPTION
### Trello card

[Trello-3772](https://trello.com/c/u5YHp41u/3772-add-structured-data-for-site-name)

### Context

Add the site name to the home page structured data and rename from 'search' to 'home' so its clearer.

### Changes proposed in this pull request

- Add site name to home page structured data

### Guidance to review

