### PR TITLE
Fix Turbolinks page change/scroll issue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,6 @@ class ApplicationController < ActionController::Base
   before_action :record_utm_codes
   before_action :add_home_breadcrumb
   before_action :declare_frontmatter
-  before_action :declare_js_packs
 
 protected
 
@@ -45,10 +44,6 @@ private
     # Not all pages have frontmatter, but ensuring it
     # is declared everywhere simplifies its use throughout.
     @front_matter ||= {}
-  end
-
-  def declare_js_packs
-    @js_packs ||= []
   end
 
   def raise_not_found

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -1,4 +1,4 @@
-<% @js_packs << 'internal' %>
+<% append_javascript_pack_tag 'internal' %>
 
 <!doctype html>
 <html lang="en" class="govuk-template">

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -1,5 +1,3 @@
-<% @js_packs << 'govuk_frontend' %>
-
 <!doctype html>
 <html lang="en" class="govuk-template">
   <% content_for :head do %>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -1,5 +1,3 @@
-<% @js_packs << 'govuk_frontend' %>
-
 <!doctype html>
 <html lang="en" class="govuk-template">
   <% content_for :head do %>

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -1,5 +1,3 @@
-<% @js_packs << 'govuk_frontend' %>
-
 <!doctype html>
 <html lang="en" class="govuk-template">
   <% content_for :head do %>

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -8,12 +8,12 @@
   <%= tag.link(rel: 'icon', type: 'image/x-icon', href: '/favicon.ico') %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <noscript><%= stylesheet_pack_tag 'application_no_js', 'data-turbolinks-track': 'reload', media: 'all' %></noscript>
-  <% @js_packs += %w[sentry gtm google_optimize js_enabled lazy_images application] %>
+  <% js_packs = %w[sentry gtm google_optimize js_enabled lazy_images govuk_frontend application] %>
   <%= yield :head %>
   <% if Rails.env.test? && params.key?(:fake_browser_time) %>
-    <% @js_packs.unshift('fake_browser_time') %>
+    <% js_packs.unshift('fake_browser_time') %>
   <% end %>
-  <%= javascript_pack_tag *@js_packs, 'data-turbolinks-track': 'reload', data:
+  <%= javascript_pack_tag *js_packs, 'data-turbolinks-track': 'reload', data:
   {
     "sentry-dsn": sentry_dsn,
     "sentry-environment": Rails.env,

--- a/app/views/teacher_training_adviser/feedbacks/new.html.erb
+++ b/app/views/teacher_training_adviser/feedbacks/new.html.erb
@@ -1,7 +1,4 @@
-<%
-@page_title = "Give feedback on this service"
-@js_packs << "govuk_frontend"
-%>
+<% @page_title = "Give feedback on this service" %>
 
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper">


### PR DESCRIPTION
### Trello card

[Trello-4566](https://trello.com/c/VqOAqE3d/4566-fix-issue-with-some-links-opening-halfway-down-page)

### Context

On some pages if you scroll down and click a link you will be taken to the page and the scroll position will be maintained (instead of scrolling back to the top of the new page). This bug was introduced when we migrated from Webpacker to Shakapacker.

The cause appears to be Turbolinks reloading the
`application.js` asset on these page changes. It only happens when the destination page uses a different layout containing different Javascript assets; in our case going from a normal content page to a page containing a form is the main culprit as we pull in an additional
`govuk_frontend` pack on these pages. Its not clear why Turbolinks then reloads the `application` pack as well.

We likely want to migrate away from Turbolinks to Turbo in the future, but we've tried that in the past and it causes a separate set of headaches with our analytics. A fix for now is to ensure all pages load the same set of Javascript packs.

### Changes proposed in this pull request

- Fix Turbolinks page change/scroll issue

### Guidance to review

