### PR TITLE
Forward query params to cookie preferences

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -28,9 +28,10 @@
         <a tabindex="-1" href="#" class="button call-to-action-button" data-action="click->cookie-acceptance#accept" data-cookie-acceptance-target="agree" id="biscuits-agree">
           <span>Accept all cookies</span>
         </a>
-        <a tabindex="-1" class="button button--secondary" href="/cookie_preference" data-cookie-acceptance-target="disagree" id="cookies-disagree">
+
+        <%= link_to(cookie_preference_path(request.query_parameters), tabindex: -1, id: "cookies-disagree", class: "button button--secondary", data: { "cookie-acceptance-target": "disagree" }) do %>
           <span>Set cookie preferences</span>
-        </a>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Trello card

[Trello-4052](https://trello.com/c/F4KZFcqG/4052-investigate-advertising-tagging-issues-for-users-who-opt-out-of-cookies)

### Context

Users will often arrive on the website with tracking query parameters in the URL. As no tags fire until they accept cookies we find that if they go to cookie preferences and then accept the original tracking query parameters are lost.

Forward query parameters to the cookie preferences page, so that if the user then accepts cookies we get the tracking information firing.

### Changes proposed in this pull request

- Forward query params to cookie preferences

### Guidance to review

