### PR TITLE
Investigate possible bug with survey buttons at the end of the event funnel

### DIFF
--- a/app/webpacker/controllers/feedback_controller.js
+++ b/app/webpacker/controllers/feedback_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static targets = ['text', 'link'];
+
+  connect() {
+    this.element.classList.add('visible');
+  }
+
+  answer() {
+    // Answer is captured by event configured in GTM.
+    this.hideLinks();
+    this.showThankYouText();
+  }
+
+  showThankYouText() {
+    this.textTarget.textContent = 'Thank you for your feedback';
+  }
+
+  hideLinks() {
+    this.linkTargets.forEach((target) => target.classList.add('hidden'));
+  }
+}

--- a/spec/javascript/controllers/feedback_controller_spec.js
+++ b/spec/javascript/controllers/feedback_controller_spec.js
@@ -1,0 +1,35 @@
+import { Application } from '@hotwired/stimulus';
+import FeedbackController from 'feedback_controller.js';
+
+describe('FeedbackController', () => {
+  document.body.innerHTML = `
+  <div id="feedback" data-controller="feedback">
+    <p id="text" data-feedback-target="text">Is this page helpful?</p>
+    <a href="javascript:void(0)" id="answerButton" data-feedback-target="link" data-action="feedback#answer">Answer</a>
+  </div>
+  `;
+
+  const application = Application.start();
+  application.register('feedback', FeedbackController);
+  const answerButton = document.getElementById('answerButton');
+
+  describe('on connect', () => {
+    it('displays the page helpful HTML', () => {
+      const feedback = document.getElementById('feedback');
+      expect(feedback.classList).toContain('visible');
+    });
+  });
+
+  describe('submitting an answer', () => {
+    it('hides the links', () => {
+      answerButton.click();
+      expect(answerButton.classList).toContain('hidden');
+    });
+
+    it('displays a thank you message', () => {
+      answerButton.click();
+      const text = document.getElementById('text');
+      expect(text.textContent).toEqual('Thank you for your feedback');
+    });
+  });
+});


### PR DESCRIPTION
### Trello card

[4611](https://trello.com/c/4LDvBoeV/4611-investigate-possible-bug-with-survey-buttons-at-the-end-of-the-event-funnel)

### Context

At the end of the event funnel, users may click on a button from the list. Previously there was a thank you message but nothing happens at the moment.

### Changes proposed in this pull request

Re-introduce feedback.js in order to handle the answer call from the click on the button events.

### Guidance to review

When user clicks on any button

<table><tr><td><img width="1164" alt="screen1" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/77098906/a40a061c-cff5-4547-a32d-962df0e4f744" border="1"></td></tr></table>

The thank you message will replace the buttons
<table><tr><td><img width="1104" alt="screen2" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/77098906/cf02c560-17ac-4864-9a3a-8f81e761ac01"></td></tr></table>
