### PR TITLE
Changing 'teacher training advisers' blog tag to 'advisers'

### DIFF
--- a/app/views/content/blog/5-reasons-to-attend-a-get-into-teaching-event.md
+++ b/app/views/content/blog/5-reasons-to-attend-a-get-into-teaching-event.md
@@ -14,7 +14,7 @@ keywords:
   - teacher training
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
   - get into teaching events
   - applications
 closing_paragraph: enriching-the-lives-of-young-people

--- a/app/views/content/blog/9-tips-to-help-you-apply-for-teacher-training.md
+++ b/app/views/content/blog/9-tips-to-help-you-apply-for-teacher-training.md
@@ -20,7 +20,7 @@ keywords:
   - adviser
   - TTA
 tags:
-  - teacher training advisers
+  - advisers
   - personal statements
   - qualifications
   - applications

--- a/app/views/content/blog/back-to-school-as-a-trainee-teacher.md
+++ b/app/views/content/blog/back-to-school-as-a-trainee-teacher.md
@@ -15,7 +15,7 @@ keywords:
   - teacher training
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
   - applications
 ---
 

--- a/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
+++ b/app/views/content/blog/choosing-the-right-teacher-training-course-provider.md
@@ -13,7 +13,7 @@ keywords:
   - teacher training advisers
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
   - applications
 ---
 

--- a/app/views/content/blog/getting-ready-to-apply.md
+++ b/app/views/content/blog/getting-ready-to-apply.md
@@ -20,7 +20,7 @@ keywords:
   - references
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
   - get into teaching events
   - applications
   - references

--- a/app/views/content/blog/jills-story-getting-back-into-the-classroom.md
+++ b/app/views/content/blog/jills-story-getting-back-into-the-classroom.md
@@ -13,7 +13,7 @@ keywords:
   - teacher training advisers
 tags:
   - returning to teaching
-  - teacher training advisers
+  - advisers
 ---
 
 After almost a decade of teaching science, I Ieft the job in 2001 when my husband and I started a family. During my time out of the classroom, I did quite a lot of work for an exam board and lots of private tuition. This kept me occupied for many years.

--- a/app/views/content/blog/marias-return-to-teaching-story.md
+++ b/app/views/content/blog/marias-return-to-teaching-story.md
@@ -15,7 +15,7 @@ keywords:
 
 tags:
   - returning to teaching
-  - teacher training advisers
+  - advisers
 ---
 
 $maria$

--- a/app/views/content/blog/my-experience-with-the-national-tutoring-programme.md
+++ b/app/views/content/blog/my-experience-with-the-national-tutoring-programme.md
@@ -14,7 +14,7 @@ keywords:
 
 tags:
   - returning to teaching
-  - teacher training advisers
+  - advisers
 ---
 
 $farooq$

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -21,7 +21,7 @@ tags:
   - autism
   - neurodiversity
   - personal statements
-  - teacher training advisers
+  - advisers
 ---
 
 $header_image$

--- a/app/views/content/blog/stephens-return-to-teaching-story.md
+++ b/app/views/content/blog/stephens-return-to-teaching-story.md
@@ -13,7 +13,7 @@ keywords:
   - teacher training advisers
 tags:
   - returning to teaching
-  - teacher training advisers
+  - advisers
 ---
 
 $stephen$

--- a/app/views/content/blog/what-to-expect-on-your-teacher-training.md
+++ b/app/views/content/blog/what-to-expect-on-your-teacher-training.md
@@ -15,7 +15,7 @@ keywords:
   - teacher training
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
 ---
 
 $seminar_room$

--- a/app/views/content/blog/why-i-became-a-teacher.md
+++ b/app/views/content/blog/why-i-became-a-teacher.md
@@ -17,7 +17,7 @@ keywords:
   - teacher training
 tags:
   - becoming a teacher
-  - teacher training advisers
+  - advisers
 closing_paragraph: enriching-the-lives-of-young-people
 ---
 

--- a/config/tags.yml
+++ b/config/tags.yml
@@ -27,7 +27,7 @@
 - school experience
 - support
 - teacher training
-- teacher training advisers
+- advisers
 - teaching internships
 - get into teaching events
 - veterans

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -35,7 +35,7 @@ describe "reading the blog", type: :feature do
   end
 
   include_context "paginating blog posts", "/blog"
-  include_context "paginating blog posts", "/blog/tag/teacher-training-advisers"
+  include_context "paginating blog posts", "/blog/tag/advisers"
 
   scenario "viewing a post" do
     path = "getting-ready-to-apply"


### PR DESCRIPTION
### Trello card

https://trello.com/c/EDtUz2sF/3775-change-blog-tag-from-teacher-training-advisers-to-advisers

### Context

We currently have a blog tag of 'teacher training advisers'. We often use this in blogs when we're actually referring to return to teaching advisers or explore teaching advisers, so we should really change this to 'advisers' for accuracy (and to avoid duplicate link text issues).

### Changes proposed in this pull request

### Guidance to review

