### PR TITLE
Make links on gray background black

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -53,7 +53,7 @@
               <% end %>
               <div>
                 <h2 class="heading-s">Can't find what you're looking for?</h2>
-                <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }})) %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }})) %> in your area.</p>
+                <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }}), class: "link--black") %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
               </div>
             </section>
           </div>


### PR DESCRIPTION
[Trello-3827](https://trello.com/c/t2mnmYAs/3827-fix-colour-contrast-issue-on-about-get-into-teaching-events)

This improves the contrast for accessibility (on the about GiT events page).
