### PR TITLE
Remove noindex from homepage

### DIFF
--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -10,7 +10,6 @@
   hero_content_width: even
   hero_bg_color: yellow
   title_bg_color: white
-  noindex: true
   mailing_list: true
   content:
     - content/home/purple-box


### PR DESCRIPTION
This was accidentally copied form the landing page variant we went ahead with for our home page after the test completed.
