### PR TITLE
No-index blog tag pages

### DIFF
--- a/app/controllers/blog/tag_controller.rb
+++ b/app/controllers/blog/tag_controller.rb
@@ -8,6 +8,7 @@ class Blog::TagController < ApplicationController
   def show
     @front_matter = {
       "title" => "Blog posts about #{params[:id].tr('-', ' ')}",
+      "noindex" => true,
     }
 
     breadcrumb "Blog", blog_index_path


### PR DESCRIPTION
### Trello card

[Trello-4308](https://trello.com/c/auA2NsRE/4308-add-noindex-to-the-blog-tag-pages)

### Context

The blog tag pages have the same intro paragraph and could be considered duplicate content according to Google Search Console. We have also not reviewed the tags yet so there are likely improvements that need to be made in this area. In the meantime we don't want to index these pages with search engines.

### Changes proposed in this pull request

- No-index blog tag pages

### Guidance to review

