### PR TITLE
Support 'course full' on internship providers page

### DIFF
--- a/app/components/grouped_cards/card_component.html.erb
+++ b/app/components/grouped_cards/card_component.html.erb
@@ -6,6 +6,12 @@
   <hr class="group__card__divider">
 
   <div class="group__card__content">
+    <% if status %>
+      <div class="group__card__fields">
+       <p><strong><%= status %></strong></p>
+      </div>
+    <% end %>
+
     <% for field, value in fields %>
       <div class="group__card__fields">
         <span><%= field.humanize %>:</span>

--- a/app/components/grouped_cards/card_component.rb
+++ b/app/components/grouped_cards/card_component.rb
@@ -12,6 +12,10 @@ module GroupedCards
       @data["header"]
     end
 
+    def status
+      @data["status"]
+    end
+
     def linked_header
       if link
         link_to tag.h4(header), link
@@ -21,7 +25,7 @@ module GroupedCards
     end
 
     def fields
-      @data.without("header", "link")
+      @data.without("header", "link", "status")
     end
 
     def linked_value(value)

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -21,461 +21,446 @@ provider_groups:
     providers:
     - header: Bluecoat SCITT Alliance
       link: https://www.bluecoatscittalliance.uk.com/vacancies/paid-graduate-internship/
+      subjects: chemistry, computing, maths, physics, languages
       name: Julie Hefferman
       email: itt@bluecoat.uk.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Amed
       email: Claire.amed@creativeeducationtrust.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: George Spencer Academy
       link: http://www.george-spencer.com/
-      name: Tammy Elward
-      email: tammyelward@satrust.com
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Learners First Schools Partnership
       link: https://www.learnersfirst.net/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Garbutt/Georgia Osborne
       email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Leicestershire Secondary SCITT
       link: https://www.leicestershiresecondaryscitt.org/events-information/teaching-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Laura Wharton
       email: lwharton@rushey-tmet.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Lionheart Teach
       link: https://www.lionheartteach.org.uk/opportunities/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Emma Lowe
       email: info@lionheartteach.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Nottingham Catholic ITT Partnership
       link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Vanessa Scott
       email: v.scott@becketonline.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Nottinghamshire Torch SCITT
       link: https://www.teachnottinghamshire.co.uk/internships.php
+      subjects: chemistry, computing, maths, physics, languages
       name: Rebecca Morgan-Jones
       email: contact@teachnottinghamshire.co.uk 
-      subjects: chemistry, computing, maths, physics, languages
     - header: Outwood Institute of Education
       link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: George W. Robson
       email: teachnorth@oie.outwood.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Tuxford Academy
       link: https://www.diverseassociation.org.uk/get-into-teaching/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Administrator
       email: interns@diverse-ac.org.uk
-      subjects: chemistry, computing, maths, physics, languages
   East of England:
     providers:
     - header: Advanced Learning Partnership
       link: https://www.advancedlearningpartnership.co.uk/
-      name: Nicola Nicolaou
-      email: nicolaoun@damealiceowens.herts.sch.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Bedfordshire Schools Trust
       link: https://www.bestteachingschool.org.uk/
-      name: Susanne Combe
-      email: scombe@bestacademies.org.uk
       subjects: chemistry, maths, physics, languages
+      status: Course full
     - header: Benfleet Team Supporting All
       link: http://www.btsa.uk/internship-scheme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Maxine Howard
       email: mhoward@theappletonschool.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Amed
       email: Claire.amed@creativeeducationtrust.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Debden Park High School (TKAT Teacher Training)
       link: https://scitt.tkat.org/842/internships
-      name: Jo Fogg
-      email: jo.fogg@tkat.org
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Farlingaye High School
       link: https://www.eastscitt.co.uk/Undergraduate-Internships/
+      subjects: maths, physics
       name: Peter Smith
       email: psmith@farlingaye.suffolk.sch.uk
-      subjects: maths, physics
     - header: Harris Initial Teacher Education
       link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
-      name: Jose Oliveira/Shona Findlay
-      email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Northgate High School, Ipswich
       link: https://www.northgate.suffolk.sch.uk/staff/training-to-teach/
-      name: Miss Mary Hallett
-      email: mch@northgate.suffolk.sch.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Ormiston Academies Trust
       link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Jemma Sherwood
       email: internships@ormistonacademies.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Redborne Teaching Partnership
       link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
