### PR TITLE
Add a HeadingComponent to standardise headings

### DIFF
--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,8 +1,14 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
     <%= tag.div(icon, class: "call-to-action__icon__container") %>
     <%= tag.div(class: "call-to-action__content") do %>
-      <%= tag.div(caption, class: "caption-m caption--purple caption--bold") if caption %>
-      <%= tag.h2(title, class: "call-to-action__heading") %>
+      <%= render Content::HeadingComponent.new(
+        heading: title,
+        tag: :h2,
+        caption: caption,
+        caption_size: :m,
+        class: %w[call-to-action__heading]
+      ) %>
+
       <%= tag.p(text) if text.present? %>
     <% end %>
     <div class="call-to-action__action">

--- a/app/components/calls_to_action/promo/left_section.html.erb
+++ b/app/components/calls_to_action/promo/left_section.html.erb
@@ -1,27 +1,2 @@
 <div class="<%= wrapper_classes %>">
-  <% if [heading, caption].any?(&:present?) %>
-    <div>
-      <h2 class="heading-m heading--margin-0">
-        <% if caption %>
-          <%= tag.div(caption, class: "caption-m caption--bold") %>
-          <br>
-        <% end %>
-        <%= tag.div(heading) if heading %>
-      </h2>
-    </div>
-  <% end %>
-
-  <% if content.present? %>
-    <div>
-      <div class="promo__content">
-        <%= content %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if link_text && link_target %>
-    <div>
-      <%= link_to(link_text, link_target, class: %w[button button--white button--inline-block]) %>
-    </div>
-  <% end %>
 </div>

--- a/app/components/calls_to_action/promo/left_section.rb
+++ b/app/components/calls_to_action/promo/left_section.rb
@@ -1,11 +1,7 @@
 class CallsToAction::Promo::LeftSection < ViewComponent::Base
-  attr_reader :caption, :heading, :link_text, :link_target, :classes
+  attr_reader :classes
 
-  def initialize(heading: nil, caption: nil, link_text: nil, link_target: nil, classes: [])
-    @caption = caption
-    @heading = heading
-    @link_text = link_text
-    @link_target = link_target
+  def initialize(classes: [])
     @classes = classes
 
     super

--- a/app/components/calls_to_action/promo/right_section.html.erb
+++ b/app/components/calls_to_action/promo/right_section.html.erb
@@ -1,11 +1,13 @@
 <div class="promo__right">
-  <h2 class="heading-l">
-    <% if caption %>
-      <%= tag.div(caption, class: "caption-l caption--purple caption--bold") %>
-    <% end %>
-
-    <%= tag.div(heading) %>
-  </h2>
+  <div>
+    <%= render Content::HeadingComponent.new(
+      heading: heading,
+      heading_size: :l,
+      tag: :h2,
+      caption: caption,
+      caption_size: :l
+    ) %>
+  </div>
 
   <%= content %>
 </div>

--- a/app/components/calls_to_action/promo/right_section.html.erb
+++ b/app/components/calls_to_action/promo/right_section.html.erb
@@ -1,13 +1,10 @@
 <div class="promo__right">
-  <div>
-    <%= render Content::HeadingComponent.new(
-      heading: heading,
-      heading_size: :l,
-      tag: :h2,
-      caption: caption,
-      caption_size: :l
-    ) %>
-  </div>
-
+  <%= render Content::HeadingComponent.new(
+    heading: heading,
+    heading_size: :l,
+    tag: :h2,
+    caption: caption,
+    caption_size: :l
+  ) %>
   <%= content %>
 </div>

