### PR TITLE
Fix mailing list integration tests

### DIFF
--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -9,16 +9,13 @@ RSpec.feature "Integration tests", :integration, type: :feature, js: true do
     WebMock.disable_net_connect!(allow_localhost: true)
   end
 
-  # I need to look into why this has started failing; it can't
-  # find the new radio buttons for the returning teacher step
-  # for some reason; disabling for now.
-  skip "Sign up journey as a new candidate" do
+  it "Sign up journey as a new candidate" do
     visit mailing_list_steps_path
     click_link "Accept all cookies"
     sign_up(rand_first_name, rand_last_name, rand_email)
   end
 
-  skip "Sign up journey as an existing candidate" do
+  it "Sign up journey as an existing candidate" do
     visit mailing_list_steps_path
     click_link "Accept all cookies"
 
@@ -34,7 +31,8 @@ RSpec.feature "Integration tests", :integration, type: :feature, js: true do
     submit_personal_details(first_name, last_name, email)
 
     expect(page).to have_text "Are you already qualified to teach?"
-    choose "No"
+    # I'm not sure why 'choose "No"' doesn't work here.
+    find("label", text: "No").click
     click_on "Next step"
 
     expect(page).to have_text("Do you have a degree?")


### PR DESCRIPTION
[Trello-4258](https://trello.com/c/5DcZLZxH/4258-fix-mailing-list-integration-tests)

For some reason the 'No' label/radio isn't found by Capybara using `choose "No"`. If we find the label explicitly and click it then it appears to work.
