### PR TITLE
Make youtube videos consistent

### DIFF
--- a/app/components/content/youtube_video_component.html.erb
+++ b/app/components/content/youtube_video_component.html.erb
@@ -1,8 +1,10 @@
-<%= tag.iframe(
-  title: title,
-  loading: "lazy",
-  src: src,
-  frameborder: 0,
-  allow: "autoplay; encrypted-media",
-  allowfullscreen: true
-) %>
+<div class="youtube-video">
+  <%= tag.iframe(
+    title: title,
+    loading: "lazy",
+    src: src,
+    frameborder: 0,
+    allow: "autoplay; encrypted-media",
+    allowfullscreen: true
+  ) %>
+</div>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -7,7 +7,7 @@
 <%= tag.div(formatted_event_description(@event.description)) %>
 
 <% if @event.video_id %>
-  <div class="teaching-event__video youtube-video-container">
+  <div class="teaching-event__video">
     <%= render Content::YoutubeVideoComponent.new(
       id: @event.video_id,
       title: "Get Into Teaching Events: Take your next step towards teaching"

--- a/app/webpacker/styles/campaign/_videos.scss
+++ b/app/webpacker/styles/campaign/_videos.scss
@@ -23,12 +23,6 @@
     }
   }
 
-  iframe {
-    width: 100%;
-    height: 300px;
-    border: 3px solid $pink;
-  }
-
   .statement {
     * {
       max-width: unset;

--- a/app/webpacker/styles/components/youtube-video.scss
+++ b/app/webpacker/styles/components/youtube-video.scss
@@ -1,0 +1,21 @@
+.youtube-video {
+  iframe {
+    width: 100%;
+    border: 3px solid $pink;
+    aspect-ratio: 16 / 9;
+  }
+
+  // Simulates 16 / 9 aspect ratio.
+  @supports not (aspect-ratio: 1) {
+    position: relative;
+    padding-bottom: 56.25%;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+}

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -52,6 +52,7 @@
 @import './components/quote';
 @import './components/photo-quote-list';
 @import './components/search';
+@import './components/youtube-video';
 @import './components/colored-stripe';
 @import './components/events/signup-info';
 @import './components/turbolinks-progress-bar';

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -700,7 +700,7 @@ $icon-size: 3rem;
     }
   }
 
-  .youtube-video-container {
+  .youtube-video {
     max-width: 40em;
     margin-block: 2em;
   }

--- a/app/webpacker/styles/utility.scss
+++ b/app/webpacker/styles/utility.scss
@@ -123,23 +123,3 @@ hr {
   border: 0;
   margin: $indent-amount 0;
 }
-
-// responsively resize youtube videos by surrounding
-// the iframe in a .youtube-video-container wrapper
-//
-// approach lifted from https://embedresponsively.com/
-.youtube-video-container {
-  position: relative;
-  padding-bottom: 56.25%;
-  height: 0;
-  overflow: hidden;
-  max-width: 100%;
-
-  iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-}

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -10,6 +10,7 @@ describe Content::YoutubeVideoComponent, type: :component do
     page
   end
 
+  it { is_expected.to have_css(".youtube-video iframe") }
   it { is_expected.to have_css("iframe[src='https://www.youtube-nocookie.com/embed/#{id}']") }
   it { is_expected.to have_css("iframe[title=#{title}]") }
   it { is_expected.to have_css("iframe[loading=lazy]") }


### PR DESCRIPTION
### Trello card

[Trello-3780](https://trello.com/c/CawjiikN/3780-standardise-youtube-videos)

### Context

We currently display YouTube videos with a pink border on some pages and without on others. We are also not consistent with the dimensions of Youtube videos; they should be 100% width and match the height of the preview image, which is always a 16:9 aspect ratio.

### Changes proposed in this pull request

- Make Youtube videos display consistent

### Guidance to review

