### PR TITLE
Changing who do you want to teach page titles

### DIFF
--- a/app/views/content/become-a-further-education-teacher.md
+++ b/app/views/content/become-a-further-education-teacher.md
@@ -1,5 +1,5 @@
 ---
-title: Become a further education teacher
+title: Teach in further education
 article_classes: ['longform']
 image: "media/images/content/hero-images/0015.jpg"
 description: |-

--- a/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -1,5 +1,5 @@
 ---
-title: "Teach disabled pupils and pupils with special educational needs"
+title: "Teach pupils with special educational needs and disabilities"
 description: |-
   As a qualified teacher you’ll have the opportunity to work with pupils with complex needs, no matter what setting you work in.
 date: "2021-05-07"

--- a/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -1,5 +1,6 @@
 ---
 title: "Teach pupils with special educational needs and disabilities"
+heading: "Teach pupils with special educational needs and disabilities (SEND)"
 description: |-
   As a qualified teacher you’ll have the opportunity to work with pupils with complex needs, no matter what setting you work in.
 date: "2021-05-07"


### PR DESCRIPTION
### Trello card

https://trello.com/c/AhAzZtSl/3879-revise-page-titles-for-organic-search-who-do-you-want-to-teach

### Context

Now that we've added 'GOV.UK' to our page titles, we should review them to try and keep them short enough to not be truncated by Google.

This PR covers the change of:

- become a further education teacher
- teaching disabled pupils and pupils with special educational needs

### Changes proposed in this pull request

### Guidance to review

