### PR TITLE
Remove Yorkshire Three Counties Alliance SCITT from Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -464,11 +464,6 @@ provider_groups:
     - header: The Sheffield SCITT
       link: https://www.sheffieldscitt.org.uk/
       email: admin@sheffieldscitt.org.uk
-    - header: Three Counties Alliance SCITT
-      link: https://ytcascitt.co.uk/
-      name: Rebecca Turner-Loisel
-      telephone: '01977 657604'
-      email: ytca@minsthorpe.cc
     - header: Yorkshire and Humber Teacher Training
       link: https://www.yhtt.co.uk
       name: Chris Fletcher


### PR DESCRIPTION
### Trello card
https://trello.com/c/GCYeJeEy

### Context
Request received via GIT support team to remove Three Counties Alliance SCITT from Assessment only page

