### PR TITLE
Amend wording on event signposting inset component

### DIFF
--- a/app/views/teaching_events/show/_other-events.erb
+++ b/app/views/teaching_events/show/_other-events.erb
@@ -3,6 +3,6 @@
   color: "grey",
   text: <<~HTML
     <p>There are lots more online and in-person events where you can get your questions answered about teaching.</p>
-    <p>#{link_to("Explore our events", events_path)}.</p>
+    <p>#{link_to("Explore all events", events_path)}.</p>
     HTML
 ) %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/n9yMvLkN

### Context
We added an inset component at the bottom of each event details page to signpost people back to the events listing page. However, given that this component appears on all event types (including provider events), the wording needs updating slightly so we are not implying that all events are 'ours'.

