### PR TITLE
Optimize HTML response transformer middleware

### DIFF
--- a/lib/error_title.rb
+++ b/lib/error_title.rb
@@ -1,15 +1,16 @@
 class ErrorTitle
-  def initialize(page)
-    @page = page
+  attr_reader :doc
+
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
+  def process
     error = doc.at_css(".govuk-error-summary")
 
     prefix_title(doc) if error.present?
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
 private

--- a/lib/external_links.rb
+++ b/lib/external_links.rb
@@ -1,10 +1,11 @@
 class ExternalLinks
-  def initialize(page)
-    @page = page
+  attr_reader :doc
+
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
+  def process
     links = doc.css("a:not(.button)")
 
     links.each do |anchor|
@@ -13,7 +14,7 @@ class ExternalLinks
       anchor.add_child(%{<span class="visually-hidden">(opens in new window)</span>})
     end
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
 private

--- a/lib/image_sizes.rb
+++ b/lib/image_sizes.rb
@@ -1,16 +1,17 @@
 # ImageSizes will automatically add width/height attributes to img
 # elements in an effort to combat Cumulative Layout Shift (CLS).
 class ImageSizes
+  attr_reader :doc
+
   IMAGES_GLOB = "app/webpacker/images/**/*.*".freeze
 
   @@cache = {}
 
-  def initialize(page)
-    @page = page
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
+  def process
     doc.css("img").each do |img|
       next if sized?(img)
       next unless enabled? && sizable?(img["src"])
@@ -18,7 +19,7 @@ class ImageSizes
       size_image(img)
     end
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
   class << self

--- a/lib/lazy_load_images.rb
+++ b/lib/lazy_load_images.rb
@@ -1,14 +1,14 @@
 class LazyLoadImages
+  attr_reader :doc
+
   # Used as a placeholder to prevent invalid HTML.
   TINY_GIF = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==".freeze
 
-  def initialize(page)
-    @page = page
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
-
+  def process
     doc.css("picture").each do |picture|
       next if picture.css("img[data-lazy-disable]").any?
 
@@ -30,7 +30,7 @@ class LazyLoadImages
       img["class"] = img["class"] << " lazyload"
     end
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
 private

--- a/lib/next_gen_images.rb
+++ b/lib/next_gen_images.rb
@@ -1,37 +1,38 @@
 class NextGenImages
+  attr_reader :doc
+
   # As we control the conversion we only need to look for
   # a subset of all the possible extensions.
   NEXT_GEN_IMAGE_EXTS = %w[.webp .jp2].freeze
 
-  def initialize(page)
-    @page = page
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
+  def process
     doc.css("img").each do |img|
-      img.replace(picture(img, doc)) unless img.parent.name == "picture"
+      img.replace(picture(img)) unless img.parent.name == "picture"
     end
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
 private
 
-  def picture(img, doc)
+  def picture(img)
     src = img["src"]
 
     Nokogiri::XML::Node.new("picture", doc) do |picture|
       source_exts = NEXT_GEN_IMAGE_EXTS + [File.extname(src)]
       source_exts.each do |ext|
-        source = source(src, ext, doc)
+        source = source(src, ext)
         picture.add_child(source) if source.present?
       end
       picture.add_child(img.dup)
     end
   end
 
-  def source(original_src, ext, doc)
+  def source(original_src, ext)
     src_uri = URI.parse(original_src)
     base_url = src_uri.absolute ? "#{src_uri.scheme}://#{src_uri.host}" : ""
     src_path = "#{src_uri.path.chomp(File.extname(original_src))}#{ext}"

--- a/lib/responsive_images.rb
+++ b/lib/responsive_images.rb
@@ -12,6 +12,8 @@
 #
 # /path/to/image--tablet.png
 class ResponsiveImages
+  attr_reader :doc
+
   BREAKPOINTS = {
     mobile: "500px",
     tablet: "768px",
@@ -19,20 +21,18 @@ class ResponsiveImages
     wide: "1500px",
   }.freeze
 
-  def initialize(page)
-    @page = page
+  def initialize(doc)
+    @doc = doc
   end
 
-  def html
-    doc = Nokogiri::HTML(@page)
-
+  def process
     doc.css("picture source").each do |source|
       BREAKPOINTS.each do |breakpoint, max_width|
         prepend_responsive_source(source, breakpoint, max_width)
       end
     end
 
-    doc.to_html(encoding: "UTF-8", indent: 2)
+    doc
   end
 
 private

--- a/spec/lib/error_title_spec.rb
+++ b/spec/lib/error_title_spec.rb
@@ -3,7 +3,7 @@ require "error_title"
 
 describe ErrorTitle do
   describe "#html" do
-    subject { instance.html }
+    subject { instance.process.to_html }
 
     let(:document) do
       <<~HTML
