### PR TITLE
Updating mailing list step in events sign up

### DIFF
--- a/app/helpers/option_set_helper.rb
+++ b/app/helpers/option_set_helper.rb
@@ -1,0 +1,6 @@
+module OptionSetHelper
+  def degree_status_text(option)
+    key = option.value.parameterize(separator: "_")
+    I18n.t("helpers.answer.mailing_list_steps_degree_status.degree_status.#{key}", default: option.value)
+  end
+end

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -7,11 +7,11 @@ class OptionSet
 
   DEGREE_STATUSES =
     {
-      "Yes, I already have a degree" => 222_750_000,
-      "Almost, I'm a final year student" => 222_750_001,
-      "Not yet, I'm a second year student" => 222_750_002,
-      "Not yet, I'm a first year student" => 222_750_003,
-      "No, and I'm not studying for one" => 222_750_004,
+      "Graduate or postgraduate" => 222_750_000,
+      "Final year" => 222_750_001,
+      "Second year" => 222_750_002,
+      "First year" => 222_750_003,
+      "I don't have a degree and am not studying for one" => 222_750_004,
       "Other" => 222_750_005,
     }.freeze
 

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -7,11 +7,11 @@ class OptionSet
 
   DEGREE_STATUSES =
     {
-      "Graduate or postgraduate" => 222_750_000,
-      "Final year" => 222_750_001,
-      "Second year" => 222_750_002,
-      "First year" => 222_750_003,
-      "I don't have a degree and am not studying for one" => 222_750_004,
+      "Yes, I already have a degree" => 222_750_000,
+      "Almost, I'm a final year student" => 222_750_001,
+      "Not yet, I'm a second year student" => 222_750_002,
+      "Not yet, I'm a first year student" => 222_750_003,
+      "No, and I'm not studying for one" => 222_750_004,
       "Other" => 222_750_005,
     }.freeze
 

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -1,5 +1,7 @@
 <%= tag.h1("About you") %>
 
+<p>These questions help us provide tailored guidance depending on your circumstances.</p>
+
 <%= f.govuk_collection_select :degree_status_id,
       f.object.degree_status_options,
       :id,
@@ -17,5 +19,5 @@
     :id,
     :value,
     options: { prompt: true } %>
-    
+
 <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code" unless f.object.hide_postcode_field? %>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -1,4 +1,4 @@
-<%= tag.h1("How close are you to applying?") %>
+<%= tag.h1("About you") %>
 
 <%= f.govuk_collection_select :degree_status_id,
       f.object.degree_status_options,

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -21,3 +21,16 @@
     options: { prompt: true } %>
 
 <%= f.govuk_text_field :address_postcode, autocomplete: "postal-code" unless f.object.hide_postcode_field? %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      What if I do not have a UK postcode?
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>We run in-person events in the UK that we can tell you about if you give us your UK postcode.</p>
+    <p>If you do not live in the UK, you do not need to give us your postcode.</p>
+    <p>Instead, you can just select 'Complete sign up' to finish signing up for your event.</p>
+  </div>
+</details>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -12,10 +12,10 @@
       :value,
       options: { prompt: true } %>
 
-<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code" unless f.object.hide_postcode_field? %>
-
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
     f.object.teaching_subject_options,
     :id,
     :value,
     options: { prompt: true } %>
+    
+<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code" unless f.object.hide_postcode_field? %>

--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -5,7 +5,7 @@
 <%= f.govuk_collection_select :degree_status_id,
       f.object.degree_status_options,
       :id,
-      :value,
+      ->(option) { degree_status_text(option) },
       options: { prompt: true } %>
 
 <%= f.govuk_collection_select :consideration_journey_stage_id,

--- a/app/views/mailing_list/steps/_degree_status.html.erb
+++ b/app/views/mailing_list/steps/_degree_status.html.erb
@@ -12,7 +12,7 @@
 <%= f.govuk_collection_radio_buttons :degree_status_id,
   f.object.degree_status_options,
   :id,
-  ->(option) { I18n.t("helpers.answer.mailing_list_steps_degree_status.degree_status.#{option.value.parameterize(separator: '_')}", default: option.value) },
+  ->(option) { degree_status_text(option) },
   legend: { tag: 'h1', text: t("helpers.label.mailing_list_steps_degree_status.degree_status_id") } do
 %>
   <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,7 +286,7 @@ en:
             consideration_journey_stage_id:
               inclusion: Select how close you are to applying for teacher training
             preferred_teaching_subject_id:
-              inclusion: Select the subject do you want to teach
+              inclusion: Select the subject you want to teach
 
         callbacks/steps/personal_details:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,7 +428,7 @@ en:
         address_postcode: What is your UK postcode? (optional)
         degree_status_id: Do you have a degree?
         consideration_journey_stage_id: How close are you to applying for teacher training?
