### PR TITLE
Handle when there are no callback slots available

### DIFF
--- a/app/helpers/callback_helper.rb
+++ b/app/helpers/callback_helper.rb
@@ -15,4 +15,8 @@ module CallbackHelper
       quota.start_at.in_time_zone.to_date.to_formatted_s(:govuk_date_long)
     end
   end
+
+  def callback_available?
+    Callbacks::Steps::Callback.callback_booking_quotas.any?
+  end
 end

--- a/app/models/callbacks/steps/callback.rb
+++ b/app/models/callbacks/steps/callback.rb
@@ -12,6 +12,10 @@ module Callbacks
       before_validation if: :address_telephone do
         self.address_telephone = address_telephone.to_s.strip.presence
       end
+
+      def can_proceed?
+        self.class.callback_booking_quotas.any?
+      end
     end
   end
 end

--- a/app/views/callbacks/steps/_callback.html.erb
+++ b/app/views/callbacks/steps/_callback.html.erb
@@ -1,18 +1,5 @@
-<h1>Choose a time for your callback</h1>
-
-<p>
-  Enter the number you’d like us to call,
-  then choose the 30 minute slot that suits you best.
-</p>
-
-<p>
-  All slots are in UK time.
-</p>
-
-<p>
-  Please include international dialling code where applicable.
-</p>
-
-<%= f.govuk_phone_field :address_telephone, width: 20 %>
-
-<%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
+<% if f.object.can_proceed? %>
+  <%= render "callbacks/steps/callback/available", f: f %>
+<% else %>
+  <%= render "callbacks/steps/callback/unavailable", f: f %>
+<% end %>

--- a/app/views/callbacks/steps/callback/_available.html.erb
+++ b/app/views/callbacks/steps/callback/_available.html.erb
@@ -1,0 +1,18 @@
+<h1>Choose a time for your callback</h1>
+
+<p>
+  Enter the number you’d like us to call,
+  then choose the 30 minute slot that suits you best.
+</p>
+
+<p>
+  All slots are in UK time.
+</p>
+
+<p>
+  Please include international dialling code where applicable.
+</p>
+
+<%= f.govuk_phone_field :address_telephone, width: 20 %>
+
+<%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>

--- a/app/views/callbacks/steps/callback/_unavailable.html.erb
+++ b/app/views/callbacks/steps/callback/_unavailable.html.erb
@@ -1,0 +1,11 @@
+<h1>We can't call you back at the moment</h1>
+
+<p>As we're getting a lot of requests, we're not able to schedule a call.</p>
+
+<h2 class="heading-m">Give us a call</h2>
+
+<p>Speak with our agents who are experts who can answer questions and offer support.</p>
+
+<p><a href="tel://0800 389 2500">Call us on: 0800 389 2500</a></p>
+
+<p>Monday to Friday between 8:30am and 5:30pm, except on <a target="blank" href="https://www.gov.uk/bank-holidays">bank holidays</a>.</p>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -17,11 +17,18 @@
     <p>Our agents are experts who can answer questions about qualifications, routes into teaching or your application.</p>
 
     <div class="mailing-list__actions">
-      <%= link_to("Book a callback", callbacks_steps_path, class: "button") %>
-      <div>
-        <small>or call us now:</small>
-        <p class="telephone">0800 389 2500</p>
-      </div>
+      <% if callback_available? %>
+        <%= link_to("Book a callback", callbacks_steps_path, class: "button") %>
+        <div>
+          <small>or call us now:</small>
+          <p class="telephone">0800 389 2500</p>
+        </div>
+      <% else %>
+        <div>
+          <small>Call us now:</small>
+          <p class="telephone">0800 389 2500</p>
+        </div>
+      <% end %>
     </div>
 
     <p>Monday to Friday between 8:30am and 5:30pm, except on <a href="https://www.gov.uk/bank-holidays">bank holidays</a>.</p>

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature "Book a callback", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "Choose a time for your callback"
+    expect(page).not_to have_text("We can't call you back at the moment")
     expect(find_field("Phone number").value).to eq(response.address_telephone)
     # Select time in local time zone (London)
     select "11:00am to 12:00pm", from: "Select your preferred day and time for a callback"
