### PR TITLE
Minor tweaks to layouts/spacing

### DIFF
--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -5,8 +5,8 @@
       <p>Get dedicated one-to-one support from an adviser with years of teaching experience.</p>
     </div>
 
-    <nav class="category__nav-cards">
-      <ul class="inset">
+    <nav class="category__nav-cards inset">
+      <ul>
         <%= render Categories::CardComponent.new(heading_tag: "h3", card:
           OpenStruct.new(
             title: "Explore teaching advisers",

--- a/app/views/content/is-teaching-right-for-me/_a_job_like_no_other.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_a_job_like_no_other.html.erb
@@ -1,14 +1,14 @@
-<div class="row inset">
+<div class="row">
   <section class="col col-full-content">
     <h2 class="heading--box-blue">A job like no other</h2>
 
-    <p class="col-640">
+    <p class="col-640 inset">
       Looking for challenge and variety? As a teacher you'll work with lots of young people with a range of abilities,
       thinking on your feet to find creative solutions to problems.
     </p>
   </section>
 
-  <section class="col col-845">
+  <section class="col col-845 inset">
     <%= render Content::PhotoQuoteListComponent.new(
       [
         {

--- a/app/views/content/is-teaching-right-for-me/_facts_and_figures.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_facts_and_figures.html.erb
@@ -1,4 +1,4 @@
-<div class="row inset">
+<div class="row">
   <section class="col col-full-content">
     <h2 class="heading--box-blue">Numbers to know</h2>
 

--- a/app/views/content/is-teaching-right-for-me/_making_a_difference.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_making_a_difference.html.erb
@@ -1,13 +1,13 @@
-<div class="row inset">
+<div class="row">
   <section class="col col-full-content">
     <h2 class="heading--box-blue">Making a difference</h2>
 
-    <p class="col-640">
+    <p class="col-640 inset">
       As a teacher, your passion and creativity will inspire and shape future generations.
     </p>
   </section>
 
-  <section class="col col-845">
+  <section class="col col-845 inset">
     <%= render Content::PhotoQuoteListComponent.new(
       [
         {

--- a/app/views/content/is-teaching-right-for-me/_your_career_your_path.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_your_career_your_path.html.erb
@@ -1,7 +1,9 @@
 <div class="row">
   <div class="grey col">
-    <section class="col col-full-content inset">
+    <section class="col col-full-content">
       <h2 class="heading--box-blue">Your career, your path</h2>
+
+      <div class="inset">
         <p>
           Teaching gives you the chance to shape a role that suits your skills, situation and ambition.
         </p>
@@ -22,6 +24,7 @@
             link: page_path("blog/abigails-career-progression-story"),
           }
         ) %>
+      </div>
     </section>
   </div>
 </div>

--- a/app/views/content/is-teaching-right-for-me/_your_career_your_path.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_your_career_your_path.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="grey">
+  <div class="grey col">
     <section class="col col-full-content inset">
       <h2 class="heading--box-blue">Your career, your path</h2>
         <p>

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -1,5 +1,5 @@
 <div class="row inset">
-  <section class="col col-720 statement">
+  <section class="col col-720 col-space-m statement">
     <div>
       <span class="pink xlarge bold">Physics initial teacher training courses for</span>
     </div>
@@ -30,7 +30,7 @@
     </p>
   </section>
 
-  <section class="col col-content-max">
+  <section class="col col-space-s col-content-max">
     <%= render TextBlockWithTwoImagesComponent.new(
       heading: "Engineering the future",
       colour: "pink",
@@ -49,7 +49,7 @@
     <% end %>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-720 col-space-m">
     <h2 class="heading-s">Engineers teach physics training programme</h2>
 
     <p>This new programme is based on the physics initial teacher training (ITT) course, and has been developed with support from the physics and engineering community. It has been adapted to help you make the transition from engineering or material sciences to teaching physics. The course is designed to capitalise on your experience and empower you with the skills needed to become a great physics teacher.
@@ -68,7 +68,7 @@
      </p>
   </section>
 
-  <section class="col col-720 col-horizontal">
+  <section class="col col-720 col-horizontal col-space-m">
     <div>
       <h2 class="heading-s">What you'll learn</h2>
 
@@ -86,7 +86,7 @@
     </div>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-720 col-space-m">
     <h2 class="heading-s">How we can help</p>
 
     <p>If you would like more information about the course and application process, you can talk to a teacher training adviser. They can help you to:</p>
@@ -102,7 +102,7 @@
     </p>
   </section>
 
-  <section class="col col-640">
+  <section class="col col-640 col-space-m">
     <%= render Content::QuoteComponent.new(
       text: "My engineering degree provided a natural transition to teaching physics and
         I value the way science – especially physics – teaches a clear thought process
@@ -113,7 +113,7 @@
     ) %>
   </section>
 
-  <section class="col col-content-max">
+  <section class="col col-content-max col-space-s">
     <%= render TextBlockWithOneImageComponent.new(
       heading: "Support with funding",
       colour: "yellow",

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -1,5 +1,5 @@
 <div class="row inset">
-  <section class="col col-720 statement">
+  <section class="col col-720 col-space-m statement">
     <div>
       <span class="pink xlarge bold">Maths is&hellip;</span>
     </div>
@@ -36,7 +36,7 @@
     </p>
   </section>
 
-  <section class="col col-content-max">
+  <section class="col col-space-s col-content-max">
     <%= render TextBlockWithTwoImagesComponent.new(
       heading: "Maths is for everyone",
       colour: "pink",
@@ -58,7 +58,7 @@
     <% end %>
   </section>
 
-  <section class="col col-640">
+  <section class="col col-640 col-space-s">
     <%= render Content::QuoteComponent.new(
       text: "You can literally change young people’s lives by being a maths teacher.
           Be the person who helps them see the beauty and importance of maths.
@@ -69,7 +69,7 @@
     ) %>
   </section>
 
-  <section class="col col-720 col-horizontal">
+  <section class="col col-720 col-horizontal col-space-m">
     <div>
       <h2 class="heading-s">What you'll be teaching</h2>
 
@@ -92,7 +92,7 @@
     </div>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-space-l col-720">
     <h2 class="heading-s">Some examples of what you teach 11 to 14 year olds:</h2>
 
     <ul>
@@ -125,7 +125,7 @@
     </p>
   </section>
 
-  <section class="col col-content-max">
+  <section class="col col-space-s col-content-max">
     <%= render TextBlockWithOneImageComponent.new(
       heading: "Getting into teacher training",
       colour: "yellow",
@@ -134,7 +134,7 @@
     ) %>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-space-m col-720">
     <h2 class="heading-s">Funding for teaching maths</h2>
 
     <p>
@@ -146,7 +146,7 @@
     </p>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-space-m col-720">
     <h2 class="heading-s">Maths internships</h2>
 
     <p>
@@ -156,7 +156,7 @@
     </p>
   </section>
 
-  <section class="col col-720">
+  <section class="col col-space-m col-720">
     <h2 class="heading-s">Improving your maths subject knowledge</h2>
 
     <p>

--- a/app/views/layouts/category.html.erb
+++ b/app/views/layouts/category.html.erb
@@ -16,9 +16,9 @@
       </section>
 
       <% grouped_categories(@page.path).each do |title, pages| %>
-        <section class="container category__cards inset main-section">
+        <section class="container category__cards main-section">
           <%= tag.h2(title, class: "heading--box-blue") %>
-          <%= tag.nav(aria: { label: "#{title} category" }, class: "category__nav-cards") do %>
+          <%= tag.nav(aria: { label: "#{title} category" }, class: "category__nav-cards inset") do %>
             <ul class="inset">
               <%= render(Categories::CardComponent.with_collection(pages, heading_tag: "h3")) %>
             </ul>

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -7,6 +7,7 @@
     img {
       max-width: 100%;
       height: auto;
+      box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     }
 
     picture:nth-of-type(1) {
@@ -74,7 +75,7 @@
       margin: $indent-amount 0;
 
       &:not(:first-child) {
-        margin-top: 4em;
+        margin-top: 3.5em;
       }
 
       .fa-check {

--- a/app/webpacker/styles/components/photo-quote-list.scss
+++ b/app/webpacker/styles/components/photo-quote-list.scss
@@ -133,7 +133,7 @@ ol.photo-quote-list {
     }
 
     blockquote {
-      margin-bottom: 0;
+      margin: $indent-amount 0 0 0;
     }
   }
 

--- a/app/webpacker/styles/components/quote.scss
+++ b/app/webpacker/styles/components/quote.scss
@@ -1,5 +1,5 @@
 .quote {
-  margin: $indent-amount 0;
+  margin: 0;
   width: 100%;
 
   &--background-yellow {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -156,7 +156,19 @@ section.container {
   }
 
   .col {
-    margin: 0 auto 3em auto;
+    margin: 0 auto 3 * $indent-amount auto;
+  }
+
+  .col-space-s {
+    margin-bottom: 1 * $indent-amount;
+  }
+
+  .col-space-m {
+    margin-bottom: 2 * $indent-amount;
+  }
+
+  .col-space-0 {
+    margin-bottom: 0;
   }
 
   .col-full-page {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -145,7 +145,6 @@ section.container {
 .inset {
   padding: 0 $indent-amount;
   box-sizing: border-box;
-  margin: 0 auto;
   width: 100%;
 }
 

--- a/app/webpacker/styles/vertical-tags.scss
+++ b/app/webpacker/styles/vertical-tags.scss
@@ -1,6 +1,7 @@
 .vertical-tags {
   $divider-colour: #0b0c0c;
 
+  margin: 0;
   display: flex;
   gap: .4em;
   flex-direction: column;


### PR DESCRIPTION
### Trello card

[Trello-3953](https://trello.com/c/LTnOS2uT/3953-make-further-tweaks-to-components-following-layout-clean-up)

### Context

We want more granular control over the spacing between content sections so that we can adjust it on the subject specific pages. We also want a drop shadow on the image collage on 'is teaching right for me?' and the blue headings to be consistently aligned with the content.

### Changes proposed in this pull request

- Spacing tweaks to subject specific pages

Adds spacing qualifiers to the `col` class so that we can tweak the spacing between sections more easily.

- Make heading indentation consistent

We want all headings with a blue background/white text to be flush with the edge of the viewport on smaller viewports.

### Guidance to review

