### PR TITLE
Allow id attribute in HTML

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -7,6 +7,6 @@ module TextFormattingHelper
   end
 
   def safe_html_format(html)
-    sanitize html, tags: %w[link strong a ul li p b br div span h1 h2 h3 h4 h5], attributes: %w[href target rel]
+    sanitize html, tags: %w[link strong a ul li p b br div span h1 h2 h3 h4 h5], attributes: %w[href target rel id]
   end
 end

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -24,7 +24,7 @@ describe TextFormattingHelper, type: :helper do
       let(:html) do
         <<~HTML
           <div>test</div>
-          <p>
+          <p id="paragraph">
             <strong>hello</strong>
             <a href="http://test.com">world</a>
           </p>


### PR DESCRIPTION
### Trello card

[Trello-3782](https://trello.com/c/hjIHpjFG/3782-allow-id-attribute-in-safe-html-rendering)

### Context

We render 'safe' HTML in some areas of the website; the new privacy policy contains jump links however the `id` attributes of the headings are being stripped out so they don't work.

### Changes proposed in this pull request

- Allow id attribute in HTML

### Guidance to review

