### PR TITLE
Add legend to event format filters

### DIFF
--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="teaching-events__filter--group with-top-border">
-    <%= f.govuk_check_boxes_fieldset(:online, legend: nil) do %>
+    <%= f.govuk_check_boxes_fieldset(:online, legend: { text: "Event format", tag: nil }) do %>
       <%= f.govuk_check_box :online, false, label: { text: "In person" } %>
       <%= f.govuk_check_box :online, true, label: { text: "Online" } %>
     <% end %>


### PR DESCRIPTION
### Trello card

[Trello-4468](https://trello.com/c/GEFL0EWH/4468-add-fieldset-legend-to-event-format-section-on-events-listing-page)

### Context

Silktide picked up that we don't have a legend for the event
format checkboxes; we should add one for improved accessibility of these fields.

### Changes proposed in this pull request

- Add legend to event format filters

### Guidance to review

