### PR TITLE
Add no results content for about GiT events page

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -62,7 +62,7 @@
       <% else %>
         <section class="col col-space-m">
           <div class="col-640">
-            <p><strong>Our autumn events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
+            <p><strong>Our autumn Get Into Teaching events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
           </div>
         </section>
 

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -47,17 +47,47 @@
         image_alt: "A woman at a Get Into Teaching event wearing a blue T-shirt with Here to Help written on it.",
       ) %>
 
-      <section class="category__cards">
-        <%= tag.nav(class: "category__nav-cards") do %>
-          <ul class="one-column horizontal">
-            <%= render(Categories::CardComponent.with_collection(categorise_events(@git_events))) %>
-          </ul>
-        <% end %>
-        <div>
-          <h2 class="heading-s">Can't find what you're looking for?</h2>
-          <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }}), class: "link--black") %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
-        </div>
-      </section>
+      <% if @git_events.any? %>
+        <section class="category__cards">
+          <%= tag.nav(class: "category__nav-cards") do %>
+            <ul class="one-column horizontal">
+              <%= render(Categories::CardComponent.with_collection(categorise_events(@git_events))) %>
+            </ul>
+          <% end %>
+          <div>
+            <h2 class="heading-s">Can't find what you're looking for?</h2>
+            <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }}), class: "link--black") %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
+          </div>
+        </section>
+      <% else %>
+        <section class="col col-space-m">
+          <div class="col-640">
+            <p><strong>Our autumn events are now closed. Details of our spring events will be published on this page in early 2023.</strong></p>
+          </div>
+        </section>
+
+        <section class="col">
+          <div class="col-640">
+            <p>In the meantime, take a look at our <%= link_to("online events", events_path({ teaching_events_search: { online: [true] }}), class: "link--black") %> or <%= link_to("events near you", events_path, class: "link--black") %>.</p>
+          </div>
+        </section>
+
+        <section class="col">
+          <div class="col-640">
+            <h2 class="heading-m">Get event updates and advice in your inbox</h2>
+
+            <p>Get a better idea if teaching is right for you with regular information on:</p>
+
+            <ul>
+              <li>what it's like to be a teacher</li>
+              <li>different ways to train</li>
+              <li>teacher training events you can attend</li>
+            </ul>
+
+            <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %></p>
+          </div>
+        </section>
+      <% end %>
     </section>
   </div>
 

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -81,7 +81,7 @@
             <ul>
               <li>what it's like to be a teacher</li>
               <li>different ways to train</li>
-              <li>teacher training events you can attend</li>
+              <li>events near you</li>
             </ul>
 
             <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %></p>

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -62,7 +62,7 @@
       <% else %>
         <section class="col col-space-m">
           <div class="col-640">
-            <p><strong>Our autumn events are now closed. Details of our spring events will be published on this page in early 2023.</strong></p>
+            <p><strong>Our autumn events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
           </div>
         </section>
 

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -84,7 +84,7 @@
               <li>events near you</li>
             </ul>
 
-            <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %></p>
+            <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %>.</p>
           </div>
         </section>
       <% end %>

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -60,32 +60,26 @@
           </div>
         </section>
       <% else %>
-        <section class="col col-space-m">
-          <div class="col-640">
-            <p><strong>Our autumn Get Into Teaching events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
-          </div>
+        <section class="col col-720 col-space-m">
+          <p><strong>Our autumn Get Into Teaching events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
         </section>
 
-        <section class="col">
-          <div class="col-640">
-            <p>In the meantime, take a look at our <%= link_to("online events", events_path({ teaching_events_search: { online: [true] }}), class: "link--black") %> or <%= link_to("events near you", events_path, class: "link--black") %>.</p>
-          </div>
+        <section class="col col-720">
+          <p>In the meantime, take a look at our <%= link_to("online events", events_path({ teaching_events_search: { online: [true] }}), class: "link--black") %> or <%= link_to("events near you", events_path, class: "link--black") %>.</p>
         </section>
 
-        <section class="col">
-          <div class="col-640">
-            <h2 class="heading-m">Get event updates and advice in your inbox</h2>
+        <section class="col col-720">
+          <h2 class="heading-m">Get event updates and advice in your inbox</h2>
 
-            <p>Get a better idea if teaching is right for you with regular information on:</p>
+          <p>Get a better idea if teaching is right for you with regular information on:</p>
 
-            <ul>
-              <li>what it's like to be a teacher</li>
-              <li>different ways to train</li>
-              <li>events near you</li>
-            </ul>
+          <ul>
+            <li>what it's like to be a teacher</li>
+            <li>different ways to train</li>
+            <li>events near you</li>
+          </ul>
 
-            <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %>.</p>
-          </div>
+          <p><%= link_to("Get event updates and advice in your inbox", mailing_list_steps_path, class: "link--black") %>.</p>
         </section>
       <% end %>
     </section>

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -97,6 +97,12 @@ describe "teaching events", type: :request do
       subject { response.body }
 
       it { expect(response).to have_http_status(:success) }
+
+      context "when there are no GiT events" do
+        let(:events) { [] }
+
+        it { is_expected.to include("Our autumn Get Into Teaching events are now closed.") }
+      end
     end
 
     describe "#git_statistics" do


### PR DESCRIPTION
### Trello card

[Trello-3911](https://trello.com/c/MEZlmkIu/3911-update-about-git-events-page-for-end-of-autumn-programme)

### Context

We currently don't display any specific message when there are no Get Into Teaching events left for the current year.

Add content for when there are 0 GiT events.

### Changes proposed in this pull request

- Add no results content for about GiT events page

### Guidance to review

Do we want to automate the year so it changes from `2023` to `2024` etc at a certain time of year?

| Mobile      | Desktop |
| ----------- | ----------- |
| ![screencapture-0-0-0-0-3000-events-about-get-into-teaching-events-2022-11-28-10_30_32](https://user-images.githubusercontent.com/29867726/204255685-031d5452-1b53-4e12-9cfe-73fe9176fca2.png)   | ![screencapture-0-0-0-0-3000-events-about-get-into-teaching-events-2022-11-28-10_30_12](https://user-images.githubusercontent.com/29867726/204255739-06545773-4c3a-4a20-8de4-bb29138c66b7.png)       |

