### PR TITLE
Prevent cookie acceptance on privacy page with query param

### DIFF
--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -115,7 +115,7 @@ export default class extends Controller {
   }
 
   isPrivacyPage() {
-    const path = window.location.href.replace(/^https?:\/\/[^/]+/, '');
+    const path = window.location.pathname;
     const cookiesPages = ['/cookie_preference', '/cookies', '/privacy-policy'];
 
     return cookiesPages.includes(path);


### PR DESCRIPTION
On the privacy pages (cookie, cookie acceptance, privacy policy) we should never show the cookie acceptance dialog as it obscures the content. This usually is the case, however, when there is a query parameter in the URL the logic fails to match as we are matching a path against a path with a query string.

Match on path without query string.