-      name: Vicki Walsh
-      email: vicki.walsh@redborne.com
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Saffron Walden County High School
       link: https://www.swchs.net/page/?title=Teaching+Internship+Programme+%2D+June+2023&pid=417
+      subjects: chemistry, computing, maths, physics, languages
       name: Angela Rodda
       email: arodda@swchs.net
-      subjects: chemistry, computing, maths, physics, languages
     - header: South Essex Training and Support Alliance
       link: https://www.setsa.info/1567/teaching-internship-programme-2023
+      subjects: chemistry, computing, maths, physics, languages
       name: David Struthers
       email: d.struthers@setsa.info
-      subjects: chemistry, computing, maths, physics, languages
     - header: The Hertfordshire and Essex High School
       link: https://www.hertsandessex.herts.sch.uk/teaching-internships/60636.html
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Ruthven
       email: claire.ruthven@hertsandessex.herts.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
   London:
     providers:
     - header: Debden Park High School (TKAT Teacher Training)
       link: https://scitt.tkat.org/842/internships
-      name: Jo Fogg
-      email: jo.fogg@tkat.org
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: GLF Teacher Training
       link: https://www.glfscitt.org/259/teaching-internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Blackburn
       email: k.blackburn@glfschools.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Harris Initial Teacher Education
       link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
-      name: Jose Oliveira/Shona Findlay
-      email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: LETTA (London East Teacher Training Alliance)
       link: https://letta.org.uk/train/teachinginternships/
+      subjects: maths, physics
       name: Ben Sperring
       email: train@letta.org.uk
-      subjects: maths, physics
     - header: New River Teaching Alliance
       link: https://nrta.co.uk/train-to-teach/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Iraj Felfeli
       email: ifelfeli@alexandrapark.school
-      subjects: chemistry, computing, maths, physics, languages
     - header: Paddington Academy
       link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
+      subjects: chemistry, maths, physics, languages
       name: Riam Muayad
       email: Riam.Muayad@paddington-academy.org
-      subjects: chemistry, maths, physics, languages
     - header: Reach Academy Feltham
       link: https://www.reachtraining.org/teaching-internships
+      subjects: chemistry, maths, physics, languages
       name: James Foreman
       email: reachteachertraining@reachacademy.org.uk
-      subjects: chemistry, maths, physics, languages
     - header: St John Southworth Catholic Academy Trust
       link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
+      subjects: chemistry, computing, maths, physics, languages
       name: Patrick Lanigan
       email: laniganp@cvms.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
       link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2023
+      subjects: computing, maths
       name: Claire Lane
       email: c.lane@waldegravesch.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Xavier Teach SouthEast
       link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Cornforth
       email: k.cornforth@xaviercet.org.uk
-      subjects: chemistry, computing, maths, physics, languages
   North East:
     providers:
     - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
       link: https://www.centreforteaching.com/initial-teacher-training/internships/
-      name: Anna Herdman
-      email: aherdman@bwcet.com
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Carmel Teacher Training Partnership
       link: https://carmelteachertraining.com/teaching-internships/
-      name: Sarah McGee
-      email: smcgee@bhcet.org.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: North East SCITT
       link: https://www.northeastscitt.co.uk/intern
+      subjects: chemistry, computing, maths, physics, languages
       name: Susan Ingram
       email: Susan.ingram@nelt.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Northern Education Trust
       link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Meriem Lairini
       email: m.lairini@northerneducationtrust.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Outwood Institute of Education
       link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: George W. Robson
       email: teachnorth@oie.outwood.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Stockton Teacher Training Partnership
       link: https://stocktonscitt.uk/paid-teaching-internship/
+      subjects: chemistry, computing, maths, physics, languages
       name: Kirsten Webber
       email: Kirsten.Webber@stockton.gov.uk
-      subjects: chemistry, computing, maths, physics, languages
   North West:
     providers:
     - header: Associated Merseyside Partnership SCITT
       link: https://www.amp-scitt.lydiatelearningtrust.co.uk/teaching-internship/
+      subjects: chemistry, computing, maths, physics, languages
       name: Alison Brady
       email: a.brady@ampscitt.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Bright Futures SCITT
       link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/our-programmes/paid-undergraduate-internship-scheme/
