### PR TITLE
Consolidate TeachingSubject presentation

### DIFF
--- a/app/helpers/welcome_content_helper.rb
+++ b/app/helpers/welcome_content_helper.rb
@@ -180,7 +180,7 @@ private
       chemistry: SCIENCES,
       physics: SCIENCES,
       physics_with_maths: SCIENCES,
-      general_science: SCIENCES,
+      science: SCIENCES,
 
       french: MFL,
       german: MFL,

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -51,7 +51,7 @@ class Crm::TeachingSubject
     end
 
     def all
-      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject { |subject| IGNORED.value?(subject.id) }.each { |subject| if subject && RENAMED[subject.value].present? then subject.value = RENAMED[subject.value]; end; }
+      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject { |subject| IGNORED.value?(subject.id) }.each { |subject| if subject && RENAMED[subject.value].present? then subject.value = RENAMED[subject.value]; end; }.sort_by { |f| [f.value] }
     end
   end
 end

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -1,47 +1,19 @@
 class Crm::TeachingSubject
-  ALL =
-    {
-      "Art" => "6b793433-cd1f-e911-a979-000d3a20838a",
-      "Art and design" => "7e2655a1-2afa-e811-a981-000d3a276620",
-      "Biology" => "802655a1-2afa-e811-a981-000d3a276620",
-      "Business studies" => "822655a1-2afa-e811-a981-000d3a276620",
-      "Chemistry" => "842655a1-2afa-e811-a981-000d3a276620",
-      "Citizenship" => "862655a1-2afa-e811-a981-000d3a276620",
-      "Classics" => "882655a1-2afa-e811-a981-000d3a276620",
-      "Computing" => "8a2655a1-2afa-e811-a981-000d3a276620",
-      "Dance" => "8c2655a1-2afa-e811-a981-000d3a276620",
-      "Design and technology" => "8e2655a1-2afa-e811-a981-000d3a276620",
-      "Drama" => "902655a1-2afa-e811-a981-000d3a276620",
-      "Economics" => "922655a1-2afa-e811-a981-000d3a276620",
-      "English" => "942655a1-2afa-e811-a981-000d3a276620",
-      "French" => "962655a1-2afa-e811-a981-000d3a276620",
-      "General science" => "982655a1-2afa-e811-a981-000d3a276620",
-      "Geography" => "9a2655a1-2afa-e811-a981-000d3a276620",
-      "German" => "9c2655a1-2afa-e811-a981-000d3a276620",
-      "Health and social care" => "9e2655a1-2afa-e811-a981-000d3a276620",
-      "History" => "a02655a1-2afa-e811-a981-000d3a276620",
-      "Languages (other)" => "a22655a1-2afa-e811-a981-000d3a276620",
-      "Maths" => "a42655a1-2afa-e811-a981-000d3a276620",
-      "Media studies" => "a62655a1-2afa-e811-a981-000d3a276620",
-      "Music" => "a82655a1-2afa-e811-a981-000d3a276620",
-      "Physical education" => "aa2655a1-2afa-e811-a981-000d3a276620",
-      "Physics" => "ac2655a1-2afa-e811-a981-000d3a276620",
-      "Physics with maths" => "ae2655a1-2afa-e811-a981-000d3a276620",
-      "Primary" => "b02655a1-2afa-e811-a981-000d3a276620",
-      "Psychology" => "b22655a1-2afa-e811-a981-000d3a276620",
-      "Religious education" => "b42655a1-2afa-e811-a981-000d3a276620",
-      "Social sciences" => "b62655a1-2afa-e811-a981-000d3a276620",
-      "Spanish" => "b82655a1-2afa-e811-a981-000d3a276620",
-      "Vocational health" => "ba2655a1-2afa-e811-a981-000d3a276620",
-    }.freeze
-
+  RENAMED = {
+    "Media studies" => "Communication and media studies"
+  }.freeze
+  PRIMARY = "b02655a1-2afa-e811-a981-000d3a276620".freeze
   IGNORED =
     {
+      "Art" => "6b793433-cd1f-e911-a979-000d3a20838a",
+      "General science" => "982655a1-2afa-e811-a981-000d3a276620",
+      "Physics with maths" => "ae2655a1-2afa-e811-a981-000d3a276620",
+      "Vocational health" => "ba2655a1-2afa-e811-a981-000d3a276620",
       "Other" => "bc2655a1-2afa-e811-a981-000d3a276620",
       "No Preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
     }.freeze
 
