### PR TITLE
Update internship providers list

### DIFF
--- a/app/views/content/assessment-only-providers/_listing.html.erb
+++ b/app/views/content/assessment-only-providers/_listing.html.erb
@@ -1,5 +1,5 @@
 <h2>Select the region of the provider</h2>
 
-<section class="assessment-only-providers">
+<section class="providers-list">
   <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
 </section>

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -223,7 +223,7 @@ provider_groups:
       email: m.lairini@northerneducationtrust.org
       subjects: chemistry, computing, maths, physics, languages
     - header: Ormiston Academies Trust
-      link: www.ormistonacademiestrust.co.uk
+      link: https://www.ormistonacademiestrust.co.uk/
       name: Jemma Sherwood
       email: jemma.sherwood@ormistonacademies.co.uk
       subjects: chemistry, computing, maths, physics, languages

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -10,7 +10,381 @@ backlink: /
 fullwidth: true
 content:
   - content/teaching-internship-providers/listing
-
+provider_groups:
+  East Midlands:
+    providers:
+      - header: Bluecoat SCITT Alliance
+        link: https://www.bluecoatscittalliance.uk.com/
+        name: Julie Hefferman
+        email: itt@bluecoat.uk.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        name: Claire Amed
+        email: claire.amed@creativeeducationtrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        name: Claire Amed
+        email: claire.amed@creativeeducationtrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        name: Claire Amed
+        email: claire.amed@creativeeducationtrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: George Spencer Academy
+        link: http://www.george-spencer.com/
+        name: Tammy Elward
+        email: tammyelward@satrust.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Leicestershire Secondary SCITT
+        link: https://www.leicestershiresecondaryscitt.org/
+        name: Laura Wharton
+        email: lwharton@rushey-tmet.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Lionheart Teach
+        link: https://www.lionheartteach.org.uk/
+        name: Emma Lowe
+        email: info@lionheartteach.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Nottingham Catholic ITT Partnership
+        link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
+        name: Vanessa Scott
+        email: v.scott@becketonline.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+  East of England:
+    providers:
+      - header: Advanced Learning Partnership
+        link: https://www.advancedlearningpartnership.co.uk/
+        name: Nicola Nicolaou
+        email: nicolaoun@damealiceowens.herts.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Bedfordshire Schools Trust
+        link: https://www.bestteachingschool.org.uk/
+        name: Susanne Combe
+        email: scombe@bestacademies.org.uk
+        subjects: chemistry, maths, physics, languages
+      - header: Benfleet Team Supporting All
+        link: http://www.btsa.uk/
+        name: Maxine Howard
+        email: mhoward@theappletonschool.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Farlingaye High School
+        link: https://www.eastscitt.co.uk/
+        name: Peter Smith
+        email: psmith@farlingaye.suffolk.sch.uk
+        subjects: maths, physics
+      - header: Redborne Teaching Partnership
+        link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
+        name: Vicki Walsh
+        email: vicki.walsh@redborne.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Saffron Walden County High School
+        link: https://www.swchs.net/
+        name: Angela Rodda
+        email: arodda@swchs.net
+        subjects: chemistry, computing, maths, physics, languages
+      - header: South Essex Training and Support Alliance
+        link: https://www.setsa.info/
+        name: David Struthers
+        email: d.struthers@setsa.ingo
+        subjects: chemistry, computing, maths, physics, languages
+      - header: TKAT SCITT
+        link: https://scitt.tkat.org/
+        name: Sarah Drury
+        email: sarah.drury@tkat.org 
+        subjects: chemistry, computing, maths, physics, languages
+      - header: TKAT SCITT
+        link: https://scitt.tkat.org/
+        name: Sarah Drury
+        email: sarah.drury@tkat.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: TKAT SCITT
+        link: https://scitt.tkat.org/
+        name: Sarah Drury
+        email: sarah.drury@tkat.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: The Hertforshire and Essex High School
+        link: https://www.hertsandessex.herts.sch.uk/
+        name: Claire Ruthven
+        email: claire.ruthven@hertsandessex.herts.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+  London:
+    providers:
+      - header: Excalibur
+        link: https://www.stjohns.excalibur.org.uk/
+        name: Emma Hawes
+        email: ehawes@stjohns.excalibur.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: LETTA (London East Teacher Training Alliance)
+        link: https://letta.org.uk/train/
+        name: Ben Sperring
+        email: train@letta.org.uk
+        subjects: maths, physics
+      - header: New River Teaching Alliance
+        link: https://nrta.co.uk/
+        name: Iraj Felfeli
+        email: ifelfeli@alexandrapark.school
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Paddington Academy
+        link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
+        name: Riam Muayad
+        email: riam.muayad@paddington-academy.org
+        subjects: chemistry, maths, physics, languages
+      - header: Reach Academy Feltham
+        link: https://www.reachacademyfeltham.com/
+        name: Ciaran Fitzgerald
+        email: recruitment@reachacademy.org.uk
+        subjects: chemistry, maths, physics, languages
+      - header: St John Southworth Catholic Academy Trust
+        link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
+        name: Patrick Lanigan
+        email: laniganp@cvms.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
+        link: https://www.waldegrave.richmond.sch.uk/591/waldegrave-training-alliance;https://www.orleanspark.school/orleans-park-teaching-alliance/1323972.html
+        name: Claire Lane
+        email: c.lane@waldegravesch.org
+        subjects: chemistry, computing, maths, physics, languages
+  North East:
+    providers:
+      - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
+        link: https://www.centreforteaching.com/initial-teacher-training/internships/
+        name: Anna Herdman
+        email: aherdman@bwcet.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Carmel Teacher Training Partnership
+        link: https://carmelteachertraining.com/teaching-internships/
+        name: Sarah McGee
+        email: smcgee@bhcet.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: North East SCITT
+        link: https://www.northeastscitt.co.uk/
+        name: Susan Ingram
+        email: susan.ingram@nelt.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/
+        name: George W. Robson
+        email: g.robson@outwood.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/
+        name: George W. Robson
+        email: g.robson@outwood.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/
+        name: George W. Robson
+        email: g.robson@outwood.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/
+        name: George W. Robson
+        email: g.robson@outwood.com
+        subjects: chemistry, computing, maths, physics, languages
+  North West:
+    providers:
+      - header: Associated Merseyside Partnership SCITT
+        link: https://www.amp-scitt.lydiatelearningtrust.co.uk/teaching-internship/
+        name: Alison Brady
+        email: a.brady@ampscitt.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Bright Futures SCITT
+        link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/
+        name: Hilary Langmead-Jones
+        email: admin@scitt.bright-futures.co.uk
+        subjects: chemistry, computing, maths, physics
+      - header: Chorlton High School
+        link: https://www.chorltonhigh.manchester.sch.uk/teaching-school/school-experience-programme
+        name: Fazia Chowdhury
+        email: f.chowdhury@chorltonhigh.manchester.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Co-op Academies Trust 
+        link: https://www.coopacademies.co.uk/teaching-internship/
+        name: Andy Gibson 
+        email: andy.gibson@coopacademies.co.uk 
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Cumbria Education Trust
+        link: https://www.williamhoward.cumbria.sch.uk/
+        name: Katy Birks
+        email: kbirks@williamhoward.cumbria.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Great Schools Trust
+        link: https://www.greatschoolstrust.org/train-with-us/train-to-teach-with-school-direct
+        name: Diane Lloyd
+        email: d.lloyd@greatschoolstrust.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: St Mary's College
+        link: https://smchull.org/about-us
+        name: Laura Fillingham
+        email: schooldirect@smchull.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Teach Manchester
+        link: https://teachmanchester.com/
+        name: Graeme Balfour
+        email: gbalfour@loreto.ac.uk
+        subjects: chemistry, computing, maths, physics, languages
+  South East:
+    providers:
+      - header: George Abbot School in partnership with George Abbot SCITT
+        link: https://www.georgeabbot.surrey.sch.uk/
+        name: Joanna Jones
+        email: jjones@georgeabbot.surrey.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Northfleet Technology College
+        link: https://ntc.kent.sch.uk/
+        name: Michael Jones
+        email: jonesm@ntc.kent.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Ringwood School
+        link: https://www.ringwood.hants.sch.uk/
+        name: Clare Adams
+        email: cadams@ringwood.hants.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Ringwood School
+        link: https://www.ringwood.hants.sch.uk/
+        name: Clare Adams
+        email: cadams@ringwood.hants.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Teach Maidenhead
+        link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
+        name: Maria Avellano
+        email: maria.avellano@furzeplatt.net
+        subjects: chemistry, computing, maths, physics, languages
+      - header: The Cherwell School
+        link: https://www.cherwell.oxon.sch.uk/
+        name: Emma Rapson
+        email: erapson@cherwellschool.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Xavier Teach SouthEast
+        link: https://www.teachsoutheast.co.uk/
+        name: Katie Cornforth
+        email: k.cornforth@xaviercet.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Xavier Teach SouthEast
+        link: https://www.teachsoutheast.co.uk/
+        name: Katie Cornforth
+        email: k.cornforth@xaviercet.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: i2i Teaching Partnership
+        link: https://www.i2ipartnership.co.uk/
+        name: Liz Wylie
+        email: lwylie@i2ipartnership.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+  South West:
+    providers:
+      - header: South West Institute for Teaching (SWIFT)
+        link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
+        name: Abby Spearing
+        email: abby.spearing@sw-ift.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: West Country Internships
+        link: https://exetermathematicsschool.ac.uk/internships/
+        name: Kerry Burnham
+        email: kburnham@exeterms.ac.uk
+        subjects: chemistry, computing, maths, physics, languages
+  West Midlands:
+    providers:
+      - header: Barr Beacon SCITT
+        link: https://barrbeaconschool.co.uk/
+        name: Michael Eszrenyi
+        email: meszrenyi@barrbeaconschool.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Biship Challoner Training School
+        link: https://www.bctsa.org/605/teaching-internship-programme
+        name: Angela Hodgin
+        email: trainingschool@bishopchalloner.bham.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
+          School Hub
+        link: https://www.princehenrys.worcs.sch.uk/
+        name: Andy Duffy
+        email: ad@princehenrys.worcs.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: St Jospeph's College
+        link: https://www.stjosephstrentvale.com/
+        name: Sam Chater
+        email: schater@stjosephsmail.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: St Peter's Catholic School Solihull
+        link: https://www.st-peters.solihull.sch.uk/teaching-school/
+        name: Anthony Jones
+        email: jonesa@st-peters.solihull.sch.uk
+        subjects: computing, maths, physics
+      - header: The Coventry SCITT
+        link: https://www.coventryscitt.org.uk/
+        name: Katie Williams
+        email: scittadmin@sidneystringeracademy.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Windsor Academy Trust
+        link: https://www.windsoracademytrust.org.uk/
+        name: Nathalie Gotling
+        email: ngotting@kingswinford.windsoracademytrust.org.uk
+        subjects: chemistry, computing, maths, physics, languages
+  Yorkshire and the Humber:
+    providers:
+      - header: Learners First Schools Partnership
+        link: https://www.learnersfirst.net/
+        name: Georgia Osborne
+        email: gosborne@learnersfirst.org
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Northern Star Academies Trust
+        link: https://www.northernlightsscitt.com/
+        name: Helen Smith
+        email: training@northernlightsscitt.com
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Sheffield SCITT
+        link: https://www.sheffieldscitt.org.uk/
+        name: Stacey Wooliscroft
+        email: hallamtsa@notredame-high.co.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Valley Learning Partnership
+        link: http://www.brighouse.calderdale.sch.uk/
+        name: Janet Brierley
+        email: j.brierley@brighouse.calderdale.sch.uk
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Wigan and West Lancashire Catholic School Direct 
+        link: https://www.catholicsd.org.uk/
+        name: Sarah Holland
+        email: hollands267@saintpetershigh.wigan.sch.uk 
+        subjects: chemistry, computing, maths, physics, languages
+      - header: Wolds Learning Partnership Trust
+        link: https://www.woldgate.net/
+        name: Kirsten Russell
+        email: krussell@wlp.education
+        subjects: chemistry, maths, physics, languages
+      - header: Yorkshire Wolds Teacher Training
+        link: https://ywtt.org.uk/ywtt-paid-internship-programme/
+        name: Sarah Barley
+        email: sarah.barley@theeducationalliance.org.uk
+        subjects: chemistry, computing, maths, physics, languages
 keywords:
   - teaching internship
   - internship

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -19,378 +19,403 @@ content:
 provider_groups:
   East Midlands:
     providers:
