### PR TITLE
Send request to dfe analytics in middleware for cached pages

### DIFF
--- a/lib/middleware/dfe_analytics.rb
+++ b/lib/middleware/dfe_analytics.rb
@@ -1,0 +1,33 @@
+module Middleware
+  class DfeAnalytics
+    def initialize(app, path, index: "index", headers: {})
+      @app = app
+      @file_handler = ActionDispatch::FileHandler.new(path, index: index, headers: headers)
+    end
+
+    def call(env)
+      # Detect if page is Cached and send request event accordingly
+      send_request_event(env) if @file_handler.attempt(env)
+
+      @app.call(env)
+    end
+
+  private
+
+    def send_request_event(env)
+      request = ActionDispatch::Request.new(env)
+
+      request_event = DfE::Analytics::Event.new
+                                           .with_type("web_request")
+                                           .with_request_details(request)
+                                           .with_response_details(response)
+                                           .with_request_uuid(request.request_id)
+
+      DfE::Analytics::SendEvents.do([request_event.as_json])
+    end
+
+    def response
+      ActionDispatch::Response.new(200, "Content-Type" => "text/html")
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-1058](https://trello.com/c/6b49g4yk/1058-bug-git-website-home-page-views-in-ga-much-greater-than-in-events-table-in-bq) 

### Context

We have a big inconsistency tracking homepage visits on the GiT website through BigQuery.

BQ Count: 1637 vs GA Count: 65,263. Please see ticket for details.

After some troubleshooting we found that there is  page caching  of static pages, the homepage being a static page.

GiT website uses [rack-page_caching](https://github.com/pkorenev/rack-page_caching) GEM, that implements caching through rack middleware.

The DfE Analytics syncs web request events with a controller after action callback.

With the rack middleware being low level intercept and the controller action higher level, there is no simple solution that comes to mind.

One solution would be to have some  JS that gets called on Page load (of the cached page) and calls an API.

However, this would be a very manual non-trivial solution and goes against the grain of the DfE Analytics GEM (ie install, configure and forget)

### Changes proposed in this pull request

We have added `DfeAnalytics` Middleware that intercepts before the `ActionDispatch:Static` (This middleware returns a cached page if there is one and returns from the middleware stack early).

The `DfeAnalytics` middleware checks if there is a cached page in the file system. If there is a cached page, then the correct type of request/response objects are instantiated and the web request event is sent to Big Query.

### Guidance to review

`DfeAnalytics` middleware is only added if page caching is enabled.

The file handling logic in `DfeAnalytics` is copied from the `ActionDispatch:Static` class. Please see [here](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/static.rb) 

Tests are still outstanding. Suggestions are most welcome.
