### PR TITLE
Add landing page for steps to become a teacher

### DIFF
--- a/app/components/content/mailing_list_component.html.erb
+++ b/app/components/content/mailing_list_component.html.erb
@@ -1,14 +1,14 @@
 <div class="action-container">
   <div class="heading-container">
     <h2 class="heading-m heading--box-purple">
-      Get the latest teaching information and support
+      <%= title %>
     </h2>
   </div>
 
   <div class="content">
     <div class="inset">
       <p>
-        Answer a couple of questions about yourself and we'll send you more information about teaching benefits, as well as helpful tips and advice to get you one step closer to a career in teaching.
+        <%= intro %>
       </p>
 
       <%= form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: mailing_list_step_path(:name), scope: :mailing_list_steps_name, method: :put do |f| %>

--- a/app/components/content/mailing_list_component.rb
+++ b/app/components/content/mailing_list_component.rb
@@ -1,5 +1,14 @@
 module Content
   class MailingListComponent < ViewComponent::Base
+    attr_reader :title, :intro
+
+    def initialize(title:, intro:)
+      super
+
+      @title = title
+      @intro = intro
+    end
+
     def privacy_policy
       @privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,6 +14,7 @@ class PagesController < ApplicationController
     "/help-and-support", #  Contains a form
     "/landing/how-much-do-teachers-get-paid", # Contains a form
     "/landing/how-much-do-teachers-get-paid-social", # Contains a form
+    "/landing/how-to-become-a-teacher", # Contains a form
   ].freeze
 
   caches_page :cookies

--- a/app/views/content/landing/how-much-do-teachers-get-paid/_mailing_list.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_mailing_list.html.erb
@@ -1,5 +1,8 @@
 <div class="row">
   <section class="col col-720">
-    <%= render Content::MailingListComponent.new %>
+    <%= render Content::MailingListComponent.new(
+      title: "Get the latest teaching information and support",
+      intro: "Answer a couple of questions about yourself and we'll send you more information about teaching benefits, as well as helpful tips and advice to get you one step closer to a career in teaching."
+    ) %>
   </section>
 </div>

--- a/app/views/content/landing/how-to-become-a-teacher.md
+++ b/app/views/content/landing/how-to-become-a-teacher.md
@@ -1,6 +1,6 @@
 ---
 title: "How to become a teacher"
-description: A description goes here
+description: Our step by step guide for how to become a teacher. Find out more about checking your qualifications, how to fund your training, and applying to train to be a teacher.
 content:
     - content/landing/how-to-become-a-teacher/header
     - content/landing/how-to-become-a-teacher/steps

--- a/app/views/content/landing/how-to-become-a-teacher.md
+++ b/app/views/content/landing/how-to-become-a-teacher.md
@@ -1,0 +1,15 @@
+---
+title: "How to become a teacher"
+description: A description goes here
+content:
+    - content/landing/how-to-become-a-teacher/header
+    - content/landing/how-to-become-a-teacher/steps
+    - content/landing/how-to-become-a-teacher/mailing_list
+    - content/landing/how-to-become-a-teacher/content
+    - content/landing/how-to-become-a-teacher/promo
+image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
+colour: "yellow"
+layout: "layouts/minimal"
+talk_to_us: false
+noindex: true
+---

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -1,0 +1,57 @@
+<div class="row">
+  <section class="col col-720">
+    <h2 class="heading--box-blue">What qualifications do I need?</h2>
+
+    <div class="inset">
+      <p>
+        You'll need to train for qualified teacher status (QTS) to be able to teach in most primary and secondary schools in England.
+      </p>
+
+      <p>
+        If you have a degree or equivalent qualification, you can do postgraduate primary or secondary teacher training.
+        If you do not have a degree and are not studying for one, you can do undergraduate teacher training.
+      </p>
+
+      <p>
+        <%= link_to("Check the qualifications you need", page_path("is-teaching-right-for-me/qualifications-you-need-to-teach")) %>.
+    </div>
+  </section>
+
+  <section class="col col-720">
+    <h2 class="heading--box-blue">Can I get help funding my training?</h2>
+
+    <div class="inset">
+      <p>
+        Undergraduate and postgraduate teacher training course fees are around £9,250.
+        You can apply for tuition fee and maintenance loans, even if you already have a student loan.
+      </p>
+
+      <p>
+        If you're interested in teaching certain subjects, you might be able to get a scholarship or bursary of up to £29k tax-free.
+        This is to support you while you are training and doesn't need to be paid back.
+      </p>
+
+      <p>
+        <%= link_to("Find out about funding", page_path("funding-and-support")) %>.
+    </div>
+  </section>
+
+    <section class="col col-720">
+    <h2 class="heading--box-blue">How do I apply for teacher training?</h2>
+
+    <div class="inset">
+      <p>
+        Full-time postgraduate teacher training courses usually take 9 months,
+        and undergraduate courses can take up to 4 years. Most courses start in September.
+      </p>
+
+      <p>
+        You can usually start applying in October before your course starts.
+        As courses are filled up on a first come first serve basis, it's important to start thinking about your course before then.
+      </p>
+
+      <p>
+        <%= link_to("Find out how to train to teach", page_path("train-to-be-a-teacher")) %>.
+    </div>
+  </section>
+</div>

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -42,11 +42,10 @@
     <div class="inset">
       <p>
         Full-time postgraduate teacher training courses usually take 9 months,