--- a/app/components/content/heading_component.rb
+++ b/app/components/content/heading_component.rb
@@ -1,0 +1,75 @@
+module Content
+  class HeadingComponent < ViewComponent::Base
+    attr_reader :heading,
+                :tag,
+                :heading_size,
+                :caption,
+                :caption_size,
+                :caption_bold,
+                :caption_purple
+
+    def initialize(
+      heading: nil,
+      tag: :h1,
+      heading_size: nil,
+      caption: nil,
+      caption_size: nil,
+      caption_bold: true,
+      caption_purple: true,
+      **kwargs
+    )
+      super
+
+      @heading = heading
+      @heading_size = heading_size
+      @caption = caption
+      @caption_size = caption_size
+      @caption_bold = caption_bold
+      @caption_purple = caption_purple
+      @tag = tag
+      @kwargs = kwargs || {}
+    end
+
+    def call
+      safe_join(
+        [
+          (content_tag(:span, caption, class: caption_classes) if caption),
+          content_tag(tag, content_tag(:span, heading), **kwargs),
+        ],
+      )
+    end
+
+    def render?
+      heading.present?
+    end
+
+    def before_render
+      validate!
+    end
+
+  private
+
+    def validate!
+      fail(ArgumentError, "heading_size must be :s, :m, :l, :xl or :xxl") unless heading_size.nil? || heading_size.in?(%i[s m l xl xxl])
+      fail(ArgumentError, "tag must be :h1, :h2, :h3 or :h4") unless tag.in?(%i[h1 h2 h3 h4])
+      fail(ArgumentError, "caption_size must be :m, :l or :xxl") unless caption_size.nil? || caption_size.in?(%i[m l xxl])
+    end
+
+    def kwargs
+      @kwargs.tap do |h|
+        h[:class] = Array.wrap(@kwargs[:class]).tap do |c|
+          c << "heading-#{heading_size}" if heading_size
+          c << "heading--with-caption" if caption
+        end
+      end
+    end
+
+    def caption_classes
+      [].tap do |c|
+        c << "caption-#{caption_size}" if caption_size
+        c << "caption--bold" if caption_bold
+        c << "caption--purple" if caption_purple
+      end
+    end
+  end
+end

--- a/app/views/content/funding-and-support/_why-teach.html.erb
+++ b/app/views/content/funding-and-support/_why-teach.html.erb
@@ -1,10 +1,12 @@
 <section class="why-teach" aria-label="Why teach?">
   <div class="why-teach__container">
     <div class="why-teach__content">
-      <h2 class="heading-l">
-        <div class="caption-l caption--bold caption--purple">Why teach?</div>
-        Find out what teaching is really like
-      </h2>
+      <%= render Content::HeadingComponent.new(
+        heading: "Find out what teaching is really like",
+        tag: :h2,
+        caption: "Why teach?",
+        caption_size: :l
+      ) %>
 
       <p>
         If you’re not sure if teaching is the right career for you,

--- a/app/views/content/is-teaching-right-for-me/_get_school_experience.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_get_school_experience.html.erb
@@ -2,7 +2,7 @@
   <div class="grey">
     <section class="col col-full-content inset">
       <%= render(CallsToAction::Promo::PromoComponent.new(border: :none, reverse: true)) do |promo| %>
-        <% promo.left_section(heading: nil, classes: %w[gse-background]) %>
+        <% promo.left_section(classes: %w[gse-background]) %>
 
           <% promo.right_section(heading: "Get school experience") do %>
               <p>School experience can help you explore what life is really like in the classroom and which subject and age range you'd like to teach.</p>

--- a/app/views/content/non-uk-teachers/_why-teach.html.erb
+++ b/app/views/content/non-uk-teachers/_why-teach.html.erb
@@ -1,10 +1,12 @@
 <section class="why-teach" aria-label="Why teach?">
   <div class="why-teach__container">
     <div class="why-teach__content">
-      <h2 class="heading-l">
-        <div class="caption-l caption--bold caption--purple">Why teach in England?</div>
-        Join a world class education system
-      </h2>
+      <%= render Content::HeadingComponent.new(
+        heading: "Join a world class education system",
+        tag: :h2,
+        caption: "Why teach in England?",
+        caption_size: :l
+      ) %>
 
       <p>
         The English education system offers international teachers the opportunity to make a real difference in children’s lives. Discover why you should teach in England.

--- a/app/views/content/non-uk-teachers/promos/_events-promo-iqts.html.erb
+++ b/app/views/content/non-uk-teachers/promos/_events-promo-iqts.html.erb
@@ -1,11 +1,5 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-  <% promo.left_section(
-      caption: "19 December 2022",
-      heading: "Advice for international applicants",
-      link_target: "/events/221219-advice-for-international-applicants",
-      link_text: "Sign up for this event") do %>
-    <p>Ask a panel of experts questions related to being an international applicant.<p>
-  <% end %>
+  <% promo.left_section(classes: []) %>
 
   <% promo.right_section(
         caption: "Online events",

--- a/app/views/content/train-to-be-a-teacher/_why-teach.html.erb
+++ b/app/views/content/train-to-be-a-teacher/_why-teach.html.erb
@@ -1,10 +1,12 @@
 <section class="why-teach" aria-label="Why teach?">
   <div class="why-teach__container">
     <div class="why-teach__content">
-      <h2 class="heading-l">
-        <div class="caption-l caption--bold caption--purple">Why teach?</div>
-        Inspire the next generation
-      </h2>
+      <%= render Content::HeadingComponent.new(
+        heading: "Inspire the next generation",
+        tag: :h2,
+        caption: "Why teach?",
+        caption_size: :l
+      ) %>
 
       <p>
         The impact of your work as a teacher will be felt beyond the classroom

--- a/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
@@ -2,7 +2,7 @@
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
-        caption: "Online and in-person events",
+        : "Online and in-person events",
         heading: "Get tips on your application") do %>
       <p>Talk to teacher training providers, expert advisers and teachers to get help writing your teacher training application.</p>
 

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,10 +3,14 @@
 
 <section class="container supplementary">
   <header>