@@ -162,6 +163,21 @@ RSpec.feature "Book a callback", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "Sorry, a technical problem means we can’t book your callback right now."
+  end
+
+  context "when here are no callback slots available" do
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \
+        receive(:get_callback_booking_quotas).and_return([])
+    end
+
+    scenario "Viewing the callback page" do
+      visit callbacks_step_path(:callback)
+
+      expect(page).not_to have_text("Choose a time for your callback")
+      expect(page).to have_text("We can't call you back at the moment")
+      expect(page).to have_link("Call us on: 0800 389 2500")
+    end
   end
 
   def fill_in_personal_details_step(

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Mailing list wizard", type: :feature do
   include_context "with wizard data"
   include_context "with stubbed latest privacy policy api"
+  include_context "with stubbed callback quotas api"
 
   let(:mailing_list_page_title) { "Get tailored guidance in your inbox | Get Into Teaching GOV.UK" }
 
@@ -39,6 +40,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_title("You've signed up | Get Into Teaching")
     expect(page).to have_text "You've signed up"
     expect(page).to have_text("You'll receive a welcome email shortly")
+    expect(page).to have_link("Book a callback")
   end
 
   scenario "Full journey as an on-campus candidate" do
@@ -379,6 +381,17 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "Enter your last name"
     expect(page).to have_text "Enter your full email address"
     expect(page).to have_title(mailing_list_page_title)
+  end
+
+  context "when there are no callback slots available" do
+    let(:quotas) { [] }
+
+    scenario "Viewing the completion page" do
+      visit mailing_list_step_path(:completed)
+
+      expect(page).to have_text("You've signed up")
+      expect(page).not_to have_link("Book a callback")
+    end
   end
 
   def fill_in_name_step(

--- a/spec/helpers/callback_helper_spec.rb
+++ b/spec/helpers/callback_helper_spec.rb
@@ -67,4 +67,21 @@ RSpec.describe CallbackHelper, type: :helper do
       }
     end
   end
+
+  describe "#callback_available?" do
+    subject { helper }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \
+        receive(:get_callback_booking_quotas) { quotas }
+    end
+
+    it { is_expected.to be_callback_available }
+
+    context "when there are no quotas" do
+      let(:quotas) { [] }
+
+      it { is_expected.not_to be_callback_available }
+    end
+  end
 end

--- a/spec/models/callbacks/steps/callback_spec.rb
+++ b/spec/models/callbacks/steps/callback_spec.rb
@@ -5,6 +5,7 @@ describe Callbacks::Steps::Callback do
   include_context "with wizard step"
   it_behaves_like "a with wizard step"
   include_context "sanitize fields", %i[address_telephone]
+  include_context "with stubbed callback quotas api"
 
   describe "attributes" do
     it { is_expected.to respond_to :phone_call_scheduled_at }
@@ -19,5 +20,15 @@ describe Callbacks::Steps::Callback do
   describe "#address_telephone" do
     it { is_expected.not_to allow_values(nil, "", "abc12345", "12", "1" * 21).for :address_telephone }
     it { is_expected.to allow_values("123456789").for :address_telephone }
+  end
+
+  describe "#can_proceed?" do
+    it { is_expected.to be_can_proceed }
+
+    context "when there are no callback slots available" do
+      let(:quotas) { [] }
+
+      it { is_expected.not_to be_can_proceed }
+    end
   end
 end

--- a/spec/requests/callbacks/steps_controller_spec.rb
+++ b/spec/requests/callbacks/steps_controller_spec.rb
@@ -4,6 +4,7 @@ describe Callbacks::StepsController, type: :request do
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed latest privacy policy api"
   include_context "with stubbed book callback api"
+  include_context "with stubbed callback quotas api"
 
   it_behaves_like "a controller with a #resend_verification action" do
     def perform_request

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -5,6 +5,7 @@ describe MailingList::StepsController, type: :request do
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed latest privacy policy api"
   include_context "with stubbed mailing list add member api"
+  include_context "with stubbed callback quotas api"
 
   it_behaves_like "a controller with a #resend_verification action" do
     def perform_request

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -76,3 +76,19 @@ shared_context "with stubbed book callback api" do
     stub_request(:post, "#{git_api_endpoint}/api/get_into_teaching/callbacks").to_return(status: 200, body: "", headers: {})
   end
 end
+
+shared_context "with stubbed callback quotas api" do
+  let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
+  let(:quotas) do
+    [
+      GetIntoTeachingApiClient::CallbackBookingQuota.new(
+        start_at: 1.week.from_now,
+        end_at: 1.week.from_now + 30.minutes,
+      ),
+    ]
+  end
+
+  before do
+    stub_request(:get, "#{git_api_endpoint}/api/callback_booking_quotas").to_return(status: 200, body: quotas.to_json, headers: {})
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-4062](https://trello.com/c/n5iRbaIL/4062-review-callback-quota-fallback-functionality-in-light-of-increased-demand)

### Context

Currently if there are no callback slots available in the CRM the API will return a default/fallback list of slots. Going forward we want to prevent users from booking a callback if the slots have been exhausted.

Remove the 'Book a callback' button on the mailing list completion page when there is no availability.

Prevent the user from proceeding past the callback step of the sign up journey if they happen to be mid-way into the journey when the slots are all used up. Instead, we will display a message encouraging them to call us.

### Changes proposed in this pull request

- Handle when there are no callback slots available

### Guidance to review

| Available      | Unavailable |
| ----------- | ----------- |
| <img width="1353" alt="Screenshot 2023-01-06 at 11 26 34" src="https://user-images.githubusercontent.com/29867726/211003590-27f6880b-cf38-4ef9-add7-56a018c110bb.png">      | <img width="1353" alt="Screenshot 2023-01-06 at 11 26 55" src="https://user-images.githubusercontent.com/29867726/211003644-9cef65d1-6e9f-41ca-9123-24bcfc1eea68.png">       |
| <img width="1268" alt="Screenshot 2023-01-06 at 11 25 59" src="https://user-images.githubusercontent.com/29867726/211003512-ac3388d7-5f8c-475e-aae9-1983f190c374.png">   | <img width="1268" alt="Screenshot 2023-01-06 at 11 26 13" src="https://user-images.githubusercontent.com/29867726/211003544-25f863f0-2b0d-4226-8ec5-41bb5189f3bd.png">        |