@@ -22,7 +22,7 @@ describe ErrorTitle do
         <div class="govuk-error-summary"></div>
       HTML
     end
-    let(:instance) { described_class.new(document) }
+    let(:instance) { described_class.new(Nokogiri::HTML(document)) }
 
     it { is_expected.to include("<title>Error: #{document_title}</title>") }
 

--- a/spec/lib/external_links_spec.rb
+++ b/spec/lib/external_links_spec.rb
@@ -3,10 +3,10 @@ require "external_links"
 
 describe ExternalLinks do
   describe "#html" do
-    subject { instance.html }
+    subject { instance.process.to_html }
 
     let(:link) { %(<a href="https://external.link">external link</a>) }
-    let(:instance) { described_class.new(link) }
+    let(:instance) { described_class.new(Nokogiri::HTML(link)) }
 
     it "adds visually hidden text" do
       is_expected.to include(

--- a/spec/lib/image_sizes_spec.rb
+++ b/spec/lib/image_sizes_spec.rb
@@ -6,13 +6,13 @@ describe ImageSizes do
   include Webpacker::Helper
 
   describe "#html" do
-    subject(:render_html) { instance.html }
+    subject(:render_html) { instance.process.to_html }
 
     let(:asset_host) { "http://example.com" }
     let(:src_url) { "#{asset_host}/a/test/image.jpg" }
     let(:fast_image_url) { src_url }
     let(:body) { %(<img src="#{src_url}">) }
-    let(:instance) { described_class.new(body) }
+    let(:instance) { described_class.new(Nokogiri::HTML(body)) }
 
     before do
       described_class.class_variable_set(:@@cache, {})

--- a/spec/lib/lazy_load_images_spec.rb
+++ b/spec/lib/lazy_load_images_spec.rb
@@ -3,7 +3,7 @@ require "lazy_load_images"
 
 describe LazyLoadImages do
   describe "#html" do
-    subject { instance.html }
+    subject { instance.process.to_html }
 
     let(:original_src) { "image.jpg" }
     let(:original_ext) { File.extname(original_src) }
@@ -11,7 +11,7 @@ describe LazyLoadImages do
     let(:source) { "<source srcset=\"#{original_src}\"></source>" }
     let(:picture) { "<picture>#{img}#{source}</picture>" }
     let(:no_js_picture) { "<noscript><picture class=\"no-js\">#{img}#{source}</picture></noscript>" }
-    let(:instance) { described_class.new(picture) }
+    let(:instance) { described_class.new(Nokogiri::HTML(picture)) }
 
     it do
       lazy_image = "<img class=\"test lazyload\" src=\"#{LazyLoadImages::TINY_GIF}\" data-src=\"#{original_src}\">"

--- a/spec/lib/next_gen_images_spec.rb
+++ b/spec/lib/next_gen_images_spec.rb
@@ -3,11 +3,11 @@ require "next_gen_images"
 
 describe NextGenImages do
   describe "#html" do
-    subject { instance.html }
+    subject { instance.process.to_html }
 
     let(:original_ext) { File.extname(original_src_path) }
     let(:body) { %(<img src="#{original_src_url}">) }
-    let(:instance) { described_class.new(body) }
+    let(:instance) { described_class.new(Nokogiri::HTML(body)) }
     let(:asset_host) { "" }
     let(:original_src_url) { "#{asset_host}#{original_src_path}" }
 

--- a/spec/lib/responsive_images_spec.rb
+++ b/spec/lib/responsive_images_spec.rb
@@ -3,7 +3,7 @@ require "responsive_images"
 
 describe ResponsiveImages do
   describe "#html" do
-    subject { instance.html }
+    subject { instance.process.to_html }
 
     let(:fingerprint) { "-fingerprint1" }
     let(:asset_host) { "" }
@@ -14,7 +14,7 @@ describe ResponsiveImages do
         <img src=\"#{src}\">
       </picture>"
     end
-    let(:instance) { described_class.new(body) }
+    let(:instance) { described_class.new(Nokogiri::HTML(body)) }
 
     before { allow(Dir).to receive(:glob).and_call_original }
 


### PR DESCRIPTION
### Trello card

[Trello-3821](https://trello.com/c/neJ3KmBj/3821-optimise-htmlresponsetransformer)

### Context

We have middleware that performs various optimisations to our HTML responses (such as injecting responsive images, adding image sizes, etc). This is proving to be a bottleneck in our dynamic page responses. The cached, static pages take a hit on the first load but subsequent requests are very fast.

I expected the main time-sink to be Nokogiri parsing/generating HTML in each transformation library (of which we have 6). To make this more performant I've refactored it so that the document is parsed only once across all transformation libraries. I did a contrived benchmark locally and the runtime went down around 50-60%.

### Changes proposed in this pull request

- Optimize HTML response transformer middleware

### Guidance to review

