### PR TITLE
Adding international content to bursaries page

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -69,7 +69,7 @@
           </div>
         <% end %>
         <p>Talk to a <a href="/teacher-training-advisers">teacher training adviser</a> for advice on funding your training. Chat by phone, text or email, as little or as often as you need.</p>
-        <p>If you're a non-UK citizen, <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about financial support for non-UK trainee teachers</a>.</p>
+        <p><a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">Find out more about funding for non-UK citizens</a>.</p>
       <% end %>
     </div>
   </div>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -51,8 +51,8 @@
             <div>
               <%= helpers.safe_format(funding_results) %>
 
-              <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible.</p>
-              <p>You might also be eligible for extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> and <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.</p>
+              <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a>.</p>
+              <p>You could also get extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> and <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.</p>
             </div>
           </div>
           <div>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -30,11 +30,11 @@
             <h3><%= sub_head %></h3>
             <div>
               <p>
-                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a>.
+                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible (non-UK citizens without settled status are unlikely to be eligible).
               </p>
 
               <p>
-                You might also be eligible for extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> and <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.
+                You might be able to get extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> and <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.
               </p>
             </div>
           </div>
@@ -51,7 +51,7 @@
             <div>
               <%= helpers.safe_format(funding_results) %>
 
-              <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a>.</p>
+              <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible.</p>
               <p>You might also be eligible for extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> and <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.</p>
             </div>
           </div>
@@ -69,6 +69,7 @@
           </div>
         <% end %>
         <p>Talk to a <a href="/teacher-training-advisers">teacher training adviser</a> for advice on funding your training. Chat by phone, text or email, as little or as often as you need.</p>
+        <p>If you're a non-UK citizen, <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about financial support for non-UK trainee teachers</a>.</p>
       <% end %>
     </div>
   </div>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -30,9 +30,15 @@ keywords:
     - RAF
     - Navy
     - Military
+inset_text:
+    international-content:
+      text: If you’re a non-UK citizen without settled immigration status in the UK, you will not usually be eligible for a bursary or scholarship, unless you train to teach languages or physics. <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">Find out more about funding for non-UK citizens</a>.
+      color: grey
 ---
 
 ## Postgraduate bursaries and scholarships
+
+$international-content$
 
 Postgraduate teaching bursaries and scholarships are only available for the subjects listed below. You cannot receive both a teaching bursary and a scholarship.
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -30,15 +30,9 @@ keywords:
     - RAF
     - Navy
     - Military
-inset_text:
-    international-content:
-      text: If you’re a non-UK citizen without settled immigration status in the UK, you will not usually be eligible for a bursary or scholarship, unless you train to teach languages or physics. <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">Find out more about funding for non-UK citizens</a>.
-      color: grey
 ---
 
 ## Postgraduate bursaries and scholarships
-
-$international-content$
 
 Postgraduate teaching bursaries and scholarships are only available for the subjects listed below. You cannot receive both a teaching bursary and a scholarship.
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -6,6 +6,12 @@
 
 <p>Figures are for courses starting in the 2023/24 academic year.</p>
 
