### PR TITLE
Add funding your training landing page

### DIFF
--- a/app/components/content/checklist_collage_component.html.erb
+++ b/app/components/content/checklist_collage_component.html.erb
@@ -8,7 +8,7 @@
     <%= link_to(cta[:text], cta[:link], class: "button") if cta.present? %>
     <%= content %>
   </div>
-  <div class="images">
+  <%= tag.div(class: image_classes) do %>
     <%= images %>
-  </div>
+  <% end %>
 </div>

--- a/app/components/content/checklist_collage_component.rb
+++ b/app/components/content/checklist_collage_component.rb
@@ -17,5 +17,9 @@ module Content
         end,
       )
     end
+
+    def image_classes
+      ["images", "images-#{image_paths.count}"]
+    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,6 +15,7 @@ class PagesController < ApplicationController
     "/landing/how-much-do-teachers-get-paid", # Contains a form
     "/landing/how-much-do-teachers-get-paid-social", # Contains a form
     "/landing/how-to-become-a-teacher", # Contains a form
+    "/landing/how-to-fund-your-teacher-training", # Contains a form
   ].freeze
 
   caches_page :cookies

--- a/app/views/content/landing/how-to-fund-your-teacher-training.md
+++ b/app/views/content/landing/how-to-fund-your-teacher-training.md
@@ -1,0 +1,15 @@
+---
+title: "How to fund your teacher training"
+description: TODO
+content:
+    - content/landing/how-to-fund-your-teacher-training/header
+    - content/landing/how-to-fund-your-teacher-training/collage
+    - content/landing/how-to-fund-your-teacher-training/mailing_list
+    - content/landing/how-to-fund-your-teacher-training/content
+    - content/landing/how-to-fund-your-teacher-training/promo
+image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
+colour: "yellow"
+layout: "layouts/minimal"
+talk_to_us: false
+noindex: true
+---

--- a/app/views/content/landing/how-to-fund-your-teacher-training.md
+++ b/app/views/content/landing/how-to-fund-your-teacher-training.md
@@ -1,6 +1,6 @@
 ---
 title: "How to fund your teacher training"
-description: TODO
+description: Find out how you could fund your teacher training with bursaries and scholarships available up to £29k, depending on the subject you're training to teach.
 content:
     - content/landing/how-to-fund-your-teacher-training/header
     - content/landing/how-to-fund-your-teacher-training/collage

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_collage.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_collage.html.erb
@@ -1,0 +1,28 @@
+<div class="row">
+  <div class="grey col">
+    <section class="col col-full-content">
+      <div class="inset">
+        <p class="col-720">
+          If you train to be a teacher, you could be eligible to receive a
+          scholarship or bursary of up to £29k to help you train.
+        </p>
+
+        <%= render Content::ChecklistCollageComponent.new(
+          checklist: [
+            "Scholarships and bursaries do not have to be paid back.",
+            "You can get a scholarship or bursary alongside tuition fee and maintenance loans.",
+            "The exact amount you could receive will depend on the subject that you train to teach."
+          ],
+          image_paths: [
+            "static/content/how-much-do-teachers-get-paid/collage2.jpg",
+          ]
+        ) do %>
+          <p>
+            If you're considering a career in teaching, we're here to help every step of the way.
+            Our free service is available both online and in-person to help you on your journey into the classroom.
+          </p>
+        <% end %>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_collage.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_collage.html.erb
@@ -17,10 +17,6 @@
             "static/content/how-much-do-teachers-get-paid/collage2.jpg",
           ]
         ) do %>
-          <p>
-            If you're considering a career in teaching, we're here to help every step of the way.
-            Our free service is available both online and in-person to help you on your journey into the classroom.
-          </p>
         <% end %>
       </div>
     </section>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -46,12 +46,12 @@
             <td></td>
           </tr>
           <tr>
-            <td>Languages</strong><br> (French, German and Spanish only)</td>
+            <td>Languages<br> (French, German and Spanish only)</td>
             <td>£25,000</td>
             <td>£27,000</td>
           </tr>
           <tr>
-            <td>Languages</strong><br> (all other languages, including ancient languages)</td>
+            <td>Languages<br> (all other languages, including ancient languages)</td>
             <td>£25,000</td>
             <td></td>
           </tr>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -93,7 +93,7 @@
       <p>You could also be eligible for up to:</p>
 
       <ul>
-        <li>£323.85 a week for 2 or more children if you're a parent</li>
+        <li>£323.85 a week to support childcare costs for 2 or more children</li>
         <li>£3,354 a year if an adult depends on you</li>
         <li>£26,291 a year if you're disabled</li>
         <li>£40,000 if you're a veteran</li>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -1,0 +1,109 @@
