### PR TITLE
Removing h2 on food for thought promo

### DIFF
--- a/app/views/content/landing/food-for-thought/_promo.html.erb
+++ b/app/views/content/landing/food-for-thought/_promo.html.erb
@@ -1,10 +1,7 @@
 <div class="row">
   <section class="col col-content-full">
     <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
-      <% promo.left_section(
-          heading: "Explore teaching advisers", classes: %w[tta-background]) do %>
-      <% end %>
-
+      <% promo.left_section(classes: %w[tta-background]) %>
       <% promo.right_section(
         heading: "Find out what teaching is really like"
       ) do %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/t59iIGyg/3951-remove-h2-from-promo-on-food-for-thought-page

### Context

For accessibility reasons, we need to remove the h2s in front of our images on our promos.

This PR is to remove the one on the promo on the food for thought page.

### Changes proposed in this pull request

### Guidance to review

