### PR TITLE
Updating train to be a teacher page titles

### DIFF
--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -1,6 +1,6 @@
 ---
-title: "Ways to train if you don't have a degree"
-heading: "Train to be a teacher if you don't have a degree"
+title: "Train to teach if you do not have a degree"
+heading: "Train to teach if you do not have a degree"
 description: |-
   Explore how you can train to be a teacher and gain qualified teacher status (QTS) if you don’t have a degree.
 related_content:
@@ -11,7 +11,7 @@ promo_content:
     - content/train-to-be-a-teacher/promos/find-your-undergraduate-course
     - content/train-to-be-a-teacher/promos/mailing-list-promo-no-degree
 navigation: 20.20
-navigation_title: If you don't have a degree
+navigation_title: If you do not have a degree
 navigation_description: You need a degree to get qualified teacher status (QTS). If you're not already studying for one, find out more about undergraduate degree courses.
 ---
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -1,6 +1,6 @@
 ---
-title: "Ways to train if you have a degree"
-heading: "Train to be a teacher if you have or are studying for a degree"
+title: "Train to teach if you have a degree or are studying for one"
+heading: "Train to teach if you have a degree or are studying for one"
 description: |-
   Discover how you can train to be a teacher and gain qualified teacher status (QTS) if you have a degree. Including school-led and university-led training.
 related_content:

--- a/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
@@ -1,6 +1,6 @@
 ---
-title: "If you've worked in a classroom"
-heading: "Train to be a teacher if you've worked in a classroom"
+title: "Train to teach if you've worked in a classroom"
+heading: "Train to teach if you've worked in a classroom"
 description: |-
   Find out how you can gain qualified teacher status (QTS) if you’ve already spent a lot of time in the classroom as a teaching assistant or in a similar role.
 related_content:

--- a/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-want-to-change-career.md
@@ -1,6 +1,6 @@
 ---
-title: If you want to change career
-heading: Train to be a teacher if you want to change career
+title: Train to teach if you're changing career
+heading: Train to teach if you're changing career
 description: |-
   Find out what extra support you can get if you want to change career and get into teaching. Bring your experience to life in the classroom.
 related_content:

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -1,8 +1,8 @@
 ---
-title: "Initial teacher training (ITT)"
-heading: "Initial teacher training (ITT)"
+title: "Teacher training"
+heading: "Teacher training"
 description: |-
-  Find out what initial teacher training (ITT) is like. Learn about your classroom placements, the theoretical learning, and how you’ll be assessed.
+  Find out what teacher training is like. Learn about your classroom placements, the theoretical learning, and how you’ll be assessed.
 related_content:
     Diary of a trainee teacher : "/blog/a-diary-of-a-trainee-teacher"
     Choosing the right teacher training course provider : "/blog/choosing-the-right-teacher-training-course-provider"

--- a/app/views/content/train-to-be-a-teacher/subject-knowledge-enhancement.md
+++ b/app/views/content/train-to-be-a-teacher/subject-knowledge-enhancement.md
@@ -1,5 +1,5 @@
 ---
-title: Improve your subject knowledge
+title: Subject knowledge enhancement (SKE)
 related_content:
     Get school experience : "/train-to-be-a-teacher/get-school-experience"
     Application tips : "/blog/application-tips-from-a-teacher-training-provider"


### PR DESCRIPTION
### Trello card

https://trello.com/c/Zdn9jsbU/3878-revise-page-titles-for-organic-search-train-to-be-a-teacher

### Context

Now we've added 'GOV.UK' to all our page titles, we should review them to make sure they're not too many characters.

This PR changes the page titles for:

- ways to train if you have a degree
- ways to train if you don't have a degree
- if you've worked in a classroom
- if you want to change career
- initial teacher training (ITT)
- improve your subject knowledge

### Changes proposed in this pull request

### Guidance to review

