### PR TITLE
Make book a callback button primary/green

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -17,7 +17,7 @@
     <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
 
     <div class="mailing-list__actions">
-      <%= link_to("Book a callback", callbacks_steps_path, class: "button button--secondary") %>
+      <%= link_to("Book a callback", callbacks_steps_path, class: "button") %>
       <div>
         <small>or call us now:</small>
         <p class="telephone">0800 389 2500</p>


### PR DESCRIPTION
### Trello card

[Trello-3969](https://trello.com/c/NkwyFlp3/3969-change-callback-button-on-mailing-list-completion-page-to-green)

### Context

Update the book a callback button on the mailing list completion page to be a primary/green button.

### Changes proposed in this pull request

- Make book a callback button primary/green

### Guidance to review

<img width="1542" alt="Screenshot 2022-12-02 at 10 02 56" src="https://user-images.githubusercontent.com/29867726/205267571-1b80af44-5dd0-42d0-b750-e56598746e4e.png">
