### PR TITLE
Fix list headings on landing pages

### DIFF
--- a/app/views/content/landing/how-to-become-a-teacher-mailing-list/_steps.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher-mailing-list/_steps.html.erb
@@ -13,19 +13,19 @@
         <li class="step">
           <header class="step__header">
             <div class="step__number">1</div>
-            <h2 class="heading-m">What qualifications do I need?</h2>
+            <span class="heading-m">What qualifications do I need?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">2</div>
-            <h2 class="heading-m">Can I get help funding my training?</h2>
+            <span class="heading-m">Can I get help funding my training?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">3</div>
-            <h2 class="heading-m">How do I find and apply for teacher training?</h2>
+            <span class="heading-m">How do I find and apply for teacher training?</span>
           </header>
         </li>
       </ol>

--- a/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_steps.html.erb
@@ -10,19 +10,19 @@
         <li class="step">
           <header class="step__header">
             <div class="step__number">1</div>
-            <h2 class="heading-m">What qualifications do I need?</h2>
+            <span class="heading-m">What qualifications do I need?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">2</div>
-            <h2 class="heading-m">Can I get help funding my training?</h2>
+            <span class="heading-m">Can I get help funding my training?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">3</div>
-            <h2 class="heading-m">How do I find and apply for teacher training?</h2>
+            <span class="heading-m">How do I find and apply for teacher training?</span>
           </header>
         </li>
       </ol>

--- a/app/views/content/landing/secure-your-september/_steps.html.erb
+++ b/app/views/content/landing/secure-your-september/_steps.html.erb
@@ -9,19 +9,19 @@
         <li class="step">
           <header class="step__header">
             <div class="step__number">1</div>
-            <h2 class="heading-m">How much could I earn as a teacher?</h2>
+            <span class="heading-m">How much could I earn as a teacher?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">2</div>
-            <h2 class="heading-m">Can I get help funding my training?</h2>
+            <span class="heading-m">Can I get help funding my training?</span>
           </header>
         </li>
         <li class="step">
           <header class="step__header">
             <div class="step__number">3</div>
-            <h2 class="heading-m">How do I find and apply for teacher training?</h2>
+            <span class="heading-m">How do I find and apply for teacher training?</span>
           </header>
         </li>
       </ol>

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -65,6 +65,7 @@
 
 .heading-m {
   @include font-size("medium");
+  font-weight: bold;
 }
 
 .heading-s {


### PR DESCRIPTION
### Trello card

[Trello-4625](https://trello.com/c/loebAiYL/4625-fix-list-headings-on-landing-pages)

### Context

The heading structure in the list section used on some of our landing pages doesn’t make sense. We currently have a lot of h2s in a list with no content beneath them (see screenshot).

### Changes proposed in this pull request

Change element from h2 to span

### Guidance to review

