### PR TITLE
Update Node version for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3.1-bullseye",
 			// Options
-			"NODE_VERSION": "12"
+			"NODE_VERSION": "14"
 		}
 	},
 


### PR DESCRIPTION
[Trello-3864](https://trello.com/c/xj8wc9YP/3864-fix-codespaces)

Codespaces is failing to build at the moment as its using Node v12 and it looks like we now need v14 for some of our npm dependencies.