+      subjects: chemistry, computing, maths, physics
       name: Hilary Langmead-Jones
       email: admin@scitt.bright-futures.co.uk
-      subjects: chemistry, computing, maths, physics
     - header: Chorlton High School
       link: https://chorltonhigh.manchester.sch.uk/working-for-us/Chorlton-High-Teaching-School-Team/school-experience-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: Fazia Chowdhury
       email: F.Chowdhury@chorltonhigh.manchester.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Co-op Academies Trust 
       link: https://www.coopacademies.co.uk/teaching-internship/
-      name: Andy Gibson 
-      email: andy.gibson@coopacademies.co.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Cumbria Education Trust
       link: https://www.williamhoward.cumbria.sch.uk/teaching-internship-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Katy Birks
       email: kbirks@williamhoward.cumbria.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Great Schools Trust
       link: https://www.greatschoolstrust.org/train-with-us/internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Diane Lloyd
       email: d.lloyd@greatschoolstrust.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Northern Education Trust
       link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Meriem Lairini
       email: m.lairini@northerneducationtrust.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Ormiston Academies Trust
       link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Jemma Sherwood
       email: internships@ormistonacademies.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Teach Manchester
       link: https://teachmanchester.com/
+      subjects: chemistry, computing, maths, physics, languages
       name: Graeme Balfour
       email: gbalfour@loreto.ac.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Valley Learning Partnership
       link: https://www.brighouse.calderdale.sch.uk/join-us/train-with-us/
+      subjects: chemistry, computing, maths, physics, languages
       name: Janet Brierley
       email: j.brierley@brighouse.calderdale.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Wigan and West Lancashire Catholic School Direct 
       link: https://www.catholicsd.org.uk/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Sarah Holland
       email: hollands267@saintpetershigh.wigan.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
   South East:
     providers:
     - header: Debden Park High School (TKAT Teacher Training)
       link: https://scitt.tkat.org/842/internships
-      name: Jo Fogg
-      email: jo.fogg@tkat.org
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: GLF Teacher Training
       link: https://www.glfscitt.org/259/teaching-internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Blackburn
       email: k.blackburn@glfschools.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: George Abbot School in partnership with George Abbot SCITT
       link: https://georgeabbottraining.co.uk/
+      subjects: chemistry, computing, maths, physics, languages
       name: Joanna Jones
       email: jjones@georgeabbot.surrey.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Northfleet Technology College
       link: https://ntc.kent.sch.uk/
+      subjects: chemistry, computing, maths, physics, languages
       name: Michael Jones
       email: jonesm@ntc.kent.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Ringwood School
       link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Clare Adams
       email: cadams@ringwood.hants.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Teach Maidenhead
       link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
+      subjects: chemistry, computing, maths, physics, languages
       name: Maria Avellano
       email: maria.avellano@furzeplatt.net
-      subjects: chemistry, computing, maths, physics, languages
     - header: The Cherwell School
       link: https://www.cherwell.oxon.sch.uk/
+      subjects: chemistry, computing, maths, physics, languages
       name: Emma Rapson
       email: erapson@cherwellschool.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Thinking Schools Academy Trust
       link: https://www.tsatrust.org.uk/
-      name: Sophie Venables
-      email: s.venables@tsatrust.org.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: Xavier Teach SouthEast
       link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Cornforth
       email: k.cornforth@xaviercet.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: i2i Teaching Partnership
       link: https://www.i2ipartnership.co.uk/1243/undergraduate-teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: Liz Wylie
       email: lwylie@i2ipartnership.co.uk
-      subjects: chemistry, computing, maths, physics, languages
   South West:
     providers:
     - header: Excalibur
       link: https://www.stjohns.excalibur.org.uk/about-us/recruitment/train-to-teach/teaching-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Emma Hawes
       email: ehawes@stjohns.excalibur.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: GLF Teacher Training
       link: https://www.glfscitt.org/259/teaching-internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Blackburn
       email: k.blackburn@glfschools.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Odyssey Teaching School Hub
       link: https://www.patesgs.org/
+      subjects: chemistry, computing, maths, physics, languages
       name: Tim Connole
       email: tconnole@patesgs.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Ringwood School
       link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Clare Adams
       email: cadams@ringwood.hants.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: South West Institute for Teaching (SWIFT)
       link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
