### PR TITLE
adding messages on primary and secondary training

### DIFF
--- a/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-apply-for-teacher-training.md
@@ -45,6 +45,8 @@ Search [postgraduate teacher training courses](https://www.gov.uk/find-postgradu
 Course providers will help you gain your [qualified teacher status (QTS)](/what-is-qts) which is what you need to teach in most schools in England. Many also help you work 
 towards a [postgraduate certificate in education (PGCE) or postgraduate diploma in education (PGDE)](/what-is-a-pgce).
 
+As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+
 ## Where to apply
 
 When you're ready, you can [apply for teacher training](https://www.gov.uk/apply-for-teacher-training).

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -32,6 +32,6 @@ Qualifications vary depending on the course. For example, you could get QTS with
 
 [Find out more about the qualifications you need to be a teacher in England](/is-teaching-right-for-me/qualifications-you-need-to-teach).
 
-As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+As part of selecting your degree course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
 
 If you're a non-UK citizen who wants to study in England, you can visit the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/) for information about studying at an English university.

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -32,4 +32,6 @@ Qualifications vary depending on the course. For example, you could get QTS with
 
 [Find out more about the qualifications you need to be a teacher in England](/is-teaching-right-for-me/qualifications-you-need-to-teach).
 
+As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+
 If you're a non-UK citizen who wants to study in England, you can visit the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/) for information about studying at an English university.

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -90,6 +90,8 @@ Your teacher training course might be provided by a university, school, college 
 
 The content of SCITT and School Direct programmes are broadly the same.
 
+As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+
 Some courses have different course structures and have placements in different kinds of schools, such as special schools. Talk to your teacher training provider to find out what they can offer you.
 
 [Find teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/).

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -28,6 +28,8 @@ You’ll also have a mentor to support you in your school placements and learnin
 
 There are full-time and part-time teacher training courses available.
 
+As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+
 [Find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/).
 
 ## What you’ll learn in initial teacher training

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -28,8 +28,6 @@ You’ll also have a mentor to support you in your school placements and learnin
 
 There are full-time and part-time teacher training courses available.
 
-As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
-
 [Find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/).
 
 ## What you’ll learn in initial teacher training
@@ -55,6 +53,8 @@ environment
 Typically, you will get 120 days of classroom experience in a minimum of two schools. Through your placements, you’ll have the opportunity to teach, plan, observe and research.
 
 You’ll get classroom experience whether you do school-led or university-led training. School-led training programmes like School Direct usually include more time in school than university-led training.
+
+Where you complete your classroom placements will depend on whether you've chosen a primary or secondary teacher training course. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
 
 Some courses may offer placements in specific kinds of schools, like special schools. You can talk to your course provider about the opportunities available.
 

--- a/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
+++ b/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
@@ -16,7 +16,7 @@ calls_to_action:
         link_target: "https://schoolexperience.education.gov.uk/"
 ---
 
-It’s good to consider what kind of teacher you want to be based on your interests, skills and experience. You might need specific training or qualifications in some areas. This page explains more about the different options.
+It’s good to consider what kind of teacher you want to be based on your interests, skills and experience. If you’re considering initial teacher training, you will also need to decide if you want to train to teach at a primary or secondary level. This page explains more about the different options.
 
 ## Teach in a primary or secondary school
 

--- a/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
+++ b/app/views/content/train-to-be-a-teacher/who-do-you-want-to-teach.md
@@ -16,7 +16,7 @@ calls_to_action:
         link_target: "https://schoolexperience.education.gov.uk/"
 ---
 
-It’s good to consider what kind of teacher you want to be based on your interests, skills and experience. If you’re considering initial teacher training, you will also need to decide if you want to train to teach at a primary or secondary level. This page explains more about the different options.
+It’s good to consider what kind of teacher you want to be based on your interests, skills and experience. You might need specific training or qualifications in some areas. This page explains more about the different options.
 
 ## Teach in a primary or secondary school
 

--- a/app/views/content/what-is-a-pgce.md
+++ b/app/views/content/what-is-a-pgce.md
@@ -70,6 +70,8 @@ You can do this through a school-led, university-led, or an apprenticeship teach
 
 You can do a full or part-time PGCE course.
 
+As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+
 ### Entry requirements
 
 Entry requirements for a postgraduate teacher training course usually include an undergraduate degree or equivalent qualification.

--- a/app/views/content/what-is-a-pgce.md
+++ b/app/views/content/what-is-a-pgce.md
@@ -70,7 +70,7 @@ You can do this through a school-led, university-led, or an apprenticeship teach
 
 You can do a full or part-time PGCE course.
 
-As part of selecting your teacher training course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
+As part of selecting your course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
 
 ### Entry requirements
 

--- a/app/views/content/what-is-qts.md
+++ b/app/views/content/what-is-qts.md
@@ -43,7 +43,7 @@ $international-content$
 
 You can get QTS through undergraduate or postgraduate initial teacher training. This mostly involves school placements with some theoretical learning.
 
-You can apply for either a primary or secondary teacher training course awarding QTS.
+You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/train-to-be-a-teacher/who-do-you-want-to-teach).
 
 You can also get a postgraduate qualification through teacher training such as a [postgraduate certificate in education (PGCE)](/what-is-a-pgce). 
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/xn2Sap4B

### Context

We are not clear enough that candidates need to choose between primary or secondary teacher training.

### Changes proposed in this pull request

Adding a message to explain that candidates need to decide between primary and secondary and linking to more information about each age level.

### Guidance to review