-  class << self
+    class << self
     def lookup_by_key(key)
       keyed_subjects.fetch(key)
     end
@@ -51,7 +23,7 @@ class Crm::TeachingSubject
     end
 
     def lookup_by_uuid(uuid)
-      ALL.invert[uuid]
+      all_hash.invert[uuid]
     end
 
     def key_with_uuid(uuid)
@@ -59,19 +31,34 @@ class Crm::TeachingSubject
     end
 
     def all_uuids
-      ALL.values
+      all_hash.values
     end
 
     def all_subjects
-      ALL.keys
-    end
-
-    def ignore?(uuid)
-      IGNORED.value?(uuid)
+      all_hash.keys
     end
 
     def keyed_subjects
-      @keyed_subjects ||= ALL.transform_keys { |key| key.parameterize(separator: "_").to_sym }
+      @keyed_subjects ||= all_hash.transform_keys { |key| key.parameterize(separator: "_").to_sym }
+    end
+
+    def all_hash
+      all.reduce({}) do |hash, subject|
+        hash[subject.value] = subject.id
+        hash
+      end
+    end
+
+    def all_without_primary
+      all.reject { |s| s.id == PRIMARY }
+    end
+
+    def all
+      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |subject|
+        IGNORED.value?(subject.id)
+      end.each do |subject|
+        subject.value = RENAMED[subject.value] if subject && RENAMED[subject.value].present?
+      end
     end
   end
 end

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -51,7 +51,20 @@ class Crm::TeachingSubject
     end
 
     def all
-      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject { |subject| IGNORED.value?(subject.id) }.each { |subject| if subject && RENAMED[subject.value].present? then subject.value = RENAMED[subject.value]; end; }.sort_by { |f| [f.value] }
+      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects
+        .sort_by(&:value)
+        .reject(&method(:ignored?))
+        .each(&method(:rename))
+    end
+
+  private
+
+    def rename(subject)
+      subject.value = RENAMED[subject.value] || subject.value
+    end
+
+    def ignored?(subject)
+      IGNORED.value?(subject.id)
     end
   end
 end

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -1,12 +1,12 @@
 class Crm::TeachingSubject
   RENAMED = {
     "Media studies" => "Communication and media studies",
+    "General science" => "Science",
   }.freeze
   PRIMARY = "b02655a1-2afa-e811-a981-000d3a276620".freeze
   IGNORED =
     {
       "Art" => "6b793433-cd1f-e911-a979-000d3a20838a",
-      "General science" => "982655a1-2afa-e811-a981-000d3a276620",
       "Physics with maths" => "ae2655a1-2afa-e811-a981-000d3a276620",
       "Vocational health" => "ba2655a1-2afa-e811-a981-000d3a276620",
       "Other" => "bc2655a1-2afa-e811-a981-000d3a276620",
@@ -52,9 +52,9 @@ class Crm::TeachingSubject
 
     def all
       GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects
-        .sort_by(&:value)
         .reject(&method(:ignored?))
         .each(&method(:rename))
+        .sort_by(&:value)
     end
 
   private

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -43,14 +43,11 @@ class Crm::TeachingSubject
     end
 
     def all_hash
-      all.reduce({}) do |hash, subject|
-        hash[subject.value] = subject.id
-        hash
-      end
+      all.to_h {|item| [item.value, item.id] }
     end
 
     def all_without_primary
-      all.reject { |s| s.id == PRIMARY }
+      all_hash.reject { |h, s| s == PRIMARY }
     end
 
     def all

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -1,6 +1,6 @@
 class Crm::TeachingSubject
   RENAMED = {
-    "Media studies" => "Communication and media studies"
+    "Media studies" => "Communication and media studies",
   }.freeze
   PRIMARY = "b02655a1-2afa-e811-a981-000d3a276620".freeze
   IGNORED =
@@ -13,7 +13,7 @@ class Crm::TeachingSubject
       "No Preference" => "bc68e0c1-7212-e911-a974-000d3a206976",
     }.freeze
 
-    class << self
+  class << self
     def lookup_by_key(key)
       keyed_subjects.fetch(key)
     end
