### PR TITLE
Updating events promos

### DIFF
--- a/app/components/calls_to_action/promo/left_section.rb
+++ b/app/components/calls_to_action/promo/left_section.rb
@@ -1,7 +1,7 @@
 class CallsToAction::Promo::LeftSection < ViewComponent::Base
   attr_reader :caption, :heading, :link_text, :link_target, :classes
 
-  def initialize(heading:, caption: nil, link_text: nil, link_target: nil, classes: [])
+  def initialize(heading: nil, caption: nil, link_text: nil, link_target: nil, classes: [])
     @caption = caption
     @heading = heading
     @link_text = link_text

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -8,7 +8,7 @@ related_content:
     Get school experience: "/train-to-be-a-teacher/get-school-experience"
     Diary of a trainee teacher: "/blog/a-diary-of-a-trainee-teacher"
 promo_content:
-    - content/funding-and-support/promos/events-promo-parent
+    - content/funding-and-support/promos/get-adviser-support-promo
 navigation: 20.25
 navigation_title: If you're a parent or carer
 navigation_description: Find out what extra grants and schemes are available if you have children or other caring responsibilities.

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -8,7 +8,7 @@ related_content:
     Becoming a teacher with a hearing impairment: "/blog/overcoming-challenges-to-become-a-teacher-hearing-impairment"
     Becoming a teacher with autism: "/blog/overcoming-challenges-to-become-a-teacher-autism"
 promo_content:
-    - content/funding-and-support/promos/events-promo-disabled
+    - content/funding-and-support/promos/get-adviser-support-promo
 navigation: 20.20
 navigation_title: If you're disabled
 navigation_description: Find out about the support you can get while training to teach if you're disabled.

--- a/app/views/content/funding-and-support/promos/_events-promo-disabled.html.erb
+++ b/app/views/content/funding-and-support/promos/_events-promo-disabled.html.erb
@@ -1,8 +1,6 @@
 
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events") do %>
-  <% end %>
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         heading: "Online and in-person events") do %>
       <p>You can talk to advisers and teacher training providers to find out what support you could get while training to teach.</p>

--- a/app/views/content/funding-and-support/promos/_events-promo-funding.html.erb
+++ b/app/views/content/funding-and-support/promos/_events-promo-funding.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         heading: "Online and in-person events") do %>
       <p>Talk to expert advisers about funding your training, from how student finance works to available scholarships and bursaries.</p>

--- a/app/views/content/funding-and-support/promos/_events-promo-parent.html.erb
+++ b/app/views/content/funding-and-support/promos/_events-promo-parent.html.erb
@@ -1,8 +1,6 @@
 
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events") do %>
-  <% end %>
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         heading: "Online and in-person events") do %>
       <p>You can talk to advisers and teacher training providers to find out what support you could get while training to teach.</p>

--- a/app/views/content/funding-and-support/promos/_get-adviser-funding-promo.html.erb
+++ b/app/views/content/funding-and-support/promos/_get-adviser-funding-promo.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/funding-and-support/promos/_get-adviser-support-promo.html.erb
+++ b/app/views/content/funding-and-support/promos/_get-adviser-support-promo.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>Talk to an experienced former teacher who can help you understand what extra support you could be entitled to during your training.</p>
 

--- a/app/views/content/funding-and-support/promos/_get-adviser-support-promo.html.erb
+++ b/app/views/content/funding-and-support/promos/_get-adviser-support-promo.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
+      heading: "Get an adviser", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>

