### PR TITLE
Link to Find has been tweaked to prevent confusion

### DIFF
--- a/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
@@ -22,7 +22,7 @@ You’ll need a degree and [qualified teacher status](/what-is-qts) (QTS) to wor
 
 [Now Teach](https://nowteach.org.uk/) is a service that specifically helps people get into teaching who are changing career.
 
-If you already have an undergraduate degree, you can [search for postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/). There are specific training courses you can choose from that match your particular subject knowledge and experience.
+If you already have an undergraduate degree, you can [search for postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/) to get QTS.
 
 If you're concerned about your subject knowledge, you may also be able to do a <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">'subject knowledge enhancement' (SKE) course</a>. This can help if you have an unrelated degree but relevant professional experience, or you haven't used your subject knowledge for a while.
 

--- a/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
@@ -22,7 +22,7 @@ You’ll need a degree and [qualified teacher status](/what-is-qts) (QTS) to wor
 
 [Now Teach](https://nowteach.org.uk/) is a service that specifically helps people get into teaching who are changing career.
 
-[Teacher training courses for graduates](https://www.find-postgraduate-teacher-training.service.gov.uk/) may also work for you. If you have knowledge and experience in a particular subject area there are specific training courses you can choose.
+If you already have an undergraduate degree, you can [search for postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/). If you have knowledge and experience in a particular subject area there are specific training courses you can choose.
 
 If you're concerned about your subject knowledge, you may also be able to do a <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">'subject knowledge enhancement' (SKE) course</a>. This can help if you have an unrelated degree but relevant professional experience, or you haven't used your subject knowledge for a while.
 

--- a/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
@@ -22,7 +22,7 @@ You’ll need a degree and [qualified teacher status](/what-is-qts) (QTS) to wor
 
 [Now Teach](https://nowteach.org.uk/) is a service that specifically helps people get into teaching who are changing career.
 
-If you already have an undergraduate degree, you can [search for postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/). If you have knowledge and experience in a particular subject area there are specific training courses you can choose.
+If you already have an undergraduate degree, you can [search for postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/). There are specific training courses you can choose from that match your particular subject knowledge and experience.
 
 If you're concerned about your subject knowledge, you may also be able to do a <a href="/train-to-be-a-teacher/subject-knowledge-enhancement">'subject knowledge enhancement' (SKE) course</a>. This can help if you have an unrelated degree but relevant professional experience, or you haven't used your subject knowledge for a while.
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/ZbPPJxxO/3798-tweak-wording-of-training-courses-for-graduates-link-on-if-you-want-to-change-career

### Context

Background:
In Ways to Train Round 2, users misunderstood relevance of 'training courses for graduates' and they thought this was for recent graduates only.

Action:
Tweak wording of this link to make it clearer this is for anyone who already has a degree...

### Changes proposed in this pull request

### Guidance to review

