### PR TITLE
Ensure events signposting is below scribble form

### DIFF
--- a/app/views/teaching_events/show.html.erb
+++ b/app/views/teaching_events/show.html.erb
@@ -24,16 +24,15 @@
       <%= render(partial: "teaching_events/show/attending-training-providers") %>
       <%= render(partial: "teaching_events/show/how-to-attend") %>
       <%= render(partial: "teaching_events/show/provider-info") if @event.show_provider_information? %>
-      <div class="hide-on-mobile">
-        <%= render(partial: "teaching_events/show/other-events") %>
-      </div>
     </article>
 
     <aside role="complementary">
       <%= render(partial: "teaching_events/show/venue-information") if @event.show_venue_information? %>
-      <div class="hide-on-desktop hide-on-tablet">
-        <%= render(partial: "teaching_events/show/other-events") %>
-      </div>
+      <% if @event.scribble_id.blank? %>
+        <div class="hide-on-desktop hide-on-tablet">
+          <%= render(partial: "teaching_events/show/other-events") %>
+        </div>
+      <% end %>
     </aside>
   </div>
 
@@ -42,6 +41,12 @@
       <%= render(partial: "teaching_events/show/scribble") %>
     </div>
   <% end %>
+
+  <div class="container teaching-event__info <%= "hide-on-mobile" if @event.scribble_id.blank? %>">
+    <article>
+      <%= render(partial: "teaching_events/show/other-events") %>
+    </article>
+  </div>
 
   <%= render(partial: "teaching_events/show/what-theyre-saying") %>
 </div>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -509,6 +509,10 @@ $icon-size: 3rem;
       margin: 0 $indent-amount;
     }
 
+    .inset-text.grey {
+      margin: 0;
+    }
+
     @include mq($from: tablet) {
       flex-direction: row;
 
@@ -557,7 +561,7 @@ $icon-size: 3rem;
   }
 
   &__scribble {
-    margin: 4em 1em;
+    margin: 0 1em;
     flex-grow: 1;
   }
 


### PR DESCRIPTION
### Trello card

[Trello-1052](https://trello.com/c/n3nm24bw/1052-move-signposting-to-all-events-below-scribble-box-for-online-qa-events)

### Context

The events sign posting was above the scribble form on the Q&A event types; this ensures it always appears at the bottom of the page, just above the 'What they're saying' section.

### Changes proposed in this pull request

- Enesure events signposting is below scribble form

### Guidance to review

