### PR TITLE
[745] Pin buildx to 0.9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+        with:
+          version: v0.9.1  # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: sha
@@ -112,6 +114,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+        with:
+          version: v0.9.1 # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: sha


### PR DESCRIPTION
### Trello card
https://trello.com/c/frBHpavp

### Context
New buildx generates a new OCI format with support for provenance. It doesn't work with Cloud foundry.

### Changes proposed in this pull request
Pin buildx to 0.9.1

### Guidance to review
Successful run: https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/3968392428
