### PR TITLE
Stronger wording for non-UK assesment only

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -482,7 +482,7 @@ provider_groups:
 inset_text:
   international-content:
     text: |-
-      If you’re a non-UK citizen, you should contact <a href="#non-uk">training providers who assess international teachers</a>. None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
+      If you’re a non-UK citizen, you should contact <a href="#group--non-uk">training providers who assess international teachers</a>. None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
     color: grey
 keywords:
   - Assessment Only

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -493,4 +493,4 @@ The accredited teacher training providers listed on this page offer the AO progr
 
 Fees range from about £1,500 to £4,000, but vary between providers so it's best to check with them directly for more information.
 
-If you’re a non-UK citizen, see training providers who offer [assessment only qualified teacher status to international teachers](#group--non-uk).
+If you’re a non-UK citizen, you should contact [training providers who assess international teachers](#group--non-uk). None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -481,7 +481,8 @@ provider_groups:
       email: institute@tesglobal.com
 inset_text:
   international-content:
-    text: If you’re a non-UK citizen, you should contact <a href="/assessment-only-providers#non-uk"> training providers who assess international teachers</a>. None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
+    text: |-
+      If you’re a non-UK citizen, you should contact <a href="#non-uk">training providers who assess international teachers</a>. None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
     color: grey
 keywords:
   - Assessment Only

--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -479,6 +479,10 @@ provider_groups:
       name: Andrew Locke
       telephone: 020 3194 3200
       email: institute@tesglobal.com
+inset_text:
+  international-content:
+    text: If you’re a non-UK citizen, you should contact <a href="/assessment-only-providers#non-uk"> training providers who assess international teachers</a>. None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
+    color: grey
 keywords:
   - Assessment Only
   - Assessment
@@ -493,4 +497,4 @@ The accredited teacher training providers listed on this page offer the AO progr
 
 Fees range from about £1,500 to £4,000, but vary between providers so it's best to check with them directly for more information.
 
-If you’re a non-UK citizen, you should contact [training providers who assess international teachers](#group--non-uk). None of the other UK regional or national providers can help with non-UK enquiries. Please do not contact them if you are not in the UK.
+$international-content$

--- a/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
+++ b/app/views/content/assessment-only-providers/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
@@ -1,3 +1,4 @@
+<a id="non-uk"></a>
 Teachers outside the UK who do not have a teaching qualification, but [meet the eligibility requirements for assessment only QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#apply-for-assessment-only-qts), can apply to be assessed by an English teacher training provider. 
 
 You will not have to visit or train in England. However, you will need to be assessed at your place of work by an examiner from your teaching training provider. Your teacher training provider can explain what type of school you must be working in to undergo assessment only QTS.

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
         sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
-          .select { |href| href.start_with?("#") }
+          .select { |href| href&.start_with?("#") }
           .reject { |href| href == "#" }
           .each do |href|
             # we need to use XPath here because Nokogiri doesn't like selectors
@@ -107,6 +107,7 @@ RSpec.feature "content pages check", type: :feature, content: true do
         sp.body
           .css("a")
           .map { |fragment| fragment["href"] }
+          .reject(&:nil?)
           .reject { |href| href.start_with?(Regexp.union("http:", "https:", "tel:", "mailto:")) }
           .reject { |href| href.start_with?("/blog/tag") }
           .reject { |href| href.match?("media/") }


### PR DESCRIPTION
### Trello card

https://trello.com/c/hlUs8iJf

### Context

The International team have had contact from a number of UK assessment only providers as they’ve been contacted by non-UK applicants about QTS.

### Changes proposed in this pull request

Stronger wording in the non-UK section to make it clear only the providers listed under non-UK will be able to help.

### Guidance to review

