### PR TITLE
Adding indented text for internationals to parents/carers and disabled page

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -30,7 +30,7 @@
             <h3><%= sub_head %></h3>
             <div>
               <p>
-                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible (non-UK citizens without settled status are unlikely to be eligible).
+                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible (non-UK citizens without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a> are unlikely to be eligible).
               </p>
 
               <p>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -30,7 +30,7 @@
             <h3><%= sub_head %></h3>
             <div>
               <p>
-                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible (non-UK citizens without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a> are unlikely to be eligible).
+                A scholarship or bursary isn't available for your chosen subject, but you can still get a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a> if you're eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible).
               </p>
 
               <p>

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -25,9 +25,11 @@ keywords:
     - Carers
 inset_text:
   international-content:
-    text: If you’re a non-UK citizen, you need to be eligible for student finance in England to receive the funding listed below. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens.</a>.
+    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens.</a>.
     color: grey
 ---
+
+$international-content$
 
 If you have children or other caring responsibilities, you may be able to get extra financial support while training to teach. 
 

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -29,8 +29,6 @@ inset_text:
     color: grey
 ---
 
-$international-content$
-
 If you have children or other caring responsibilities, you may be able to get extra financial support while training to teach. 
 
 You do not have to pay this money back, and you’ll get it on top of your other student finance.
