### PR TITLE
Add salaries and benefits test variants

### DIFF
--- a/app/views/content/salaries-and-benefits-search.md
+++ b/app/views/content/salaries-and-benefits-search.md
@@ -1,0 +1,145 @@
+---
+noindex: true
+title: "Teaching salaries and benefits"
+heading: "Salaries and benefits"
+description: |-
+  All qualified teachers will have a starting salary of at least £28,000 (or higher in London). Find out about teacher pay scales and more benefits of teaching.
+date: "2021-06-24"
+image: "media/images/content/hero-images/0008.jpg"
+backlink: "../../"
+promo_content:
+    - content/train-to-be-a-teacher/promos/mailing-list-promo-salaries
+related_content:
+    Steps to become a teacher : "/steps-to-become-a-teacher"
+    Train to be a teacher if you have or are studying for a degree : "/train-to-be-a-teacher/if-you-have-a-degree"
+    Scholarships and bursaries for training to teach : "/funding-and-support/scholarships-and-bursaries"
+    Why I became a teacher : "/blog/the-head-of-science-inspiring-students-in-blackpool"
+    Abigail's career progression story : "/blog/abigails-career-progression-story"
+---
+
+For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
+
+Figures are for teachers in the 2022/23 academic year.
+
+## Teaching salaries
+
+All qualified teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London.
+
+### Qualified teacher salary
+
+Your school will have their own pay scales for qualified teachers. Pay increases will always be linked to performance, not length of service, and will be reviewed every year.
+
+The teacher pay scales for qualified teachers are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £28,000 | £38,810 |
+| London fringe                            | £29,344 | £40,083 |
+| Outer London                             | £32,407 | £43,193 |
+| Inner London                             | £34,502 | £44,756 |
+
+Most established teachers will earn more than this maximum by progressing onto the upper pay range for teachers, or by becoming a leading practitioner.
+
+If you’re not sure whether you'll be teaching in inner, outer or the fringe of London, talk to your school.
+
+### Upper pay range for teachers
+
+If you can demonstrate excellence against all of the teacher standards, you can be put onto the upper pay range for teachers.
+
+This is for teachers who make a sustained and substantial contribution to their school.
+
+The upper pay ranges for teachers are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £40,625 | £43,685 |
+| London fringe                            | £41,858 | £44,919 |
+| Outer London                             | £44,687 | £48,055 |
+| Inner London                             | £49,320 | £53,482 |
+
+### Leading practitioner salaries
+
+If you’re an established and exceptional teacher, and regularly show the highest standards of classroom teaching, you can be put onto a higher pay scale.
+
+Although they may not lead departments, leading practitioners coach and mentor other teachers and induct trainees and early career teachers (ECTs).
+
+The teacher pay scales for leading practitioners are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £44,523 | £67,685 |
+| London fringe                            | £45,749 | £68,913 |
+| Outer London                             | £48,055 | £71,220 |
+| Inner London                             | £52,936 | £76,104 |
+
+### Headteacher salaries
+
+A headteacher is the most senior person in a school. They are ultimately responsible for all teachers and pupils. 
+
+Their role is wide ranging, but includes leading and motivating teachers, and ensuring all pupils get a good education.
+
+The salary ranges for headteachers are:
+
+| Area                                     | Minimum | Maximum  |
+| -------                                  | -----   | -----    |
+| England (excluding London)     | £50,122 | £123,057 |
+| London fringe                            | £51,347 | £124,274 |
+| Outer London                             | £53,637 | £126,539 |
+| Inner London                             | £58,501 | £131,353 |
+
+### Other payments
+
+You might also get extra payments for taking on extra responsibilities.
+
+These payments are called ‘teaching and learning responsibility’ (TLR) payments. The extra responsibilities you might take on are:
+
+* progressing the education of people beyond your assigned pupils
+* leading, developing and enhancing the teaching practice of others
+* TLR payments come in 2 main pay ranges (TLR 1 and TLR 2) depending on your responsibilities
+
+| Level         | Minimum | Maximum|
+| -------       | -----   | -----  |
+| TLR 1         | £8,706  | £14,732|
+| TLR 2         | £3,017  | £7,368 |
+
+### Unqualified teacher salaries
+
+Many schools in England require teachers to have 'qualified teacher status' (QTS). If you do not have this, you can work
+in some schools as an unqualified teacher.
+
+The unqualified teacher salary ranges are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £19,340 | £30,172 |
+| London fringe                            | £20,594 | £31,421  |
+| Outer London                             | £22,924 | £33,759 |
+| Inner London                             | £24,254 | £35,081 |
+
+## Holidays
+
+You'll get more days holiday than people in many other professions. In school, full-time teachers work 195 days per year. 
+
+For comparison, you'd work 227 days per year (on average) if you worked full time in an office.
+
+## Teachers' pension scheme
+
+The teachers’ pension scheme is one of the most generous in the country. It is a 'defined benefit' pension and is:
+
+* based on your teaching salary rather than the amount of money you pay in
+* registered with HM Revenue and Customs - so your contributions are tax-free
+* flexible and allows you to take some of it as a tax-free lump sum
+
+You also get other insurance benefits too. Find out more about the [teachers' pension scheme](/what-pension-does-a-teacher-get).
+
+## Support for early career teachers
+
+All teachers are given extra support during their first 2 years in teaching called [ECF-based training](/support-for-early-career-teachers). This helps early career teachers (ECTs) develop their knowledge, teaching skills and working habits.
+
+This support includes:
+
+* paid time away from classroom teaching to focus on your development
+* a high quality training programme based on the [early career framework](https://www.gov.uk/government/publications/early-career-framework)
+* a mentor who will give you guidance and support
+
+The term early career teacher (ECT) replaced newly qualified teacher (NQT).

--- a/app/views/content/salaries-and-benefits-social.md
+++ b/app/views/content/salaries-and-benefits-social.md
@@ -1,0 +1,145 @@
+---
+noindex: true
+title: "Teaching salaries and benefits"
+heading: "Salaries and benefits"
+description: |-
+  All qualified teachers will have a starting salary of at least £28,000 (or higher in London). Find out about teacher pay scales and more benefits of teaching.
+date: "2021-06-24"
+image: "media/images/content/hero-images/0008.jpg"
+backlink: "../../"
+promo_content:
+    - content/train-to-be-a-teacher/promos/mailing-list-promo-salaries
+related_content:
+    Steps to become a teacher : "/steps-to-become-a-teacher"
+    Train to be a teacher if you have or are studying for a degree : "/train-to-be-a-teacher/if-you-have-a-degree"
+    Scholarships and bursaries for training to teach : "/funding-and-support/scholarships-and-bursaries"
+    Why I became a teacher : "/blog/the-head-of-science-inspiring-students-in-blackpool"
+    Abigail's career progression story : "/blog/abigails-career-progression-story"
+---
+
+For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
+
+Figures are for teachers in the 2022/23 academic year.
+
+## Teaching salaries
+
+All qualified teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London.
+
+### Qualified teacher salary
+
+Your school will have their own pay scales for qualified teachers. Pay increases will always be linked to performance, not length of service, and will be reviewed every year.
+
+The teacher pay scales for qualified teachers are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £28,000 | £38,810 |
+| London fringe                            | £29,344 | £40,083 |
+| Outer London                             | £32,407 | £43,193 |
+| Inner London                             | £34,502 | £44,756 |
+
+Most established teachers will earn more than this maximum by progressing onto the upper pay range for teachers, or by becoming a leading practitioner.
+
+If you’re not sure whether you'll be teaching in inner, outer or the fringe of London, talk to your school.
+
+### Upper pay range for teachers
+
+If you can demonstrate excellence against all of the teacher standards, you can be put onto the upper pay range for teachers.
+
+This is for teachers who make a sustained and substantial contribution to their school.
+
+The upper pay ranges for teachers are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £40,625 | £43,685 |
+| London fringe                            | £41,858 | £44,919 |
+| Outer London                             | £44,687 | £48,055 |
+| Inner London                             | £49,320 | £53,482 |
+
+### Leading practitioner salaries
+
+If you’re an established and exceptional teacher, and regularly show the highest standards of classroom teaching, you can be put onto a higher pay scale.
+
+Although they may not lead departments, leading practitioners coach and mentor other teachers and induct trainees and early career teachers (ECTs).
+
+The teacher pay scales for leading practitioners are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £44,523 | £67,685 |
+| London fringe                            | £45,749 | £68,913 |
+| Outer London                             | £48,055 | £71,220 |
+| Inner London                             | £52,936 | £76,104 |
+
+### Headteacher salaries
+
+A headteacher is the most senior person in a school. They are ultimately responsible for all teachers and pupils. 
+
+Their role is wide ranging, but includes leading and motivating teachers, and ensuring all pupils get a good education.
+
+The salary ranges for headteachers are:
+
+| Area                                     | Minimum | Maximum  |
+| -------                                  | -----   | -----    |
+| England (excluding London)     | £50,122 | £123,057 |
+| London fringe                            | £51,347 | £124,274 |
+| Outer London                             | £53,637 | £126,539 |
+| Inner London                             | £58,501 | £131,353 |
+
+### Other payments
+
+You might also get extra payments for taking on extra responsibilities.
+
+These payments are called ‘teaching and learning responsibility’ (TLR) payments. The extra responsibilities you might take on are:
+
+* progressing the education of people beyond your assigned pupils
+* leading, developing and enhancing the teaching practice of others
+* TLR payments come in 2 main pay ranges (TLR 1 and TLR 2) depending on your responsibilities
+
+| Level         | Minimum | Maximum|
+| -------       | -----   | -----  |
+| TLR 1         | £8,706  | £14,732|
+| TLR 2         | £3,017  | £7,368 |
+
+### Unqualified teacher salaries
+
+Many schools in England require teachers to have 'qualified teacher status' (QTS). If you do not have this, you can work
+in some schools as an unqualified teacher.
+
+The unqualified teacher salary ranges are:
+
+| Area                                     | Minimum | Maximum |
+| -------                                  | -----   | -----   |
+| England (excluding London)     | £19,340 | £30,172 |
+| London fringe                            | £20,594 | £31,421  |
+| Outer London                             | £22,924 | £33,759 |
+| Inner London                             | £24,254 | £35,081 |
+
+## Holidays
+
+You'll get more days holiday than people in many other professions. In school, full-time teachers work 195 days per year. 
+
+For comparison, you'd work 227 days per year (on average) if you worked full time in an office.
+
+## Teachers' pension scheme
+
+The teachers’ pension scheme is one of the most generous in the country. It is a 'defined benefit' pension and is:
+
+* based on your teaching salary rather than the amount of money you pay in
+* registered with HM Revenue and Customs - so your contributions are tax-free
+* flexible and allows you to take some of it as a tax-free lump sum
+
+You also get other insurance benefits too. Find out more about the [teachers' pension scheme](/what-pension-does-a-teacher-get).
+
+## Support for early career teachers
+
+All teachers are given extra support during their first 2 years in teaching called [ECF-based training](/support-for-early-career-teachers). This helps early career teachers (ECTs) develop their knowledge, teaching skills and working habits.
+
+This support includes:
+
+* paid time away from classroom teaching to focus on your development
+* a high quality training programme based on the [early career framework](https://www.gov.uk/government/publications/early-career-framework)
+* a mentor who will give you guidance and support
+
+The term early career teacher (ECT) replaced newly qualified teacher (NQT).


### PR DESCRIPTION
### Trello card

[Trello-4215](https://trello.com/c/zzzWpI4a/4215-create-two-copies-of-the-original-salaries-and-benefits-page-for-landing-page-testing)

### Context

We are running an A/B test for a new salaries and benefits landing page; to be able to split the traffic we need variants of the main salaries and benefits page for 'search' traffic and 'social' traffic.

These are temporary and will be removed after the test has finished, so the content is just duplicated for ease.

### Changes proposed in this pull request

- Add salaries and benefits test variants

### Guidance to review

[Search page](https://review-get-into-teaching-app-3119.london.cloudapps.digital/salaries-and-benefits-search)
[Social page](https://review-get-into-teaching-app-3119.london.cloudapps.digital/salaries-and-benefits-social)