### PR TITLE
Whitelist GitHub preview domain

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,5 +72,5 @@ Rails.application.configure do
   config.x.dfe_analytics = true
 
   # Allow access from Codespaces
-  config.hosts << /[a-z0-9\-]+\.githubpreview\.dev/
+  config.hosts << /[a-z0-9\-]+\.(preview\.app\.github|githubpreview)\.dev/
 end


### PR DESCRIPTION
Whitelist the GitHub preview app domain for Codespaces (this seems to have changed from `githubpreview.dev` to `preview.app.github.dev` but I'm leaving the old domain in incase it starts using it as well as the new one).
