### PR TITLE
Update git_wizard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-wizard.git
-  revision: 1cfc90fe09ba661c761d29a5a653a014e23ea386
+  revision: d2f364735f51715696f63fa0bc220cfd17b32ef8
   specs:
-    git_wizard (2.1.0)
+    git_wizard (2.2.0)
       activemodel (>= 6.0.3.4)
       activesupport (>= 6.0.3.4)
 
@@ -322,7 +322,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
-    minitest (5.17.0)
+    minitest (5.18.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -73,13 +73,7 @@ describe EventStepsController, type: :request do
 
   describe "#show when skipping verification" do
     let(:step_path) { event_steps_path(readable_event_id, :authenticate, { skip_verification: true }) }
-    let(:identity_data) do
-      {
-        first_name: "John",
-        last_name: "Doe",
-        email: "john@doe.com",
-      }
-    end
+    let(:identity_data) { { email: "john@doe.com" } }
 
     before do
       allow_any_instance_of(Events::Steps::PersonalDetails).to \


### PR DESCRIPTION
[Trello-4372](https://trello.com/c/iDqBrbp4/4372-clean-up-existingcandidaterequest-model)

The update removes first/last name from the matchback requests; the API no longer uses these fields and instead matches back only on email.