@@ -43,19 +43,15 @@ class Crm::TeachingSubject
     end
 
     def all_hash
-      all.to_h {|item| [item.value, item.id] }
+      all.to_h { |item| [item.value, item.id] }
     end
 
     def all_without_primary
-      all_hash.reject { |h, s| s == PRIMARY }
+      all_hash.reject { |_h, s| s == PRIMARY }
     end
 
     def all
-      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |subject|
-        IGNORED.value?(subject.id)
-      end.each do |subject|
-        subject.value = RENAMED[subject.value] if subject && RENAMED[subject.value].present?
-      end
+      GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject { |subject| IGNORED.value?(subject.id) }.each { |subject| if subject && RENAMED[subject.value].present? then subject.value = RENAMED[subject.value]; end; }
     end
   end
 end

--- a/app/models/crm/teaching_subject.rb
+++ b/app/models/crm/teaching_subject.rb
@@ -39,7 +39,7 @@ class Crm::TeachingSubject
     end
 
     def keyed_subjects
-      @keyed_subjects ||= all_hash.transform_keys { |key| key.parameterize(separator: "_").to_sym }
+      all_hash.transform_keys { |key| key.parameterize(separator: "_").to_sym }
     end
 
     def all_hash

--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -48,10 +48,7 @@ module Events
       end
 
       def teaching_subject_options
-        @teaching_subject_options ||=
-          GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
-            Crm::TeachingSubject.ignore?(type.id)
-          end
+        @teaching_subject_options ||= Crm::TeachingSubject.all
       end
 
       def teaching_subject_option_ids

--- a/app/models/mailing_list/steps/subject.rb
+++ b/app/models/mailing_list/steps/subject.rb
@@ -17,9 +17,7 @@ module MailingList
     private
 
       def query_teaching_subjects
-        GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects.reject do |type|
-          Crm::TeachingSubject.ignore?(type.id)
-        end
+        Crm::TeachingSubject.all
       end
     end
   end

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -10,7 +10,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["preferred_teaching_subject_id"] = self.class.options.key(preferred_teaching_subject_id)
+        answers["preferred_teaching_subject_id"] = Crm::TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id)
       end
     end
 

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -1,19 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class SubjectInterestedTeaching < GITWizard::Step
-    extend ApiOptions
-
     attribute :preferred_teaching_subject_id, :string
 
     validates :preferred_teaching_subject_id, lookup_items: { method: :get_teaching_subjects }
 
-    OMIT_SUBJECT_IDS = [
-      "bc2655a1-2afa-e811-a981-000d3a276620", # Other
-      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
-      "b02655a1-2afa-e811-a981-000d3a276620", # Primary
-    ].freeze
-
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::LookupItemsApi, :get_teaching_subjects, OMIT_SUBJECT_IDS)
+      Crm::TeachingSubject.all_without_primary
     end
 
     def reviewable_answers

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -1,17 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class SubjectLikeToTeach < GITWizard::Step
-    extend ApiOptions
-
-    OMIT_SUBJECT_IDS = [
-      "b02655a1-2afa-e811-a981-000d3a276620", # Primary
-    ].freeze
-
     attribute :preferred_teaching_subject_id, :string
 
     validates :preferred_teaching_subject_id, lookup_items: { method: :get_teaching_subjects }
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::LookupItemsApi, :get_teaching_subjects, OMIT_SUBJECT_IDS)
+      Crm::TeachingSubject.all_without_primary
     end
 
     def skipped?
@@ -20,7 +14,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["preferred_teaching_subject_id"] = self.class.options.key(preferred_teaching_subject_id)
+        answers["preferred_teaching_subject_id"] = Crm::TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id)
       end
     end
   end

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -1,17 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class SubjectTaught < GITWizard::Step
-    extend ApiOptions
-
-    OMIT_SUBJECT_IDS = [
-      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
-    ].freeze
-
     attribute :subject_taught_id, :string
 
     validates :subject_taught_id, lookup_items: { method: :get_teaching_subjects }
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::LookupItemsApi, :get_teaching_subjects, OMIT_SUBJECT_IDS)
+      Crm::TeachingSubject.all
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -5,7 +5,7 @@ module TeacherTrainingAdviser::Steps
     validates :subject_taught_id, lookup_items: { method: :get_teaching_subjects }
 
     def self.options