-      - header: Bluecoat SCITT Alliance
-        link: https://www.bluecoatscittalliance.uk.com/
-        name: Julie Hefferman
-        email: itt@bluecoat.uk.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Creative Education Trust
-        link: https://www.creativeeducationtrust.org.uk/internship
-        name: Claire Amed
-        email: claire.amed@creativeeducationtrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Creative Education Trust
-        link: https://www.creativeeducationtrust.org.uk/internship
-        name: Claire Amed
-        email: claire.amed@creativeeducationtrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Creative Education Trust
-        link: https://www.creativeeducationtrust.org.uk/internship
-        name: Claire Amed
-        email: claire.amed@creativeeducationtrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: George Spencer Academy
-        link: http://www.george-spencer.com/
-        name: Tammy Elward
-        email: tammyelward@satrust.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Leicestershire Secondary SCITT
-        link: https://www.leicestershiresecondaryscitt.org/
-        name: Laura Wharton
-        email: lwharton@rushey-tmet.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Lionheart Teach
-        link: https://www.lionheartteach.org.uk/
-        name: Emma Lowe
-        email: info@lionheartteach.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Nottingham Catholic ITT Partnership
-        link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
-        name: Vanessa Scott
-        email: v.scott@becketonline.co.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Bluecoat SCITT Alliance
+      link: https://www.bluecoatscittalliance.uk.com/
+      name: Julie Hefferman
+      email: itt@bluecoat.uk.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Creative Education Trust
+      link: https://www.creativeeducationtrust.org.uk/internship
+      name: Claire Amed
+      email: claire.amed@creativeeducationtrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: George Spencer Academy
+      link: http://www.george-spencer.com/
+      name: Tammy Elward
+      email: tammyelward@satrust.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Leicestershire Secondary SCITT
+      link: https://www.leicestershiresecondaryscitt.org/
+      name: Laura Wharton
+      email: lwharton@rushey-tmet.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Lionheart Teach
+      link: https://www.lionheartteach.org.uk/
+      name: Emma Lowe
+      email: info@lionheartteach.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Nottingham Catholic ITT Partnership
+      link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
+      name: Vanessa Scott
+      email: v.scott@becketonline.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Outwood Institute of Education
+      link: https://oie.outwood.com/
+      name: George W. Robson
+      email: g.robson@outwood.com
+      subjects: chemistry, computing, maths, physics, languages
   East of England:
     providers:
