### PR TITLE
Adding noindex to support for international applicants page

### DIFF
--- a/app/views/content/guidance/financial-support-for-international-applicants.md
+++ b/app/views/content/guidance/financial-support-for-international-applicants.md
@@ -1,6 +1,5 @@
 ---
 title: Financial support for international applicants
-draft: true
 noindex: true
 ---
 

--- a/app/views/content/guidance/financial-support-for-international-applicants.md
+++ b/app/views/content/guidance/financial-support-for-international-applicants.md
@@ -1,6 +1,7 @@
 ---
 title: Financial support for international applicants
 draft: true
+noindex: true
 ---
 
 This page has moved.


### PR DESCRIPTION
### Trello card

https://trello.com/c/I7UuWXU2/3871-add-noindex-to-financial-support-for-international-applicants-page

### Context

There used to be information on financial support for international applicants on the GIT site but this has now moved to GOV.UK.

We cannot set up a redirect to a different domain so we have a page on GIT that acts as a quasi redirect (Financial support for international applicants)

This page gets occasional organic search traffic so we should probably noindex it.

### Changes proposed in this pull request

### Guidance to review