-    <h1>
-      <span class="caption-xxl">Error 403</span>
-      <%= @page_title %>
-    </h1>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 403",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
   </header>
 
   <article class="text-content">

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -3,10 +3,14 @@
 
 <section class="container supplementary">
   <header>
-    <h1>
-      <span class="caption-xxl">Error 500</span>
-      <%= @page_title %>
-    </h1>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 500",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
   </header>
 
   <article class="text-content">

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,10 +3,14 @@
 
 <section class="container supplementary">
   <header>
-    <h1>
-      <span class="caption-xxl">Error 404</span>
-      <%= @page_title %>
-    </h1>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 404",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
   </header>
 
   <article class="text-content">

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -3,10 +3,14 @@
 
 <section class="container supplementary">
   <header>
-    <h1>
-      <span class="caption-xxl">Error 429</span>
-      <%= @page_title %>
-    </h1>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 429",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
   </header>
 
   <article class="text-content">

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -3,10 +3,14 @@
 
 <section class="container supplementary">
   <header>
-    <h1>
-      <span class="caption-xxl">Error 422</span>
-      <%= @page_title %>
-    </h1>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 422",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
   </header>
 
   <article class="text-content">

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -12,14 +12,10 @@
 
           <% if !@front_matter["image"] %>
             <header>
-              <% if @front_matter["title_caption"].present? %>
-                <%= tag.span(@front_matter["title_caption"], class: "caption") %>
-              <% end %>
-
-              <%= tag.h1 do %>
-                <%= @front_matter["heading"] || @front_matter["title"] %>
-              <% end %>
-
+              <%= render Content::HeadingComponent.new(
+                heading: @front_matter["heading"] || @front_matter["title"],
+                heading_size: :xxl
+              ) %>
             </header>
           <% end %>
 

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -18,10 +18,6 @@
 
               <%= tag.h1 do %>
                 <%= @front_matter["heading"] || @front_matter["title"] %>
-
-                <% if @front_matter["subheading"].present? || @front_matter["subtitle"].present? %>
-                  <%= tag.div(@front_matter["subheading"] || @front_matter["subtitle"], class: "subheading") %>
-                <% end %>
               <% end %>
 
             </header>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -10,16 +10,6 @@
         <section class="main-section container">
           <%= render(partial: "sections/content_errors") %>
 
-          <% if !@front_matter["image"] %>
-            <header>
-              <% if @front_matter["title_caption"].present? %>
-                <%= tag.span(@front_matter["title_caption"], class: "caption") %>
-              <% end %>
-
-              <%= tag.h1(@front_matter["title"]) %>
-            </header>
-          <% end %>
-
           <%= tag.article(class: article_classes(@front_matter)) do %>
 
             <%= yield %>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -13,10 +13,6 @@
   &__cards {
 	  padding-bottom: 2em;
     width: 100%;
-
-    > h2 {
-      margin-top: 2em;
-    }
   }
 
   &__nav-cards ul {

--- a/app/webpacker/styles/components/promo.scss
+++ b/app/webpacker/styles/components/promo.scss
@@ -67,7 +67,6 @@
     flex-direction: column;
 
     @include mq($from: tablet) {
-      gap: $indent-amount / 2;
       padding-right: $indent-amount;
     }
 

--- a/app/webpacker/styles/components/promo.scss
+++ b/app/webpacker/styles/components/promo.scss
@@ -37,9 +37,6 @@
     background-image: url("../images/content/homepage/here-to-help.jpg");
     background-position: center;
     background-size: cover;
-    display: flex;
-    flex-direction: column;
-    gap: .5em;
     padding-block: 2em;
     min-height: 8em;
 
@@ -62,26 +59,6 @@
       background-image: url("../images/content/hero-images/0021.jpg");
       background-position-y: 50%;
     }