-      - header: Advanced Learning Partnership
-        link: https://www.advancedlearningpartnership.co.uk/
-        name: Nicola Nicolaou
-        email: nicolaoun@damealiceowens.herts.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Bedfordshire Schools Trust
-        link: https://www.bestteachingschool.org.uk/
-        name: Susanne Combe
-        email: scombe@bestacademies.org.uk
-        subjects: chemistry, maths, physics, languages
-      - header: Benfleet Team Supporting All
-        link: http://www.btsa.uk/
-        name: Maxine Howard
-        email: mhoward@theappletonschool.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Farlingaye High School
-        link: https://www.eastscitt.co.uk/
-        name: Peter Smith
-        email: psmith@farlingaye.suffolk.sch.uk
-        subjects: maths, physics
-      - header: Redborne Teaching Partnership
-        link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
-        name: Vicki Walsh
-        email: vicki.walsh@redborne.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Saffron Walden County High School
-        link: https://www.swchs.net/
-        name: Angela Rodda
-        email: arodda@swchs.net
-        subjects: chemistry, computing, maths, physics, languages
-      - header: South Essex Training and Support Alliance
-        link: https://www.setsa.info/
-        name: David Struthers
-        email: d.struthers@setsa.ingo
-        subjects: chemistry, computing, maths, physics, languages
-      - header: TKAT SCITT
-        link: https://scitt.tkat.org/
-        name: Sarah Drury
-        email: sarah.drury@tkat.org 
-        subjects: chemistry, computing, maths, physics, languages
-      - header: TKAT SCITT
-        link: https://scitt.tkat.org/
-        name: Sarah Drury
-        email: sarah.drury@tkat.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: TKAT SCITT
-        link: https://scitt.tkat.org/
-        name: Sarah Drury
-        email: sarah.drury@tkat.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: The Hertforshire and Essex High School
-        link: https://www.hertsandessex.herts.sch.uk/
-        name: Claire Ruthven
-        email: claire.ruthven@hertsandessex.herts.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Advanced Learning Partnership
+      link: https://www.advancedlearningpartnership.co.uk/
+      name: Nicola Nicolaou
+      email: nicolaoun@damealiceowens.herts.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Bedfordshire Schools Trust
+      link: https://www.bestteachingschool.org.uk/
+      name: Susanne Combe
+      email: scombe@bestacademies.org.uk
+      subjects: chemistry, maths, physics, languages
+    - header: Benfleet Team Supporting All
+      link: http://www.btsa.uk/
+      name: Maxine Howard
+      email: mhoward@theappletonschool.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Creative Education Trust
+      link: https://www.creativeeducationtrust.org.uk/internship
+      name: Claire Amed
+      email: claire.amed@creativeeducationtrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Farlingaye High School
+      link: https://www.eastscitt.co.uk/
+      name: Peter Smith
+      email: psmith@farlingaye.suffolk.sch.uk
+      subjects: maths, physics
+    - header: Ormiston Academies Trust
+      link: www.ormistonacademiestrust.co.uk
+      name: Jemma Sherwood
+      email: jemma.sherwood@ormistonacademies.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Redborne Teaching Partnership
+      link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
+      name: Vicki Walsh
+      email: vicki.walsh@redborne.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Saffron Walden County High School
+      link: https://www.swchs.net/
+      name: Angela Rodda
+      email: arodda@swchs.net
+      subjects: chemistry, computing, maths, physics, languages
+    - header: South Essex Training and Support Alliance
+      link: https://www.setsa.info/
+      name: David Struthers
+      email: d.struthers@setsa.ingo
+      subjects: chemistry, computing, maths, physics, languages
+    - header: TKAT SCITT
+      link: https://scitt.tkat.org/
+      name: Sarah Drury
+      email: sarah.drury@tkat.org 
+      subjects: chemistry, computing, maths, physics, languages
+    - header: The Hertforshire and Essex High School
+      link: https://www.hertsandessex.herts.sch.uk/
+      name: Claire Ruthven
+      email: claire.ruthven@hertsandessex.herts.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
   London:
     providers:
-      - header: Excalibur
-        link: https://www.stjohns.excalibur.org.uk/
-        name: Emma Hawes
-        email: ehawes@stjohns.excalibur.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: LETTA (London East Teacher Training Alliance)
-        link: https://letta.org.uk/train/
-        name: Ben Sperring
-        email: train@letta.org.uk
-        subjects: maths, physics
-      - header: New River Teaching Alliance
-        link: https://nrta.co.uk/
-        name: Iraj Felfeli
-        email: ifelfeli@alexandrapark.school
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Paddington Academy
-        link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
-        name: Riam Muayad
-        email: riam.muayad@paddington-academy.org
-        subjects: chemistry, maths, physics, languages
-      - header: Reach Academy Feltham
-        link: https://www.reachacademyfeltham.com/
-        name: Ciaran Fitzgerald
-        email: recruitment@reachacademy.org.uk
-        subjects: chemistry, maths, physics, languages
-      - header: St John Southworth Catholic Academy Trust
-        link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
-        name: Patrick Lanigan
-        email: laniganp@cvms.co.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
-        link: https://www.waldegrave.richmond.sch.uk/591/waldegrave-training-alliance;https://www.orleanspark.school/orleans-park-teaching-alliance/1323972.html
-        name: Claire Lane
-        email: c.lane@waldegravesch.org
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Excalibur
+      link: https://www.stjohns.excalibur.org.uk/
+      name: Emma Hawes
+      email: ehawes@stjohns.excalibur.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: LETTA (London East Teacher Training Alliance)
+      link: https://letta.org.uk/train/
+      name: Ben Sperring
+      email: train@letta.org.uk
+      subjects: maths, physics
+    - header: New River Teaching Alliance
+      link: https://nrta.co.uk/
+      name: Iraj Felfeli
+      email: ifelfeli@alexandrapark.school
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Paddington Academy
+      link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
+      name: Riam Muayad
+      email: riam.muayad@paddington-academy.org
+      subjects: chemistry, maths, physics, languages
+    - header: Reach Academy Feltham
+      link: https://www.reachacademyfeltham.com/
+      name: Ciaran Fitzgerald
+      email: recruitment@reachacademy.org.uk
+      subjects: chemistry, maths, physics, languages
+    - header: St John Southworth Catholic Academy Trust
+      link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
+      name: Patrick Lanigan
+      email: laniganp@cvms.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: TKAT SCITT
+      link: https://scitt.tkat.org/
+      name: Sarah Drury
+      email: sarah.drury@tkat.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
+      link: https://www.waldegrave.richmond.sch.uk/591/waldegrave-training-alliance;https://www.orleanspark.school/orleans-park-teaching-alliance/1323972.html
+      name: Claire Lane
+      email: c.lane@waldegravesch.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Xavier Teach SouthEast
+      link: https://www.teachsoutheast.co.uk/
+      name: Katie Cornforth
+      email: k.cornforth@xaviercet.org.uk
+      subjects: chemistry, computing, maths, physics, languages
   North East:
     providers:
