### PR TITLE
Fix retaining query params on cookie prefs link

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -29,7 +29,7 @@
           <span>Accept all cookies</span>
         </a>
 
-        <%= link_to(cookie_preference_path(request.query_parameters), tabindex: -1, id: "cookies-disagree", class: "button button--secondary", data: { "cookie-acceptance-target": "disagree" }) do %>
+        <%= link_to(cookie_preference_path, tabindex: -1, id: "cookies-disagree", class: "button button--secondary", data: { "cookie-acceptance-target": "disagree" }) do %>
           <span>Set cookie preferences</span>
         <% end %>
       </div>

--- a/app/webpacker/controllers/cookie-acceptance_controller.js
+++ b/app/webpacker/controllers/cookie-acceptance_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
     if (cookiePrefs.cookieSet) return;
 
     this.showDialog();
+    this.retrainQueryStringOnDisagree();
   }
 
   accept(event) {
@@ -31,6 +32,20 @@ export default class extends Controller {
   showDialog() {
     this.overlayTarget.classList.add('visible');
     this.startInterceptingTabKeydown();
+  }
+
+  retrainQueryStringOnDisagree() {
+    // In case there are tracking parameters passed through the query string
+    // we want to retain then so when they go to /cookie_preferences and accept it
+    // will action them correctly (otherwise they are lost on the page change).
+    const existingParams = new URLSearchParams(window.location.search);
+    const url = new URL(this.disagreeTarget.href);
+
+    existingParams.forEach((value, key) => {
+      url.searchParams.set(key, value);
+    });
+
+    this.disagreeTarget.href = url.pathname + url.search;
   }
 
   resetFocus() {

--- a/spec/javascript/controllers/cookie-acceptance_controller_spec.js
+++ b/spec/javascript/controllers/cookie-acceptance_controller_spec.js
@@ -19,7 +19,7 @@ describe('CookieAcceptanceController', () => {
                 <a tabindex="-1" href="#" id="biscuits-agree" data-cookie-acceptance-target="agree" class="call-to-action-button" data-action="click->cookie-acceptance#accept">
                     Yes, I agree. Continue to the new <span>website</span>
                 </a>
-                <a tabindex="-1" class="secondary-link" href='https://getintoteaching.education.gov.uk/' data-cookie-acceptance-target="disagree" id="cookies-disagree">
+                <a tabindex="-1" class="secondary-link" href='/cookie_preferences' data-cookie-acceptance-target="disagree" id="cookies-disagree">
                   No, I want to go to the current website <i class="fas fa-chevron-right"></i>
                 </a>
             </div>
@@ -33,6 +33,11 @@ describe('CookieAcceptanceController', () => {
 
   beforeEach(() => {
     Cookies.remove('git-cookie-preferences-v1');
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('https://getintoteaching.education.gov.uk/?query=param'),
+    });
 
     acceptButton = document.getElementById('biscuits-agree');
     infoButton = document.querySelector('.cookies-info');
@@ -61,6 +66,10 @@ describe('CookieAcceptanceController', () => {
     it('shows the cookie acceptance dialog', () => {
       const overlay = document.getElementById('overlay');
       expect(overlay.classList.contains('visible')).toBe(true);
+    });
+
+    it('updates the disagree href to retain query parameters', () => {
+      expect(disagreeButton.href).toEqual('http://localhost/cookie_preferences?query=param');
     });
 
     it('updates the tab indexes', () => {


### PR DESCRIPTION
### Trello card

[Trello-4052](https://trello.com/c/F4KZFcqG/4052-investigate-advertising-tagging-issues-for-users-who-opt-out-of-cookies)

### Context

We were previously passing the query parameters through as part of the template rendering, but our static page cache prevents this from updating properly.

Instead, we need to update the path in Javascript when we sho the dialog.

### Changes proposed in this pull request

- Fix retaining query params on cookie prefs link

### Guidance to review

