### PR TITLE
removing reference to teaching assistants

### DIFF
--- a/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-experience.md
@@ -14,11 +14,11 @@ navigation_title: If you've worked in a classroom
 navigation_description: If you've spent a lot of time working in a classroom, you may be able to show you meet the standards for qualified teacher status (QTS) through an assessment.
 ---
 
-If you have been working in a classroom for a significant amount of time, as a teaching assistant or in a similar role, you may be able to get [qualified teacher status](/what-is-qts) (QTS) through a 12-week ‘assessment only’ programme. You  must also have a degree.
+If you have been working in a classroom for a significant amount of time as an unqualified teacher, you may be able to get [qualified teacher status](/what-is-qts) (QTS) through a 12-week ‘assessment only’ programme. You  must also have a degree.
 
 You’ll need to show that you already meet the standards for QTS. For example, you may meet the standards if:
 
-- you’ve already been employed as an unqualified teacher or teaching assistant for a significant amount of time (for example, 2 years) and you’ve worked in more than one school
+- you’ve already been employed as an unqualified teacher for a significant amount of time (for example, 2 years) and you’ve worked in more than one school
 - you’re a [qualified teacher who trained overseas](/non-uk-teachers/teach-in-england-if-you-trained-overseas)
 
 Entry criteria may vary by teacher training provider. You should ask them about eligibility before you apply and make sure that you qualify.


### PR DESCRIPTION
### Trello card

https://trello.com/c/2mlQQH1k

### Context

We currently say that teaching assistants are eligible for assessment only but the ITT accreditation team have confirmed that this isn’t correct

### Changes proposed in this pull request

Removing references to teaching assistants.

### Guidance to review