-      - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
-        link: https://www.centreforteaching.com/initial-teacher-training/internships/
-        name: Anna Herdman
-        email: aherdman@bwcet.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Carmel Teacher Training Partnership
-        link: https://carmelteachertraining.com/teaching-internships/
-        name: Sarah McGee
-        email: smcgee@bhcet.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: North East SCITT
-        link: https://www.northeastscitt.co.uk/
-        name: Susan Ingram
-        email: susan.ingram@nelt.co.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Northern Education Trust
-        link: https://www.northerneducationtrust.org/
-        name: Meriem Lairini
-        email: m.lairini@northerneducationtrust.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Northern Education Trust
-        link: https://www.northerneducationtrust.org/
-        name: Meriem Lairini
-        email: m.lairini@northerneducationtrust.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Northern Education Trust
-        link: https://www.northerneducationtrust.org/
-        name: Meriem Lairini
-        email: m.lairini@northerneducationtrust.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Outwood Institute of Education
-        link: https://oie.outwood.com/
-        name: George W. Robson
-        email: g.robson@outwood.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Outwood Institute of Education
-        link: https://oie.outwood.com/
-        name: George W. Robson
-        email: g.robson@outwood.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Outwood Institute of Education
-        link: https://oie.outwood.com/
-        name: George W. Robson
-        email: g.robson@outwood.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Outwood Institute of Education
-        link: https://oie.outwood.com/
-        name: George W. Robson
-        email: g.robson@outwood.com
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
+      link: https://www.centreforteaching.com/initial-teacher-training/internships/
+      name: Anna Herdman
+      email: aherdman@bwcet.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Carmel Teacher Training Partnership
+      link: https://carmelteachertraining.com/teaching-internships/
+      name: Sarah McGee
+      email: smcgee@bhcet.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: North East SCITT
+      link: https://www.northeastscitt.co.uk/
+      name: Susan Ingram
+      email: susan.ingram@nelt.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Northern Education Trust
+      link: https://www.northerneducationtrust.org/
+      name: Meriem Lairini
+      email: m.lairini@northerneducationtrust.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Outwood Institute of Education
+      link: https://oie.outwood.com/
+      name: George W. Robson
+      email: g.robson@outwood.com
+      subjects: chemistry, computing, maths, physics, languages
   North West:
     providers:
-      - header: Associated Merseyside Partnership SCITT
-        link: https://www.amp-scitt.lydiatelearningtrust.co.uk/teaching-internship/
-        name: Alison Brady
-        email: a.brady@ampscitt.co.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Bright Futures SCITT
-        link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/
-        name: Hilary Langmead-Jones
-        email: admin@scitt.bright-futures.co.uk
-        subjects: chemistry, computing, maths, physics
-      - header: Chorlton High School
-        link: https://www.chorltonhigh.manchester.sch.uk/teaching-school/school-experience-programme
-        name: Fazia Chowdhury
-        email: f.chowdhury@chorltonhigh.manchester.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Co-op Academies Trust 
-        link: https://www.coopacademies.co.uk/teaching-internship/
-        name: Andy Gibson 
-        email: andy.gibson@coopacademies.co.uk 
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Cumbria Education Trust
-        link: https://www.williamhoward.cumbria.sch.uk/
-        name: Katy Birks
-        email: kbirks@williamhoward.cumbria.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Great Schools Trust
-        link: https://www.greatschoolstrust.org/train-with-us/train-to-teach-with-school-direct
-        name: Diane Lloyd
-        email: d.lloyd@greatschoolstrust.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: St Mary's College
-        link: https://smchull.org/about-us
-        name: Laura Fillingham
-        email: schooldirect@smchull.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Teach Manchester
-        link: https://teachmanchester.com/
-        name: Graeme Balfour
-        email: gbalfour@loreto.ac.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Associated Merseyside Partnership SCITT
+      link: https://www.amp-scitt.lydiatelearningtrust.co.uk/teaching-internship/
+      name: Alison Brady
+      email: a.brady@ampscitt.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Bright Futures SCITT
+      link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/
+      name: Hilary Langmead-Jones
+      email: admin@scitt.bright-futures.co.uk
+      subjects: chemistry, computing, maths, physics
+    - header: Chorlton High School
+      link: https://www.chorltonhigh.manchester.sch.uk/teaching-school/school-experience-programme
+      name: Fazia Chowdhury
+      email: f.chowdhury@chorltonhigh.manchester.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Co-op Academies Trust 
+      link: https://www.coopacademies.co.uk/teaching-internship/
+      name: Andy Gibson 
+      email: andy.gibson@coopacademies.co.uk 
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Cumbria Education Trust
+      link: https://www.williamhoward.cumbria.sch.uk/
+      name: Katy Birks
+      email: kbirks@williamhoward.cumbria.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Great Schools Trust
+      link: https://www.greatschoolstrust.org/train-with-us/train-to-teach-with-school-direct
+      name: Diane Lloyd
+      email: d.lloyd@greatschoolstrust.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Northern Education Trust
+      link: https://www.northerneducationtrust.org/
+      name: Meriem Lairini
+      email: m.lairini@northerneducationtrust.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Ormiston Academies Trust
+      link: www.ormistonacademiestrust.co.uk
+      name: Jemma Sherwood
+      email: jemma.sherwood@ormistonacademies.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: St Mary's College
+      link: https://smchull.org/about-us
+      name: Laura Fillingham
+      email: schooldirect@smchull.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Teach Manchester
+      link: https://teachmanchester.com/
+      name: Graeme Balfour
+      email: gbalfour@loreto.ac.uk
+      subjects: chemistry, computing, maths, physics, languages
   South East:
     providers:
