### PR TITLE
Prevent caching of JS/CSS assets in development

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -20,4 +20,15 @@ const options = {
   },
 }
 
+// add hashing of generated JS and CSS files to fix caching
+// issue in development see: https://github.com/shakacode/shakapacker/issues/88
+baseWebpackConfig.output.filename = 'js/[name]-[contenthash].js'
+baseWebpackConfig.output.chunkFilename = 'js/[name]-[contenthash].chunk.js'
+
+baseWebpackConfig.plugins.forEach(plugin => {
+  if (plugin.options && plugin.options.filename === 'css/[name].css') {
+    plugin.options.filename = 'css/[name]-[contenthash].css'
+  }
+})
+
 module.exports = merge({}, baseWebpackConfig, options)

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -68,7 +68,10 @@ development:
     # live_reload: true
     client:
       # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
-      overlay: true
+      overlay: {
+        warnings: false,
+        errors: true
+      }
       # May also be a string
       # webSocketURL:
       #  hostname: '0.0.0.0'


### PR DESCRIPTION
### Trello card

[Trello-4299](https://trello.com/c/rzc4Pc09/4299-fix-shakapacker-not-reflecting-updated-css-js-in-development)

### Context

By default Shakapacker generates applicaton.js/css without any digest. This causes the browser to serve the cached version of the asset even after the contents have changed.

### Changes proposed in this pull request

- Prevent caching of JS/CSS assets in development

Change webpack to always generate JS/CSS asset filenames with a digest.

Also update webpack overlay to only show errors as we have deprecation warnings in dependencies we can't do anything about.

### Guidance to review