-
-    > div {
-      padding: 0 1em .3em 1em;
-      max-width: 60%;
-    }
-
-    h2 > *,
-    .promo__content {
-      display: inline-block;
-      background-color: $yellow;
-      padding: .4rem .8rem;
-    }
-
-    p {
-      margin: 0;
-    }
-
-    .button {
-      display: inline-block;
-    }
   }
 
   &__right {
@@ -94,11 +71,7 @@
       padding-right: $indent-amount;
     }
 
-    > * {
-      margin: 1rem 0;
-    }
-
-    p {
+    p, h2 {
       margin-top: 0;
     }
 
@@ -110,10 +83,6 @@
     label,
     input {
       margin-bottom: .4em;
-    }
-
-    p:last-of-type {
-      margin-bottom: 0;
     }
 
     form {

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -48,10 +48,6 @@
   font-weight: bold;
 }
 
-.subheading {
-  font-size: 0.6em;
-}
-
 .heading-xxl {
   @include font-size("xxlarge");
 

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -96,6 +96,10 @@
   transform: translateY(-50%);
 }
 
+.heading--with-caption {
+  margin-top: 0;
+}
+
 .heading--box-transparent {
   @include box-heading(transparent, $black);
 }

--- a/docs/content.md
+++ b/docs/content.md
@@ -6,6 +6,7 @@ This documentation aims to be a reference for content editors that want to make 
 
 1. [Finding a Page/Content to Edit](#finding-a-pagecontent-to-edit)
 2. [Content Editing Tips/Info](#content-editing-tips-info)
+	* [Headings](#headings)
 	* [Frontmatter](#frontmatter)
 	* [Links](#links)
 	* [SEO](#seo)
@@ -49,6 +50,20 @@ If you are looking to edit content associated with a form element in particular 
 The majority of pages on the website are formatted in Markdown, which is a lightweight markup language designed for creating and formatting text. 
 
 There is a [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet/) that serves as a good reference on how to standard formatting, such as making something **bold** or *italic*. In conjunction with page frontmatter (see below) we can do some extra GiT-specific things in our Markdown, which this section aims to explain.
+
+### Headings
+
+Where possible we should use the `HeadingComponent` to render a heading; especially if it contains a caption. For example:
+
+```
+render HeadingComponent.new(
+  heading: "My heading",
+  tag: :h2,
+  heading_size: :l,
+  caption: "My caption",
+  caption_size: :m
+)
+```
 
 ### Frontmatter
 

--- a/spec/components/calls_to_action/promo/promo_component_spec.rb
+++ b/spec/components/calls_to_action/promo/promo_component_spec.rb
@@ -5,15 +5,7 @@ RSpec.describe CallsToAction::Promo::PromoComponent, type: :component do
   let(:reverse) { false }
   let(:component) { described_class.new(border: border, reverse: reverse) }
 
-  let(:left_args) do
-    {
-      caption: "left-caption",
-      heading: "left-heading",
-      link_text: "left-link-text",
-      link_target: "/left-link-target",
-    }
-  end
-
+  let(:left_args) { {} }
   let(:right_args) do
     {
       caption: "right-caption",
@@ -23,7 +15,7 @@ RSpec.describe CallsToAction::Promo::PromoComponent, type: :component do
 
   before do
     render_inline(component) do |c|
-      c.left_section(**left_args) { "left-content" }
+      c.left_section(**left_args)
       c.right_section(**right_args) { "right-content" }
     end
   end
@@ -40,41 +32,18 @@ RSpec.describe CallsToAction::Promo::PromoComponent, type: :component do
   end
 
   describe "left side" do
-    it { is_expected.to have_css(".promo__left h2", text: "left-heading") }
-    it { is_expected.to have_css(".promo__left h2 > .caption-m", text: "left-caption") }
-    it { is_expected.to have_css(".promo__left .promo__content", text: "left-content") }
-    it { is_expected.to have_link("left-link-text", href: "/left-link-target") }
-
-    context "when the caption is omitted" do
-      let(:left_args) { { heading: "left-heading-no-link" } }
-
-      it { is_expected.not_to have_css(".promo__left .caption") }
-    end
-
-    context "when the link is omitted" do
-      let(:left_args) { { caption: "left-caption-no-link", heading: "left-heading-no-link" } }
-
-      it { is_expected.not_to have_css(".promo__left a") }
-    end
-
     context "when classes are provided" do
-      let(:left_args) { { heading: "heading", classes: %w[one two three] } }
+      let(:left_args) { { classes: %w[one two three] } }
 
       it {
         is_expected.to have_css(".promo__left.one.two.three")
       }
     end
-
-    context "when there is no caption or heading" do
-      let(:left_args) { { heading: nil, caption: nil } }
-
-      it { is_expected.not_to have_css(".promo__left h2") }
-    end
   end
 
   describe "right side" do
     it { is_expected.to have_css(".promo__right h2", text: "right-heading") }
-    it { is_expected.to have_css(".promo__right h2 > .caption-l", text: "right-caption") }
+    it { is_expected.to have_css(".promo__right .caption-l", text: "right-caption") }
     it { is_expected.to have_css(".promo__right", text: "right-content") }
 
     context "when the caption is omitted" do

--- a/spec/components/content/heading_component_spec.rb
+++ b/spec/components/content/heading_component_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe Content::HeadingComponent, type: :component do
+  let(:heading) { "Heading" }
+  let(:tag) { :h2 }
+  let(:heading_size) { :xl }
+  let(:caption) { nil }
+  let(:caption_size) { :m }
+  let(:caption_bold) { false }
+  let(:caption_purple) { false }
+
+  let(:component) do
+    described_class.new(
+      heading: heading,
+      tag: tag,
+      heading_size: heading_size,
+      caption: caption,
+      caption_size: caption_size,
+      caption_bold: caption_bold,
+      caption_purple: caption_purple,
+      class: %w[custom-class],
+    )
+  end
+
+  subject(:render) do
+    render_inline(component)
+    page
+  end
+
+  it { is_expected.to have_css("h2.heading-xl.custom-class span", text: heading) }
+
+  it { is_expected.not_to have_css(".heading--with-caption") }
+
+  context "when heading is blank" do
+    let(:heading) { "" }
+
+    it { is_expected.not_to have_css("h2") }
+  end
+
+  context "when given a caption" do
+    let(:caption) { "Caption" }
+
+    it { is_expected.to have_css("h2.heading--with-caption") }
+    it { is_expected.to have_css("span.caption-m", text: caption) }
+
+    it { is_expected.not_to have_css("span.caption--purple") }
+    it { is_expected.not_to have_css("span.caption--bold") }
+
+    context "when caption_purple is true" do
+      let(:caption_purple) { true }
+
+      it { is_expected.to have_css("span.caption--purple") }
+    end
+
+    context "when caption_bold is true" do
+      let(:caption_bold) { true }
+
+      it { is_expected.to have_css("span.caption--bold") }
+    end
+  end
+
+  describe "validation" do
+    context "when the heading_size is invaid" do
+      let(:heading_size) { :massive }
+
+      it { expect { render }.to raise_error(ArgumentError, "heading_size must be :s, :m, :l, :xl or :xxl") }
+    end
+
+    context "when the tag is invaid" do
+      let(:tag) { :div }
+
+      it { expect { render }.to raise_error(ArgumentError, "tag must be :h1, :h2, :h3 or :h4") }
+    end
+
+    context "when the caption_size is invaid" do
+      let(:caption_size) { :tiny }
+
+      it { expect { render }.to raise_error(ArgumentError, "caption_size must be :m, :l or :xxl") }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-3870](https://trello.com/c/EaKaoEaP/3870-address-heading-structure-on-promo-modules-including-find-module)

### Context

We have inconsistencies around how we display headings on the website. We also currently embed captions within the heading tag which is not accessible. In an effort to make headings more consistent going forward we're introducing a `HeadingComponent` and also moving the caption outside the heading as part of this.

### Changes proposed in this pull request

- Add heading component

Adds a `HeadingComponent` to help ensure consistent headings throughout the site, specifically when used with a caption.

- Remove subheadings/subtitles

These no longer appear to be referenced so we can remove the style and presentation code in the layout.

- Use HeadingComponent for captions

Anywhere we use a caption we want to render it via the `HeadingComponent` for consistency.

Remove all content from `left_section` of `PromoComponent` as we no longer want to display any here and it contained a caption.

- Update content guidance for headings

### Guidance to review

I started replacing all heading tags with the new component but the number of changes is enormous; I think it would be better to do this gradually as we go in and change content.

We can add more to the `HeadingComponent` to support box headings/highlighting/margins but I'll pick this up in a follow-up PR.

The headings updated so far are in the promo sections, the home page, the 'why teach' sections and the content page headings.