### PR TITLE
Update integration specs for new privacy policy

### DIFF
--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -44,10 +44,6 @@ RSpec.feature "Integration tests", :integration, type: :feature, js: true do
 
     expect(page).to have_text "If you give us your postcode"
     fill_in "Your postcode (optional)", with: "TE57 1NG"
-    click_on "Next step"
-
-    expect(page).to have_text("Accept privacy policy")
-    click_label "Yes"
     click_on "Complete sign up"
 
     expect(page).to have_text("you're signed up")


### PR DESCRIPTION
### Trello card

[Trello-](https://trello.com/c/CplXLIuG/4004-update-integration-steps-to-remove-privacy-policy-step)

### Context

We no longer have the privacy policy step; remove it from the integration tests.

### Changes proposed in this pull request

- Update integration specs for new privacy policy

### Guidance to review

