### PR TITLE
Add i2i Teaching Partnership to Assessment only page

### DIFF
--- a/app/views/content/assessment-only-providers.md
+++ b/app/views/content/assessment-only-providers.md
@@ -263,8 +263,13 @@ provider_groups:
     - header: GLF Schools’ Teacher Training
       link: http://www.glynsurreyscitt.co.uk/846/assessment-only-route
       name: Helen Shaw
-      telephone: '0208 716 4934'
+      telephone: '020 8716 4934'
       email: info@glftt.org
+    - header: i2i Teaching Partnership SCITT
+      link: https://www.i2ipartnership.co.uk/
+      name: Krissy Taylor
+      telephone: '01252 900550'
+      email: ktaylor@i2ipartnership.co.uk
     - header: Kent and Medway Training
       link: https://www.kmtraining.org.uk/
       email: polly.butterfield-tracey@kmtraining.org.uk


### PR DESCRIPTION
### Trello card
https://trello.com/c/rmMT9QVn

### Context
Request received via GIT support team (and approved by Accreditation team) to add i2i Teaching Partnership to Assessment only page

