### PR TITLE
Upgrade to the specific dev version of dfe-analytics GEM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "faraday_middleware"
 
 gem "fastimage"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.8.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", ref: "9322e797fab1101c533c1009af23a60f486b860e"
 
 gem "hashids"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 6287146b3da5d38e52ee18b0b5c1f1c4e6020f33
-  tag: v1.8.0
+  revision: 9322e797fab1101c533c1009af23a60f486b860e
+  tag: 9322e797fab1101c533c1009af23a60f486b860e
   specs:
     dfe-analytics (1.8.0)
       google-cloud-bigquery (~> 1.38)


### PR DESCRIPTION
### Trello card
[Trello-1107](https://trello.com/c/fBBPetwX/1107-refer-serious-misconduct-apply-for-qts-unable-to-upgrade-to-latest-dfe-analytics-gem)
### Context

dfe-analytics GEM upgrade to version v1.8.0 has caused break changes to other projects, hence a fix is required.


### Changes proposed in this pull request

Upgrade GEM and test the changes to ensure functionality has not regressed.

### Guidance to review