-      Crm::TeachingSubject.all
+      Crm::TeachingSubject.all_hash
     end
 
     def skipped?
@@ -14,7 +14,7 @@ module TeacherTrainingAdviser::Steps
 
     def reviewable_answers
       super.tap do |answers|
-        answers["subject_taught_id"] = self.class.options.key(subject_taught_id)
+        answers["subject_taught_id"] = Crm::TeachingSubject.lookup_by_uuid(subject_taught_id)
       end
     end
   end

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -5,7 +5,7 @@ module TeacherTrainingAdviser::Steps
     validates :degree_subject, presence: true
 
     def self.options
-      Crm::TeachingSubject.all
+      Crm::TeachingSubject.all_hash
     end
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -1,17 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class WhatSubjectDegree < GITWizard::Step
-    extend ApiOptions
-
-    OMIT_SUBJECT_IDS = [
-      "bc68e0c1-7212-e911-a974-000d3a206976", # No Preference
-    ].freeze
-
     attribute :degree_subject, :string
 
     validates :degree_subject, presence: true
 
     def self.options
-      generate_api_options(GetIntoTeachingApiClient::LookupItemsApi, :get_teaching_subjects, OMIT_SUBJECT_IDS)
+      Crm::TeachingSubject.all
     end
 
     def skipped?

--- a/spec/factories/events/personalised_updates_factory.rb
+++ b/spec/factories/events/personalised_updates_factory.rb
@@ -13,8 +13,7 @@ FactoryBot.define do
     address_postcode { "TE57 1NG" }
 
     preferred_teaching_subject_id do
-      GetIntoTeachingApiClient::LookupItemsApi.new
-        .get_teaching_subjects.first.id
+      Crm::TeachingSubject.all.first.id
     end
   end
 end

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -336,7 +336,7 @@ RSpec.feature "Event wizard", type: :feature do
     {
       degree_status_id: 222_750_000,
       consideration_journey_stage_id: 222_750_000,
-      preferred_teaching_subject_id: Crm::TeachingSubject.lookup_by_key(:art),
+      preferred_teaching_subject_id: Crm::TeachingSubject.lookup_by_key(:art_and_design),
       address_postcode: "TE57 1NG",
     }
   end

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe WelcomeHelper, type: :helper do
 
     context "when stored in the mailinglist session store" do
       context "when the subject name is a common noun" do
-        %i[art_and_design biology chemistry general_science languages_other maths physics_with_maths physics].each do |subject_key|
+        %i[art_and_design biology chemistry languages_other maths physics].each do |subject_key|
           describe "#{subject_key} is lowercased" do
             let(:subject_id) { Crm::TeachingSubject.lookup_by_key(subject_key) }
 

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe WelcomeHelper, type: :helper do
 
     context "when stored in the mailinglist session store" do
       context "when the subject name is a common noun" do
-        %i[art_and_design biology chemistry languages_other maths physics].each do |subject_key|
+        %i[art_and_design biology chemistry science languages_other maths physics].each do |subject_key|
           describe "#{subject_key} is lowercased" do
             let(:subject_id) { Crm::TeachingSubject.lookup_by_key(subject_key) }
 

--- a/spec/models/crm/teaching_subject_spec.rb
+++ b/spec/models/crm/teaching_subject_spec.rb
@@ -2,6 +2,21 @@ require "rails_helper"
 
 describe Crm::TeachingSubject do
   describe "class_methods" do
+    let(:stubbed_subjects) do
+      [
+        GetIntoTeachingApiClient::TeachingSubject.new(
+          id: "ac2655a1-2afa-e811-a981-000d3a276620", value: "Physics"
+        ),
+        GetIntoTeachingApiClient::TeachingSubject.new(
+          id: "a22655a1-2afa-e811-a981-000d3a276620", value: "Languages (other)"
+        ),
+      ]
+    end
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to receive(:get_teaching_subjects) { stubbed_subjects }
+    end
+
     describe ".lookup_by_key" do
       it { expect(described_class.lookup_by_key(:physics)).to eq("ac2655a1-2afa-e811-a981-000d3a276620") }
       it { expect(described_class.lookup_by_key(:languages_other)).to eq("a22655a1-2afa-e811-a981-000d3a276620") }
