### PR TITLE
Switch home page CTAs

### DIFF
--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -1,19 +1,19 @@
 <div class="homepage-feature blocks">
   <%= render CallsToAction::HomepageComponent.new(
-    icon: "icon-calendar",
-    title: "Online and in-person events",
-    text: "Talk to teachers, expert advisers and teacher training providers at an event to find out more about getting into teaching.",
-    link_text: "Find an event",
-    link_target: "/events",
-    image: "media/images/content/homepage/here-to-help.jpg")
-  %>
-
-  <%= render CallsToAction::HomepageComponent.new(
     icon: "icon-person",
     title: "Get one-to-one support",
     text: "Talk to an adviser with years of teaching experience to find out if teaching is for you and how to take your next steps.",
     link_text: "Get an adviser",
     link_target: "/tta-service",
     image: "media/images/content/homepage/teacher-training-adviser.jpg")
+  %>
+
+  <%= render CallsToAction::HomepageComponent.new(
+    icon: "icon-calendar",
+    title: "Online and in-person events",
+    text: "Talk to teachers, expert advisers and teacher training providers at an event to find out more about getting into teaching.",
+    link_text: "Find an event",
+    link_target: "/events",
+    image: "media/images/content/homepage/here-to-help.jpg")
   %>
 </div>

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -125,7 +125,7 @@
     grid-template-columns: 1.2fr .8fr;
     overflow: visible;
 
-    &:first-child .call-to-action__image {
+    &:last-child .call-to-action__image {
       background-position: 70%;
     }
 


### PR DESCRIPTION
### Trello card

[Trello-3962](https://trello.com/c/IXg4JLAM/3962-switch-events-and-adviser-blocks-on-the-get-help-and-support-page)

### Context

We want to highlight the TTA CTA more prominently, so moving it to the left side of the page.

### Changes proposed in this pull request

- Switch home page CTAs

### Guidance to review

