### PR TITLE
Allow searching with distance but no postcode

### DIFF
--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -111,7 +111,7 @@ private
 
   def setup_results
     @event_search = TeachingEvents::Search.new_decrypt(search_params)
-    @national_git_events = git_events.select(&:is_online) if @event_search.results.empty?
+    @national_git_events = git_events.select(&:is_online) if @event_search.valid? && @event_search.results.empty?
   end
 
   def render_gone

--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -22,7 +22,6 @@ module TeachingEvents
     attribute :distance, :integer
 
     validates :postcode, postcode: { allow_blank: true, accept_partial_postcode: true }
-    validates :postcode, presence: true, if: -> { distance.present? }
 
     validates :distance, inclusion: { in: DISTANCES.values }, allow_nil: true
 

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -35,7 +35,7 @@ describe TeachingEvents::Search do
           it { is_expected.to allow_value(val).for(:postcode) }
         end
 
-        [nil, "", "M", "Manchester", "M1-2WD"].each do |val|
+        %w[M Manchester M1-2WD].each do |val|
           it { is_expected.not_to allow_value(val).for(:postcode) }
         end
       end


### PR DESCRIPTION
### Trello card

[Trello-3784](https://trello.com/c/pzop8GSN/3784-address-500-errors-served-on-event-search)

### Context

We think users are entering a postcode then searching by distance and finding 0 results, prompting them to remove their postcode (instead of changing the distance to nationwide).

Allow searching by distance without a postcode; treating it as if they have selected nationwide, which is likely their intent.

### Changes proposed in this pull request

- Allow searching with distance but no postcode

### Guidance to review

