### PR TITLE
Make clear that applicants for iQTS are not eligible for student finance

### DIFF
--- a/app/views/content/non-uk-teachers/international-qualified-teacher-status/_find-out-about-fees.md
+++ b/app/views/content/non-uk-teachers/international-qualified-teacher-status/_find-out-about-fees.md
@@ -1,5 +1,7 @@
 Fees start at about £9,000 in total but will vary between training providers – check with participating providers for more details.
 
+Applicants for iQTS are not eligible for loans, bursaries or any other type of financial support from the UK government. 
+
 If you are already employed in a school, you can discuss with your training provider whether you can continue working in that school while you complete your iQTS qualification.  
 
 You might be able to get a salary for your work in a placement school – this will vary between schools and between providers. 


### PR DESCRIPTION
Make clear that applicants for iQTS are not eligible for student finance

### Trello card

https://trello.com/c/wodYlmcD/137-update-iqts-page-with-student-finance-info

### Context
Applicant was wrongly awarded student finance which now needs to be repaid.

### Changes proposed in this pull request
Clearer guidance applicants are not eligible. 

### Guidance to review

