### PR TITLE
Patch openssl vulerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN mkdir /app
 WORKDIR /app
 
 RUN apk update
+
+# patches
+RUN apk add --no-cache openssl=1.1.1t-r0 
+
 RUN apk add --no-cache build-base tzdata shared-mime-info nodejs yarn git \
         chromium chromium-chromedriver && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
[Trello-4260](https://trello.com/c/5ygbyXqA/4260-fix-snyk-vulnerabilities)

The version of openssl in the alpine docker image has vulnerabilities, see:

https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314624 
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314641 
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-3314643