+      subjects: chemistry, computing, maths, physics, languages
       name: Abby Spearing
       email: Abby.spearing@sw-ift.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Thinking Schools Academy Trust
       link: https://www.tsatrust.org.uk/
-      name: Sophie Venables
-      email: s.venables@tsatrust.org.uk
       subjects: chemistry, computing, maths, physics, languages
+      status: Course full
     - header: West Country Internships
       link: https://exetermathematicsschool.ac.uk/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Kerry Burnham
       email: kburnham@exeterms.ac.uk
-      subjects: chemistry, computing, maths, physics, languages
   West Midlands:
     providers:
     - header: Arthur Terry SCITT
       link: https://arthurterryteachingschool.atlp.org.uk/teaching-internship-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Robert Bloomfield
       email: rbloomfield@arthurterry.bham.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Barr Beacon SCITT
       link: https://bbscitt.co.uk/teaching-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Michael Eszrenyi
       email: meszrenyi@barrbeaconschool.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Bishop Challoner Training School
       link: https://www.bctsa.org/605/teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: Angela Hodgkin
       email: trainingschool@bishopchalloner.bham.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Amed
       email: Claire.amed@creativeeducationtrust.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Ormiston Academies Trust
       link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Jemma Sherwood
       email: internships@ormistonacademies.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Outwood Institute of Education
       link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: George W. Robson
       email: teachnorth@oie.outwood.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
         School Hub
       link: https://www.princehenrys.worcs.sch.uk/
+      subjects: chemistry, computing, maths, physics, languages
       name: Andy Duffy
       email: ad@princehenrys.worcs.sch.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: St Joseph's College
       link: https://www.sjcscitt.co.uk/page/?title=DfE+Teaching+Internships&pid=26
+      subjects: chemistry, computing, maths, physics, languages
       name: Sam Chater
       email: schater@stjosephsmail.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: St Peter's Catholic School Solihull
       link: https://www.st-peters.solihull.sch.uk/teaching-school/
+      subjects: chemistry, computing, maths, physics
       name: Anthony Jones
       email: jonesa@st-peters.solihull.sch.uk
-      subjects: chemistry, computing, maths, physics
     - header: The Coventry SCITT
       link: https://www.coventryscitt.org.uk/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Katie Williams
       email: scittadmin@sidneystringeracademy.org.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: The Polesworth School
       link: https://www.thecatinstitute.org/page/?title=Internships&pid=110
+      subjects: chemistry, computing, maths, physics, languages
       name: Michelle Borders
       email: mborders@catschools.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: Windsor Academy Trust
       link: https://www.windsoracademytrust.org.uk/professional-learning/teaching-internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Nathalie Gotting
       email: ngotting@kingswinford.windsoracademytrust.org.uk
-      subjects: chemistry, computing, maths, physics, languages
   Yorkshire and the Humber:
     providers:
     - header: Learners First Schools Partnership
       link: https://www.learnersfirst.net/internships/
+      subjects: chemistry, computing, maths, physics, languages
       name: Claire Garbutt/Georgia Osborne
       email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Northern Education Trust
       link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+      subjects: chemistry, computing, maths, physics, languages
       name: Meriem Lairini
       email: m.lairini@northerneducationtrust.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Northern Star Academies Trust
       link: https://www.northernlightsscitt.com/our-programmes/teaching-internships1/
+      subjects: chemistry, computing, maths, physics, languages
       name: Helen Smith
       email: training@northernlightsscitt.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Outwood Institute of Education
       link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+      subjects: chemistry, computing, maths, physics, languages
       name: George W. Robson
       email: teachnorth@oie.outwood.com
-      subjects: chemistry, computing, maths, physics, languages
     - header: Scarborough Teaching Alliance - Coast and Vale Learning Trust
       link: https://www.scarboroughteachingalliance.co.uk/events/
+      subjects: chemistry, computing, maths, physics, languages
       name: Ashleigh Southall
       email: a.southall@coastandvale.academy
-      subjects: chemistry, computing, maths, physics, languages
     - header: Sheffield SCITT
       link: https://www.sheffieldscitt.org.uk/internship
+      subjects: chemistry, computing, maths, physics, languages
       name: Stacey Wooliscroft
       email: hallamtsa@notredame-high.co.uk
