### PR TITLE
Set button type to submit on events form

### DIFF
--- a/app/views/content/help-and-support/_events.html.erb
+++ b/app/views/content/help-and-support/_events.html.erb
@@ -12,7 +12,7 @@
             <%= f.hidden_field :online, multiple: true, value: false %>
             <%= f.label :postcode, "Enter postcode" %>
             <%= f.text_field :postcode, autocomplete: "postal-code" %>
-            <%= tag.button("Search", class: "button", id: "event-search") %>
+            <%= tag.button("Search", class: "button", type: :submit, id: "event-search") %>
           <% end %>
 
           <p>Or <%= link_to("find an online event", events_path(add_online_events(params))) %>.</p>


### PR DESCRIPTION
### Trello card

[Trello-4469](https://trello.com/c/2t4pFaRC/4469-investigate-changing-postcode-button-in-events-promo-to-submit)

### Context

All forms should have a button of type `submit`; update the events form on the help and support page to comply for improved accessibility.

### Changes proposed in this pull request

- Set button type to submit on events form

### Guidance to review

