### PR TITLE
Remove blur from Optimize experiment

### DIFF
--- a/app/webpacker/javascript/google_optimize.js
+++ b/app/webpacker/javascript/google_optimize.js
@@ -15,18 +15,9 @@ export default class GoogleOptimize {
 
     this.listenForTurbolinksBeforeVisit();
     this.listenForConsentChange();
-
-    if (!this.seenCookieDialog && this.isExperimentPath()) {
-      this.blurContentHandler = this.blurContent.bind(this);
-      document.addEventListener('DOMContentLoaded', this.blurContentHandler);
-    }
   }
 
   dispose() {
-    if (this.blurContentHandler) {
-      document.removeEventListener('DOMContentLoaded', this.blurContentHandler);
-    }
-
     if (this.antiFlickerHandler) {
       document.removeEventListener('DOMContentLoaded', this.antiFlickerHandler);
     }
@@ -78,19 +69,6 @@ export default class GoogleOptimize {
       complete();
     };
     document.addEventListener('DOMContentLoaded', this.antiFlickerHandler);
-  }
-
-  blurContent() {
-    // Remove the cookie dialog dark overlay.
-    this.cookieDialogOverlay.remove();
-
-    // Blur the page.
-    document.body.classList.add('blur');
-
-    // Add in our own dark overlay below the cookie dialog.
-    const overlay = document.createElement('div');
-    overlay.classList.add('optimize-overlay');
-    document.body.append(overlay);
   }
 
   listenForConsentChange() {

--- a/spec/javascript/google_optimize_spec.js
+++ b/spec/javascript/google_optimize_spec.js
@@ -61,14 +61,6 @@ describe('Google Optimize', () => {
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
 
-      it('blurs the cookie acceptance background to obscure the content', () => {
-        expect(
-          document.querySelector('.cookie-acceptance .dialog__background')
-        ).toBeNull();
-        expect(document.body.classList.contains('blur')).toBe(true);
-        expect(document.querySelector('.optimize-overlay')).not.toBeNull();
-      });
-
       it('does not append the Google Optimize script to the head', () => {
         expect(
           document.head.querySelector(
@@ -89,14 +81,6 @@ describe('Google Optimize', () => {
 
     describe('when not on an experiment path', () => {
       beforeEach(() => run('/no-experiment'));
-
-      it('does not blur the cookie acceptance background', () => {
-        expect(
-          document.querySelector('.cookie-acceptance .dialog__background')
-        ).not.toBeNull();
-        expect(document.body.classList.contains('blur')).toBe(false);
-        expect(document.querySelector('.optimize-overlay')).toBeNull();
-      });
 
       it('does not deploy the anti-flicker fix', () => {
         expect(document.querySelector('.anti-flicker')).toBeNull();
@@ -128,14 +112,6 @@ describe('Google Optimize', () => {
 
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
-
-      it('does not blur the cookie acceptance background', () => {
-        expect(
-          document.querySelector('.cookie-acceptance .dialog__background')
-        ).not.toBeNull();
-        expect(document.body.classList.contains('blur')).toBe(false);
-        expect(document.querySelector('.optimize-overlay')).toBeNull();
-      });
 
       it('deploys the anti-flicker fix', () => {
         expect(document.querySelector('.anti-flicker')).not.toBeNull();
@@ -199,14 +175,6 @@ describe('Google Optimize', () => {
 
     describe('when on an experiment path', () => {
       beforeEach(() => run(experimentPath));
-
-      it('does not blur the cookie acceptance background', () => {
-        expect(
-          document.querySelector('.cookie-acceptance .dialog__background')
-        ).not.toBeNull();
-        expect(document.body.classList.contains('blur')).toBe(false);
-        expect(document.querySelector('.optimize-overlay')).toBeNull();
-      });
 
       it('does not deploy the anti-flicker fix', () => {
         expect(document.querySelector('.anti-flicker')).toBeNull();


### PR DESCRIPTION
### Trello card

[Trello-4434](https://trello.com/c/WRldjmDA/4434-remove-blur-effect-from-optimize-experiments)

### Context

Currently, when a user visits a page running an A/B test if they have not accepted cookies the content behind the cookie dialog is blurred. This is to ensure they can't see the original page if they then get redirected to the variant page on accepting cookies/opting-in to the experiment.

We think this isn't a great user experience and - given most A/B tests are the same or similar for above the fold content - we would rather show the original briefly and switch out to the variant without the blurring effect.

### Changes proposed in this pull request

- Remove blur from Optimize experiment

### Guidance to review

Visit a page running optimize [like this one](https://review-get-into-teaching-app-3222.london.cloudapps.digital/steps-to-become-a-teacher-search) without accepting cookies and check the page isn't blurred.