-        and undergraduate courses can take up to 4 years. Most courses start in September.
+        and undergraduate courses can take up to 4 years.
       </p>
-
       <p>
-        You can usually start applying in October before your course starts.
+      Most courses start in September. You can usually start applying in October before your course starts.
       </p>
 
       <p>

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -47,7 +47,6 @@
 
       <p>
         You can usually start applying in October before your course starts.
-        As courses are filled up on a first come, first served basis, it's important to start thinking about your course before then.
       </p>
 
       <p>

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -22,13 +22,13 @@
 
     <div class="inset">
       <p>
-        Undergraduate and postgraduate teacher training course fees are around £9,250.
+        Undergraduate and postgraduate teacher training course fees are around £9,250 per year.
         You can apply for tuition fee and maintenance loans, even if you already have a student loan.
       </p>
 
       <p>
         If you're interested in teaching certain subjects, you might be able to get a scholarship or bursary of up to £29k tax-free.
-        This is to support you while you are training and doesn't need to be paid back.
+        This is to support you while you are training and does not need to be paid back.
       </p>
 
       <p>

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -13,7 +13,7 @@
       </p>
 
       <p>
-        <%= link_to("Check the qualifications you need", page_path("is-teaching-right-for-me/qualifications-you-need-to-teach")) %>.
+        <%= link_to("Check the qualifications you need to teach", page_path("is-teaching-right-for-me/qualifications-you-need-to-teach")) %>.
     </div>
   </section>
 

--- a/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_content.html.erb
@@ -32,7 +32,7 @@
       </p>
 
       <p>
-        <%= link_to("Find out about funding", page_path("funding-and-support")) %>.
+        <%= link_to("Find out about funding your teacher training", page_path("funding-and-support")) %>.
     </div>
   </section>
 
@@ -47,7 +47,7 @@
 
       <p>
         You can usually start applying in October before your course starts.
-        As courses are filled up on a first come first serve basis, it's important to start thinking about your course before then.
+        As courses are filled up on a first come, first served basis, it's important to start thinking about your course before then.
       </p>
 
       <p>

--- a/app/views/content/landing/how-to-become-a-teacher/_header.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_header.html.erb
@@ -1,0 +1,6 @@
+<%= render Content::CampaignHeroComponent.new(
+  title: ["How to become", "a teacher"],
+  colour: @front_matter["colour"],
+  image: @front_matter["image"],
+  background_colour: "grey"
+) %>

--- a/app/views/content/landing/how-to-become-a-teacher/_mailing_list.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_mailing_list.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+  <section class="col col-720">
+    <%= render Content::MailingListComponent.new(
+      title: " Sign up for our emails",
+      intro: "Tailored to your own situation, you get all the latest information as well as advice and support."
+    ) %>
+  </section>
+</div>

--- a/app/views/content/landing/how-to-become-a-teacher/_mailing_list.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_mailing_list.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <section class="col col-720">
     <%= render Content::MailingListComponent.new(
-      title: " Sign up for our emails",
-      intro: "Tailored to your own situation, you get all the latest information as well as advice and support."
+      title: " Find out more about how to become a teacher",
+      intro: "Answer a couple of questions and we'll send you more information, as well as helpful tips and advice to get you one step closer to a career in teaching."
     ) %>
   </section>
 </div>

--- a/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
@@ -1,0 +1,10 @@
+<%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
+  <% promo.left_section( classes: %w[ml-background]) %>
+  <% promo.right_section(
+    heading: "Find out more about getting into teaching"
+  ) do %>
+      <p>Explore how you can get into teaching primary or secondary and find top tips on making a successful application.</p>
+
+      <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
+  <% end %>
+<% end %>

--- a/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
@@ -26,10 +26,6 @@
           </header>
         </li>
       </ol>
