### PR TITLE
Adding Find link to engineers teach physics courses

### DIFF
--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -64,7 +64,7 @@
      <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p>You can <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">find teacher training courses</a> and filter by 'physics' and 'engineers teach physics'.
+    <p>You can <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">find teacher training courses</a> and filter by 'physics' then 'engineers teach physics'.
      </p>
   </section>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -133,7 +133,7 @@
      <a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for bursaries and scholarships</a>.
     </p>
      <p>
-     You can also <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">find teacher training courses</a> for physics that do not focus on engineers and material scientists.
+     You can also <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">search for physics teacher training courses</a> that are not part of the Engineers teach physics training programme.
     </p>
 
   </section>

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -64,7 +64,7 @@
      <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p>You can <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">find teacher training courses</a> and filter by 'physics' then 'engineers teach physics'.
+    <p>You can <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">search for physics teacher training courses</a> and then filter by 'Engineers teach physics'.
      </p>
   </section>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -133,7 +133,7 @@
      <a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for bursaries and scholarships</a>.
     </p>
      <p>
-     You can also <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">search for physics teacher training courses</a> that are not part of the Engineers teach physics training programme.
+     You can also <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">search for physics teacher training courses</a> that are not part of the Engineers teach physics training programme.
     </p>
 
   </section>

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -64,7 +64,7 @@
      <p>You'll also be invited to an annual community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p>Courses starting in the 2022/23 academic year are now closed. You’ll be able to find courses starting in the 2023/24 academic year in autumn 2022.
+    <p>You can <a href="https://www.find-postgraduate-teacher-training.service.gov.uk/">find teacher training courses</a> and filter by 'physics' and 'engineers teach physics'.
      </p>
   </section>
 
@@ -133,7 +133,7 @@
      <a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for bursaries and scholarships</a>.
     </p>
      <p>
-     <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find out about other physics teacher training courses</a>.
+     You can also <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">find teacher training courses</a> for physics that do not focus on engineers and material scientists.
     </p>
 
   </section>


### PR DESCRIPTION
### Trello card

https://trello.com/c/6co6d0bm/3777-add-link-to-find-courses-on-engineers-teach-physics-page

### Context

The new engineers teach physics courses are now up on Find so we need to add a link to our engineers teach physics page.

### Changes proposed in this pull request

### Guidance to review

