### PR TITLE
Update button type to be submit

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -160,7 +160,7 @@
       </fieldset>
 
       <p class="save-with-confirmation">
-        <button type="button"
+        <button type="submit"
           data-action="cookie-preferences#save"
           class="call-to-action-button">
           Save


### PR DESCRIPTION
### Trello card

[Trello-2800](https://trello.com/c/pofP6wt7/2800-investigate-adding-submit-button-to-cookie-preferences)

### Context

Silktide flagged that this button should have a `type="submit"` for compatibility with screen readers as its submitting a form.

### Changes proposed in this pull request

- Update button type to be submit

### Guidance to review