--- a/app/views/content/funding-and-support/promos/_get-adviser-veterans-promo.erb
+++ b/app/views/content/funding-and-support/promos/_get-adviser-veterans-promo.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[veteran-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[veteran-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>You can get dedicated guidance and support with your journey into teacher training from one of our veteran teacher training advisers.</p>
 

--- a/app/views/content/funding-and-support/promos/_mailing-list-promo.html.erb
+++ b/app/views/content/funding-and-support/promos/_mailing-list-promo.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support in your inbox", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Get tailored guidance"
   ) do %>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -9,7 +9,7 @@ related_content:
     Salaries and benefits: "/salaries-and-benefits"
 promo_content:
     - content/train-to-be-a-teacher/promos/find-your-course
-    - content/funding-and-support/promos/events-promo-funding
+    - content/funding-and-support/promos/get-adviser-funding-promo
 navigation: 20.15
 navigation_description: Find out if you're eligible for extra funding depending on the subject you're training to teach.
 before-content:

--- a/app/views/content/non-uk-teachers/promos/_adviser-promo-returners.html.erb
+++ b/app/views/content/non-uk-teachers/promos/_adviser-promo-returners.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/non-uk-teachers/promos/_adviser-promo-teach-in-england.html.erb
+++ b/app/views/content/non-uk-teachers/promos/_adviser-promo-teach-in-england.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/non-uk-teachers/promos/_adviser-promo-training-in-england.html.erb
+++ b/app/views/content/non-uk-teachers/promos/_adviser-promo-training-in-england.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
@@ -28,7 +28,7 @@ keywords:
   - interviews
   - offers
 promo_content:
-    - content/train-to-be-a-teacher/promos/events-promo-apply
+    - content/train-to-be-a-teacher/promos/adviser-promo-apply
 navigation: 20.25
 navigation_title: How to apply
 navigation_description: Discover tips on preparing your teacher training application, from writing your personal statement to choosing your references.

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -10,7 +10,7 @@ related_content:
     Who do you want to teach? : "/train-to-be-a-teacher/who-do-you-want-to-teach"
 promo_content:
     - content/train-to-be-a-teacher/promos/find-your-course
-    - content/train-to-be-a-teacher/promos/events-promo-degree
+    - content/train-to-be-a-teacher/promos/adviser-promo-degree
 navigation: 20.05
 navigation_title: If you have or are studying for a degree
 navigation_description: Find out how to get qualified teacher status (QTS) through postgraduate teacher training if you have a degree or you’re studying for one. 

--- a/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
@@ -10,7 +10,7 @@ related_content:
     Get into teaching maths : "/subjects/maths"
     Initial teacher training : "/train-to-be-a-teacher/initial-teacher-training"
 promo_content:
-    - content/train-to-be-a-teacher/promos/events-promo-degree
+    - content/train-to-be-a-teacher/promos/adviser-promo-career-changers
 navigation: 20.15
 navigation_title: If you want to change career
 navigation_description: Use the experience you’ve gathered so far to inspire students and train to bring your skills and expertise to the classroom.

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -9,7 +9,7 @@ related_content:
     What to expect on your teacher training : "/blog/what-to-expect-on-your-teacher-training"
     Training and support for early career teachers : "/support-for-early-career-teachers"
 promo_content:
-    - content/train-to-be-a-teacher/promos/events-promo-degree
+    - content/train-to-be-a-teacher/promos/mailing-list-promo-itt
 ---
 
 Your initial teacher training (ITT) will vary depending on your course provider and the qualifications you're working towards.

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>An adviser can help you with your application, from tips on writing your personal statement, to choosing your references.</p>
 

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>
-      <p>An adviser can help you with your application, from tips on writing your personal statement, to choosing your referees.</p>
+      <p>An adviser can help you with your application, from tips on writing your personal statement, to choosing your references.</p>
 
       <%= link_to("Find out more about advisers", "/teacher-training-advisers", class: "button") %>
   <% end %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-apply.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
+      heading: "Get an adviser", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-assessment-only.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-assessment-only.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-assessment-only.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-assessment-only.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
+      heading: "Get an adviser", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-career-changers.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-career-changers.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>An adviser can talk you through the support available if you're changing career and answer all your questions about getting into teaching.</p>
 

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-career-changers.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-career-changers.html.erb
@@ -1,6 +1,6 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
+      heading: "Get an adviser", classes: %w[tta-background]) do %>
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>
-      <p>Your adviser can talk to you about your different training options and help you find the best one for you.</p>
+      <p>An adviser can talk to you about your different training options and help find the best one for you.</p>
 
       <%= link_to("Find out more about advisers", "/teacher-training-advisers", class: "button") %>
   <% end %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>
-      <p>An adviser can talk to you about your different training options and help find the best one for you.</p>
+      <p>An adviser can talk to you about your different training options and help you choose the right course for you.</p>
 
       <%= link_to("Find out more about advisers", "/teacher-training-advisers", class: "button") %>
   <% end %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-degree.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>An adviser can talk to you about your different training options and help you choose the right course for you.</p>
 

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ect.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ect.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Teacher training advisers", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ske.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ske.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(heading: "Get free one-to-one support") do %>
       <p>Your adviser can help you understand how subject knowledge enhancement courses work and support you with your teacher training application.</p>
 

