### PR TITLE
Update internships providers list (19/05/23)

### DIFF
--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -9,7 +9,7 @@ promo_content:
     - content/train-to-be-a-teacher/promos/eta-promo-internships
 quote_list:
   ql-1:
-    quotes: 
+    quotes:
       - heading: "Chloe, former teaching intern"
         text: "You’ll get the opportunity to experience a range of activities to help you get a feel for school life. Internships last 3 weeks, start in June and you’ll be paid £300 per week."
 backlink: /
@@ -27,8 +27,7 @@ provider_groups:
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
       subjects: chemistry, computing, maths, physics, languages
-      name: Claire Amed
-      email: Claire.amed@creativeeducationtrust.org.uk
+      status: Course full
     - header: George Spencer Academy
       link: http://www.george-spencer.com/
       subjects: chemistry, computing, maths, physics, languages
@@ -57,7 +56,7 @@ provider_groups:
       link: https://www.teachnottinghamshire.co.uk/internships.php
       subjects: chemistry, computing, maths, physics, languages
       name: Rebecca Morgan-Jones
-      email: contact@teachnottinghamshire.co.uk 
+      email: contact@teachnottinghamshire.co.uk
     - header: Outwood Institute of Education
       link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
       subjects: chemistry, computing, maths, physics, languages
@@ -86,8 +85,7 @@ provider_groups:
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
       subjects: chemistry, computing, maths, physics, languages
-      name: Claire Amed
-      email: Claire.amed@creativeeducationtrust.org.uk
+      status: Course full
     - header: Debden Park High School (TKAT Teacher Training)
       link: https://scitt.tkat.org/842/internships
       subjects: chemistry, computing, maths, physics, languages
@@ -127,8 +125,7 @@ provider_groups:
     - header: The Hertfordshire and Essex High School
       link: https://www.hertsandessex.herts.sch.uk/teaching-internships/60636.html
       subjects: chemistry, computing, maths, physics, languages
-      name: Claire Ruthven
-      email: claire.ruthven@hertsandessex.herts.sch.uk
+      status: Course full
   London:
     providers:
     - header: Debden Park High School (TKAT Teacher Training)
@@ -224,7 +221,7 @@ provider_groups:
       subjects: chemistry, computing, maths, physics, languages
       name: Fazia Chowdhury
       email: F.Chowdhury@chorltonhigh.manchester.sch.uk
-    - header: Co-op Academies Trust 
+    - header: Co-op Academies Trust
       link: https://www.coopacademies.co.uk/teaching-internship/
       subjects: chemistry, computing, maths, physics, languages
       status: Course full
@@ -258,7 +255,7 @@ provider_groups:
       subjects: chemistry, computing, maths, physics, languages
       name: Janet Brierley
       email: j.brierley@brighouse.calderdale.sch.uk
-    - header: Wigan and West Lancashire Catholic School Direct 
+    - header: Wigan and West Lancashire Catholic School Direct
       link: https://www.catholicsd.org.uk/internships/
       subjects: chemistry, computing, maths, physics, languages
       name: Sarah Holland
@@ -354,8 +351,7 @@ provider_groups:
     - header: Arthur Terry SCITT
       link: https://arthurterryteachingschool.atlp.org.uk/teaching-internship-programme/
       subjects: chemistry, computing, maths, physics, languages
-      name: Robert Bloomfield
-      email: rbloomfield@arthurterry.bham.sch.uk
+      status: Course full
     - header: Barr Beacon SCITT
       link: https://bbscitt.co.uk/teaching-internships/
       subjects: chemistry, computing, maths, physics, languages
@@ -369,8 +365,7 @@ provider_groups:
     - header: Creative Education Trust
       link: https://www.creativeeducationtrust.org.uk/internship
       subjects: chemistry, computing, maths, physics, languages
-      name: Claire Amed
-      email: Claire.amed@creativeeducationtrust.org.uk
+      status: Course full
     - header: Ormiston Academies Trust
       link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
       subjects: chemistry, computing, maths, physics, languages