-      - header: George Abbot School in partnership with George Abbot SCITT
-        link: https://www.georgeabbot.surrey.sch.uk/
-        name: Joanna Jones
-        email: jjones@georgeabbot.surrey.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Northfleet Technology College
-        link: https://ntc.kent.sch.uk/
-        name: Michael Jones
-        email: jonesm@ntc.kent.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Ringwood School
-        link: https://www.ringwood.hants.sch.uk/
-        name: Clare Adams
-        email: cadams@ringwood.hants.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Ringwood School
-        link: https://www.ringwood.hants.sch.uk/
-        name: Clare Adams
-        email: cadams@ringwood.hants.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Teach Maidenhead
-        link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
-        name: Maria Avellano
-        email: maria.avellano@furzeplatt.net
-        subjects: chemistry, computing, maths, physics, languages
-      - header: The Cherwell School
-        link: https://www.cherwell.oxon.sch.uk/
-        name: Emma Rapson
-        email: erapson@cherwellschool.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Thinking Schools Academy Trust
-        link: https://www.tsatrust.org.uk/
-        name: Sophie Venables
-        email: s.venables@tsatrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Thinking Schools Academy Trust
-        link: https://www.tsatrust.org.uk/
-        name: Sophie Venables
-        email: s.venables@tsatrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Xavier Teach SouthEast
-        link: https://www.teachsoutheast.co.uk/
-        name: Katie Cornforth
-        email: k.cornforth@xaviercet.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Xavier Teach SouthEast
-        link: https://www.teachsoutheast.co.uk/
-        name: Katie Cornforth
-        email: k.cornforth@xaviercet.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: i2i Teaching Partnership
-        link: https://www.i2ipartnership.co.uk/
-        name: Liz Wylie
-        email: lwylie@i2ipartnership.co.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: George Abbot School in partnership with George Abbot SCITT
+      link: https://www.georgeabbot.surrey.sch.uk/
+      name: Joanna Jones
+      email: jjones@georgeabbot.surrey.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Northfleet Technology College
+      link: https://ntc.kent.sch.uk/
+      name: Michael Jones
+      email: jonesm@ntc.kent.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Ringwood School
+      link: https://www.ringwood.hants.sch.uk/
+      name: Clare Adams
+      email: cadams@ringwood.hants.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: TKAT SCITT
+      link: https://scitt.tkat.org/
+      name: Sarah Drury
+      email: sarah.drury@tkat.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Teach Maidenhead
+      link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
+      name: Maria Avellano
+      email: maria.avellano@furzeplatt.net
+      subjects: chemistry, computing, maths, physics, languages
+    - header: The Cherwell School
+      link: https://www.cherwell.oxon.sch.uk/
+      name: Emma Rapson
+      email: erapson@cherwellschool.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Thinking Schools Academy Trust
+      link: https://www.tsatrust.org.uk/
+      name: Sophie Venables
+      email: s.venables@tsatrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Xavier Teach SouthEast
+      link: https://www.teachsoutheast.co.uk/
+      name: Katie Cornforth
+      email: k.cornforth@xaviercet.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: i2i Teaching Partnership
+      link: https://www.i2ipartnership.co.uk/
+      name: Liz Wylie
+      email: lwylie@i2ipartnership.co.uk
+      subjects: chemistry, computing, maths, physics, languages
   South West:
     providers:
-      - header: South West Institute for Teaching (SWIFT)
-        link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
-        name: Abby Spearing
-        email: abby.spearing@sw-ift.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: West Country Internships
-        link: https://exetermathematicsschool.ac.uk/internships/
-        name: Kerry Burnham
-        email: kburnham@exeterms.ac.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Odyssey Teaching School Hub
+      link: www.patesgs.org
+      name: Tim Connole
+      email: tconnole@patesgs.org  01242 538272
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Ringwood School
+      link: https://www.ringwood.hants.sch.uk/
+      name: Clare Adams
+      email: cadams@ringwood.hants.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: South West Institute for Teaching (SWIFT)
+      link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
+      name: Abby Spearing
+      email: abby.spearing@sw-ift.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Thinking Schools Academy Trust
+      link: https://www.tsatrust.org.uk/
+      name: Sophie Venables
+      email: s.venables@tsatrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: West Country Internships
+      link: https://exetermathematicsschool.ac.uk/internships/
+      name: Kerry Burnham
+      email: kburnham@exeterms.ac.uk
+      subjects: chemistry, computing, maths, physics, languages
   West Midlands:
     providers:
-      - header: Barr Beacon SCITT
-        link: https://barrbeaconschool.co.uk/
-        name: Michael Eszrenyi
-        email: meszrenyi@barrbeaconschool.co.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Biship Challoner Training School
-        link: https://www.bctsa.org/605/teaching-internship-programme
-        name: Angela Hodgin
-        email: trainingschool@bishopchalloner.bham.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
-          School Hub
-        link: https://www.princehenrys.worcs.sch.uk/
-        name: Andy Duffy
-        email: ad@princehenrys.worcs.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: St Jospeph's College
-        link: https://www.stjosephstrentvale.com/
-        name: Sam Chater
-        email: schater@stjosephsmail.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: St Peter's Catholic School Solihull
-        link: https://www.st-peters.solihull.sch.uk/teaching-school/
-        name: Anthony Jones
-        email: jonesa@st-peters.solihull.sch.uk
-        subjects: computing, maths, physics
-      - header: The Coventry SCITT
-        link: https://www.coventryscitt.org.uk/
-        name: Katie Williams
-        email: scittadmin@sidneystringeracademy.org.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Windsor Academy Trust
-        link: https://www.windsoracademytrust.org.uk/
-        name: Nathalie Gotling
-        email: ngotting@kingswinford.windsoracademytrust.org.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Arthur Terry SCITT
+      link: " www.atnts.com"
+      name: Robert Bloomfield
+      email: rbloomfield@arthurterry.bham.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Barr Beacon SCITT
+      link: https://barrbeaconschool.co.uk/
+      name: Michael Eszrenyi
+      email: meszrenyi@barrbeaconschool.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Biship Challoner Training School
+      link: https://www.bctsa.org/605/teaching-internship-programme
+      name: Angela Hodgin
+      email: trainingschool@bishopchalloner.bham.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Creative Education Trust
+      link: https://www.creativeeducationtrust.org.uk/internship
+      name: Claire Amed
+      email: claire.amed@creativeeducationtrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Ormiston Academies Trust
+      link: www.ormistonacademiestrust.co.uk
+      name: Jemma Sherwood
+      email: jemma.sherwood@ormistonacademies.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Outwood Institute of Education
+      link: https://oie.outwood.com/
+      name: George W. Robson
+      email: g.robson@outwood.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
+        School Hub
+      link: https://www.princehenrys.worcs.sch.uk/
+      name: Andy Duffy
+      email: ad@princehenrys.worcs.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: St Jospeph's College
+      link: https://www.stjosephstrentvale.com/
+      name: Sam Chater
+      email: schater@stjosephsmail.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: St Peter's Catholic School Solihull
+      link: https://www.st-peters.solihull.sch.uk/teaching-school/
+      name: Anthony Jones
+      email: jonesa@st-peters.solihull.sch.uk
+      subjects: computing, maths, physics
+    - header: The Coventry SCITT
+      link: https://www.coventryscitt.org.uk/
+      name: Katie Williams
+      email: scittadmin@sidneystringeracademy.org.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Windsor Academy Trust
+      link: https://www.windsoracademytrust.org.uk/
+      name: Nathalie Gotling
+      email: ngotting@kingswinford.windsoracademytrust.org.uk
+      subjects: chemistry, computing, maths, physics, languages
   Yorkshire and the Humber:
     providers:
