### PR TITLE
Remove University of Hull from Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -460,10 +460,6 @@ provider_groups:
       name: Rebecca Turner-Loisel
       telephone: '01977 657604'
       email: ytca@minsthorpe.cc
-    - header: University of Hull
-      name: Initial Teacher Education Partners
-      link: https://www.hull.ac.uk
-      email: FACE-ITEPartners@hull.ac.uk
     - header: Yorkshire and Humber Teacher Training
       link: https://www.yhtt.co.uk
       name: Chris Fletcher


### PR DESCRIPTION
### Trello card
https://trello.com/c/tUB0bVes

### Context
Request received via GIT support team to remove University of Hull from Assessment only page