@@ -38,6 +36,8 @@ You do not have to pay this money back, and you’ll get it on top of your other
 Figures are for the 2023/24 academic year.
 
 There are full and part-time teacher training courses available, but you must be doing a full-time course to be eligible for the following funding. If you’re doing a part-time course, you may be eligible for [Universal Credit](https://www.gov.uk/guidance/universal-credit-and-students).
+
+$international-content$
 
 ## If you're a parent
 

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -25,7 +25,7 @@ keywords:
     - Carers
 inset_text:
   international-content:
-    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens.</a>.
+    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
     color: grey
 ---
 

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -25,7 +25,7 @@ keywords:
     - Carers
 inset_text:
   international-content:
-    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
+    text: Most non-UK citizens without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a> will not be eligible for this financial support. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
     color: grey
 ---
 

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -20,6 +20,10 @@ keywords:
     - Financial Support
     - Disabled students
     - Disabled Students’ Allowances
+inset_text:
+  international-content:
+    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support (unless you’re an Afghan or Ukraine resettlement scheme applicant). You will still be entitled to adjustments to help you train. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens.</a>.
+    color: grey
 ---
 
 The experience and perspective of a diverse workforce is valued in school culture.

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -26,6 +26,8 @@ inset_text:
     color: grey
 ---
 
+$international-content$
+
 The experience and perspective of a diverse workforce is valued in school culture.
 
 If you’re disabled, have a mental health condition or educational needs, you can get support to become a teacher.

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -22,7 +22,7 @@ keywords:
     - Disabled Students’ Allowances
 inset_text:
   international-content:
-    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support (unless you’ve applied to the Afghan or Ukraine resettlement schemes). You will still be entitled to adjustments to help you train. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
+    text: Most non-UK citizens without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a> will not be eligible for this financial support (unless you’ve applied to the Afghan or Ukraine resettlement schemes). You will still be entitled to adjustments to help you train. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
     color: grey
 ---
 

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -22,15 +22,15 @@ keywords:
     - Disabled Students’ Allowances
 inset_text:
   international-content:
-    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support (unless you’re an Afghan or Ukraine resettlement scheme applicant). You will still be entitled to adjustments to help you train. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens.</a>.
+    text: Most non-UK citizens without settled immigration status in the UK will not be eligible for this financial support (unless you’ve applied to the Afghan or Ukraine resettlement schemes). You will still be entitled to adjustments to help you train. Find out about the <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">financial support available for non-UK citizens</a>.
     color: grey
 ---
-
-$international-content$
 
 The experience and perspective of a diverse workforce is valued in school culture.
 
 If you’re disabled, have a mental health condition or educational needs, you can get support to become a teacher.
+
+$international-content$
 
 ## Disabled Students’ Allowance and other support
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -7,7 +7,7 @@
 <p>Figures are for courses starting in the 2023/24 academic year.</p>
 
 <%= render Content::InsetTextComponent.new(
-  text: "If you’re a non-UK citizen without <a href="/https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
+  text: "If you’re a non-UK citizen without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
   unless you train to teach languages or physics. <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">Find out more about funding for non-UK citizens</a>.",
   color: "grey"
 ) %>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -7,7 +7,7 @@
 <p>Figures are for courses starting in the 2023/24 academic year.</p>
 
 <%= render Content::InsetTextComponent.new(
-  text: "If you’re a non-UK citizen without settled immigration status in the UK, you will not usually be eligible for a bursary or scholarship,
+  text: "If you’re a non-UK citizen without <a href=\"/https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk\">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
   unless you train to teach languages or physics. <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">Find out more about funding for non-UK citizens</a>.",
   color: "grey"
 ) %>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -7,7 +7,7 @@
 <p>Figures are for courses starting in the 2023/24 academic year.</p>
 
 <%= render Content::InsetTextComponent.new(
-  text: "If you’re a non-UK citizen without <a href=\"/https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk\">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
+  text: "If you’re a non-UK citizen without <a href="/https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
   unless you train to teach languages or physics. <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">Find out more about funding for non-UK citizens</a>.",
   color: "grey"
 ) %>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -7,7 +7,7 @@
 <p>Figures are for courses starting in the 2023/24 academic year.</p>
 
 <%= render Content::InsetTextComponent.new(
-  text: "If you’re a non-UK citizen without <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
+  text: "If you’re a non-UK citizen without <a href=\"https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk\">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,
   unless you train to teach languages or physics. <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">Find out more about funding for non-UK citizens</a>.",
   color: "grey"
 ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
         name: "Biology"
         group: "Secondary"
         sub_head: "Biology - Secondary"
-        funding: "Bursaries of £20,000 are available for trainee biology teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Bursaries of £20,000 are available for trainee biology teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       business_studies:
         name: "Business studies"
         group: "Secondary"
@@ -100,7 +100,7 @@ en:
         name: "Chemistry"
         group: "Secondary"
         sub_head: "Chemistry - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee chemistry teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee chemistry teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       citizenship:
         name: "Citizenship"
         group: "Secondary"
@@ -111,7 +111,7 @@ en:
         group: "Secondary"
         sub_head: "Classics - Secondary"
         funding: |-
-          Bursaries of £25,000 may be available for trainee teachers when more than 50% of the course content covers an ancient language, if you're eligible (non-UK citizens without settled status are unlikely to be eligible).
+          Bursaries of £25,000 may be available for trainee teachers when more than 50% of the course content covers an ancient language, if you're eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible).
 
           Your course provider will confirm if this applies.
       communication_and_media_studies:
@@ -123,7 +123,7 @@ en:
         name: "Computing"
         group: "Secondary"
         sub_head: "Computing - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       dance:
         name: "Dance"
         group: "Secondary"
@@ -133,7 +133,7 @@ en:
         name: "Design and technology"
         group: "Secondary"
         sub_head: "Design and technology - Secondary"
-        funding: "Bursaries of £20,000 are available for trainee design and technology teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Bursaries of £20,000 are available for trainee design and technology teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       drama:
         name: "Drama"
         group: "Secondary"
@@ -148,7 +148,7 @@ en:
         name: "English"
         group: "Secondary"
         sub_head: "English - Secondary"
-        funding: "Bursaries of £15,000 are available for trainee English teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Bursaries of £15,000 are available for trainee English teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       english_as_a_second_or_other_language:
         name: "English as a second or other language"
         group: "Secondary"
@@ -158,7 +158,7 @@ en:
         name: "Geography"
         group: "Secondary"
         sub_head: "Geography - Secondary"
-        funding: "Bursaries of £25,000 are available for trainee geography teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Bursaries of £25,000 are available for trainee geography teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
       health_and_social_care:
         name: "Health and social care"
         group: "Secondary"
@@ -178,12 +178,12 @@ en:
 
           Bursaries of £25,000 are available for all trainee language teachers, including ancient languages.
 
-          Non-UK citizens without settled status in the UK are eligible for this support.
+          Non-UK citizens without indefinite leave to remain in the UK are eligible for this support.
       maths:
         name: "Maths"
         group: "Secondary"
         sub_head: "Maths - Secondary"
-        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible)."
+        funding: "Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
         next_steps: |-
           If you have a passion for maths, find out more about <a href="/subjects/maths">becoming a maths teacher</a>.
       music:

--- a/spec/components/funding_widget_component_spec.rb
+++ b/spec/components/funding_widget_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe FundingWidgetComponent, type: :component do
       let(:funding_widget) { FundingWidget.new(subject: "maths") }
 
       it "contains subject-specific funding content" do
-        expect(page).to have_text("Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without settled status are unlikely to be eligible).")
+        expect(page).to have_text("Scholarships of £29,000 and bursaries of £27,000 are available for trainee maths teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible).")
       end
 
       it "contains subject-specific next steps content" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/Zp3EFYvI/4440-add-international-inset-text-to-if-youre-a-parent-or-carer-if-youre-disabled-and-if-youre-a-veteran-pages

### Context

Most international users won't be eligible for the support detailed on the 'if you're a parent or carer' and 'if you're disabled' pages.

We need to highlight this and effectively signpost them on to other relevant support.

### Changes proposed in this pull request

### Guidance to review

