### PR TITLE
Pull in 24 months worth of future events

### DIFF
--- a/app/models/teaching_events/search.rb
+++ b/app/models/teaching_events/search.rb
@@ -6,7 +6,7 @@ module TeachingEvents
     include EncryptedAttributes
     encrypt_attributes :postcode
 
-    FUTURE_MONTHS = 6
+    FUTURE_MONTHS = 24
 
     DISTANCES = {
       "Nationwide" => nil,
@@ -52,7 +52,7 @@ module TeachingEvents
 
   private
 
-    def query(limit: 100)
+    def query(limit: 1_000)
       conditions = {
         type_ids: type_condition,
         postcode: postcode_condition,

--- a/spec/models/teaching_events/search_spec.rb
+++ b/spec/models/teaching_events/search_spec.rb
@@ -223,7 +223,7 @@ describe TeachingEvents::Search do
 
   describe "#start_before" do
     specify "is 6 months in the future" do
-      expect(described_class.new.send(:start_before)).to be_within(1.second).of(6.months.from_now)
+      expect(described_class.new.send(:start_before)).to be_within(1.second).of(24.months.from_now)
     end
   end
 end

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -88,7 +88,7 @@ describe "teaching events", type: :request do
       expected_type_ids = [EventType.get_into_teaching_event_id]
       allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
         receive(:search_teaching_events_grouped_by_type)
-          .with(a_hash_including(type_ids: expected_type_ids, start_after: now, quantity_per_type: 100))
+          .with(a_hash_including(type_ids: expected_type_ids, start_after: now, quantity_per_type: 1_000))
           .and_return(events_by_type)
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3786](https://trello.com/c/q5BBQJJT/3786-change-search-to-load-in-24-months-of-results-1000-type)

### Context

When we changed from the old events design to the new one we inadvertently changed the number of events we were pulling in from 24 months (1000/type) to 6 months (100/type).

Revert back to the original behaviour.

### Changes proposed in this pull request

- Pull in 24 months worth of future events

### Guidance to review