-
-      <p class="inset">
-        Read on to find out more.
-      </p>
     </section>
   </div>
 </div>

--- a/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
@@ -2,7 +2,7 @@
   <div class="grey col">
     <section class="col col-720 centered">
       <p class="inset">
-        We can help you to understand what's involved and decide if a
+        We can help you understand what's involved and decide if a
         career teaching in a primary or secondary school in England is right for you.
       </p>
 

--- a/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="grey col">
+    <section class="col col-720 centered">
+      <p class="inset">
+        We can help you to understand what's involved and decide if a
+        career teaching in a primary or secondary school in England is right for you.
+      </p>
+
+      <ol class="steps">
+        <li class="step">
+          <header class="step__header">
+            <div class="step__number">1</div>
+            <h2 class="heading-m">What qualifications do I need?</h2>
+          </header>
+        </li>
+        <li class="step">
+          <header class="step__header">
+            <div class="step__number">2</div>
+            <h2 class="heading-m">Can I get help funding my training?</h2>
+          </header>
+        </li>
+        <li class="step">
+          <header class="step__header">
+            <div class="step__number">3</div>
+            <h2 class="heading-m">How do I find and apply for teacher training?</h2>
+          </header>
+        </li>
+      </ol>
+
+      <p class="inset">
+        Read on to find out more.
+      </p>
+    </section>
+  </div>
+</div>

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -54,7 +54,7 @@
   ul,
   ol {
     @include mq($until: tablet) {
-      padding-left: 1.2em;
+      padding-left: $indent-amount;
     }
   }
 

--- a/app/webpacker/styles/steps.scss
+++ b/app/webpacker/styles/steps.scss
@@ -1,20 +1,24 @@
 .steps {
   position: relative;
-  margin: 0;
+  margin-top: 2.5em;
   box-sizing: border-box;
   list-style: none;
-  padding: 0;
+  padding: 0 $indent-amount;
+
+  @include mq($from: tablet) {
+    padding: 0;
+  }
 
   &:before {
     content: "";
     width: 0;
-    height: calc(100% - 20px);
+    height: calc(100% - 47px);
     position: absolute;
     top: 20px;
     left: 37px;
     border-left: 6px dotted $black;
     @include mq($until: tablet) {
-      left: 45px;
+      left: 52px;
     }
   }
 
@@ -42,6 +46,8 @@
       font-size: 28px;
       background-color: $yellow;
       position: relative;
+      flex-shrink: 0;
+
       @include mq($until: tablet) {
         width: 60px;
         height: 60px;

--- a/spec/components/content/mailing_list_component_spec.rb
+++ b/spec/components/content/mailing_list_component_spec.rb
@@ -8,8 +8,10 @@ describe Content::MailingListComponent, type: :component do
     page
   end
 
-  let(:component) { described_class.new }
+  let(:component) { described_class.new(title: "title", intro: "intro") }
 
+  it { is_expected.to have_css("h2", text: "title") }
+  it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container") }
   it { is_expected.to have_css("form") }
   it { is_expected.to have_link("privacy notice", href: "/privacy-policy?id=#{policy['id']}") }

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -7,6 +7,7 @@ class PageLister
     /privacy-policy
     /landing/how-much-do-teachers-get-paid
     /landing/how-much-do-teachers-get-paid-social
+    /landing/how-to-become-a-teacher
   ].freeze
 
   class << self


### PR DESCRIPTION
### Trello card

[Trello-4236](https://trello.com/c/qgr0nNpm/4236-design-new-steps-landing-page-for-paid-traffic)

### Context

We want to run a test involving the steps to become a teacher page with the advertising team.

### Changes proposed in this pull request

- Allow MailingListCompponent to be customised

We need to be able to specify the title/intro on a a use-by-use basis as it won't always be the same.

- Add how to become a teacher landing page

Add a new landing page for how to become a teacher.

### Guidance to review

[Link to page](https://review-get-into-teaching-app-3158.london.cloudapps.digital/landing/how-to-become-a-teacher)

| Desktop      | Mobile |
| ----------- | ----------- |
| ![screencapture-0-0-0-0-3000-landing-how-to-become-a-teacher-2023-03-02-10_48_34](https://user-images.githubusercontent.com/29867726/222421892-4ffd824a-abb2-401e-b671-3afa7d79bb31.png)      | ![screencapture-0-0-0-0-3000-landing-how-to-become-a-teacher-2023-03-02-10_48_58](https://user-images.githubusercontent.com/29867726/222421904-6b15d371-c557-408e-ace3-ed4b06cae5d8.png)       |

