### PR TITLE
updating help and support page titles

### DIFF
--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -49,7 +49,7 @@ module MailingList
     end
 
     def set_step_page_title
-      @page_title = "Get personalised guidance to your inbox"
+      @page_title = "Get tailored guidance in your inbox"
 
       if @current_step&.title
         @page_title += ", #{@current_step.title.downcase} step"

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -50,7 +50,8 @@ module MailingList
 
     def set_step_page_title
       @page_title = "Get personalised guidance to your inbox"
-      unless @current_step.nil?
+
+      if @current_step&.title
         @page_title += ", #{@current_step.title.downcase} step"
       end
     end

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -21,7 +21,7 @@ class TeachingEventsController < ApplicationController
 
   def index
     @front_matter = {
-      title: "Find an event near you",
+      title: "Find an event near you or online",
       description: "Find out more about getting into teaching at a free event where you can get all your questions answered by teachers, advisers and training providers.",
     }.with_indifferent_access
 

--- a/app/models/mailing_list/steps/name.rb
+++ b/app/models/mailing_list/steps/name.rb
@@ -39,6 +39,10 @@ module MailingList
         super
       end
 
+      def title
+        nil
+      end
+
     private
 
       def channel_invalid?

--- a/app/views/content/help-and-support.md
+++ b/app/views/content/help-and-support.md
@@ -1,5 +1,5 @@
 ---
-title: "Help and support on getting into teaching"
+title: "Help and support getting into teaching"
 heading: "Get help and support"
 image: "media/images/content/hero-images/0025.jpg"
 title_paragraph: We're here to answer your questions and provide advice about getting into teaching, whether you're just thinking about teaching or you're ready to apply.

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Mailing list wizard", type: :feature do
   include_context "with wizard data"
 
-  let(:mailing_list_page_title) { "Get personalised guidance to your inbox, name step | Get Into Teaching" }
+  let(:mailing_list_page_title) { "Get personalised guidance to your inbox | Get Into Teaching GOV.UK" }
 
   scenario "Full journey as a new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Mailing list wizard", type: :feature do
   include_context "with wizard data"
 
-  let(:mailing_list_page_title) { "Get personalised guidance to your inbox | Get Into Teaching GOV.UK" }
+  let(:mailing_list_page_title) { "Get tailored guidance in your inbox | Get Into Teaching GOV.UK" }
 
   scenario "Full journey as a new candidate" do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \


### PR DESCRIPTION
### Trello card

https://trello.com/c/iegZqeh0/3896-revise-page-titles-for-organic-search-get-help-and-support

### Context

Now that we've added 'GOV.UK' to our page titles, we should review them to try and make sure they don't get truncated by Google.

This PR is for page titles in the get help and support section.

### Changes proposed in this pull request

### Guidance to review

