### PR TITLE
Adding primary and secondary language to the salaries page

### DIFF
--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -52,11 +52,11 @@ keywords:
 
 For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
 
-Figures are for teachers in the 2022/23 academic year.
+Figures are for primary and secondary teachers in the 2022/23 academic year.
 
-## Teaching salaries
+## Primary and secondary teaching salaries
 
-All qualified teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London.
+All qualified primary and secondary teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London.
 
 ### Qualified teacher salary
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -52,7 +52,7 @@ keywords:
 
 For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
 
-Figures are for primary and secondary teachers in the 2022/23 academic year.
+Figures are for the 2022/23 academic year.
 
 ## Primary and secondary teaching salaries
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/YOEgLSEc/4435-add-primary-and-secondary-language-to-salaries-page

### Context

Lots of search terms to do with teacher salaries include ‘primary’ and ‘secondary’, but our page doesn’t currently mention either anywhere.

By introducing these terms, we could help boost our search performance and increase traffic to the site.

If users are searching specifically for primary and secondary salaries, we’re also not being very clear on the page that it’s the same for both (we know this, but users don’t).

### Changes proposed in this pull request

### Guidance to review

