### PR TITLE
Add South West Teacher Training to Assessment only page

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -357,6 +357,11 @@ provider_groups:
       name: Julie Walker
       telephone: 0300 123 1967
       email: JLWalker@somerset.gov.uk
+    - header: South West Teacher Training
+      link: https://www.swtt.net/
+      name: Carrie McMillan
+      telephone: 01392 686165
+      email: swtt@westexe.devon.sch.uk
     - header: Wessex Schools Training Partnership
       name: Claire Porter
       telephone: 01202 662038


### PR DESCRIPTION
### Trello card
https://trello.com/c/p2U8TWZV

### Context
Request received via support team to add South West Teacher Training SCITT to the Assessment only page
