### PR TITLE
Fix unused promo section

### DIFF
--- a/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_events-promo-apply.html.erb
@@ -1,8 +1,7 @@
-
 <%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
   <% promo.left_section(classes: %w[events-background]) %>
   <% promo.right_section(
-        : "Online and in-person events",
+        caption: "Online and in-person events",
         heading: "Get tips on your application") do %>
       <p>Talk to teacher training providers, expert advisers and teachers to get help writing your teacher training application.</p>
 


### PR DESCRIPTION
### Trello card

[Trello-3976](https://trello.com/c/z4gfDc9s/3976-fix-snyk-security-scanner-error)

### Context

We are getting a false positive error from Snyk/brakeman scanning this file as there is a syntax error on line 5. It's
not causing issues to users/our tests because the partial is unused.

Fix syntax error (we want to use this partial again the future).

### Changes proposed in this pull request

- Fix events promo section

### Guidance to review

