### PR TITLE
Link to funding/ support if you're disabled added

### DIFF
--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -44,6 +44,4 @@ I am a little concerned about disclosing the fact that I am autistic, as I didn�
 
 My answer would be: only if it’s right for you! It’s certainly not for everyone, but if you feel pulled towards it (or if you feel like something inside you is pushing you towards it despite your best efforts!) then go for it. Don’t worry about whether or not you will be able to gain a place on a course, as there is a lot of help out there. Your own ambition should be your only limit.
 
-All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).
-
-Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
+All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers). You can also find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -44,6 +44,6 @@ I am a little concerned about disclosing the fact that I am autistic, as I didn�
 
 My answer would be: only if it’s right for you! It’s certainly not for everyone, but if you feel pulled towards it (or if you feel like something inside you is pushing you towards it despite your best efforts!) then go for it. Don’t worry about whether or not you will be able to gain a place on a course, as there is a lot of help out there. Your own ambition should be your only limit.
 
-Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
-
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).
+
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -26,7 +26,7 @@ tags:
 
 $header_image$
 
-Felix offered to speak to Teacher Training Adviser, Jane Wilkinson, about the challenges faced by someone who lives with additional needs and their progress towards achieving the dream of becoming a teacher.
+Felix offered to speak to Teacher Training Adviser, Jane Wilkinson, about the challenges faced by someone who lives with additional needs and their progress towards achieving the dream of becoming a teacher. 
 
 ## What inspired you to teach?
 

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -44,4 +44,6 @@ I am a little concerned about disclosing the fact that I am autistic, as I didn�
 
 My answer would be: only if it’s right for you! It’s certainly not for everyone, but if you feel pulled towards it (or if you feel like something inside you is pushing you towards it despite your best efforts!) then go for it. Don’t worry about whether or not you will be able to gain a place on a course, as there is a lot of help out there. Your own ambition should be your only limit.
 
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
+
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
@@ -38,6 +38,6 @@ The application process went smoothly thanks to the help of my [teacher training
 
 If someone came up to me and asked if they should teach, my answer would be yes and no! No, because teaching is not for everyone and it is a hugely demanding job so it is extremely important to understand the amount of patience, dedication and commitment you will need! However, teaching is a natural skill that anyone can learn as long as you are passionate about the subject and age group you’re teaching. Yes, because teaching allows students to absorb your knowledge and you can watch them flourish throughout the years, which makes the job so fascinating and unique!
 
-Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
-
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).
+
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
@@ -38,6 +38,4 @@ The application process went smoothly thanks to the help of my [teacher training
 
 If someone came up to me and asked if they should teach, my answer would be yes and no! No, because teaching is not for everyone and it is a hugely demanding job so it is extremely important to understand the amount of patience, dedication and commitment you will need! However, teaching is a natural skill that anyone can learn as long as you are passionate about the subject and age group you’re teaching. Yes, because teaching allows students to absorb your knowledge and you can watch them flourish throughout the years, which makes the job so fascinating and unique!
 
-All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).
-
-Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
+All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers). You can also find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).

--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
@@ -38,4 +38,6 @@ The application process went smoothly thanks to the help of my [teacher training
 
 If someone came up to me and asked if they should teach, my answer would be yes and no! No, because teaching is not for everyone and it is a hugely demanding job so it is extremely important to understand the amount of patience, dedication and commitment you will need! However, teaching is a natural skill that anyone can learn as long as you are passionate about the subject and age group you’re teaching. Yes, because teaching allows students to absorb your knowledge and you can watch them flourish throughout the years, which makes the job so fascinating and unique!
 
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
+
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).

--- a/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
+++ b/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
@@ -3,6 +3,8 @@ title: Who do you want to teach
 heading: Who do you want to teach
 description: |-
   Explore who’d you’d like to teach and the qualifications you need to work with early years, further education, and pupils with special educational needs.
+related_content:
+    Get support training to teach if you're disabled: "/funding-and-support/if-youre-disabled"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo-who-do-you-want-to-teach
 ---
@@ -21,8 +23,6 @@ If you want to [teach in primary or secondary schools](/train-to-be-a-teacher/if
 England.
 
 You will need a degree to teach all student groups except those in further education, depending on the type of further education you are teaching.
-
-Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled). 
 
 ## Teach disabled pupils and pupils with special educational needs
 

--- a/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
+++ b/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
@@ -22,6 +22,8 @@ England.
 
 You will need a degree to teach all student groups except those in further education, depending on the type of further education you are teaching.
 
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled). 
+
 ## Teach disabled pupils and pupils with special educational needs
 
 Most disabled pupils and pupils with special educational needs learn in mainstream schools.

--- a/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
+++ b/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
@@ -4,7 +4,7 @@ heading: Who do you want to teach
 description: |-
   Explore who’d you’d like to teach and the qualifications you need to work with early years, further education, and pupils with special educational needs.
 related_content:
-    Get support training to teach if you're disabled: "/funding-and-support/if-youre-disabled"
+    Get support training to teach if you're disabled : "/funding-and-support/if-youre-disabled"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo-who-do-you-want-to-teach
 ---


### PR DESCRIPTION
### Trello card

https://trello.com/c/CTj6V5ta/2884-signpost-to-the-disability-support-page-across-the-website?filter=member:dominiccollins19

### Context

Research highlighted that the disability support page ([Funding and support if you're disabled](https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled)) is only signposted to on the steps page. Increasing the number of signposts across the site will signal to users that teaching is for everyone. "Support training to teach if you're disabled" link added to 3 pages.

### Changes proposed in this pull request

### Guidance to review