-        preferred_teaching_subject_id: What subject do you want to teach?
+        preferred_teaching_subject_id: What do you want to teach?
 
       callbacks_steps_personal_details:
         first_name: First name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,7 +425,7 @@ en:
       events_steps_contact_details:
         address_telephone: What is your telephone number? (optional)
       events_steps_personalised_updates:
-        address_postcode: What is your postcode? (optional)
+        address_postcode: What is your UK postcode? (optional)
         degree_status_id: Do you have a degree?
         consideration_journey_stage_id: How close are you to applying for teacher training?
         preferred_teaching_subject_id: What subject do you want to teach?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -466,10 +466,10 @@ en:
           resent: We've sent you another email
       events_steps_personalised_updates:
         address_postcode: |-
-          We want to send you relevant information about events in your area.
+          If you give us your postcode, we'll let you know about events happening near you.
       mailing_list_signup:
         address_postcode: |-
-          We want to send you relevant information about events in your area.
+          If you give us your postcode, we'll let you know about events happening near you.
 
     legend:
       events_steps_further_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,7 +282,7 @@ en:
             address_postcode:
               invalid: Enter a valid UK postcode, or leave blank
             degree_status_id:
-              inclusion: Select the stage of your degree you are at
+              inclusion: Select your degree stage
             consideration_journey_stage_id:
               inclusion: Select how close you are to applying for teacher training
             preferred_teaching_subject_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,7 +280,7 @@ en:
         events/steps/personalised_updates:
           attributes:
             address_postcode:
-              invalid: Enter a valid postcode, or leave blank
+              invalid: Enter a valid UK postcode, or leave blank
             degree_status_id:
               inclusion: Select the stage of your degree you are at
             consideration_journey_stage_id:

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -310,7 +310,7 @@ RSpec.feature "Event wizard", type: :feature do
     if page.has_text?("What is your UK postcode? (optional)")
       fill_in "What is your UK postcode? (optional)", with: postcode
     end
-    select_value_or_default "What subject do you want to teach?", preferred_teaching_subject
+    select_value_or_default "What do you want to teach?", preferred_teaching_subject
   end
 
   def select_value_or_default(label, value = nil)

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -337,8 +337,8 @@ RSpec.feature "Event wizard", type: :feature do
     {
       degree_status_id: 222_750_000,
       consideration_journey_stage_id: 222_750_000,
-      address_postcode: "TE57 1NG",
       preferred_teaching_subject_id: TeachingSubject.lookup_by_key(:art),
+      address_postcode: "TE57 1NG",
     }
   end
 

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature "Event wizard", type: :feature do
     end
     click_on "Complete sign up"
 
-    expect(page).not_to have_text("What is your postcode? (optional)")
+    expect(page).not_to have_text("What is your UK postcode? (optional)")
     fill_in_personalised_updates
 
     expect_sign_up_with_attributes(
@@ -307,8 +307,8 @@ RSpec.feature "Event wizard", type: :feature do
   )
     select_value_or_default "Do you have a degree?", degree_status
     select_value_or_default "How close are you to applying for teacher training?", consideration_journey_stage
-    if page.has_text?("What is your postcode? (optional)")
-      fill_in "What is your postcode? (optional)", with: postcode
+    if page.has_text?("What is your UK postcode? (optional)")
+      fill_in "What is your UK postcode? (optional)", with: postcode
     end
     select_value_or_default "What subject do you want to teach?", preferred_teaching_subject
   end

--- a/spec/helpers/option_set_helper_spec.rb
+++ b/spec/helpers/option_set_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe OptionSetHelper, type: "helper" do
+  describe "#degree_status_text" do
+    let(:option) { GetIntoTeachingApiClient::PickListItem.new(id: 1, value: "Graduate or postgraduate") }
+
+    subject { degree_status_text(option) }
+
+    it { is_expected.to eq("Yes, I already have a degree") }
+
+    context "when the option is not recognised" do
+      let(:option) { GetIntoTeachingApiClient::PickListItem.new(id: 1, value: "Postgrad") }
+
+      it { is_expected.to eq("Postgrad") }
+    end
+  end
+end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -14,7 +14,7 @@ describe Events::Steps::PersonalisedUpdates do
   end
 
   describe "validations" do
-    let(:msg) { "Enter a valid postcode, or leave blank" }
+    let(:msg) { "Enter a valid UK postcode, or leave blank" }
 
     it { is_expected.to allow_value("TE571NG").for :address_postcode }
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }


### PR DESCRIPTION
### Trello card

https://trello.com/c/PuQSyO66/4375-improve-postcode-content-and-error-message-in-events-funnel-to-avoid-confusion-for-international-users

### Context

Updating the postcode copy to make it clearer for international users and also improving the content.

### Changes proposed in this pull request

### Guidance to review

