### PR TITLE
Use an older Lychee version

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v1.5.1
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Trello card
https://trello.com/c/maWVGvc6/729-fix-lychee-workflow-error

### Context
Lychee v1.5.2 seems to have introduced some breaking changes either with the set-output removal for $GITHUB_ENV or a directory issue

### Changes proposed in this pull request
- Fix the version to the last known working version v1.5.1

### Guidance to review

