### PR TITLE
Update focus state for accessibility

### DIFF
--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -1,5 +1,10 @@
-select,
-input {
+@mixin input-focus {
+  outline-color: $pink;
+  outline-offset: 2px;
+}
+
+select.govuk-select,
+input.govuk-input {
   @include font-size("small");
   margin-left: $indent-amount;
   margin-right: $indent-amount;
@@ -9,11 +14,15 @@ input {
   width: 100%;
 
   &:focus {
-    outline: 3px solid $yellow;
-    outline-offset: 0;
+    @include input-focus;
     -webkit-box-shadow: inset 0 0 0 2px;
     box-shadow: inset 0 0 0 2px;
   }
+}
+
+input.govuk-radios__input:focus + .govuk-radios__label:before {
+  @include input-focus;
+  box-shadow: none;
 }
 
 input {


### PR DESCRIPTION
### Trello card

[Trello-4579](https://trello.com/c/ijZaSnYQ/4579-fix-colour-contrast-on-sign-up-forms-and-event-boxes)

### Context

The yellow colour we currently use to indicate a focus state on an input does not have sufficient contrast with the white background.

Update to use the `pink` color for focus states.

### Changes proposed in this pull request

- Update focus state for accessibility

### Guidance to review

