### PR TITLE
Pin page speed task http request action

### DIFF
--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -21,7 +21,7 @@ jobs:
         key: HTTP-USERNAME, HTTP-PASSWORD
 
     - name: Run Page Speed Tas
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@fd5cf60c69049efb1397207cc8b442709a869685
       with:
         url: 'https://get-into-teaching-app-pagespeed.london.cloudapps.digital/pagespeed/run'
         method: 'POST'


### PR DESCRIPTION
[Trello-3956](https://trello.com/c/578fYyFQ/3956-look-into-page-speed-action-failing)

The page speed task started failing ~20 days ago, it looks like it times out after 15 minutes. I think a change in the http request action we're using has caused it; rolling back to a sha on the date it was last working for us to rule it out.