### PR TITLE
Link to support page added.

### DIFF
--- a/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
+++ b/app/views/content/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment.md
@@ -38,4 +38,6 @@ The application process went smoothly thanks to the help of my [teacher training
 
 If someone came up to me and asked if they should teach, my answer would be yes and no! No, because teaching is not for everyone and it is a hugely demanding job so it is extremely important to understand the amount of patience, dedication and commitment you will need! However, teaching is a natural skill that anyone can learn as long as you are passionate about the subject and age group you’re teaching. Yes, because teaching allows students to absorb your knowledge and you can watch them flourish throughout the years, which makes the job so fascinating and unique!
 
+Find out about the [support you can get while training to teach if you're disabled](/funding-and-support/if-youre-disabled).
+
 All of our advisers are experienced teachers who will provide you with additional support when preparing and applying for teacher training. [Sign up for a teacher training adviser](/teacher-training-advisers).


### PR DESCRIPTION
### Trello card

https://trello.com/c/CTj6V5ta/2884-signpost-to-the-disability-support-page-across-the-website?filter=member:dominiccollins19

### Context

Research highlighted that the disability support page ([Funding and support if you're disabled](https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled)) is only signposted to on the steps page. Increasing the number of signposts across the site will signal to users that teaching is for everyone.

### Changes proposed in this pull request

### Guidance to review

