### PR TITLE
Update link color for accessibility

### DIFF
--- a/app/components/chat_component.html.erb
+++ b/app/components/chat_component.html.erb
@@ -13,7 +13,7 @@
     <p>
       <strong>Chat not available</strong>
       <br>
-      Email: <%= mail_to("getintoteaching.getintoteaching@education.gov.uk") %>
+      Email: <%= mail_to("getintoteaching.getintoteaching@education.gov.uk", class: "link--dark") %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
[Trello-4310](https://trello.com/c/ppLp0C5A/4310-fix-colour-contrast-issue-on-help-and-support-page-when-javascript-disabled)

Update the email link color we display when JS is disabled for better contrast.