### PR TITLE
Link to support page added

### DIFF
--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-autism.md
@@ -44,4 +44,6 @@ I am a little concerned about disclosing the fact that I am autistic, as I didn�
 
 My answer would be: only if it’s right for you! It’s certainly not for everyone, but if you feel pulled towards it (or if you feel like something inside you is pushing you towards it despite your best efforts!) then go for it. Don’t worry about whether or not you will be able to gain a place on a course, as there is a lot of help out there. Your own ambition should be your only limit.
 
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled). 
+
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).


### PR DESCRIPTION
### Trello card

https://trello.com/c/CTj6V5ta/2884-signpost-to-the-disability-support-page-across-the-website?filter=member:dominiccollins19

### Context

Research highlighted that the disability support page ([Funding and support if you're disabled](https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled)) is only signposted to on the steps page. Increasing the number of signposts across the site will signal to users that teaching is for everyone.

### Changes proposed in this pull request

### Guidance to review

