### PR TITLE
Add test to check for cached dynamic pages

### DIFF
--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -28,6 +28,9 @@ RSpec.feature "content pages check", type: :feature, content: true do
   before(:all) do
     statuses_deemed_successful = Rack::Utils::SYMBOL_TO_STATUS_CODE.values_at(:ok, :moved_permanently)
 
+    stub_request(:get, "https://host.api/endpoint/api/privacy_policies/latest")
+      .to_return(status: 200, body: { id: 123, text: "text" }.to_json, headers: {})
+
     @stored_pages = PageLister.content_urls.map do |path|
       visit(path)
 
@@ -92,6 +95,13 @@ RSpec.feature "content pages check", type: :feature, content: true do
             expect(page).to have_http_status(:success), "invalid image src on #{sp.path} - #{src}"
             images.push(src)
           end
+      end
+    end
+
+    scenario "pages containing forms are excluded from the cache" do
+      @stored_pages.each do |sp|
+        form = sp.body.css("form[method=post]")
+        expect(PagesController::DYNAMIC_PAGE_PATHS).to include(sp.path) if form.present?
       end
     end
 

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -1,17 +1,4 @@
 class PageLister
-  IGNORE = %w[
-    /test
-    /guidance_archive
-    /index
-    /steps-to-become-a-teacher/v2-index
-    /privacy-policy
-    /landing/how-much-do-teachers-get-paid
-    /landing/how-to-become-a-teacher
-    /landing/how-to-fund-your-teacher-training
-    /landing/train-to-teach-if-you-have-a-degree
-    /landing/home
-  ].freeze
-
   class << self
     def md_files
       Dir["app/views/content/**/[^_]*.md"]
@@ -34,7 +21,7 @@ class PageLister
     end
 
     def content_urls
-      files.map(&method(:remove_folders)).map(&method(:remove_extension)) - IGNORE
+      files.map(&method(:remove_folders)).map(&method(:remove_extension))
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-4436](https://trello.com/c/OAqeDuJi/4436-improve-page-cache-exclusion)

### Context

When we add a form to a static page it is still automatically cached by the `rack-page_caching` gem unless we explicitly list it as dynamic in the `PagesController`. This is open to human error and can result in a form going live that ends up being cached and therefore the CSRF token will be incorrect (as the cached version will expire).

### Changes proposed in this pull request

- Add test to check for cached dynamic pages

Add a test to check all pages that contain POST method forms are listed as dynamic and excluded from the cache.

Stub the privacy policy requst for all content specs so we no longer need to exclude certain pages (that otherwise would fail when they try and request the privacy policy).


### Guidance to review

I may take this further and see if I can exclude pages containing forms from the caching mechanism automatically so we don't need to maintain a list manually; we should be able to prevent the cache with middleware, but this feels like a nice to have regardless.