### PR TITLE
changing info box link

### DIFF
--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -17,7 +17,7 @@ backlink: "../../"
 inset_text:
   new-international-funding:
     text: |-
-      If you're a non-UK citizen interested in teaching languages or physics in England, you could be eligible for an <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees#financial-support-for-non-UK-trainee-languages-and-physics-teachers">international relocation payment worth £10,000</a>.
+      If you're a non-UK citizen interested in teaching languages or physics in England, you could be eligible for an <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees#get-an-international-relocation-payment-irp-worth-10000">international relocation payment worth £10,000</a>.
 keywords:
   - International
   - Overseas

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -17,7 +17,7 @@ backlink: "../../"
 inset_text:
   new-international-funding:
     text: |-
-      If you're a non-UK citizen interested in teaching languages or physics in England, you could be eligible for an <a href="/non-uk-teachers/teach-in-england-if-you-trained-overseas#get-an-international-relocation-payment-irp-worth-10000">international relocation payment worth £10,000</a>.
+      If you're a non-UK citizen interested in teaching languages or physics in England, you could be eligible for an <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees#financial-support-for-non-UK-trainee-languages-and-physics-teachers">international relocation payment worth £10,000</a>.
 keywords:
   - International
   - Overseas


### PR DESCRIPTION
### Trello card

### Context

International team have been in contact to ask that the link is changed to point to the fees and funding page for trainees

### Changes proposed in this pull request

Changed the link in the info bar to point to the fees and funding for trainees page

### Guidance to review

