### PR TITLE
Updating steps page title and description

### DIFF
--- a/app/views/content/steps-to-become-a-teacher.md
+++ b/app/views/content/steps-to-become-a-teacher.md
@@ -1,8 +1,9 @@
 ---
-  title: "Steps to become a teacher"
+  title: "How to become a teacher"
+  heading: "Steps to become a teacher"
   layout: "layouts/steps"
   description: |-
-    Find out how to become a teacher with our step-by-step guide. Decide who to teach, check your qualifications, and find out how to train to be a teacher.
+    Find out how to become a teacher with our step-by-step guide. Decide who to teach, check your qualifications, and find out how to train.
   date: "2021-06-24"
   image: "static/content/hero-images/0017.jpg"
   backlink: "../"


### PR DESCRIPTION
### Trello card

https://trello.com/c/v6DPjwpe/4365-change-title-and-meta-description-for-steps-page-for-organic-search

### Context

How to become a teacher is a much higher search term than steps to become a teacher - while we do the bigger steps work in the background, it's a good idea to update the page title and meta description in the mean time to make sure we're capturing this term to try and pick up more organic traffic.

### Changes proposed in this pull request

### Guidance to review

