### PR TITLE
Add inset component with event links

### DIFF
--- a/app/components/content/inset_text_component.html.erb
+++ b/app/components/content/inset_text_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.section(class: "inset-text") do %>
+<%= tag.section(class: classes) do %>
   <%= tag.h2(title) if title.present? %>
   <%= tag.p(helpers.safe_html_format(text)) %>
 <% end %>

--- a/app/components/content/inset_text_component.rb
+++ b/app/components/content/inset_text_component.rb
@@ -1,12 +1,19 @@
 module Content
   class InsetTextComponent < ViewComponent::Base
-    attr_reader :title, :text
+    attr_reader :title, :text, :color
 
-    def initialize(text:, title: nil)
+    def initialize(text:, title: nil, color: "yellow")
       super
 
       @text = text
       @title = title
+      @color = color
+    end
+
+    def classes
+      %w[inset-text].tap do |c|
+        c << color
+      end
     end
   end
 end

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -24,11 +24,16 @@
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
       <%= render(partial: "teaching_events/show/how-to-attend") %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
-      <%= render(partial: "teaching_events/show/other-events") %>
+      <div class="hide-on-mobile">
+        <%= render(partial: "teaching_events/show/other-events") %>
+      </div>
     </article>
 
     <aside role="complementary">
       <%= render(partial: "teaching_events/show/venue-information") if @event.show_venue_information? %>
+      <div class="hide-on-desktop hide-on-tablet">
+        <%= render(partial: "teaching_events/show/other-events") %>
+      </div>
     </aside>
   </div>
 

--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -24,6 +24,7 @@
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
       <%= render(partial: "teaching_events/show/how-to-attend") %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
+      <%= render(partial: "teaching_events/show/other-events") %>
     </article>
 
     <aside role="complementary">

--- a/app/views/teaching_events/show/_other-events.erb
+++ b/app/views/teaching_events/show/_other-events.erb
@@ -2,7 +2,7 @@
   title: "Find more events",
   color: "grey",
   text: <<~HTML
-    <p>We have lots more online and in-person events where you can get your questions answered about teaching.</p>
+    <p>There are lots more online and in-person events where you can get your questions answered about teaching.</p>
     <p>#{link_to("Explore our events", events_path)}</p>
     HTML
 ) %>

--- a/app/views/teaching_events/show/_other-events.erb
+++ b/app/views/teaching_events/show/_other-events.erb
@@ -3,6 +3,6 @@
   color: "grey",
   text: <<~HTML
     <p>There are lots more online and in-person events where you can get your questions answered about teaching.</p>
-    <p>#{link_to("Explore our events", events_path)}</p>
+    <p>#{link_to("Explore our events", events_path)}.</p>
     HTML
 ) %>

--- a/app/views/teaching_events/show/_other-events.erb
+++ b/app/views/teaching_events/show/_other-events.erb
@@ -1,0 +1,8 @@
+<%= render Content::InsetTextComponent.new(
+  title: "Find more events",
+  color: "grey",
+  text: <<~HTML
+    <p>We have lots more online and in-person events where you can get your questions answered about teaching.</p>
+    <p>#{link_to("Explore our events", events_path)}</p>
+    HTML
+) %>

--- a/app/webpacker/styles/components/inset-text.scss
+++ b/app/webpacker/styles/components/inset-text.scss
@@ -1,9 +1,29 @@
-.inset-text {
-  margin-top: $indent-amount;
-  margin-bottom: $indent-amount;
+section.inset-text {
+  margin-top: 2 * $indent-amount;
+  margin-bottom: 2 * $indent-amount;
   padding: $indent-amount;
-  background-color: $yellow-light;
-  border-left: 6px solid $black;
+  border-left: 6px solid;
+
+  &.yellow {
+    background-color: $yellow-light;
+    border-left-color: $black;
+  }
+
+  &.grey {
+    border-left-color: $grey-mid;
+  }
+
+  h2 {
+    margin-top: 0;
+  }
+
+  p:first-child {
+    margin-top: 0;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 
   h2,
   p {

--- a/spec/components/content/inset_text_component_spec.rb
+++ b/spec/components/content/inset_text_component_spec.rb
@@ -3,14 +3,15 @@ require "rails_helper"
 describe Content::InsetTextComponent, type: :component do
   let(:title) { "Title" }
   let(:text) { "Text" }
-  let(:component) { described_class.new(text: text, title: title) }
+  let(:color) { "yellow" }
+  let(:component) { described_class.new(text: text, title: title, color: color) }
 
   subject do
     render_inline(component)
     page
   end
 
-  it { is_expected.to have_css("section.inset-text") }
+  it { is_expected.to have_css("section.inset-text.yellow") }
   it { is_expected.to have_css(".inset-text p", text: text) }
   it { is_expected.to have_css(".inset-text h2", text: title) }
 
@@ -30,5 +31,11 @@ describe Content::InsetTextComponent, type: :component do
     let(:text) { %{<script>alert();</script>} }
 
     it { is_expected.not_to have_css("script") }
+  end
+
+  context "when the color is grey" do
+    let(:color) { "grey" }
+
+    it { is_expected.not_to have_css("section.insett-text.grey") }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-4088](https://trello.com/c/j1z9e2Rw/4088-signpost-people-to-all-events-listings-from-individual-event-pages)

### Context

We want to sign post other events from the individual event pages as most people who land on an individual event page bounce without looking at other events.

### Changes proposed in this pull request

- Add inset component with event links
 
Update the event pages to have an inset text component in grey that notifies the user that there are more events available.

### Guidance to review

[Example page](https://review-get-into-teaching-app-3072.london.cloudapps.digital/events/230304-get-into-teaching-north-west-event)

<img width="770" alt="Screenshot 2023-01-10 at 15 36 31" src="https://user-images.githubusercontent.com/29867726/211594585-77c1965c-ddd6-4b80-8aab-056a4129a916.png">
