### PR TITLE
Remove Essex Primary SCITT and Cumbria Teacher Training SCITT from Assessment only page

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -217,9 +217,6 @@ provider_groups:
       name: Karen Craven
       telephone: 0161 973 1179 (ext 2289)
       email: karencraven@thedeantrust.co.uk
-    - header: Cumbria Teacher Training
-      link: http://www.ctt.ac.uk
-      email: scittlead@ctt.ac.uk
     - header: Educate Group Initial Teacher Training
       link: https://educate-group.co.uk/initial-teacher-training/
       name: Claire King

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -37,11 +37,6 @@ provider_groups:
       name: Steve Fox
       telephone: 01376 556398
       email: admin@midessexteachertraining.com
-    - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
-      link: https://www.essexprimaryscitt.co.uk/
-      name: Fiona Willett
-      telephone: '0738885808'
-      email: fiona@essexprimaryscitt.co.uk
     - header: Norfolk Teacher Training Centre
       link: https://www.norfolkttc.org.uk/
       name: Jacqui Waring


### PR DESCRIPTION
### Trello card
https://trello.com/c/TUD2m1Qz

https://trello.com/c/0ICITwG9

### Context
We have received requests via the GIT support team to remove Essex Primary SCITT and Cumbria Teacher Training SCITT from the Assessment only page
