### PR TITLE
Remove HotJar from the website

### DIFF
--- a/app/views/pages/cookies.md
+++ b/app/views/pages/cookies.md
@@ -64,20 +64,6 @@ gather this data.
 | `UA-179982899-1` | Registers a unique ID to generate statistics about how you use the website       | 1 minute |
 | `_gid`           | Helps count how many people visit this site by tracking if you’ve visited before | 24 hours |
 
-#### Hotjar cookies
-
-| Name                           | Purpose                                                                                          | Expires after          |
-| -----                          | -------                                                                                          | --------               |
-| `_hjid`                        | Registers a unique ID to generate statistics abouthow you use the website.                       | 365 days               |
-| `_hjRecordingLastActivity`     | Gets updated when a visitor recording starts and when you perform an action that Hotjar records. | End of browser session |
-| `_hjTLDTest`                   | Used to determine where cookies will be stored. After this check, the cookie is removed.         | End of browser session |
-| `_hjUserAttributesHash`        | Holds information about your visit so your information can be kept up to date.                   | End of browser session |
-| `_hjCachedUserAttributes`      | Stores User Attributes which are sent whenever the user is not in the sample.                    | End of browser session |
-| `_hjLocalStorageTest`          | Used to check if the Hotjar Tracking Script can use local storage.                               | Under 100ms            |
-| `_hjIncludedInPageviewSample`  | Lets Hotjar know whether you are included in data sampling.                                      | 30 minutes             |
-| `_hjIncludedInSessionSample`   | Set to let Hotjar know whether you are included in data sampling.                                | 30 minutes             |
-| `_hjAbsoluteSessionInProgress` | Used to detect your first pageview session.                                                      | 30 Minutes             |
-
 ### Marketing
 
 We use cookies to make our marketing more engaging and relevant to

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -35,7 +35,6 @@ SecureHeaders::Configuration.default do |config|
   zendesk     = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
-  hotjar      = %w[*.hotjar.com vc.hotjar.io wss://*.hotjar.com]
   jquery      = %w[code.jquery.com]
   pinterest   = %w[*.pinterest.com *.pinterest.co.uk *.pinimg.com]
   scribble    = %w[embed.scribblelive.com]
@@ -67,16 +66,16 @@ SecureHeaders::Configuration.default do |config|
 
     default_src: %w['none'],
     base_uri: self_base,
-    child_src: self_base.concat(youtube, pinterest, snapchat, hotjar),
-    connect_src: self_base.concat(google_apis, pinterest, hotjar, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat, sentry, gtm_server),
+    child_src: self_base.concat(youtube, pinterest, snapchat),
+    connect_src: self_base.concat(google_apis, pinterest, google_analytics, google_supported, google_doubleclick, facebook, tta_service_hosts, zendesk, snapchat, sentry, gtm_server),
     font_src: self_base.concat(govuk, data, %w[fonts.gstatic.com]),
     form_action: self_base.concat(snapchat, facebook, govuk),
-    frame_src: self_base.concat(scribble, snapchat, facebook, youtube, hotjar, google_doubleclick, google_analytics, data, pinterest, optimize),
+    frame_src: self_base.concat(scribble, snapchat, facebook, youtube, google_doubleclick, google_analytics, data, pinterest, optimize),
     frame_ancestors: self_base,
     img_src: self_base.concat(govuk, pinterest, facebook, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, optimize, gtm_server, reddit, %w[cx.atdmt.com linkbam.uk]),
     manifest_src: self_base,
     media_src: self_base.concat(zendesk).concat(assets),
-    script_src: self_base.concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, hotjar, scribble, twitter, snapchat, youtube, zendesk, optimize, reddit),
+    script_src: self_base.concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, scribble, twitter, snapchat, youtube, zendesk, optimize, reddit),
     style_src: self_base.concat(quoted_unsafe_inline, govuk, google_apis, google_supported, optimize),
     worker_src: self_base.concat(blob),
   }


### PR DESCRIPTION
### Trello card

[Trello-4595](https://trello.com/c/gQTniMvs/4595-remove-hotjar-from-the-site)

### Context

We have removed HotJar from our GTM container, so we can remove references from our Cookie policy and the CSP.

### Changes proposed in this pull request

- Remove HotJar from the website

### Guidance to review

