### PR TITLE
tweaking non-UK meta descriptions

### DIFF
--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-UK-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-UK-trainees.md
@@ -1,7 +1,7 @@
 ---
 title: "Fees and financial support for non-UK trainee teachers"
 description: |-
-  Learn more about bursaries, scholarships and the international relocation payment.
+  Learn more about funding and financial support for non-UK students, including details of the international relocation payment.
 related_content:
     Career progression stories: "/blog/tag/career-progression"
     Salaries and benefits of teaching in England : "/salaries-and-benefits"

--- a/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas.md
+++ b/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas.md
@@ -3,7 +3,7 @@ title: Return to England after teaching overseas
 image: "static/content/hero-images/0014.jpg"
 backlink: "../../"
 description: |-
-  Return to England after teaching overseas and bring your skills and experience back to an English classroom. Get support to make your transition easier.
+  Return to England after teaching outside the UK and bring your skills and experience back to an English classroom. Get support to make your transition easier.
 related_content:
     Salaries and benefits of teaching in England : "/salaries-and-benefits"
     Returning to teaching with international experience : "/blog/returning-to-teaching-with-international-experience"

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -1,7 +1,7 @@
 ---
 title: "Teach in England if you trained outside the UK"
 description: |-
-  Teach in England if you're a qualified teacher from overseas. Explore the benefits of teaching in England and join a world class education system.
+  Teach in England if you're a qualified teacher from outside the UK. Explore the benefits of teaching in England and join a world class education system.
 related_content:
     Career progression stories: "/blog/tag/career-progression"
     Salaries and benefits of teaching in England : "/salaries-and-benefits"

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -1,7 +1,7 @@
 ---
 title: "Train to teach in England as an international student"
 description: |-
-  Find out how to train to teach in England as an international student. Get help and guidance on your qualifications, funding and visa.
+  Find out how to train to teach in England as a student from outside the UK. Get help and guidance on your qualifications, funding and visa.
 related_content:
     Get support training to teach if you're disabled: "/funding-and-support/if-youre-disabled"
     Initial teacher training in England : "/train-to-be-a-teacher/initial-teacher-training"


### PR DESCRIPTION
### Trello card

https://trello.com/c/TwtllO6w

### Context

We need to update the meta descriptions of non-UK pages to make sure it is clear this is for those outside of the UK. We have also updated to use non-UK rather than international or overseas.

### Changes proposed in this pull request

- making it clear these pages are for non-UK users
- changing international or overseas to non-UK

### Guidance to review

