### PR TITLE
Remove talk to us section from overseas page

### DIFF
--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -14,6 +14,7 @@ navigation_description: Find out how you can bring your skills and perspective t
 date: "2021-05-27"
 image: "media/images/content/hero-images/0002.jpg"
 backlink: "../../"
+talk_to_us: false
 keywords:
   - International
   - Overseas

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -77,6 +77,6 @@
         <% end %>
       <% end %>
 
-      <%= render FooterComponent.new %>
+      <%= render FooterComponent.new(**@front_matter.slice("talk_to_us").symbolize_keys) %>
     <% end %>
 </html>


### PR DESCRIPTION
We want to remove the talk to us section from the 'Teach in England if you trained overseas' page.

Allow the `FooterComponent` arguments to be overwritten in frontmatter.
