### PR TITLE
Editing link to Find on teach SEND page

### DIFF
--- a/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -28,7 +28,7 @@ Most disabled pupils and pupils with special educational needs learn in mainstre
 
 No matter what settings you train and work in – whether it's mainstream schools, special schools, or both – you’ll work with pupils with complex needs.
 
-You can [find a course which specialises in special educational needs and disability (SEND)](https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2) if you have a particular interest in this area.
+You can [look for a teacher training course](https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2) and filter by 'courses with an SEND specialism' if you have a particular interest in the area.
 
 However, it’s not essential to do a course specialising in SEND.
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/tZz5crgW/3970-amend-the-send-page-to-clarify-how-to-find-courses-with-a-send-specialism

### Context

Editing our link to Find on the teach SEND page to better explain to users how they can filter their courses to find SEND specialism courses.

### Changes proposed in this pull request

### Guidance to review