@@ -28,7 +43,7 @@ describe Crm::TeachingSubject do
 
       it { is_expected.to include({ physics: "ac2655a1-2afa-e811-a981-000d3a276620" }) }
       it { is_expected.to include({ languages_other: "a22655a1-2afa-e811-a981-000d3a276620" }) }
-      it { expect(keyed_subjects.count).to eq(described_class::ALL.count) }
+      it { expect(keyed_subjects.count).to eq(described_class::all.count) }
     end
 
     describe ".key_with_uuid" do
@@ -40,18 +55,13 @@ describe Crm::TeachingSubject do
     describe ".all_uuids" do
       subject { described_class.all_uuids }
 
-      it { is_expected.to eq(described_class::ALL.values) }
+      it { is_expected.to eq(described_class::all_hash.values) }
     end
 
     describe ".all_subjects" do
       subject { described_class.all_subjects }
 
-      it { is_expected.to eq(described_class::ALL.keys) }
-    end
-
-    describe ".ignore?" do
-      it { expect(described_class).to be_ignore(described_class::IGNORED.values.sample) }
-      it { expect(described_class).not_to be_ignore(described_class.all_uuids.sample) }
+      it { is_expected.to eq(described_class::all_hash.keys) }
     end
   end
 end

--- a/spec/models/crm/teaching_subject_spec.rb
+++ b/spec/models/crm/teaching_subject_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Crm::TeachingSubject do
   describe "class_methods" do
