### PR TITLE
Disable Turbolinks on TTA service paths

### DIFF
--- a/lib/disable_turbolinks.rb
+++ b/lib/disable_turbolinks.rb
@@ -1,0 +1,15 @@
+class DisableTurbolinks
+  attr_reader :doc
+
+  def initialize(doc)
+    @doc = doc
+  end
+
+  def process
+    doc.css("a[href='/tta-service']").each do |anchor|
+      anchor["data-turbolinks"] = false
+    end
+
+    doc
+  end
+end

--- a/lib/middleware/html_response_transformer.rb
+++ b/lib/middleware/html_response_transformer.rb
@@ -5,6 +5,7 @@ require "external_links"
 require "image_sizes"
 require "error_title"
 require "accessible_footnotes"
+require "disable_turbolinks"
 
 module Middleware
   class HtmlResponseTransformer
@@ -16,6 +17,7 @@ module Middleware
       ExternalLinks,
       ErrorTitle,
       AccessibleFootnotes,
+      DisableTurbolinks,
     ].freeze
 
     def initialize(app)

--- a/spec/lib/disable_turbolinks_spec.rb
+++ b/spec/lib/disable_turbolinks_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "disable_turbolinks"
+
+describe DisableTurbolinks do
+  describe "#html" do
+    subject { instance.process.to_html }
+
+    let(:anchor) { %(<a href="/tta-service">Get an adviser</a>) }
+    let(:instance) { described_class.new(Nokogiri::HTML(anchor)) }
+
+    it { is_expected.to include(%(data-turbolinks="false")) }
+
+    context "when the link is not /tta-service" do
+      let(:anchor) { %(<a href="/tta-service-other">Other</a>) }
+
+      it { is_expected.not_to include(%(data-turbolinks)) }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-4612](https://trello.com/c/jT8Sx8e5/4612-update-the-adviser-funnel-start-page-to-have-a-normal-url-rather-than-the-tta-service-redirect)

### Context

Currently, the links to `/tta-service` are handled by Turbolinks, which results in the page URL being `/tta-service` after the redirect instead of
`teacher-training-advisers/sign_up/identity`. We want to make sure the URL updates to the correct path after redirecting so that A/B tests and Google Analytics are correct.

### Changes proposed in this pull request

- Disable Turbolinks on `/tta-service` paths.

### Guidance to review

Find any link to the adviser service on the website, click it and ensure the URL is updated to `/teacher-training-advisers/sign_up/identity` instead of `/tta-service`.

