### PR TITLE
Fix cache deletion for home page

### DIFF
--- a/lib/middleware/page_cache_exclusion.rb
+++ b/lib/middleware/page_cache_exclusion.rb
@@ -8,13 +8,19 @@ module Middleware
       status, headers, response = @app.call(env)
 
       if dynamic_page?(body(response))
-        Rack::PageCaching::Cache.delete("#{env['PATH_INFO']}.html")
+        Rack::PageCaching::Cache.delete("#{cache_path(env['PATH_INFO'])}.html")
       end
 
       [status, headers, response]
     end
 
   private
+
+    def cache_path(path_info)
+      # The home page is a special case; the path
+      # is not the same as the cache file location.
+      path_info == "/" ? "/index" : path_info
+    end
 
     def body(response)
       response.is_a?(ActionDispatch::Response::RackBody) ? response.body : response.first

--- a/spec/lib/middleware/page_cache_exclusion_spec.rb
+++ b/spec/lib/middleware/page_cache_exclusion_spec.rb
@@ -65,6 +65,12 @@ describe Middleware::PageCacheExclusion, type: :request do
       it { is_expected.to have_received(:delete).with("#{path}.html") }
     end
 
+    context "when the root path" do
+      let(:path) { root_path }
+
+      it { is_expected.to have_received(:delete).with("/index.html") }
+    end
+
     context "when the response body is an instance of ActionDispatch::Response::RackBody" do
       let(:form_method) { "PoSt" }
       let(:response) do


### PR DESCRIPTION
### Trello card

[Trello-4485](https://trello.com/c/rxPZXfap/4485-fix-homepage-cache-exclusion-issue)

### Context

We auto-delete the page cache if a form is detected. When doing this we use the request path to find the cached filename. The homepage is unique because the path is not the same as the cached page filename (the path is `/` and the filename is `/index.html`). We need to account for this explicitly to ensure the cached file is removed when the homepage contains a form.

### Changes proposed in this pull request

- Fix cache deletion for home page

### Guidance to review

I've added a [Trello ticket](https://trello.com/c/nV6cjqlo/4486-improve-page-path-matching-logic-for-page-cache-exclusion-middleware) to see if we can improve this, but we need to get this fix out asap.
