### PR TITLE
Enable Google Optimize for Salaries & Benefits A/B test

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -6,4 +6,8 @@
 #   - /events
 #   - /
 
-paths: []
+paths:
+  - /salaries-and-benefits-search
+  - /salaries-and-benefits-social
+  - /landing/how-much-do-teachers-get-paid
+  - /landing/how-much-do-teachers-get-paid-social

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -238,7 +238,16 @@ describe ApplicationHelper do
   describe "#google_optimize_config" do
     subject { google_optimize_config }
 
-    it { is_expected.to eq({ paths: [] }) }
+    it "includes pages currently under test" do
+      is_expected.to eq({
+        paths: [
+          "/salaries-and-benefits-search",
+          "/salaries-and-benefits-social",
+          "/landing/how-much-do-teachers-get-paid",
+          "/landing/how-much-do-teachers-get-paid-social",
+        ],
+      })
+    end
   end
 
   describe "#sentry_dsn" do


### PR DESCRIPTION
### Trello card

[Trello-4219](https://trello.com/c/du2JEJxY/4219-enable-google-optimize-on-all-salaries-and-benefits-landing-page-testing-pages)

### Context

Enable Google Optimize on the web pages used as part of the salaries and benefits A/B test.

### Changes proposed in this pull request

- Enable Google Optimize for Salaries & Benefits A/B test

### Guidance to review