+<div class="row">
+  <section class="col col-720">
+    <h2 class="heading--box-blue">How can I fund my teacher training?</h2>
+
+    <div class="inset">
+      <p>
+        Different bursaries and scholarships are available depending on the subject you're training to teach.
+      </p>
+
+      <h3>Postgraduate bursaries and scholarships</h3>
+
+      <table class="first-column-headings right-aligned-values">
+        <caption>Postgraduate bursaries and scholarships are available for the subjects listed below.</caption>
+        <thead>
+          <tr>
+            <th scope="col">Subject</th>
+            <th scope="col">Bursary</th>
+            <th scope="col">Scholarship</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Biology</td>
+            <td>£20,000</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Chemistry</td>
+            <td>£27,000</td>
+            <td>£29,000</td>
+          </tr>
+          <tr>
+            <td>Computing</td>
+            <td>£27,000</td>
+            <td>£29,000</td>
+          </tr>
+          <tr>
+            <td>Design and technology</td>
+            <td>£20,000</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>English</td>
+            <td>£15,000</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Geography</td>
+            <td>£25,000</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Languages</strong><br> (French, German and Spanish only)</td>
+            <td>£25,000</td>
+            <td>£27,000</td>
+          </tr>
+          <tr>
+            <td>Languages</strong><br> (all other languages, including ancient languages)</td>
+            <td>£25,000</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Maths</td>
+            <td>£27,000</td>
+            <td>£29,000</td>
+          </tr>
+          <tr>
+            <td>Physics</td>
+            <td>£27,000</td>
+            <td>£29,000</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Undergraduate bursaries</h3>
+
+      <p>You might be eligible for a bursary of £9,000 if you do:</p>
+
+      <ul>
+        <li>an undergraduate maths or physics course leading to qualified teacher status (QTS)</li>
+        <li>an opt-in undergraduate QTS course in computing, languages, maths or physics</li>
+      </ul>
+
+      <p><%= link_to("Find out more about how to get a bursary or scholarship", page_path("funding-and-support/scholarships-and-bursaries")) %>.</p>
+    </div>
+  </section>
+
+  <section class="col col-720">
+    <h2 class="heading--box-blue">More financial support</h2>
+
+    <div class="inset">
+      <p>
+        You can get a tuition fee and maintenance loan to fund your teacher training,
+        even if you've had student finance before.
+      </p>
+
+      <p>You could also be eligible for up to:</p>
+
+      <ul>
+        <li>£323.85 a week for 2 or more children if you're a parent</li>
+        <li>£3,354 a year if an adult depends on you</li>
+        <li>£26,291 a year if you're disabled</li>
+        <li>£40,000 if you're a veteran</li>
+      </ul>
+
+      <p><%= link_to("Find out more about how you could fund your training", page_path("funding-and-support")) %>.</p>
+    </div>
+  </section>
+</div>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -68,15 +68,6 @@
         </tbody>
       </table>
 
-      <h3>Undergraduate bursaries</h3>
-
-      <p>You might be eligible for a bursary of £9,000 if you do:</p>
-
-      <ul>
-        <li>an undergraduate maths or physics course leading to qualified teacher status (QTS)</li>
-        <li>an opt-in undergraduate QTS course in computing, languages, maths or physics</li>
-      </ul>
-
       <p><%= link_to("Find out more about how to get a bursary or scholarship", page_path("funding-and-support/scholarships-and-bursaries")) %>.</p>
     </div>
   </section>
@@ -96,7 +87,6 @@
         <li>£323.85 a week to support childcare costs for 2 or more children</li>
         <li>£3,354 a year if an adult depends on you</li>
         <li>£26,291 a year if you're disabled</li>
-        <li>£40,000 if you're a veteran</li>
       </ul>
 
       <p><%= link_to("Find out more about how you could fund your training", page_path("funding-and-support")) %>.</p>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -3,10 +3,6 @@
     <h2 class="heading--box-blue">How can I fund my teacher training?</h2>
 
     <div class="inset">
