### PR TITLE
Fix colour contrast warning on WAVE tool

### DIFF
--- a/app/webpacker/styles/header/skiplink.scss
+++ b/app/webpacker/styles/header/skiplink.scss
@@ -1,6 +1,7 @@
 .skiplink {
   position: absolute;
   left: -9999em;
+  color: $white;
 
   &:focus {
     left: 0;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -51,6 +51,7 @@
   &__heading {
     @include font-size("large");
     color: $white;
+    background-color: $purple;
 
     line-height: 1.25em;
     max-width: 80%;
@@ -58,6 +59,7 @@
 
   &__text {
     color: $white;
+    background-color: $purple;
   }
 
   &__cta {


### PR DESCRIPTION
### Trello card

[Trello-4035](https://trello.com/c/0MQH4IOi/4035-investigate-colour-contrast-failure-flagged-by-webaim)

### Context

The WAVE chrome extension reports a colour contrast issue on the steps heading/text; it incorrectly thinks we are rendering white text on a white background.

It also picks up on a contrast issue with the skip to main content link, but as this is hidden until you focus on it it's a non-issue (after focusing there is no colour contrast problem).

We can silence this warning by giving the elements an explicit purple background.

### Changes proposed in this pull request

- Fix colour contrast warning on WAVE tool

### Guidance to review

There's one remaining colour contrast issue on the skip to main content l
