### PR TITLE
Changing international funding card description

### DIFF
--- a/app/views/content/funding-and-support/if-you-come-from-outside-england.md
+++ b/app/views/content/funding-and-support/if-you-come-from-outside-england.md
@@ -11,7 +11,7 @@ promo_content:
     - content/funding-and-support/promos/mailing-list-promo
 navigation: 20.35
 navigation_title: If you come from outside England
-navigation_description: Find out about the different arrangements for getting financial support if you live outside England.
+navigation_description: Find out about financial support if you come from Scotland, Wales, Northern Ireland, the Channel Islands or outside the UK.
 keywords:
     - Student Finance
     - Financial Support


### PR DESCRIPTION
### Trello card

https://trello.com/c/X34kwyg6/3986-rename-international-card-on-funding-and-support-category-page

### Context

In UR, we found that users were confused by this card on the fund your training page - the heading and the description suggest different things.

We should change the description to make the content clearer.

### Changes proposed in this pull request

### Guidance to review

