### PR TITLE
Namespace dfe-analytics web_request events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,10 @@ protected
     @content_errors << error
   end
 
+  def current_namespace
+    "get_into_teaching"
+  end
+
 private
 
   def session_expired(exception)

--- a/spec/requests/big_query_analytics_spec.rb
+++ b/spec/requests/big_query_analytics_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe "BigQuery Analytics", type: :request do
     expect { get root_path }.to have_sent_analytics_event_types(:web_request)
   end
 
+  it "namespaces DFE analytics web request events" do
+    get root_path
+
+    event_namespaces = enqueued_jobs
+      .find { |j| j["job_class"] == "DfE::Analytics::SendEvents" }["arguments"]
+      .flatten
+      .map { |a| a["namespace"] }
+
+    expect(event_namespaces).to all(eq("get_into_teaching"))
+  end
+
   it "sends DFE Analytics entity events" do
     params = { teacher_training_adviser_feedback: attributes_for(:feedback) }
     post teacher_training_adviser_feedbacks_path, params: params


### PR DESCRIPTION
### Trello card

[Trello-4481](https://trello.com/c/iT26TLTj/4481-migrate-tta-service-to-the-git-website)

### Context

We want to namespace the dfe-analytics web_request events so that we can easily distinguish between the adviser sign up on the GiT website and the Get an advsier service.

### Changes proposed in this pull request

- Namespace dfe-analytics web_request events

### Guidance to review

There does't appear to be a way of testing this; the `dfe-analytics` spec matchers only support event type.