+<%= render Content::InsetTextComponent.new(
+  text: "If you’re a non-UK citizen without settled immigration status in the UK, you will not usually be eligible for a bursary or scholarship,
+  unless you train to teach languages or physics. <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">Find out more about funding for non-UK citizens</a>.",
+  color: "grey"
+) %>
+
 <section id="funding-widget">
   <%= render FundingWidgetComponent.new(
     @funding_widget,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
 
           Bursaries of £25,000 are available for all trainee language teachers, including ancient languages.
 
-          Non-UK citizens without settled status in the UK are still eligible for this support.
+          Non-UK citizens without settled status in the UK are eligible for this support.
       maths:
         name: "Maths"
         group: "Secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
         name: "Chemistry"
         group: "Secondary"
         sub_head: "Chemistry - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee chemistry teachers."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee chemistry teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       citizenship:
         name: "Citizenship"
         group: "Secondary"
@@ -114,6 +114,8 @@ en:
           Bursaries of £25,000 may be available for trainee teachers when more than 50% of the course content covers an ancient language.
 
           Your course provider will confirm if this applies.
+
+          Non-UK citizens without settled status are unlikely to be eligible.
       communication_and_media_studies:
         name: "Communication and media studies"
         group: "Secondary"
@@ -123,7 +125,7 @@ en:
         name: "Computing"
         group: "Secondary"
         sub_head: "Computing - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee computing teachers."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       dance:
         name: "Dance"
         group: "Secondary"
@@ -133,7 +135,7 @@ en:
         name: "Design and technology"
         group: "Secondary"
         sub_head: "Design and technology - Secondary"
-        funding: "Bursaries of £20,000 are available for trainee design and technology teachers."
+        funding: "Bursaries of £20,000 are available for trainee design and technology teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       drama:
         name: "Drama"
         group: "Secondary"
@@ -148,7 +150,7 @@ en:
         name: "English"
         group: "Secondary"
         sub_head: "English - Secondary"
-        funding: "Bursaries of £15,000 are available for trainee English teachers."
+        funding: "Bursaries of £15,000 are available for trainee English teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       english_as_a_second_or_other_language:
         name: "English as a second or other language"
         group: "Secondary"
@@ -158,7 +160,7 @@ en:
         name: "Geography"
         group: "Secondary"
         sub_head: "Geography - Secondary"
-        funding: "Bursaries of £25,000 are available for trainee geography teachers."
+        funding: "Bursaries of £25,000 are available for trainee geography teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       health_and_social_care:
         name: "Health and social care"
         group: "Secondary"
@@ -177,11 +179,13 @@ en:
           Scholarships of £27,000 are available for trainee French, German, and Spanish language teachers.
 
           Bursaries of £25,000 are available for all trainee language teachers, including ancient languages.
+
+          Non-UK citizens without settled status in the UK are still eligible for this support.
       maths:
         name: "Maths"
         group: "Secondary"
         sub_head: "Maths - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
         next_steps: |-
           If you have a passion for maths, find out more about <a href="/subjects/maths">becoming a maths teacher</a>.
       music:
@@ -198,7 +202,7 @@ en:
         name: "Physics"
         group: "Secondary"
         sub_head: "Physics - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee physics teachers."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee physics teachers (including non-UK citizens)."
         next_steps: |-
           Discover how to become a physics teacher if you’re an <a href="/subjects/engineers-teach-physics">engineering or material sciences graduate.</a>
       psychology:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,11 +111,9 @@ en:
         group: "Secondary"
         sub_head: "Classics - Secondary"
         funding: |-
-          Bursaries of £25,000 may be available for trainee teachers when more than 50% of the course content covers an ancient language.
+          Bursaries of £25,000 may be available for trainee teachers when more than 50% of the course content covers an ancient language, if you're eligible (non-UK citizens without settled status are unlikely to be eligible).
 
           Your course provider will confirm if this applies.
-
-          Non-UK citizens without settled status are unlikely to be eligible.
       communication_and_media_studies:
         name: "Communication and media studies"
         group: "Secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
         name: "Biology"
         group: "Secondary"
         sub_head: "Biology - Secondary"
-        funding: "Bursaries of £20,000 are available for trainee biology teachers."
+        funding: "Bursaries of £20,000 are available for trainee biology teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
       business_studies:
         name: "Business studies"
         group: "Secondary"

--- a/spec/components/funding_widget_component_spec.rb
+++ b/spec/components/funding_widget_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe FundingWidgetComponent, type: :component do
       let(:funding_widget) { FundingWidget.new(subject: "maths") }
 
       it "contains subject-specific funding content" do
-        expect(page).to have_text("Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers.")
+        expect(page).to have_text("Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible).")
       end
 
       it "contains subject-specific next steps content" do


### PR DESCRIPTION
### Trello card

https://trello.com/b/lRXllOHK/git-website-sprint-board

### Context

We're not clear on our bursaries and scholarships page which support international users are and are not eligible for.

We should add in our indented text component to link to international funding information and also tweak our funding widget to make this clearer.

### Changes proposed in this pull request

### Guidance to review

