### PR TITLE
Adding singposting for providers to change event listings

### DIFF
--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -81,4 +81,8 @@
       rel="noopener norefferer">
     please fill in our online form</a>.
   </p>
+
+  <p>
+  If you'd like to edit or remove your event listing, please email getintoteaching.helpdesk@education.gov.uk.
+  </p>
 </section>


### PR DESCRIPTION
### Trello card

https://trello.com/c/PnwYJZce/4415-signpost-providers-wanting-to-change-event-listings-to-support-team

### Context

We had a provider use our feedback form to request that their event listing be deleted. This is not ideal - the feedback form is supposed to be for anonymous feedback, not for requests that need actioning quickly.

We should add some copy to singpost providers where to go if they want to edit or remove an event listing.

### Changes proposed in this pull request

### Guidance to review

