### PR TITLE
Update copy on mailing list postcode step

### DIFF
--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -10,3 +10,16 @@
   } do %>
   <p>If you give us your postcode, we'll let you know about events happening near you.</p>
 <% end %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      What if I do not have a UK postcode?
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>We run in-person events in the UK that we can tell you about if you give us your UK postcode.</p>
+    <p>If you do not live in the UK, you do not need to give us your postcode.</p>
+    <p>Instead, you can just select 'Complete sign up' to receive tailored guidance around teacher training.</p>
+  </div>
+</details>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,7 +451,7 @@ en:
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
-        address_postcode: Your postcode (optional)
+        address_postcode: Your UK postcode (optional)
 
       search:
         search: Search for ...

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_title("You've signed up | Get Into Teaching")
@@ -80,7 +80,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "You've signed up"
@@ -120,7 +120,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "Test, you're signed up"
@@ -159,7 +159,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "You've signed up"
@@ -351,7 +351,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: ""
+    fill_in "Your UK postcode (optional)", with: ""
     click_on "Complete sign up"
 
     expect(page).to have_text "You've signed up"

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Integration tests", :integration, type: :feature, js: true do
     click_on "Next step"
 
     expect(page).to have_text "If you give us your postcode"
-    fill_in "Your postcode (optional)", with: "TE57 1NG"
+    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text("you're signed up")


### PR DESCRIPTION
### Trello card

[Trello-4276](https://trello.com/c/8Cf2f1J7/4276-update-postcode-step-to-avoid-confusion-for-international-users)

### Context

The postcode step confuses international candidates as we only accept UK postcodes, but this isn't clear at the moment.

### Changes proposed in this pull request

- Update copy on mailing list postcode step

Update the title to include 'UK' and add a helper section for international candidates.

### Guidance to review

