### PR TITLE
Update dfe-analytics gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "faraday_middleware"
 
 gem "fastimage"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 
 gem "hashids"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 6dc16420e0b5c6b2b722887589b0bc2212798802
-  tag: v1.3.2
+  revision: bfa569a60b4fca7545ca7b72764c526b65d913b9
+  tag: v1.5.3
   specs:
-    dfe-analytics (1.3.2)
+    dfe-analytics (1.5.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -260,7 +260,7 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.2.0)
+    google-cloud-errors (1.3.0)
     googleauth (0.16.2)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -48,4 +48,6 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  config.user_identifier = proc { |user| user&.username }
 end

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,10 +1,10 @@
 class User
-  attr_reader :username, :id
+  attr_reader :username
 
   ROLES = { publisher: "publisher", author: "author" }.freeze
 
   def initialize(username, role)
-    @id = @username = username
+    @username = username
     @role = role
   end
 

--- a/spec/lib/basic_auth_spec.rb
+++ b/spec/lib/basic_auth_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe BasicAuth do
           is_expected.to be_an_instance_of(User)
 
           expect(user.username).to eq("username1")
-          expect(user.id).to eq(user.username)
 
           is_expected.not_to be_publisher
           is_expected.not_to be_author


### PR DESCRIPTION
### Trello card

[Trello-3550](https://trello.com/c/zWz5rZU8/3550-remove-decorator-id-attribute-for-dfe-analytics)

### Context

Update to the latest version and remove the now-redundant `id` attribute on `User` as we can tell dfe-analytics which attribute to use (in our case `username`).

### Changes proposed in this pull request

- Update dfe-analytics gem

### Guidance to review

