### PR TITLE
Run postgres for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -577,6 +577,19 @@ jobs:
     name: Run Integration Tests on QA
     runs-on: ubuntu-latest
     needs: [ build_base, qa ]
+    services:
+      postgres:
+        image: postgres:13.10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     env:
       DOCKER_IMAGE_TEST: ${{needs.build_base.outputs.DOCKER_IMAGE_TEST}}
     steps:
@@ -597,9 +610,14 @@ jobs:
           secret: INFRA-KEYS
           key: HTTP-USERNAME, HTTP-PASSWORD, MAILSAC-API-KEY
 
+      - name: Prepare DB
+        run: |-
+          docker run --net=host -t --rm -e RAILS_ENV=test -e DATABASE_URL="postgresql://postgres:postgres@localhost" ${{ env.DOCKER_IMAGE_TEST }} \
+          bundle exec rails db:prepare
+
       - name: Run Integration Tests
         run: |-
-          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true -e HTTP_USERNAME -e HTTP_PASSWORD -e MAILSAC_API_KEY \
+          docker run -t --rm -e RAILS_ENV=test -e NODE_ENV=test -e CI=true -e HTTP_USERNAME -e HTTP_PASSWORD -e MAILSAC_API_KEY -e DATABASE_URL="postgresql://postgres:postgres@localhost" \
             ${{env.DOCKER_IMAGE_TEST}} bundle exec rspec --tag integration
         env:
           HTTP_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.HTTP-USERNAME }}


### PR DESCRIPTION
The integration tests boot a local version of the app (in docker) and then hit our QA/test instance for the actual tests. The app is no longer booting, however, as it needs postgres available locally - this adds the postgres service and configures the test database.
