### PR TITLE
Swtch events/TTA help and support sections

### DIFF
--- a/app/views/content/help-and-support.md
+++ b/app/views/content/help-and-support.md
@@ -12,7 +12,7 @@ talk_to_us: false
 content:
   - content/help-and-support/header
   - content/help-and-support/talk-to-us
-  - content/help-and-support/events
-  - content/help-and-support/mailing_list
   - content/help-and-support/categories
+  - content/help-and-support/mailing_list
+  - content/help-and-support/events
 ---

--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -1,25 +1,27 @@
-<section class="category">
-  <section class="container category__cards main-section">
-    <h2 class="heading--box-blue">Talk to an adviser</h2>
-    <div class="inset">
-      <p>Get dedicated one-to-one support from an adviser with years of teaching experience.</p>
-    </div>
+<div class="row">
+  <section class="category col-space-m">
+    <section class="container category__cards main-section">
+      <h2 class="heading--box-blue">Talk to an adviser</h2>
+      <div class="inset">
+        <p>Get dedicated one-to-one support from an adviser with years of teaching experience.</p>
+      </div>
 
-    <nav class="category__nav-cards inset">
-      <ul>
-        <%= render Categories::CardComponent.new(heading_tag: "h3", card:
-          OpenStruct.new(
-            title: "Explore teaching advisers",
-            description: "If you're a student and not in your final year of study, an adviser can help you find out more about teaching as a career.",
-            path: "/explore-teaching-advisers"
-          )) %>
-        <%= render Categories::CardComponent.new(heading_tag: "h3", card:
-          OpenStruct.new(
-            title: "Teacher training advisers",
-            description: "If you already have a degree or are a final year student, an adviser can help you understand how to get into teaching.",
-            path: "/teacher-training-advisers"
-          )) %>
-      </ul>
-    </nav>
+      <nav class="category__nav-cards inset">
+        <ul>
+          <%= render Categories::CardComponent.new(heading_tag: "h3", card:
+            OpenStruct.new(
+              title: "Explore teaching advisers",
+              description: "If you're a student and not in your final year of study, an adviser can help you find out more about teaching as a career.",
+              path: "/explore-teaching-advisers"
+            )) %>
+          <%= render Categories::CardComponent.new(heading_tag: "h3", card:
+            OpenStruct.new(
+              title: "Teacher training advisers",
+              description: "If you already have a degree or are a final year student, an adviser can help you understand how to get into teaching.",
+              path: "/teacher-training-advisers"
+            )) %>
+        </ul>
+      </nav>
+    </section>
   </section>
-</section>
+</div>

--- a/app/views/content/help-and-support/_events.html.erb
+++ b/app/views/content/help-and-support/_events.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <section class="col col-full-content">
-    <%= render(CallsToAction::Promo::PromoComponent.new(border: :bottom)) do |promo| %>
+    <%= render(CallsToAction::Promo::PromoComponent.new(border: :top)) do |promo| %>
       <% promo.left_section(classes: %w[events-background]) %>
       <% promo.right_section(
             caption: "Events near you",


### PR DESCRIPTION
### Trello card

[Trello-3962](https://trello.com/c/IXg4JLAM/3962-switch-events-and-adviser-blocks-on-the-get-help-and-support-page)

### Context

We want the TTA section to be higher up/more prominent.

### Changes proposed in this pull request

- Switch events/TTA help and support sections

### Guidance to review

