### PR TITLE
Upgrade to Stimulus v3

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,3 +1,0 @@
-> 1%
-last 3 versions
-ie 11

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,2 @@
 defaults
+not IE 11

--- a/app/webpacker/controllers/abbreviation_controller.js
+++ b/app/webpacker/controllers/abbreviation_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   connect() {

--- a/app/webpacker/controllers/accordion_controller.js
+++ b/app/webpacker/controllers/accordion_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['header', 'content'];

--- a/app/webpacker/controllers/aspect_ratio_controller.js
+++ b/app/webpacker/controllers/aspect_ratio_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static values = {

--- a/app/webpacker/controllers/badge_controller.js
+++ b/app/webpacker/controllers/badge_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static values = { path: String, jsonKey: String };

--- a/app/webpacker/controllers/banner_controller.js
+++ b/app/webpacker/controllers/banner_controller.js
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 import CookiePreferences from '../javascript/cookie_preferences';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static values = { name: String };

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['online', 'offline', 'unavailable', 'chat'];

--- a/app/webpacker/controllers/conditional_field_controller.js
+++ b/app/webpacker/controllers/conditional_field_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['source', 'showhide'];

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -1,5 +1,5 @@
 import CookiePreferences from '../javascript/cookie_preferences';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['modal', 'overlay', 'agree', 'disagree', 'info'];

--- a/app/webpacker/controllers/cookie_preferences_controller.js
+++ b/app/webpacker/controllers/cookie_preferences_controller.js
@@ -1,5 +1,5 @@
 import CookiePreferences from '../javascript/cookie_preferences';
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['category'];

--- a/app/webpacker/controllers/funding_widget_controller.js
+++ b/app/webpacker/controllers/funding_widget_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['form'];

--- a/app/webpacker/controllers/index.js
+++ b/app/webpacker/controllers/index.js
@@ -1,8 +1,8 @@
 // Load all the controllers within this directory and all subdirectories.
 // Controller files must be named *_controller.js.
 
-import { Application } from 'stimulus';
-import { definitionsFromContext } from 'stimulus/webpack-helpers';
+import { Application } from '@hotwired/stimulus';
+import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
 
 const application = Application.start();
 const context = require.context('controllers', true, /_controller\.js$/);

--- a/app/webpacker/controllers/internal_events_controller.js
+++ b/app/webpacker/controllers/internal_events_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['name', 'startAt', 'partialUrl', 'errorMessage'];

--- a/app/webpacker/controllers/last_step_controller.js
+++ b/app/webpacker/controllers/last_step_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['complete'];

--- a/app/webpacker/controllers/link_controller.js
+++ b/app/webpacker/controllers/link_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['content'];

--- a/app/webpacker/controllers/mailing-list_controller.js
+++ b/app/webpacker/controllers/mailing-list_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 const countKey = 'mailingListPageCount';
 const mailingListDismissedKey = 'mailingListDismissed';

--- a/app/webpacker/controllers/map_controller.js
+++ b/app/webpacker/controllers/map_controller.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['container'];

--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['primary', 'nav', 'menu'];

--- a/app/webpacker/controllers/scribble_controller.js
+++ b/app/webpacker/controllers/scribble_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   connect() {

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 import accessibleAutocomplete from 'accessible-autocomplete';
 import Redacter from '../javascript/redacter';
 

--- a/app/webpacker/controllers/table_controller.js
+++ b/app/webpacker/controllers/table_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   connect() {

--- a/app/webpacker/styles/components/campaign-hero.scss
+++ b/app/webpacker/styles/components/campaign-hero.scss
@@ -89,7 +89,7 @@
     @include mq($from: mobile) {
       grid-area: 1 / 2 / 2 / 4;
       display: flex;
-      justify-content: end;
+      justify-content: flex-end;
     }
 
     img {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -76,7 +76,7 @@ $mobile-cutoff: 800px;
 
     &__title {
       grid-area: 2 / 1 / 4 / 4;
-      align-self: end;
+      align-self: flex-end;
     }
 
     &__subtitle,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serialize-javascript": "^6.0.0",
     "set-value": "^4.0.1",
     "sinon": "^14.0.0",
-    "stimulus": "^2.0.0",
+    "stimulus": "^3.1",
     "trix": "^1.3.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",

--- a/spec/javascript/controllers/abbreviation_controller_spec.js
+++ b/spec/javascript/controllers/abbreviation_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import AbbreviationController from 'abbreviation_controller.js';
 
 describe('AccordionController', () => {

--- a/spec/javascript/controllers/accordion_controller_spec.js
+++ b/spec/javascript/controllers/accordion_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import AccordionController from 'accordion_controller.js';
 
 describe('AccordionController', () => {

--- a/spec/javascript/controllers/aspect_ratio_controller_spec.js
+++ b/spec/javascript/controllers/aspect_ratio_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import AspectRatioController from 'aspect_ratio_controller';
 
 describe('AspectRatioController', () => {

--- a/spec/javascript/controllers/badge_controller_spec.js
+++ b/spec/javascript/controllers/badge_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import BadgeController from 'badge_controller.js';
 
 describe('BadgeController', () => {

--- a/spec/javascript/controllers/banner_controller_spec.js
+++ b/spec/javascript/controllers/banner_controller_spec.js
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import BannerController from 'banner_controller';
 
 describe('BannerController', () => {

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import ChatController from 'chat_controller.js';
 
 describe('ChatController', () => {

--- a/spec/javascript/controllers/conditional_field_controller_spec.js
+++ b/spec/javascript/controllers/conditional_field_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import ConditionalFieldController from 'conditional_field_controller.js';
 
 describe('ConditionalFieldController', () => {

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import CookieAcceptanceController from 'cookie-acceptance_controller.js';
 
 describe('CookieAcceptanceController', () => {

--- a/spec/javascript/controllers/cookie_preferences_controller_spec.js
+++ b/spec/javascript/controllers/cookie_preferences_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import CookiePreferencesController from 'cookie_preferences_controller.js';
 import Cookies from 'js-cookie';
 import CookiePreferences from 'cookie_preferences';

--- a/spec/javascript/controllers/internal_events_controller_spec.js
+++ b/spec/javascript/controllers/internal_events_controller_spec.js
@@ -1,5 +1,5 @@
 import InternalEventsController from 'internal_events_controller.js';
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 
 describe('InternalEventsController', () => {
   document.body.innerHTML = `

--- a/spec/javascript/controllers/last_step_controller_spec.js
+++ b/spec/javascript/controllers/last_step_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import LastStepController from 'last_step_controller';
 
 describe('LastStepController', () => {

--- a/spec/javascript/controllers/link_controller_spec.js
+++ b/spec/javascript/controllers/link_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import LinkController from 'link_controller.js';
 
 describe('LinkController', () => {

--- a/spec/javascript/controllers/mailing-list_controller_spec.js
+++ b/spec/javascript/controllers/mailing-list_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import MailingListController from 'mailing-list_controller.js';
 import StubLocalStorage from '../stubs/local_storage';
 

--- a/spec/javascript/controllers/navigation_controller_spec.js
+++ b/spec/javascript/controllers/navigation_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import NavigationController from 'navigation_controller.js';
 
 describe('NavigationController', () => {

--- a/spec/javascript/controllers/scribble_controller_spec.js
+++ b/spec/javascript/controllers/scribble_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import ScribbleController from 'scribble_controller';
 
 describe('ScribbleController', () => {

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import SearchboxController from 'searchbox_controller.js';
 
 describe('SearchboxController', () => {

--- a/spec/javascript/controllers/table_controller_spec.js
+++ b/spec/javascript/controllers/table_controller_spec.js
@@ -1,4 +1,4 @@
-import { Application } from 'stimulus';
+import { Application } from '@hotwired/stimulus';
 import TableController from 'table_controller.js';
 
 describe('TableController', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,6 +1497,16 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.2.0"
 
+"@hotwired/stimulus-webpack-helpers@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
+  integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
+
+"@hotwired/stimulus@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.1.0.tgz#20215251e5afe6e0a3787285181ba1bfc9097df0"
+  integrity sha512-iDMHUhiEJ1xFeicyHcZQQgBzhtk5mPR0QZO3L6wtqzMsJEk2TKECuCQTGKjm+KJTHVY0dKq1dOOAWvODjpd2Mg==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1954,25 +1964,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@stimulus/core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
-  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
-  dependencies:
-    "@stimulus/mutation-observers" "^2.0.0"
-
-"@stimulus/multimap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
-  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
-
-"@stimulus/mutation-observers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
-  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
-  dependencies:
-    "@stimulus/multimap" "^2.0.0"
-
 "@stimulus/polyfills@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stimulus/polyfills/-/polyfills-2.0.0.tgz#64b3e247c762330f80d88e993d1d26b24e3c13b1"
@@ -1987,11 +1978,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stimulus/test/-/test-2.0.0.tgz#eed53eb04710ce8c3773c9bb8e4a1e2f5e740393"
   integrity sha512-n8X6H5l6FAznX8Gziyeyp7RCiCR7Sxo2zErebFwuWrBz4ZCq7AYQfhZ6gLgq9878XhJZx58d63AmXvuYRkRGAw==
-
-"@stimulus/webpack-helpers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
-  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -9421,13 +9407,13 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stimulus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
-  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+stimulus@^3.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-3.1.0.tgz#225298f1936f96b0eafa883b8b304266427912c3"
+  integrity sha512-ln+BtLkhemwJozr5N3I5q0kGlSv6fmcPi3JtDjBo7gnnz2tAYhK2WBhyY/EN/4+CWIwqp3qPm3Pc+i9CjIXrtg==
   dependencies:
-    "@stimulus/core" "^2.0.0"
-    "@stimulus/webpack-helpers" "^2.0.0"
+    "@hotwired/stimulus" "^3.1.0"
+    "@hotwired/stimulus-webpack-helpers" "^1.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
### Trello card

[Trello-3788](https://trello.com/c/rQiw6rJc/3788-update-redis-stimulus-dfe-analytics)

### Context

We are a major version behind Stimulus; updating drops support for IE11 which is now fine according to GDS as less than 2% of our user base are on IE11.

### Changes proposed in this pull request

- Upgrade to Stimulus 3
- Use flex-end instead of end (fixes warning)

### Guidance to review

There should be no user-facing changes apart from IE11 users who will get the JS-disabled experience as we only compile for ES6 now.

Also removes duplicate/mistyped browserstlist file.