### PR TITLE
Enable Optimize on train to be a teacher pages

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -6,4 +6,7 @@
 #   - /events
 #   - /
 
-paths: []
+paths:
+  - /landing/train-to-teach
+  - /train-to-be-a-teacher
+

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -183,7 +183,10 @@ describe ApplicationHelper do
 
     it "includes pages currently under test" do
       is_expected.to eq({
-        paths: [],
+        paths: [
+          "/landing/train-to-teach",
+          "/train-to-be-a-teacher",
+        ],
       })
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-4536](https://trello.com/c/PSzaVWJa/4536-create-and-test-a-new-train-to-be-a-teacher-landing-page-for-paid-search-test-12)

### Context

We are running an A/B test on the `/train-to-be-a-teacher` page with a new landing page, so we need Optimize enabled on both.

### Changes proposed in this pull request

- Enable Optimize on train to be a teacher pages

### Guidance to review

