### PR TITLE
Enable Google Optimize on home/landing

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -14,3 +14,5 @@ paths:
   - /mailinglist/signup/name
   - /mailinglist/signup
   - /landing/how-to-fund-your-teacher-training
+  - /
+  - /landing/home

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -191,6 +191,8 @@ describe ApplicationHelper do
           "/mailinglist/signup/name",
           "/mailinglist/signup",
           "/landing/how-to-fund-your-teacher-training",
+          "/",
+          "/landing/home",
         ],
       })
     end


### PR DESCRIPTION
We are running an A/B test on the home page with a home landing page; this enables Optimize on the
respective paths.