-      - header: Learners First Schools Partnership
-        link: https://www.learnersfirst.net/
-        name: Georgia Osborne
-        email: gosborne@learnersfirst.org
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Northern Star Academies Trust
-        link: https://www.northernlightsscitt.com/
-        name: Helen Smith
-        email: training@northernlightsscitt.com
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Sheffield SCITT
-        link: https://www.sheffieldscitt.org.uk/
-        name: Stacey Wooliscroft
-        email: hallamtsa@notredame-high.co.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Valley Learning Partnership
-        link: http://www.brighouse.calderdale.sch.uk/
-        name: Janet Brierley
-        email: j.brierley@brighouse.calderdale.sch.uk
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Wigan and West Lancashire Catholic School Direct 
-        link: https://www.catholicsd.org.uk/
-        name: Sarah Holland
-        email: hollands267@saintpetershigh.wigan.sch.uk 
-        subjects: chemistry, computing, maths, physics, languages
-      - header: Wolds Learning Partnership Trust
-        link: https://www.woldgate.net/
-        name: Kirsten Russell
-        email: krussell@wlp.education
-        subjects: chemistry, maths, physics, languages
-      - header: Yorkshire Wolds Teacher Training
-        link: https://ywtt.org.uk/ywtt-paid-internship-programme/
-        name: Sarah Barley
-        email: sarah.barley@theeducationalliance.org.uk
-        subjects: chemistry, computing, maths, physics, languages
+    - header: Learners First Schools Partnership
+      link: https://www.learnersfirst.net/
+      name: Georgia Osborne
+      email: gosborne@learnersfirst.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Northern Education Trust
+      link: https://www.northerneducationtrust.org/
+      name: Meriem Lairini
+      email: m.lairini@northerneducationtrust.org
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Northern Star Academies Trust
+      link: https://www.northernlightsscitt.com/
+      name: Helen Smith
+      email: training@northernlightsscitt.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Outwood Institute of Education
+      link: https://oie.outwood.com/
+      name: George W. Robson
+      email: g.robson@outwood.com
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Sheffield SCITT
+      link: https://www.sheffieldscitt.org.uk/
+      name: Stacey Wooliscroft
+      email: hallamtsa@notredame-high.co.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Valley Learning Partnership
+      link: http://www.brighouse.calderdale.sch.uk/
+      name: Janet Brierley
+      email: j.brierley@brighouse.calderdale.sch.uk
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Wigan and West Lancashire Catholic School Direct 
+      link: https://www.catholicsd.org.uk/
+      name: Sarah Holland
+      email: hollands267@saintpetershigh.wigan.sch.uk 
+      subjects: chemistry, computing, maths, physics, languages
+    - header: Wolds Learning Partnership Trust
+      link: https://www.woldgate.net/
+      name: Kirsten Russell
+      email: krussell@wlp.education
+      subjects: chemistry, maths, physics, languages
+    - header: Yorkshire Wolds Teacher Training
+      link: https://ywtt.org.uk/ywtt-paid-internship-programme/
+      name: Sarah Barley
+      email: sarah.barley@theeducationalliance.org.uk
+      subjects: chemistry, computing, maths, physics, languages
 keywords:
   - teaching internship
   - internship

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -1,11 +1,17 @@
 ---
 title: Teaching internships
+heading: "Experience teaching with an internship"
 description: |-
   Find teaching internships to gain new skills and see what classroom life is like for £300 per week. Explore languages, computing, maths and physics internships.
 date: "2021-04-14"
 image: false
 promo_content:
     - content/train-to-be-a-teacher/promos/eta-promo-internships
+quote_list:
+  ql-1:
+    quotes: 
+      - heading: "Chloe, former teaching intern"
+        text: "You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week."
 backlink: /
 fullwidth: true
 content:
@@ -405,20 +411,3 @@ keywords:
   - T.I. programme
   - TI programme
 ---
-
-<section>
-  <div class="content-alert content-alert--fullwidth">
-    <div>
-      <span class="icon icon-warning" aria-hidden="true"></span>
-    </div>
-    <div>
-      <h2 class="heading-m">Apply from January 2023</h2>
-      
-      <p>You'll be able to apply for a teaching internship from January 2023. More information on how to apply will be available on this page once applications open.</p>
-
-      <p>Sign up for our emails and we'll send you helpful advice and insights about getting into teaching. If you're eligible for a teaching internship, we'll also let you know when applications open.</p>
-
-      <p><a class="button button--white" href="/mailinglist/signup">Sign up for email guidance</a></p>
-    </div>
-  </div>
-</section>

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -82,7 +82,7 @@ provider_groups:
       email: psmith@farlingaye.suffolk.sch.uk
       subjects: maths, physics
     - header: Ormiston Academies Trust
-      link: www.ormistonacademiestrust.co.uk
+      link: https://www.ormistonacademiestrust.co.uk
       name: Jemma Sherwood
       email: jemma.sherwood@ormistonacademies.co.uk
       subjects: chemistry, computing, maths, physics, languages
@@ -287,7 +287,7 @@ provider_groups:
   South West:
     providers:
     - header: Odyssey Teaching School Hub
-      link: www.patesgs.org
+      link: https://www.patesgs.org/
       name: Tim Connole
       email: tconnole@patesgs.org  01242 538272
       subjects: chemistry, computing, maths, physics, languages
@@ -314,7 +314,7 @@ provider_groups:
   West Midlands:
     providers:
     - header: Arthur Terry SCITT
-      link: " www.atnts.com"
+      link: https://arthurterryteachingschool.atlp.org.uk/
       name: Robert Bloomfield
       email: rbloomfield@arthurterry.bham.sch.uk
       subjects: chemistry, computing, maths, physics, languages
@@ -334,7 +334,7 @@ provider_groups:
       email: claire.amed@creativeeducationtrust.org.uk
       subjects: chemistry, computing, maths, physics, languages
     - header: Ormiston Academies Trust
-      link: www.ormistonacademiestrust.co.uk
+      link: https://www.ormistonacademiestrust.co.uk
       name: Jemma Sherwood
       email: jemma.sherwood@ormistonacademies.co.uk
       subjects: chemistry, computing, maths, physics, languages

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -106,7 +106,7 @@ provider_groups:
       name: Sarah Drury
       email: sarah.drury@tkat.org 
       subjects: chemistry, computing, maths, physics, languages
-    - header: The Hertforshire and Essex High School
+    - header: The Hertfordshire and Essex High School
       link: https://www.hertsandessex.herts.sch.uk/
       name: Claire Ruthven
       email: claire.ruthven@hertsandessex.herts.sch.uk
@@ -223,7 +223,7 @@ provider_groups:
       email: m.lairini@northerneducationtrust.org
       subjects: chemistry, computing, maths, physics, languages
     - header: Ormiston Academies Trust
-      link: https://www.ormistonacademiestrust.co.uk/
+      link: https://www.ormistonacademiestrust.co.uk
       name: Jemma Sherwood
       email: jemma.sherwood@ormistonacademies.co.uk
       subjects: chemistry, computing, maths, physics, languages
