### PR TITLE
Enable Google Optimize on homepage

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -7,6 +7,7 @@
 #   - /
 
 paths:
+  - /
   - /salaries-and-benefits-search
   - /salaries-and-benefits-social
   - /landing/how-much-do-teachers-get-paid

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -184,6 +184,7 @@ describe ApplicationHelper do
     it "includes pages currently under test" do
       is_expected.to eq({
         paths: [
+          "/",
           "/salaries-and-benefits-search",
           "/salaries-and-benefits-social",
           "/landing/how-much-do-teachers-get-paid",


### PR DESCRIPTION
We want to run an experiment on the homepage; enable Google Optimize so the script is included.