### PR TITLE
Changing mailing list copy

### DIFF
--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -1,7 +1,7 @@
 <h1>Get personalised guidance on teacher training in your inbox</h1>
 
 <p>
-If you're interested in training to teach in primary, secondary and special schools in England, we can help you get everything you need to know to start a career in teaching.
+If you're interested in training to teach in primary, secondary and special schools in England, get everything you need to know to start a career in teaching.
 </p>
 
 <p>
@@ -9,7 +9,7 @@ Find out how to get:
 </p>
 
 <ul>
-  <li> a taste of teaching</li>
+  <li> a taste of life in the classroom</li>
   <li> funding to train</li>
   <li> one-to-one support</li>
   <li> advice from trainees or newly qualified teachers</li>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -1,7 +1,11 @@
-<h1>Get personalised guidance to your inbox</h1>
+<h1>Get personalised guidance on teacher training in your inbox</h1>
 
 <p>
-  Get one step closer to the classroom with guidance tailored to you, including how to get:
+If you're interested in training to teach in primary, secondary and special schools in England, we can help you get everything you need to know to start a career in teaching.
+</p>
+
+<p>
+Find out how to get:
 </p>
 
 <ul>

--- a/docs/mailing-list-flow.md
+++ b/docs/mailing-list-flow.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 graph TD;
-  name_and_email[Get personalised guidance to your inbox] -- Doesn't exist in CRM --> degree[Do you have a degree?]
+  name_and_email[Get personalised guidance on teacher training in your inbox] -- Doesn't exist in CRM --> degree[Do you have a degree?]
   name_and_email -- Exists in CRM --> already_registered[You're already registered with us]
   
   already_registered -- Not on mailing list --> degree

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     expect(page).to have_title(mailing_list_page_title)
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -52,7 +52,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     channel_id = channels.first.id
     visit mailing_list_steps_path({ id: :name, channel: channel_id, sub_channel: sub_channel_id })
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     # Error to ensure channel/sub-channel persists over page reload.
     click_on "Next step"
     expect(page).to have_text("Enter your full email address")
@@ -91,7 +91,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     channel_id = channels.first.id
     visit mailing_list_steps_path({ id: :name, channel: channel_id, sub_channel: sub_channel_id })
 
-    expect(page).to have_text("Get personalised guidance to your inbox")
+    expect(page).to have_text("Get personalised guidance on teacher training in your inbox")
     fill_in_name_step
     click_on "Next step"
 
@@ -126,7 +126,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path({ id: :name, channel: "invalid", sub_channel: sub_channel_id })
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -167,7 +167,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step(first_name: first_name)
     click_on "Next step"
 
@@ -210,7 +210,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -241,7 +241,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -265,7 +265,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -342,7 +342,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
 
     visit mailing_list_steps_path
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step
     click_on "Next step"
 
@@ -359,7 +359,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
       receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
 
-    expect(page).to have_text "Get personalised guidance to your inbox"
+    expect(page).to have_text "Get personalised guidance on teacher training in your inbox"
     fill_in_name_step(email: "test2@user.com")
     click_on "Next step"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/AdCyp9Tz/4216-improve-copy-on-mailing-list-start-page-to-make-it-clear-its-not-for-qualified-teachers

### Context

We need to improve the copy on the mailing list start page to make it clear that it provides guidance for teacher training.

### Changes proposed in this pull request

### Guidance to review

