### PR TITLE
Update GiT API client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,11 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: faced708d161b73a567d7eea766c6afb5795834c
+  revision: 7f776f597109304f275db26852051b19070e568d
   specs:
-    get_into_teaching_api_client (2.3.0)
+    get_into_teaching_api_client (3.0.0)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (2.3.0)
+    get_into_teaching_api_client_faraday (3.0.0)
       activesupport
       faraday
       faraday-encoding
@@ -188,7 +188,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.2)
+    faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -104,7 +104,7 @@ describe Events::Steps::PersonalisedUpdates do
 
     let(:teaching_subject_types) do
       subjects = TeachingSubject::ALL.merge(TeachingSubject::IGNORED)
-      subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
+      subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 
     before do

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -8,7 +8,7 @@ describe MailingList::Steps::Subject do
   end
 
   let(:teaching_subject_types) do
-    TeachingSubject::ALL.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
+    TeachingSubject::ALL.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
   end
 
   it_behaves_like "a with wizard step"
@@ -30,7 +30,7 @@ describe MailingList::Steps::Subject do
 
     let(:teaching_subject_types) do
       subjects = TeachingSubject::ALL.merge(TeachingSubject::IGNORED)
-      subjects.map { |k, v| GetIntoTeachingApiClient::LookupItem.new({ id: v, value: k }) }
+      subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 
     it { is_expected.to eq(TeachingSubject.all_uuids) }


### PR DESCRIPTION
### Trello card

[Trello-4235](https://trello.com/c/oBTl036B/4235-implement-latest-batch-of-dependency-updates)

### Context

Update the API client to the latest version, which includes a breaking change that splits out `LookupItem` into new `Country` and `TeachingSubject` models.

### Changes proposed in this pull request

- Update GiT API client

### Guidance to review

