### PR TITLE
Updating postcode error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,7 +245,7 @@ en:
           attributes:
             postcode:
               blank: Enter a postcode
-              invalid: Enter a valid postcode
+              invalid: Enter a valid UK postcode
 
         events/search:
           attributes:
@@ -280,7 +280,7 @@ en:
         events/steps/personalised_updates:
           attributes:
             address_postcode:
-              invalid: Enter a valid postcode, or leave blank
+              invalid: Enter a valid UK postcode, or leave blank
             degree_status_id:
               inclusion: Select the stage of your degree you are at
             consideration_journey_stage_id:
@@ -341,7 +341,7 @@ en:
           attributes:
             address_postcode:
               blank: Enter your postcode
-              invalid: Enter a valid postcode
+              invalid: Enter a valid UK postcode
 
         # one-page mailing list
         mailing_list/signup:
@@ -363,7 +363,7 @@ en:
               blank: Choose a subject from the list
               inclusion: Choose a subject from the list
             address_postcode:
-              invalid: Enter a valid postcode
+              invalid: Enter a valid UK postcode
             timed_one_time_password:
               wrong_code: Enter the code you received by email
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -14,7 +14,7 @@ describe Events::Steps::PersonalisedUpdates do
   end
 
   describe "validations" do
-    let(:msg) { "Enter a valid postcode, or leave blank" }
+    let(:msg) { "Enter a valid UK postcode, or leave blank" }
 
     it { is_expected.to allow_value("TE571NG").for :address_postcode }
     it { is_expected.to allow_value("TE57 1NG").for :address_postcode }

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe MailingList::Steps::Postcode do
   include_context "with wizard step"
-  let(:msg) { "Enter a valid postcode" }
+  let(:msg) { "Enter a valid UK postcode" }
 
   it_behaves_like "a with wizard step"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/xfqyBTaJ/4414-improve-postcode-error-message-on-mailing-list-funnel

### Context

We should update our postcode error message so that it specifies it must be a 'UK' postcode.

### Changes proposed in this pull request

### Guidance to review