@@ -323,7 +323,7 @@ provider_groups:
       name: Michael Eszrenyi
       email: meszrenyi@barrbeaconschool.co.uk
       subjects: chemistry, computing, maths, physics, languages
-    - header: Biship Challoner Training School
+    - header: Bishop Challoner Training School
       link: https://www.bctsa.org/605/teaching-internship-programme
       name: Angela Hodgin
       email: trainingschool@bishopchalloner.bham.sch.uk
@@ -349,7 +349,7 @@ provider_groups:
       name: Andy Duffy
       email: ad@princehenrys.worcs.sch.uk
       subjects: chemistry, computing, maths, physics, languages
-    - header: St Jospeph's College
+    - header: St Joseph's College
       link: https://www.stjosephstrentvale.com/
       name: Sam Chater
       email: schater@stjosephsmail.com
@@ -366,7 +366,7 @@ provider_groups:
       subjects: chemistry, computing, maths, physics, languages
     - header: Windsor Academy Trust
       link: https://www.windsoracademytrust.org.uk/
-      name: Nathalie Gotling
+      name: Nathalie Gotting
       email: ngotting@kingswinford.windsoracademytrust.org.uk
       subjects: chemistry, computing, maths, physics, languages
   Yorkshire and the Humber:

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -27,3 +27,9 @@
      <li>one-to-one guidance from outstanding classroom teachers</li>
      <li>opportunities to network with qualified subject specialists</li>
   </ul>
+
+<h2>Select the region of the provider</h2>
+
+<section class="providers-list">
+  <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
+</section>

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,6 +1,6 @@
 <p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom.</p>
 
-<p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
+<p> You’ll get to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
 
 <section class="col col-640">
   <%= render Content::QuoteComponent.new(
@@ -37,7 +37,6 @@
 
 <p>You'll get a feel for school life, which could include:</p>
   <ul>
-     <li>classroom experience, helping with lessons and providing support to pupils</li>
      <li>shadowing experienced teachers and observing lessons</li>
      <li>jointly planning and delivering lessons</li>
      <li>one-to-one guidance from outstanding classroom teachers</li>

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,6 +1,6 @@
-<p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom.</p>
+<p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom. You’ll get to experience a range of activities to help you get a feel for school life.</p>
 
-<p> You’ll get to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
+<p>Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
 
 <section class="col col-640">
   <%= render Content::QuoteComponent.new(

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -2,7 +2,14 @@
 
 <p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.  </p>
 
-<p>"My teaching internship solidified that I wanted to become a teacher! The support I had was amazing, I was treated like a member of staff, and I was welcomed by everyone." - Chloe, former teaching intern.</p>
+<section class="col col-640">
+    <%= render Content::QuoteComponent.new(
+      text: "The support I had was amazing, I was treated like a member of staff, and I was welcomed by everyone.",
+      name: "Chloe, former teaching intern",
+      background: "grey",
+      large: false
+    ) %>
+  </section>
 
 <h2>Internship subjects</h2>
 
@@ -17,21 +24,35 @@
 
 <p> If you’re interested in teaching a different subject, you can still <a href="/train-to-be-a-teacher/get-school-experience">get school experience</a> and find out what it’s like to be in a classroom.</p>
 
-<p> “Towards the end of the internship, I was able to teach parts of lessons that I had planned, and I really started to find my feet at the front of the classroom!” - Ben, former teaching intern. </p>
+<section class="col col-640">
+    <%= render Content::QuoteComponent.new(
+      text: "Towards the end of the internship, I was able to teach parts of lessons that I had planned, and I really started to find my feet at the front of the classroom.",
+      name: "Ben, former teaching intern",
+      background: "grey",
+      large: false
+    ) %>
+  </section>
 
 <h2> What you'll cover</h2>
 
 <p>You'll get a feel for school life, which could include:</p>
   <ul>
-     <li>classroom experience, which could include helping with lessons and providing support to pupils</li>
+     <li>classroom experience, helping with lessons and providing support to pupils</li>
      <li>shadowing experienced teachers and observing lessons</li>
      <li>jointly planning and delivering lessons</li>
      <li>one-to-one guidance from outstanding classroom teachers</li>
      <li>opportunities to network with qualified subject specialists</li>
   </ul>
 
-  <p>“I observed lessons, provided 1:1 support to pupils, and even taught classes! The internship was particularly beneficial in providing a unique insight into teaching training and the application process.” - Carly, former teaching intern. </p>
-
+<section class="col col-640">
+    <%= render Content::QuoteComponent.new(
+      text: “I observed lessons, provided 1:1 support to pupils, and even taught classes! The internship was particularly beneficial in providing a unique insight into teaching training and the application process.,
+      name: "Carly, former teaching intern",
+      background: "grey",
+      large: false
+    ) %>
+  </section>
+ 
 <h2>How to apply</h2>
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -56,7 +56,7 @@
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>
 
-<p> To have the best chance of succeeding in your application, <a href="/teacher-training-advisers">get an adviser</a>. They offer one-to-one support, and are all experienced teachers.</p>
+<p> To have the best chance of succeeding in your application, <a href="/explore-teaching-advisers"</a>. They offer one-to-one support, and are all experienced teachers.</p>
 
 <h3>Find a teaching internship in your region</h3>
 

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,6 +1,6 @@
 <p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom.</p>
 
-<p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.  </p>
+<p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
 
 <section class="col col-640">
     <%= render Content::QuoteComponent.new(

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -3,13 +3,13 @@
 <p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
 
 <section class="col col-640">
-    <%= render Content::QuoteComponent.new(
-      text: "The support I had was amazing, I was treated like a member of staff, and I was welcomed by everyone.",
-      name: "Chloe, former teaching intern",
-      background: "grey",
-      large: false
-    ) %>
-  </section>
+  <%= render Content::QuoteComponent.new(
+    text: "The support I had was amazing, I was treated like a member of staff, and I was welcomed by everyone.",
+    name: "Chloe, former teaching intern",
+    background: "grey",
+    large: false
+  ) %>
+</section>
 
 <h2>Internship subjects</h2>
 
@@ -25,13 +25,13 @@
 <p> If you’re interested in teaching a different subject, you can still <a href="/train-to-be-a-teacher/get-school-experience">get school experience</a> and find out what it’s like to be in a classroom.</p>
 
 <section class="col col-640">
-    <%= render Content::QuoteComponent.new(
-      text: "Towards the end of the internship, I was able to teach parts of lessons that I had planned, and I really started to find my feet at the front of the classroom.",
-      name: "Ben, former teaching intern",
-      background: "grey",
-      large: false
-    ) %>
-  </section>
+  <%= render Content::QuoteComponent.new(
+    text: "Towards the end of the internship, I was able to teach parts of lessons that I had planned, and I really started to find my feet at the front of the classroom.",
+    name: "Ben, former teaching intern",
+    background: "grey",
+    large: false
+  ) %>
+</section>
 
 <h2> What you'll cover</h2>
 
@@ -45,13 +45,13 @@
   </ul>
 
 <section class="col col-640">
-    <%= render Content::QuoteComponent.new(
-      text: “I observed lessons, provided 1:1 support to pupils, and even taught classes! The internship was particularly beneficial in providing a unique insight into teaching training and the application process.,
-      name: "Carly, former teaching intern",
-      background: "grey",
-      large: false
-    ) %>
-  </section>
+  <%= render Content::QuoteComponent.new(
+    text: "I observed lessons, provided 1:1 support to pupils, and even taught classes! The internship was particularly beneficial in providing a unique insight into teaching training and the application process.",
+    name: "Carly, former teaching intern",
+    background: "grey",
+    large: false
+  ) %>
+</section>
 
 <h2>How to apply</h2>
 

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -56,7 +56,7 @@
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>
 
-<p> To have the best chance of succeeding in your application, <a href="/explore-teaching-advisers"</a>. They offer one-to-one support, and are all experienced teachers.</p>
+<p> To have the best chance of succeeding in your application, <a href="/explore-teaching-advisers"> get help from an adviser</a>. They offer one-to-one support, and are all experienced teachers.</p>
 
 <h3>Find a teaching internship in your region</h3>
 

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,8 +1,8 @@
 <p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom.</p>
 
-<p> You’ll get to spend 3 weeks in a school, gain new skills, and be paid £300 per week.</p>
+<p> You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week.  </p>
 
-<p> Internships usually take place during June and July. Places fill up quickly.</p>
+<p>"My teaching internship solidified that I wanted to become a teacher! The support I had was amazing, I was treated like a member of staff, and I was welcomed by everyone." - Chloe, former teaching intern.</p>
 
 <h2>Internship subjects</h2>
 
@@ -17,6 +17,8 @@
 
 <p> If you’re interested in teaching a different subject, you can still <a href="/train-to-be-a-teacher/get-school-experience">get school experience</a> and find out what it’s like to be in a classroom.</p>
 
+<p> “Towards the end of the internship, I was able to teach parts of lessons that I had planned, and I really started to find my feet at the front of the classroom!” - Ben, former teaching intern. </p>
+
 <h2> What you'll cover</h2>
 
 <p>You'll get a feel for school life, which could include:</p>
@@ -28,7 +30,15 @@
      <li>opportunities to network with qualified subject specialists</li>
   </ul>
 
-<h2>Select the region of the provider</h2>
+  <p>“I observed lessons, provided 1:1 support to pupils, and even taught classes! The internship was particularly beneficial in providing a unique insight into teaching training and the application process.” - Carly, former teaching intern. </p>
+
+<h2>How to apply</h2>
+
+<p>You can apply for an internship directly to one of the schools listed below.</p>
+
+<p> To have the best chance of succeeding in your application, <a href="/teacher-training-advisers">get an adviser</a>. They offer one-to-one support, and are all experienced teachers.</p>
+
+<h3>Find a teaching internship in your region</h3>
 
 <section class="providers-list">
   <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -52,7 +52,7 @@
       large: false
     ) %>
   </section>
- 
+
 <h2>How to apply</h2>
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -51,7 +51,7 @@
   }
 }
 
