### PR TITLE
Updating adviser start page for internationals

### DIFF
--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -14,12 +14,12 @@
 </p>
 
 <p>
-  If you're already a qualified teacher, you'll need English qualified teacher status (QTS) and want to
-  teach a secondary subject to be eligible for an adviser.
+  If you got your qualifications outside the UK, call us on <a href="tel:08003892500">0800 389 2500</a> to check if you're eligible.
 </p>
 
 <p>
-  If you got your qualifications outside the UK, call us on <a href="tel:08003892500">0800 389 2500</a> to check if you're eligible.
+  If you're already a qualified teacher, you'll need English qualified teacher status (QTS) and want to
+  teach a secondary subject to be eligible for an adviser.
 </p>
 
 <%= render Content::InsetTextComponent.new(


### PR DESCRIPTION
### Trello card

https://trello.com/c/LXOcE9Rx/4627-clarify-guidance-for-international-trainees-and-teachers-on-git-adviser-funnel-start-page

### Context

In moving the adviser funnel to GIT, we need to make sure that we are still being clear that international teachers need QTS to be eligible for an adviser.

We are currently implying that both international trainees and teachers should ring the contact centre to check their qualifications. We ideally want trainees to ring about their degree, and want to direct teachers towards the non uk teachers page, so we should tweak the order of the content on the start page to make this clearer.

### Changes proposed in this pull request

### Guidance to review

