### PR TITLE
Change site name in structured data

### DIFF
--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -72,7 +72,7 @@ module StructuredDataHelper
 
   def home_structured_data
     data = {
-      name: suffix_title(nil),
+      name: "Get Into Teaching",
       url: root_url,
       potentialAction: {
         "@type": "SearchAction",

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -187,7 +187,7 @@ describe StructuredDataHelper, type: "helper" do
       expect(data).to include({
         "@type": "WebSite",
         url: root_url,
-        name: "Get Into Teaching GOV.UK",
+        name: "Get Into Teaching",
       })
     end
 


### PR DESCRIPTION
### Trello card

[Trello-3959](https://trello.com/c/B1iLhK9S/3959-amend-structured-data-site-name-in-an-attempt-to-get-google-to-display-it)

### Context

Google is not registering out site name from the structure data. As far as we can tell its in the correct format, so we think Google may be ignoring our site name because it things we're trying to impersonate a government body (which is one of the reasons they list).

Remove `GOV.UK` from the site name to see if Google registers it.

### Changes proposed in this pull request

- Change site name in structured data

### Guidance to review

