### PR TITLE
Prevent GTM loading until consent is set

### DIFF
--- a/app/webpacker/javascript/gtm.js
+++ b/app/webpacker/javascript/gtm.js
@@ -6,6 +6,8 @@ export default class Gtm {
   }
 
   init() {
+    this.containerInitialized = false;
+
     this.initWindow();
     this.sendDefaultConsent();
     this.initContainer();
@@ -29,6 +31,12 @@ export default class Gtm {
   }
 
   initContainer() {
+    if (!this.cookiePreferences.cookieSet || this.containerInitialized) {
+      return;
+    }
+
+    this.containerInitialized = true;
+
     (function (w, d, s, l, i) {
       w[l] = w[l] || [];
       w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
@@ -44,6 +52,7 @@ export default class Gtm {
   listenForConsentChanges() {
     document.addEventListener('cookies:accepted', () => {
       window.gtag('consent', 'update', this.consent());
+      this.initContainer();
     });
   }
 
@@ -66,7 +75,7 @@ export default class Gtm {
   }
 
   consentValue(category) {
-    return new CookiePreferences().allowedCategories.includes(category)
+    return this.cookiePreferences.allowedCategories.includes(category)
       ? 'granted'
       : 'denied';
   }
@@ -74,5 +83,9 @@ export default class Gtm {
   get originalLocation() {
     const l = window.location;
     return `${l.protocol}://${l.hostname}${l.pathname}${l.search}`;
+  }
+
+  get cookiePreferences() {
+    return new CookiePreferences();
   }
 }

--- a/spec/javascript/gtm_spec.js
+++ b/spec/javascript/gtm_spec.js
@@ -60,13 +60,6 @@ describe('Google Tag Manager', () => {
         ])
       );
     });
-
-    it('appends the GTM script', () => {
-      const scriptTag = document.querySelector(
-        "script[src^='https://www.googletagmanager.com/gtm.js?id=ABC-123']"
-      );
-      expect(scriptTag).not.toBeNull();
-    });
   });
 
   describe('on Turbolinks page changes', () => {
@@ -92,6 +85,13 @@ describe('Google Tag Manager', () => {
       run();
     });
 
+    it('does not append the GTM script', () => {
+      const scriptTag = document.querySelector(
+        "script[src^='https://www.googletagmanager.com/gtm.js?id=ABC-123']"
+      );
+      expect(scriptTag).toBeNull();
+    });
+
     it('sends GTM defaults with all cookies denied', () => {
       expect(window.gtag).toHaveBeenCalledWith('consent', 'default', {
         analytics_storage: 'denied',
@@ -100,12 +100,22 @@ describe('Google Tag Manager', () => {
     });
 
     describe('when cookies are accepted', () => {
-      it('updates GTM of all cookie preferences', () => {
+      beforeEach(() => {
         new CookiePreferences().setCategories({ marketing: true });
+      });
+
+      it('updates GTM of all cookie preferences', () => {
         expect(window.gtag).toHaveBeenCalledWith('consent', 'update', {
           analytics_storage: 'denied',
           ad_storage: 'granted',
         });
+      });
+
+      it('appends the GTM script', () => {
+        const scriptTag = document.querySelector(
+          "script[src^='https://www.googletagmanager.com/gtm.js?id=ABC-123']"
+        );
+        expect(scriptTag).not.toBeNull();
       });
     });
   });
@@ -122,6 +132,13 @@ describe('Google Tag Manager', () => {
         analytics_storage: 'granted',
         ad_storage: 'denied',
       });
+    });
+
+    it('appends the GTM script', () => {
+      const scriptTag = document.querySelector(
+        "script[src^='https://www.googletagmanager.com/gtm.js?id=ABC-123']"
+      );
+      expect(scriptTag).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
### Trello card

[Trello-3927](https://trello.com/c/gMNw6FUh/3927-investigate-issue-with-omnigov-tags-not-firing)

### Context

When a user first lands on the website the default consent of 'block everything' is applied prior to loading the GTM container. Once they opt-in/out of cookies we update GTM with the new consent level and tags will fire on triggers thereafter.

This is an issue for the first page view, as the page view event triggers _before_ the consent is set by the user. Instead, we want to delay loading the GTM container until the initial consent is set. This results in the page view event firing _after_ the consent is applied, even though the page view has already happened.

### Changes proposed in this pull request

- Prevent GTM loading until consent is set

### Guidance to review

