### PR TITLE
Fix link color for accessibility

### DIFF
--- a/app/components/content/talk_to_us_component.html.erb
+++ b/app/components/content/talk_to_us_component.html.erb
@@ -5,7 +5,7 @@
 
   <div class="content">
     <div class="inset">
-      <p>Get support through live chat or on the phone, Monday to Friday, <strong>8:30am until 5:30pm</strong> except on <a href="https://www.gov.uk/bank-holidays">bank holidays</a>.</p>
+      <p>Get support through live chat or on the phone, Monday to Friday, <strong>8:30am until 5:30pm</strong> except on <a class="link--dark" href="https://www.gov.uk/bank-holidays">bank holidays</a>.</p>
     </div>
 
     <div class="contact-options">


### PR DESCRIPTION
### Trello card

[Trello-4179](https://trello.com/c/uXHvcGZj/4179-fix-colour-contrast-issue-on-help-and-support-page)

### Context

There is not enough contrast in this link with the background; using our standard dark link color should fix that.

### Changes proposed in this pull request

- Fix link color for accessibility 

### Guidance to review