--- a/docs/content.md
+++ b/docs/content.md
@@ -31,7 +31,7 @@ This documentation aims to be a reference for content editors that want to make 
 
 ## Finding a Page/Content to Edit
 
-When you want to edit content on the website the first step is to find out where that content resides in the [repository](https://github.com/DFE-Digital/get-into-teaching-app). 
+When you want to edit content on the website the first step is to find out where that content resides in the [repository](https://github.com/DFE-Digital/get-into-teaching-app).
 
 The majority of web pages on the site are within the [/app/views/content](https://github.com/DFE-Digital/get-into-teaching-app/tree/master/app/views/content) directory; this reflects the top-level pages of the website (including the home page). If, for example, you wanted to edit [the 'how to apply for teacher training' blog post](https://getintoteaching.education.gov.uk/blog) content you would edit the file [/app/views/content/blog/how-to-apply-for-teacher-training.md](https://github.com/DFE-Digital/get-into-teaching-app/blob/master/app/views/content/blog/how-to-apply-for-teacher-training.md). The structure here mimics the URL of the pages (the home page is a special case):
 
@@ -49,7 +49,7 @@ If you are looking to edit content associated with a form element in particular 
 
 ## Content Editing Info/Tips
 
-The majority of pages on the website are formatted in Markdown, which is a lightweight markup language designed for creating and formatting text. 
+The majority of pages on the website are formatted in Markdown, which is a lightweight markup language designed for creating and formatting text.
 
 There is a [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet/) that serves as a good reference on how to standard formatting, such as making something **bold** or *italic*. In conjunction with page frontmatter (see below) we can do some extra GiT-specific things in our Markdown, which this section aims to explain.
 
@@ -200,7 +200,7 @@ The above example would render out as follows:
 When adding an iFrame elemet as part of Markdown content or a HTML page we should ensure it has an appropriate `title` attribute that explains the contents of the iFrame (in most of our cases we are showing a video). For example:
 
 ```
-<iframe 
+<iframe
   title="A video about returning to teaching"
   ...
 ></iframe>
@@ -394,7 +394,7 @@ The first step is finding out what the build error is:
 
 * Scroll down to the 'checks' section of your pull request.
 * Find the check that has failed (it will have a red cross next to it and there may be multiple) .
-* Open the 'details' link next to the check(s) that have failed and you should be automatically taken to the failure details, often highlighted in red. 
+* Open the 'details' link next to the check(s) that have failed and you should be automatically taken to the failure details, often highlighted in red.
 * Cross-reference this error with the errors below to discover the issue and resolution.
 
 ### A link to a heading on the same page is broken
@@ -431,10 +431,10 @@ Check your filename only contains lower case characters, numbers and underscores
 
 ## Internship providers
 
-Occasionally we are sent a new spreadsheet to update the list of internship providers on the `teaching-internship-providers.csv` page. We have a rake task to make this easy to do:
+Occasionally we are sent a new spreadsheet to update the list of internship providers on the `teaching-internship-providers.md` page. We have a rake task to make this easy to do:
 
 - Export the XLSX to CSV
 - Rename it `internship_providers.csv` and place it in the root application directory
 - Run `bundle exec rake csv_to_yaml:internship_providers`
-- Overwrite the regions in `teaching-internship-providers.csv` with the output of the task
+- Overwrite the regions in `teaching-internship-providers.md` with the output of the task
 - Delete the `internship_providers.csv` file as you don't need to commit it


### PR DESCRIPTION
### Trello card

[Trello-4577](https://trello.com/c/u1714XbZ/4577-update-internships-providers-list-19-05-23)

### Context

New internships providers list was sent to us and this is the update to the teaching-internship-providers.md content page

### Changes proposed in this pull request

ran the rake task as documented in ```https://github.com/DFE-Digital/get-into-teaching-app/blob/master/docs/content.md#internship-providers```

### Guidance to review

Check that the list of internships providers got updated in the review app

