### PR TITLE
Automatically exclude pages from the cache

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,21 +9,9 @@ class PagesController < ApplicationController
   ].freeze
 
   PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}
-  DYNAMIC_PAGE_PATHS = [
-    "/train-to-be-a-teacher/if-you-have-a-degree", # Contains a form
-    "/train-to-be-a-teacher/if-you-dont-have-a-degree", # Contains a form
-    "/train-to-be-a-teacher/initial-teacher-training", # Contains a form
-    "/help-and-support", #  Contains a form
-    "/landing/how-much-do-teachers-get-paid", # Contains a form
-    "/landing/how-much-do-teachers-get-paid-social", # Contains a form
-    "/landing/how-to-become-a-teacher", # Contains a form
-    "/landing/how-to-fund-your-teacher-training", # Contains a form
-    "/landing/train-to-teach-if-you-have-a-degree", # Contains a form
-    "/landing/home", # Contains a form
-  ].freeze
 
   caches_page :cookies
-  caches_page :show, unless: proc { |env| DYNAMIC_PAGE_PATHS.include?(env.request.path) }
+  caches_page :show
 
   before_action :set_welcome_guide_info, if: -> { request.path.start_with?("/welcome") && (params[:subject] || params[:degree_status]) }
   rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template

--- a/config/initializers/middleware.rb
+++ b/config/initializers/middleware.rb
@@ -1,4 +1,8 @@
 require "middleware/html_response_transformer"
+require "middleware/page_cache_exclusion"
+
+# Prevent certain pages from being cached
+Rails.application.config.middleware.use(Middleware::PageCacheExclusion)
 
 # Page caching middleware
 Rails.application.config.middleware.use Rack::PageCaching,

--- a/lib/middleware/page_cache_exclusion.rb
+++ b/lib/middleware/page_cache_exclusion.rb
@@ -1,0 +1,27 @@
+module Middleware
+  class PageCacheExclusion
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, response = @app.call(env)
+
+      if dynamic_page?(body(response))
+        Rack::PageCaching::Cache.delete("#{env['PATH_INFO']}.html")
+      end
+
+      [status, headers, response]
+    end
+
+  private
+
+    def body(response)
+      response.is_a?(ActionDispatch::Response::RackBody) ? response.body : response.first
+    end
+
+    def dynamic_page?(body)
+      body&.match(/method="post"/i)
+    end
+  end
+end

--- a/lib/middleware/page_cache_exclusion.rb
+++ b/lib/middleware/page_cache_exclusion.rb
@@ -21,7 +21,7 @@ module Middleware
     end
 
     def dynamic_page?(body)
-      body&.match(/method="post"/i)
+      body&.match(/method="(post|put|patch)"/i)
     end
   end
 end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -98,13 +98,6 @@ RSpec.feature "content pages check", type: :feature, content: true do
       end
     end
 
-    scenario "pages containing forms are excluded from the cache" do
-      @stored_pages.each do |sp|
-        form = sp.body.css("form[method=post]")
-        expect(PagesController::DYNAMIC_PAGE_PATHS).to include(sp.path) if form.present?
-      end
-    end
-
     scenario "all images have alt text" do
       @stored_pages.each do |sp|
         expect(sp.body.css("img")).to all(have_attribute("alt"))

--- a/spec/lib/middleware/page_cache_exclusion_spec.rb
+++ b/spec/lib/middleware/page_cache_exclusion_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+require "middleware/page_cache_exclusion"
+
+describe Middleware::PageCacheExclusion, type: :request do
+  let(:path) { "/test" }
+  let(:response) do
+    [
+      <<~HTML,
+        <form action="/test" method="get">
+          cachable form example
+        </form>
+      HTML
+    ]
+  end
+
+  before do
+    allow(Rack::PageCaching::Cache).to receive(:delete)
+
+    app = ->(env) { [200, env, response] }
+    middleware = described_class.new(app)
+    middleware.call(Rack::MockRequest.env_for("http://example.com#{path}"))
+  end
+
+  subject { Rack::PageCaching::Cache }
+
+  it { is_expected.not_to have_received(:delete) }
+
+  context "when the response body is nil" do
+    let(:response) { [nil] }
+
+    it { is_expected.not_to have_received(:delete) }
+  end
+
+  context "when the response body is an instance of ActionDispatch::Response::RackBody" do
+    let(:response) { ActionDispatch::Response::RackBody.new(ActionDispatch::Response.new) }
+
+    it { is_expected.not_to have_received(:delete) }
+  end
+
+  context "when the response body contains a form with post method (case insensitive)" do
+    let(:form) do
+      <<~HTML
+        <form action="/test" method="POst">
+          post form example
+        </form>
+      HTML
+    end
+    let(:response) { [form] }
+
+    it { is_expected.to have_received(:delete).with("#{path}.html") }
+
+    context "when the response body is an instance of ActionDispatch::Response::RackBody" do
+      let(:response) do
+        ActionDispatch::Response::RackBody.new(
+          ActionDispatch::Response.new.tap do |r|
+            r.body = form
+          end,
+        )
+      end
+
+      it { is_expected.to have_received(:delete).with("#{path}.html") }
+    end
+  end
+end

--- a/spec/lib/middleware/page_cache_exclusion_spec.rb
+++ b/spec/lib/middleware/page_cache_exclusion_spec.rb
@@ -37,19 +37,36 @@ describe Middleware::PageCacheExclusion, type: :request do
     it { is_expected.not_to have_received(:delete) }
   end
 
-  context "when the response body contains a form with post method (case insensitive)" do
+  shared_context "when the response body contains a matching form method" do
     let(:form) do
       <<~HTML
-        <form action="/test" method="POst">
+        <form action="/test" method="#{form_method}">
           post form example
         </form>
       HTML
     end
     let(:response) { [form] }
 
-    it { is_expected.to have_received(:delete).with("#{path}.html") }
+    context "when a POST form method" do
+      let(:form_method) { "PoSt" }
+
+      it { is_expected.to have_received(:delete).with("#{path}.html") }
+    end
+
+    context "when a PUT form method" do
+      let(:form_method) { "PUT" }
+
+      it { is_expected.to have_received(:delete).with("#{path}.html") }
+    end
+
+    context "when a PATCH form method" do
+      let(:form_method) { "patch" }
+
+      it { is_expected.to have_received(:delete).with("#{path}.html") }
+    end
 
     context "when the response body is an instance of ActionDispatch::Response::RackBody" do
+      let(:form_method) { "PoSt" }
       let(:response) do
         ActionDispatch::Response::RackBody.new(
           ActionDispatch::Response.new.tap do |r|


### PR DESCRIPTION
### Trello card

[Trello-4436](https://trello.com/c/OAqeDuJi/4436-improve-page-cache-exclusion)

### Context

Currently we maintain a manual array of page paths that we want to exclude from the static page cache. These tend to be pages that contain a form with a post request method (if we cache these pages the CSRF token is also cached and becomes invalid, causing the form submission to fail). Going forward we want to automate this process as its currently prone to human error.

### Changes proposed in this pull request

- Automatically exclude pages from the cache

Add middleware to check if a response contains a form and - if it does - remove the cached version of the page that is created earlier up the middleware stack.

### Guidance to review

Visit a static page with a POST form, for example [this one](https://review-get-into-teaching-app-3226.london.cloudapps.digital/landing/how-much-do-teachers-get-paid) and check if submits correctly. It should also return `cache-control` headers that don't allow caching. If you visit a page that does allow caching, like [this one](https://review-get-into-teaching-app-3226.london.cloudapps.digital/) it should return with `cache-control` headers using a 5m TTL.