-.assessment-only-providers {
+.providers-list {
   .group__card {
     min-height: 12em;
   }

--- a/lib/agency.rb
+++ b/lib/agency.rb
@@ -1,0 +1,39 @@
+class Agency
+  attr_reader :region
+
+  def initialize(data)
+    @data = data
+
+    data.tap do |d|
+      @name = d["Supplier Name"]
+      @branch = d["Branch Name"]
+      @email = d["Email"]
+      @address1 = d["Address1"]
+      @address2 = d["Address2"]
+      @town = d["Town"]
+      @county = d["County"]
+      @postcode = d["Postcode"]
+      @region = d["Region"]
+      @phone = d["Phone"]
+      @website = d["Website"]
+    end
+  end
+
+  def to_h
+    {
+      "name" => @name,
+      "email" => @email,
+      "branch" => @branch,
+      "phone" => @phone,
+      "website" => @website,
+      "address" => [@address1, @address2, @town, @county, @postcode]
+        .compact
+        .reject(&:blank?)
+        .join(", "),
+    }
+  end
+
+  def to_str
+    [@name, @email, @city, @postcode, @region].join("|")
+  end
+end

--- a/lib/internship_provider.rb
+++ b/lib/internship_provider.rb
@@ -1,0 +1,30 @@
+class InternshipProvider
+  attr_reader :region
+
+  def initialize(data)
+    @data = data
+
+    data.tap do |d|
+      @school_name = d["school_name"]
+      @region = d["region"]
+      @school_website = d["school_website"]
+      @contact_name = d["contact_name"]
+      @contact_email = d["contact_email"]
+      @subjects = d["subjects"]
+    end
+  end
+
+  def to_h
+    {
+      "header" => @school_name.strip,
+      "link" => @school_website.strip,
+      "name" => @contact_name.strip,
+      "email" => @contact_email.strip,
+      "subjects" => @subjects.strip,
+    }
+  end
+
+  def to_str
+    [@name, @email, @city, @postcode, @region].join("|")
+  end
+end

--- a/lib/tasks/csv_to_yaml.rake
+++ b/lib/tasks/csv_to_yaml.rake
@@ -1,0 +1,37 @@
+require "csv"
+require "yaml"
+require "internship_provider"
+require "agency"
+
+desc "CSV to Yaml import"
+namespace :csv_to_yaml do
+  desc "Convert internship providers CSV to Yaml"
+  task internship_providers: :environment do
+    csv = CSV.read("internship_providers.csv", headers: true)
+
+    providers = csv.each.with_object({}) do |r, h|
+      ip = InternshipProvider.new(r)
+      h[ip.region.to_s] ||= {}
+      h[ip.region.to_s]["providers"] ||= []
+      h[ip.region.to_s]["providers"] << ip.to_h
+    end
+
+    providers.transform_values! { |v| { "providers" => v["providers"].sort_by { |a| a["header"] } } }
+
+    puts providers.sort.to_h.to_yaml
+  end
+
+  desc "Convert agencies CSV to Yaml"
+  task agencies: :environment do
+    csv = CSV.read("agencies.csv", headers: true)
+
+    agencies = csv.each.with_object(Hash.new { |h, k| h[k] = [] }) do |r, h|
+      a = Agency.new(r)
+      h[a.region.to_s] << a.to_h
+    end
+
+    agencies.transform_values! { |v| v.sort_by { |a| a["name"] } }
+
+    puts agencies.sort.to_h.to_yaml
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-4121](https://trello.com/c/eXswYL3z/4121-publish-internship-providers-list)

### Context

The internships programme is launching and we need a list of providers adding to the website.

### Changes proposed in this pull request

- Add rake task to import CSV to Yaml

Add rake tasks to import CSV files into Yaml for internship providers and agencies.

- Update internship providers list

Update the list of internship providers with the latest CSV provided.

### Guidance to review

Also includes a script to import agencies that Pete had lying around and may come in useful at a later date.