-      subjects: chemistry, computing, maths, physics, languages
     - header: St Mary's College
       link: https://www.scrcat.org/vacancies
+      subjects: chemistry, computing, maths, physics, languages
       name: Laura Fillingham
       email: schooldirect@smchull.org
-      subjects: chemistry, computing, maths, physics, languages
     - header: Wolds Learning Partnership Trust
       link: https://www.woldgate.net/jobs.html
+      subjects: chemistry, maths, physics, languages
       name: Kirsten Russell
       email: krussell@WLP.education
-      subjects: chemistry, maths, physics, languages
     - header: Yorkshire Wolds Teacher Training
       link: https://ywtt.org.uk/ywtt-paid-internship-programme/
+      subjects: chemistry, computing, maths, physics, languages
       name: Sarah Barley
       email: sarah.barley@theeducationalliance.org.uk
-      subjects: chemistry, computing, maths, physics, languages
 keywords:
   - teaching internship
   - internship

--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -41,7 +41,8 @@
         margin: 1em 0;
       }
 
-      &__fields {
+      &__fields,
+      &__fields p {
         @include font-size(xsmall);
         white-space: normal;
 

--- a/lib/internship_provider.rb
+++ b/lib/internship_provider.rb
@@ -11,6 +11,7 @@ class InternshipProvider
       @contact_name = d["contact_name"]
       @contact_email = d["contact_email"]
       @subjects = d["subjects"]
+      @full = ActiveModel::Type::Boolean.new.cast(d["full"])
     end
   end
 
@@ -18,10 +19,15 @@ class InternshipProvider
     {
       "header" => @school_name.strip,
       "link" => @school_website.strip,
-      "name" => @contact_name.strip,
-      "email" => @contact_email.strip,
       "subjects" => @subjects.strip,
-    }
+    }.tap do |h|
+      if @full
+        h["status"] = "Course full"
+      else
+        h["name"] = @contact_name.strip
+        h["email"] = @contact_email.strip
+      end
+    end
   end
 
   def to_str

--- a/spec/components/grouped_cards/card_component_spec.rb
+++ b/spec/components/grouped_cards/card_component_spec.rb
@@ -4,7 +4,7 @@ describe GroupedCards::CardComponent, type: "component" do
   subject { render_inline(instance) && page }
 
   let(:instance) { described_class.new organisation }
-  let(:organisation) do
+  let(:base_organisation) do
     {
       "header" => "First organisation",
       "name" => "Joe Bloggs",
@@ -12,6 +12,7 @@ describe GroupedCards::CardComponent, type: "component" do
       "email" => "joe.bloggs@first.org",
     }
   end
+  let(:organisation) { base_organisation }
 
   it { is_expected.to have_css "h4", text: "First organisation" }
   it { is_expected.to have_css ".group__card__fields span", text: "Name" }
@@ -22,16 +23,23 @@ describe GroupedCards::CardComponent, type: "component" do
 
   context "with link" do
     let(:organisation) do
-      {
-        "header" => "First organisation",
-        "link" => "https://education.gov.uk",
-        "name" => "Joe Bloggs",
-        "email" => "joe.bloggs@first.org",
-      }
+      base_organisation.tap do |h|
+        h["link"] = "https://education.gov.uk"
+      end
     end
 
     it { is_expected.to have_link href: "https://education.gov.uk" }
     it { is_expected.to have_css "a h4", text: "First organisation" }
     it { is_expected.to have_link "joe.bloggs@first.org", href: "mailto:joe.bloggs@first.org" }
+  end
+
+  context "with a status" do
+    let(:organisation) do
+      base_organisation.tap do |h|
+        h["status"] = "Course full"
+      end
+    end
+
+    it { is_expected.to have_css "p strong", text: organisation["status"] }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-4514](https://trello.com/c/L3Kt6Pzt/4514-update-internships-provider-data-functionality-to-allow-for-course-full-status)

### Context

We want to highlight to candidates when a provider course is 'full'. To do this we are going to accept a new 'full' column on the spreadsheet that must contain a boolean value. When full, we will remove the contact details and place a 'Course full' status at the top of the card.

### Changes proposed in this pull request

- Support 'course full' on internship providers page

### Guidance to review

