### PR TITLE
Accessibility updates

### DIFF
--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -25,6 +25,6 @@
   </div>
 
   <div class="teaching-events__filter--group">
-    <%= tag.button("Update results", class: "button") %>
+    <%= tag.button("Update results", class: "button", type: :submit) %>
   </div>
 <% end %>

--- a/lib/accessible_footnotes.rb
+++ b/lib/accessible_footnotes.rb
@@ -1,0 +1,29 @@
+class AccessibleFootnotes
+  attr_reader :doc
+
+  def initialize(doc)
+    @doc = doc
+  end
+
+  def process
+    doc.css("a.footnote").each do |footnote|
+      footnote.prepend_child(accessible_prefix(doc, "Footnote "))
+    end
+
+    doc.css("a.reversefootnote").each do |footnote|
+      number = footnote["href"].scan(%r{\d+}).first
+      footnote.prepend_child(accessible_prefix(doc, "Location of footnote #{number}"))
+    end
+
+    doc
+  end
+
+private
+
+  def accessible_prefix(doc, prefix)
+    Nokogiri::XML::Node.new("span", doc) do |span|
+      span["class"] = "visually-hidden"
+      span.content = prefix
+    end
+  end
+end

--- a/lib/middleware/html_response_transformer.rb
+++ b/lib/middleware/html_response_transformer.rb
@@ -4,6 +4,7 @@ require "responsive_images"
 require "external_links"
 require "image_sizes"
 require "error_title"
+require "accessible_footnotes"
 
 module Middleware
   class HtmlResponseTransformer
@@ -14,6 +15,7 @@ module Middleware
       LazyLoadImages,
       ExternalLinks,
       ErrorTitle,
+      AccessibleFootnotes,
     ].freeze
 
     def initialize(app)

--- a/spec/lib/accessible_footnotes_spec.rb
+++ b/spec/lib/accessible_footnotes_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "accessible_footnotes"
+
+describe AccessibleFootnotes do
+  describe "#html" do
+    subject(:render_html) { instance.process.to_html }
+
+    let(:body) do
+      <<~HTML
+        <a href="#fn:2" class="footnote">2</a>
+        <a href="#fnref:2" class="reversefootnote">↩</a>
+      HTML
+    end
+    let(:instance) { described_class.new(Nokogiri::HTML(body)) }
+
+    it { is_expected.to include(%(<a href="#fn:2" class="footnote"><span class="visually-hidden">Footnote </span>2</a>)) }
+    it { is_expected.to include(%(<a href="#fnref:2" class="reversefootnote"><span class="visually-hidden">Location of footnote 2</span>↩</a>)) }
+  end
+end

--- a/spec/requests/accessible_footnotes_spec.rb
+++ b/spec/requests/accessible_footnotes_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Accessible footnotes", type: :request do
+  before do
+    get "/content-page"
+  end
+
+  subject { response.body }
+
+  it "makes footnotes accessible" do
+    is_expected.to include(%(<a href="#fn:1" class="footnote" rel="footnote"><span class="visually-hidden">Footnote </span>1</a>))
+    is_expected.to include(%(<a href="#fn:2" class="footnote" rel="footnote"><span class="visually-hidden">Footnote </span>2</a>))
+
+    is_expected.to include(%(<a href="#fnref:1" class="reversefootnote" role="doc-backlink"><span class="visually-hidden">Location of footnote 1</span>↩</a>))
+    is_expected.to include(%(<a href="#fnref:2" class="reversefootnote" role="doc-backlink"><span class="visually-hidden">Location of footnote 2</span>↩</a>))
+  end
+end

--- a/spec/support/views/content/content-page.md
+++ b/spec/support/views/content/content-page.md
@@ -17,3 +17,10 @@ An image without explicit width/height attributes:
 
 <img src="/packs/v1/static/content/hero-images/0013-3570599669a8da7d375320f4003d2d61.jpg">
 
+A footnote[^1] and another footnote[^2].
+
+[^1]:
+    The first footnote
+
+[^2]:
+    The second footnote


### PR DESCRIPTION
### Trello card

[Trello-4380](https://trello.com/c/1HQVGzYP/4380-fix-footnote-links-in-blogs)
[Trello-4402](https://trello.com/c/17OTS3qw/4402-investigate-changing-event-filter-button-to-submit)

### Context

All forms should have a `submit` type button for accessibility.

The footnote links are processed by Kramdown and end up being rendered as links with a number or icon indicating the link back to the footnote. This isn't a very accessible approach; instead, we add a preprocessor to add visually hidden text that is more descriptive for screen readers.

### Changes proposed in this pull request

- Make footnote links accessible
- Change button to submit type

### Guidance to review

