### PR TITLE
Fix integration specs on TTA sign up

### DIFF
--- a/spec/integration/teacher_training_adviser_spec.rb
+++ b/spec/integration/teacher_training_adviser_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe "Sign up", :integration, type: :feature, js: true do
   end
 
   it "Full journey as a new candidate" do
-    submit_personal_details(rand_first_name, rand_last_name, rand_email, button_text: "Continue")
+    submit_personal_details(rand_first_name, rand_last_name, rand_email)
     complete_sign_up
   end
 
   it "Full journey as an existing candidate" do
     email = "ttauser@mailsac.com"
-    submit_personal_details(rand_first_name, rand_last_name, email, button_text: "Continue")
+    submit_personal_details(rand_first_name, rand_last_name, email)
 
-    submit_code(email, button_text: "Continue")
+    submit_code(email)
 
     expect_current_step(:returning_teacher)
   end
@@ -40,6 +40,6 @@ RSpec.describe "Sign up", :integration, type: :feature, js: true do
     )
     submit_uk_callback_step("123456789")
     submit_review_answers_step
-    expect(page).to have_text("Sign up complete")
+    expect(page).to have_text("you're signed up")
   end
 end

--- a/spec/support/spec_helpers/integration.rb
+++ b/spec/support/spec_helpers/integration.rb
@@ -8,19 +8,19 @@ module SpecHelpers
       Capybara.app_host = "https://#{creds[:username]}:#{creds[:password]}@#{host}"
     end
 
-    def submit_personal_details(first_name, last_name, email, button_text: "Next step")
+    def submit_personal_details(first_name, last_name, email)
       fill_in "First name", with: first_name
       fill_in "Last name", with: last_name
       fill_in "Email address", with: email
-      click_on button_text
+      click_on "Next step"
     end
 
-    def submit_code(email, button_text: "Next step")
+    def submit_code(email)
       wait_for_jobs
       expect(page).to have_text("You're already registered with us")
       code = retrieve_verification_code(email)
       fill_in "To verify your details, we've sent a code to your email address.", with: code
-      click_on button_text
+      click_on "Next step"
     end
 
     def submit_label_step(text, step)
@@ -30,7 +30,7 @@ module SpecHelpers
       # for radio/checkbox inputs on integration tests.
       find("label", text: text).click
 
-      click_on "Continue"
+      click_on "Next step"
     end
 
     def rand


### PR DESCRIPTION
We changed the button text to be "Next step" instead of "Continue" in the last PR for consistency with the other sign up journeys, but did not update the integration tests.
