### PR TITLE
Update meta description on blog index page

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -8,7 +8,7 @@ class BlogController < ApplicationController
   def index
     @front_matter = {
       "title" => "Get Into Teaching Blog",
-      "description" => "Meta description goes here",
+      "description" => "Read about the real life experiences of teachers and teachers in training, as well as tips on how to start your journey into the classroom.",
     }
 
     breadcrumb "Blog", blog_index_path

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -6,7 +6,10 @@ class BlogController < ApplicationController
   layout "layouts/blog/index"
 
   def index
-    @front_matter = { "title" => "Get Into Teaching Blog" }
+    @front_matter = {
+      "title" => "Get Into Teaching Blog",
+      "description" => "Meta description goes here",
+    }
 
     breadcrumb "Blog", blog_index_path
 


### PR DESCRIPTION
### Trello card

[Trello-3642](https://trello.com/c/n6xSVSTF/3642-add-meta-descriptions-to-the-blog-landing-page)

### Context

We currently don't have a meta description on the blog index page; we should add one for SEO.

### Changes proposed in this pull request

- Update meta description on blog index page

### Guidance to review

