### PR TITLE
[735] Remove HTTP auth from pagespeed

### DIFF
--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Run Page Speed
-      uses: fjogeleit/http-request-action@86014825e97036cd3e0903bbc72b3c5fff7474c4
+      uses: fjogeleit/http-request-action@fd5cf60c69049efb1397207cc8b442709a869685
       with:
         url: https://get-into-teaching-app-pagespeed.london.cloudapps.digital/pagespeed/run
         method: POST

--- a/.github/workflows/pagespeed.yml
+++ b/.github/workflows/pagespeed.yml
@@ -8,24 +8,10 @@ jobs:
   pagespeed:
     runs-on: ubuntu-latest
     steps:
-
-    - uses: Azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - uses: DfE-Digital/keyvault-yaml-secret@v1
-      id:  keyvault-yaml-secret
-      with:
-        keyvault: ${{ secrets.KEY_VAULT}}
-        secret: INFRA-KEYS
-        key: HTTP-USERNAME, HTTP-PASSWORD
-
-    - name: Run Page Speed Tas
+    - name: Run Page Speed
       uses: fjogeleit/http-request-action@86014825e97036cd3e0903bbc72b3c5fff7474c4
       with:
-        url: 'https://get-into-teaching-app-pagespeed.london.cloudapps.digital/pagespeed/run'
-        method: 'POST'
-        username: ${{ steps.keyvault-yaml-secret.outputs.HTTP-USERNAME }}
-        password: ${{ steps.keyvault-yaml-secret.outputs.HTTP-PASSWORD }}
+        url: https://get-into-teaching-app-pagespeed.london.cloudapps.digital/pagespeed/run
+        method: POST
         timeout: 3600000 # 1hr in ms
         preventFailureOnNoResponse: true


### PR DESCRIPTION
### Trello card
https://trello.com/c/1IlDCQuo

### Context
Failing pagespeed job with `Access denied`: https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/3655563663

### Changes proposed in this pull request
The pagespeed endpoint doesn't require authentication so we don't need to send the credentials

### Guidance to review
https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/3648073887
It still failed, but hopefully that's another issue