### PR TITLE
Enable Google Optimize on mailing list sign up

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -11,3 +11,5 @@ paths:
   - /salaries-and-benefits-social
   - /landing/how-much-do-teachers-get-paid
   - /landing/how-much-do-teachers-get-paid-social
+  - /mailinglist/signup/name
+  - /mailinglist/signup

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -188,6 +188,8 @@ describe ApplicationHelper do
           "/salaries-and-benefits-social",
           "/landing/how-much-do-teachers-get-paid",
           "/landing/how-much-do-teachers-get-paid-social",
+          "/mailinglist/signup/name",
+          "/mailinglist/signup",
         ],
       })
     end


### PR DESCRIPTION
### Trello card

[Trello-4270](https://trello.com/c/MzoHsQZY/4270-enable-google-optimize-on-mailing-list-start-page)

### Context

Allow the Google Optimize script to execute on the mailing list sign up pages.

### Changes proposed in this pull request

- Enable Google Optimize on mailing list sign up

### Guidance to review