--- a/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ske.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_adviser-promo-ske.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% promo.right_section(heading: "Get free one-to-one support") do %>
-      <p>Your adviser can help you understand how to do a subject knowledge enhancement course and support you with your teacher training application.</p>
+      <p>Your adviser can help you understand how subject knowledge enhancement courses work and support you with your teacher training application.</p>
 
       <%= link_to("Find out more about advisers", "/teacher-training-advisers", class: "button") %>
   <% end %>

--- a/app/views/content/train-to-be-a-teacher/promos/_eta-promo-internships.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_eta-promo-internships.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get an adviser", classes: %w[tta-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[tta-background]) %>
   <% promo.right_section(
     heading: "Get free one-to-one support"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
@@ -1,8 +1,6 @@
 
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events") do %>
-  <% end %>
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         caption: "Online and in-person events",
         heading: "Get tips on your application") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_events-promo-degree.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-promo-degree.html.erb
@@ -1,8 +1,6 @@
 
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events") do %>
-  <% end %>
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         caption: "Online and in-person events",
         heading: "Find out more about teaching") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_events-promo-ske.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-promo-ske.html.erb
@@ -1,8 +1,6 @@
 
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Get Into Teaching events") do %>
-  <% end %>
+  <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
         caption: "Online and in-person events",
         heading: "Get your questions answered") do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <span class="caption-l caption--bold caption--purple">Find your course</span>
+    <h2 class="heading-m">Find your teacher training course</h2>
     <p>
       You can search for postgraduate teacher training courses to get a PGCE.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <h2 class="heading-m">Find your teacher training course</h2>
+    <h2 class="heading-m heading--margin-top-0">Find your teacher training course</h2>
     <p>
       You can search for postgraduate teacher training courses to get a PGCE.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <h2 class="heading-m">Find your teacher training course</h2>
+    <h2 class="heading-m heading--margin-top-0">Find your teacher training course</h2>
     <p>
       Take a look at the different teacher training courses available.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <span class="caption-l caption--bold caption--purple">Find your teacher training course</span>
+    <h2 class="heading-m">Find your teacher training course</h2>
     <p>
       Take a look at the different teacher training courses available.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-undergraduate-course.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-undergraduate-course.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <h2 class="heading-m">Find your teacher training course</h2>
+    <h2 class="heading-m heading--margin-top-0">Find your teacher training course</h2>
     <p>
       You can search for undergraduate courses that will start you on your teaching career.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-undergraduate-course.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-undergraduate-course.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="right">
-    <span class="caption-l caption--bold caption--purple">Find your course</span>
+    <h2 class="heading-m">Find your teacher training course</h2>
     <p>
       You can search for undergraduate courses that will start you on your teaching career.
     </p>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-itt.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-itt.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teacher training"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-no-degree.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-no-degree.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-pgce.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-pgce.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-qts.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-qts.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about getting into teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-salaries.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-salaries.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-who-do-you-want-to-teach.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo-who-do-you-want-to-teach.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_mailing-list-promo.html.erb
@@ -1,8 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      heading: "Advice and support", classes: %w[ml-background]) do %>
-  <% end %>
-
+  <% promo.left_section(classes: %w[ml-background]) %>
   <% promo.right_section(
     heading: "Find out more about teaching"
   ) do %>

--- a/app/views/content/train-to-be-a-teacher/subject-knowledge-enhancement.md
+++ b/app/views/content/train-to-be-a-teacher/subject-knowledge-enhancement.md
@@ -8,7 +8,7 @@ related_content:
 description: |-
   Find out more about subject knowledge enhancement (SKE) courses which will help you brush up the subject you want to teach.
 promo_content:
-    - content/train-to-be-a-teacher/promos/events-promo-ske
+    - content/train-to-be-a-teacher/promos/adviser-promo-ske
 keywords:
   - Subject knowledge
   - Subject knowledge enhancement

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -48,10 +48,7 @@
         </section>
 
         <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-          <% promo.left_section(
-              heading: "Advice and support", classes: %w[ml-background]) do %>
-          <% end %>
-
+          <% promo.left_section( classes: %w[ml-background]) %>
           <% promo.right_section(
             heading: "Find out more about getting into teaching"
           ) do %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/3WP4dxDN/3863-change-promo-modules-towards-the-end-of-the-autumn-events-programme

### Context

Now that the autumn programme of GIT events is coming to an end, we should consider changing some of the events promos on our pages.

### Changes proposed in this pull request

### Guidance to review