-    let!(:stubbed_subjects) do
+    let(:stubbed_subjects) do
       [
         GetIntoTeachingApiClient::TeachingSubject.new(
           id: "ac2655a1-2afa-e811-a981-000d3a276620", value: "Physics",

--- a/spec/models/crm/teaching_subject_spec.rb
+++ b/spec/models/crm/teaching_subject_spec.rb
@@ -5,10 +5,10 @@ describe Crm::TeachingSubject do
     let(:stubbed_subjects) do
       [
         GetIntoTeachingApiClient::TeachingSubject.new(
-          id: "ac2655a1-2afa-e811-a981-000d3a276620", value: "Physics"
+          id: "ac2655a1-2afa-e811-a981-000d3a276620", value: "Physics",
         ),
         GetIntoTeachingApiClient::TeachingSubject.new(
-          id: "a22655a1-2afa-e811-a981-000d3a276620", value: "Languages (other)"
+          id: "a22655a1-2afa-e811-a981-000d3a276620", value: "Languages (other)",
         ),
       ]
     end
@@ -43,7 +43,7 @@ describe Crm::TeachingSubject do
 
       it { is_expected.to include({ physics: "ac2655a1-2afa-e811-a981-000d3a276620" }) }
       it { is_expected.to include({ languages_other: "a22655a1-2afa-e811-a981-000d3a276620" }) }
-      it { expect(keyed_subjects.count).to eq(described_class::all.count) }
+      it { expect(keyed_subjects.count).to eq(described_class.all.count) }
     end
 
     describe ".key_with_uuid" do
@@ -55,13 +55,13 @@ describe Crm::TeachingSubject do
     describe ".all_uuids" do
       subject { described_class.all_uuids }
 
-      it { is_expected.to eq(described_class::all_hash.values) }
+      it { is_expected.to eq(described_class.all_hash.values) }
     end
 
     describe ".all_subjects" do
       subject { described_class.all_subjects }
 
-      it { is_expected.to eq(described_class::all_hash.keys) }
+      it { is_expected.to eq(described_class.all_hash.keys) }
     end
   end
 end

--- a/spec/models/crm/teaching_subject_spec.rb
+++ b/spec/models/crm/teaching_subject_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Crm::TeachingSubject do
   describe "class_methods" do
-    let(:stubbed_subjects) do
+    let!(:stubbed_subjects) do
       [
         GetIntoTeachingApiClient::TeachingSubject.new(
           id: "ac2655a1-2afa-e811-a981-000d3a276620", value: "Physics",
@@ -62,6 +62,10 @@ describe Crm::TeachingSubject do
       subject { described_class.all_subjects }
 
       it { is_expected.to eq(described_class.all_hash.keys) }
+    end
+
+    specify "orders the array by name" do
+      expect(described_class.all).to eq(stubbed_subjects.reverse)
     end
   end
 end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -103,7 +103,7 @@ describe Events::Steps::PersonalisedUpdates do
     subject { instance.teaching_subject_options }
 
     let(:teaching_subject_types) do
-      subjects = Crm::TeachingSubject::ALL.merge(Crm::TeachingSubject::IGNORED)
+      subjects = Crm::TeachingSubject::all_hash.merge(Crm::TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -103,7 +103,7 @@ describe Events::Steps::PersonalisedUpdates do
     subject { instance.teaching_subject_options }
 
     let(:teaching_subject_types) do
-      subjects = Crm::TeachingSubject::all_hash.merge(Crm::TeachingSubject::IGNORED)
+      subjects = Crm::TeachingSubject.all_hash.merge(Crm::TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -8,7 +8,7 @@ describe MailingList::Steps::Subject do
   end
 
   let(:teaching_subject_types) do
-    Crm::TeachingSubject::all_hash.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
+    Crm::TeachingSubject.all_hash.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
   end
 
   it_behaves_like "a with wizard step"
@@ -29,7 +29,7 @@ describe MailingList::Steps::Subject do
     subject { instance.teaching_subject_ids }
 
     let(:teaching_subject_types) do
-      subjects = Crm::TeachingSubject::all_hash.merge(Crm::TeachingSubject::IGNORED)
+      subjects = Crm::TeachingSubject.all_hash.merge(Crm::TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 

--- a/spec/models/mailing_list/steps/subject_spec.rb
+++ b/spec/models/mailing_list/steps/subject_spec.rb
@@ -8,7 +8,7 @@ describe MailingList::Steps::Subject do
   end
 
   let(:teaching_subject_types) do
-    Crm::TeachingSubject::ALL.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
+    Crm::TeachingSubject::all_hash.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
   end
 
   it_behaves_like "a with wizard step"
@@ -29,7 +29,7 @@ describe MailingList::Steps::Subject do
     subject { instance.teaching_subject_ids }
 
     let(:teaching_subject_types) do
-      subjects = Crm::TeachingSubject::ALL.merge(Crm::TeachingSubject::IGNORED)
+      subjects = Crm::TeachingSubject::all_hash.merge(Crm::TeachingSubject::IGNORED)
       subjects.map { |k, v| GetIntoTeachingApiClient::TeachingSubject.new({ id: v, value: k }) }
     end
 

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -5,7 +5,7 @@ describe MailingList::Wizard do
 
   let(:uuid) { SecureRandom.uuid }
   let(:degree_status_id) { Crm::OptionSet.lookup_by_key(:degree_status, :final_year) }
-  let(:preferred_teaching_subject_id) { Crm::TeachingSubject.lookup_by_key(:physics_with_maths) }
+  let(:preferred_teaching_subject_id) { Crm::TeachingSubject.lookup_by_key(:physics) }
   let(:store) do
     { uuid => {
       "email" => "email@address.com",
@@ -43,7 +43,7 @@ describe MailingList::Wizard do
   end
 
   describe "#complete!" do
-    let(:variant) { "/email/subject/physics_with_maths/degree-status/final_year" }
+    let(:variant) { "/email/subject/physics/degree-status/final_year" }
     let(:request) do
       GetIntoTeachingApiClient::MailingListAddMember.new({
         email: wizardstore[:email],
@@ -77,6 +77,7 @@ describe MailingList::Wizard do
         "degree_status_id" => wizardstore[:degree_status_id],
         "preferred_teaching_subject_id" => wizardstore[:preferred_teaching_subject_id],
       })
+
       expect(wizardstore).to have_received(:prune!).with({ leave: MailingList::Wizard::ATTRIBUTES_TO_LEAVE }).once
     end
 

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  
+
   describe "attributes" do
     it { is_expected.to respond_to :preferred_teaching_subject_id }
   end

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  it_behaves_like "with a wizard step that exposes API lookup items as options",
-                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
-
+  
   describe "attributes" do
     it { is_expected.to respond_to :preferred_teaching_subject_id }
   end

--- a/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_interested_teaching_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectInterestedTeaching do
     it { is_expected.not_to allow_values("", nil, "invalid-id").for :preferred_teaching_subject_id }
   end
 
+  describe "#options" do
+    subject { described_class.options }
+
+    it { is_expected.to eq(Crm::TeachingSubject.all_without_primary) }
+  end
+
   describe "#skipped?" do
     it "returns false if HaveADegree step was shown and preferred_education_phase_id is secondary" do
       expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?).and_return(false)

--- a/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  it_behaves_like "with a wizard step that exposes API lookup items as options",
-                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
 
   describe "attributes" do
     it { is_expected.to respond_to :preferred_teaching_subject_id }

--- a/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_like_to_teach_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectLikeToTeach do
     end
   end
 
+  describe "#options" do
+    subject { described_class.options }
+
+    it { is_expected.to eq(Crm::TeachingSubject.all_without_primary) }
+  end
+
   describe "#reviewable_answers" do
     subject { instance.reviewable_answers }
 

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  it_behaves_like "with a wizard step that exposes API lookup items as options",
-                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
-
+  
   describe "attributes" do
     it { is_expected.to respond_to :subject_taught_id }
   end

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
     it { is_expected.to respond_to :subject_taught_id }
   end
 
+  describe "#options" do
+    subject { described_class.options }
+
+    it { is_expected.to eq(Crm::TeachingSubject.all) }
+  end
+
   describe "#subject_taught_id" do
     it "allows a valid subject_taught_id" do
       subject_item = GetIntoTeachingApiClient::TeachingSubject.new(id: "abc-123")

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
   describe "#options" do
     subject { described_class.options }
 
-    it { is_expected.to eq(Crm::TeachingSubject.all) }
+    it { is_expected.to eq(Crm::TeachingSubject.all_hash) }
   end
 
   describe "#subject_taught_id" do

--- a/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/subject_taught_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::SubjectTaught do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  
+
   describe "attributes" do
     it { is_expected.to respond_to :subject_taught_id }
   end

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
     it { is_expected.to allow_value("Maths").for :degree_subject }
   end
 
+  describe "#options" do
+    subject { described_class.options }
+
+    it { is_expected.to eq(Crm::TeachingSubject.all) }
+  end
+
   describe "#skipped?" do
     it "returns false if HaveADegree step was shown and degree_options is studying" do
       expect_any_instance_of(TeacherTrainingAdviser::Steps::HaveADegree).to receive(:skipped?).and_return(false)

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  it_behaves_like "with a wizard step that exposes API lookup items as options",
-                  :get_teaching_subjects, described_class::OMIT_SUBJECT_IDS
-
+  
   describe "attributes" do
     it { is_expected.to respond_to :degree_subject }
   end

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  
+
   describe "attributes" do
     it { is_expected.to respond_to :degree_subject }
   end

--- a/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/what_subject_degree_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::WhatSubjectDegree do
   describe "#options" do
     subject { described_class.options }
 
-    it { is_expected.to eq(Crm::TeachingSubject.all) }
+    it { is_expected.to eq(Crm::TeachingSubject.all_hash) }
   end
 
   describe "#skipped?" do

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -35,6 +35,7 @@ shared_context "with a TTA wizard step" do
   end
 end
 
+
 shared_context "with wizard data" do
   let(:degree_status_option_types) do
     Crm::OptionSet::DEGREE_STATUSES.map do |k, v|
@@ -49,7 +50,7 @@ shared_context "with wizard data" do
   end
 
   let(:teaching_subject_types) do
-    Crm::TeachingSubject::ALL.map do |k, v|
+    Crm::TeachingSubject::all_hash.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -35,7 +35,6 @@ shared_context "with a TTA wizard step" do
   end
 end
 
-
 shared_context "with wizard data" do
   let(:degree_status_option_types) do
     Crm::OptionSet::DEGREE_STATUSES.map do |k, v|
@@ -50,7 +49,7 @@ shared_context "with wizard data" do
   end
 
   let(:teaching_subject_types) do
-    Crm::TeachingSubject::all_hash.map do |k, v|
+    Crm::TeachingSubject.all_hash.map do |k, v|
       GetIntoTeachingApiClient::PickListItem.new({ id: v, value: k })
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-4591](https://trello.com/c/UQdgvC0I/4591-consolidate-and-streamline-teaching-subjects-on-git-funnels)

### Context

We currently retrieve teaching subjects from the API in a multitude of different ways. We want to be consistent in how we retrieve subjects and also in how we filter/display them.

### Changes proposed in this pull request

- Consolidate TeachingSubject presentation

Centralise the teaching subject queries to the `Crm::TeachingSubject` model and update all references to go through this.

### Guidance to review

