### PR TITLE
Enable Google Optimize on variant test pages

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -10,5 +10,7 @@ paths:
   - /steps-to-become-a-teacher-search
   - /funding-and-support/scholarships-and-bursaries-search
   - /train-to-be-a-teacher/if-you-have-a-degree-search
+  - /landing/train-to-teach-if-you-have-a-degree
   - /mailinglist/signup/name
   - /mailinglist/signup
+  - /landing/how-to-fund-your-teacher-training

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -187,8 +187,10 @@ describe ApplicationHelper do
           "/steps-to-become-a-teacher-search",
           "/funding-and-support/scholarships-and-bursaries-search",
           "/train-to-be-a-teacher/if-you-have-a-degree-search",
+          "/landing/train-to-teach-if-you-have-a-degree",
           "/mailinglist/signup/name",
           "/mailinglist/signup",
+          "/landing/how-to-fund-your-teacher-training",
         ],
       })
     end


### PR DESCRIPTION
### Trello card

### Context

Currently we only fire Google Optimize on the original page and not the variant (as the traffic is all sent to the original page and redirected to the variant from there).

We're seeing oddness around far more traffic going to the original than the variant (although GA shows more of a split) so we're assuming the Optimize snippet also needs to execute on the variant page in order for it to register correctly.

### Changes proposed in this pull request

- Enable Google Optimize on variant test pages

### Guidance to review