-      <p>
-        Different bursaries and scholarships are available depending on the subject you're training to teach.
-      </p>
-
       <h3>Postgraduate bursaries and scholarships</h3>
 
       <table class="first-column-headings right-aligned-values">

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::CampaignHeroComponent.new(
-  title: ["How to fund your", "teacher training"],
+  title: ["Fund your", "teacher training"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
   background_colour: "grey"

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
@@ -1,0 +1,6 @@
+<%= render Content::CampaignHeroComponent.new(
+  title: ["How to fund your", "teacher training"],
+  colour: @front_matter["colour"],
+  image: @front_matter["image"],
+  background_colour: "grey"
+) %>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_mailing_list.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_mailing_list.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+  <section class="col col-720">
+    <%= render Content::MailingListComponent.new(
+      title: "Find out more about funding your training",
+      intro: "Get more information about funding your teacher training, as well as tips and advice on becoming a teacher."
+    ) %>
+  </section>
+</div>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_promo.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_promo.html.erb
@@ -1,0 +1,10 @@
+<%= render(CallsToAction::Promo::PromoComponent.new) do |promo| %>
+  <% promo.left_section( classes: %w[ml-background]) %>
+  <% promo.right_section(
+    heading: "Find out more about getting into teaching"
+  ) do %>
+      <p>Explore how you can get into teaching primary or secondary and find top tips on making a successful application.</p>
+
+      <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
+  <% end %>
+<% end %>

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -47,6 +47,10 @@
     grid-template-columns: (4 * $indent-amount) auto (2 * $indent-amount);
     grid-template-rows: auto (2 * $indent-amount) auto;
 
+    &.images-1 {
+      display: none;
+    }
+
     img {
       max-width: 100%;
       height: auto;
@@ -70,6 +74,10 @@
     @include mq($from: tablet) {
       grid-template-columns: (2 * $indent-amount) auto (4 * $indent-amount) (6 * $indent-amount) (2 * $indent-amount);
       grid-template-rows: auto (2 * $indent-amount) $indent-amount auto;
+
+      &.images-1 {
+        display: grid;
+      }
 
       img {
         max-width: 100%;

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -30,6 +30,7 @@
 @import "welcome-guide";
 @import "category";
 @import "statement";
+@import "table";
 
 @import "./sections/hero";
 @import "./sections/hero/content";

--- a/app/webpacker/styles/markdown.scss
+++ b/app/webpacker/styles/markdown.scss
@@ -81,33 +81,8 @@
   }
 
   table {
-    $table-spacing: .5em;
-    border-spacing: 0 $table-spacing;
     margin: 1em $indent-amount 2em;
     width: 90%;
-    border-color: $grey;
-
-    thead > tr {
-      > th {
-        text-align: left;
-        padding: 0 $table-spacing $table-spacing $table-spacing;
-        margin-bottom: $table-spacing;
-        border-bottom: 1px solid $grey-light;
-        word-break: normal;
-
-        &:first-child {
-          padding-left: 0;
-        }
-
-        &:last-child {
-          padding-right: 0;
-        }
-      }
-    }
-
-    tbody td {
-      @include font-size("xsmall");
-    }
   }
 
   .inset {

--- a/app/webpacker/styles/table.scss
+++ b/app/webpacker/styles/table.scss
@@ -1,0 +1,45 @@
+table {
+  $table-spacing: .5em;
+  border-spacing: 0 $table-spacing;
+  border-color: $grey;
+  width: 100%;
+
+  caption {
+    text-align: left;
+  }
+
+  thead > tr {
+    > th {
+      text-align: left;
+      padding: 0 $table-spacing $table-spacing $table-spacing;
+      margin-bottom: $table-spacing;
+      border-bottom: 1px solid $grey-light;
+      word-break: normal;
+
+      &:first-child {
+        padding-left: 0;
+      }
+
+      &:last-child {
+        padding-right: 0;
+      }
+    }
+  }
+
+  tbody td {
+    @include font-size("xsmall");
+  }
+
+  &.first-column-headings {
+    tr > td:first-child {
+      font-weight: bold;
+    }
+  }
+
+  &.right-aligned-values {
+    tr > td:not(:first-child),
+    tr > th:not(:first-child) {
+      text-align: right;
+    }
+  }
+}

--- a/spec/components/content/checklist_collage_component_spec.rb
+++ b/spec/components/content/checklist_collage_component_spec.rb
@@ -33,6 +33,7 @@ describe Content::ChecklistCollageComponent, type: :component do
   it { is_expected.to have_css(".checklist-collage") }
   it { is_expected.to have_link(cta[:text], href: cta[:link]) }
   it { is_expected.to have_css("p", text: "content") }
+  it { is_expected.to have_css(".images.images-3") }
 
   it "renders the checlist items" do
     checklist.each do |item|

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -8,6 +8,7 @@ class PageLister
     /landing/how-much-do-teachers-get-paid
     /landing/how-much-do-teachers-get-paid-social
     /landing/how-to-become-a-teacher
+    /landing/how-to-fund-your-teacher-training
   ].freeze
 
   class << self


### PR DESCRIPTION
### Trello card

[Trello-4268](https://trello.com/c/iwpatEHI/4268-create-and-test-a-new-bursaries-and-scholarships-landing-page-for-paid-traffic-test-3)

### Context

We are working with the advertising team on testing some landing page variations; one of these is around bursaries and scholarships.

### Changes proposed in this pull request

- Add funding your training landing page

Add a new landing page for funding your training. Update collage component to support a single image that hides on mobile. Extract table CSS so we can use it outwith the markdown class.

### Guidance to review

We should check other tables on the website still look right as the CSS has changed.