### PR TITLE
Enable tracking of YouTube video interactions

### DIFF
--- a/app/components/content/youtube_video_component.html.erb
+++ b/app/components/content/youtube_video_component.html.erb
@@ -5,6 +5,7 @@
     src: src,
     frameborder: 0,
     allow: "autoplay; encrypted-media",
-    allowfullscreen: true
+    allowfullscreen: true,
+    enablejsapi: true,
   ) %>
 </div>

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -13,6 +13,10 @@ navigation_description: Find out how you can bring your skills and perspective t
 date: "2021-05-27"
 image: "static/content/hero-images/0002.jpg"
 backlink: "../../"
+youtube_video:
+  why-train-to-teach:
+    id: u0W7UTnGcc0
+    title: A video about why you should Train to Teach in England
 inset_text:
   new-international-funding:
     text: |-
@@ -229,7 +233,7 @@ You may be eligible for the [levelling up premium payment](https://www.gov.uk/gu
 
 You can only receive the [international relocation payment (IRP)](#get-an-international-relocation-payment-irp-worth-10000) once, and you cannot receive both the levelling up premium payment and the early career payment in the same year.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/u0W7UTnGcc0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+$why-train-to-teach$
 
 ## Plan your move to England
 

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -14,6 +14,10 @@ navigation_description: Find out how to train to teach in England as a non-UK ci
 date: "2021-05-27"
 image: "static/content/hero-images/0003.jpg"
 backlink: "../../"
+youtube_video:
+  why-train-to-teach:
+    id: u0W7UTnGcc0
+    title: A video about why you should Train to Teach in England
 inset_text:
   new-international-funding:
     text: |-
@@ -294,7 +298,7 @@ Meet other non-UK teachers and trainees and find information about English schoo
 
 Watch our video interviews with non-UK citizens who've successfully relocated to train and teach in England.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/u0W7UTnGcc0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+$why-train-to-teach$
 
 [Join the Aspiring Teachers Forum on Facebook](https://www.facebook.com/groups/1357146377672255/).
 

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -17,6 +17,7 @@ describe Content::YoutubeVideoComponent, type: :component do
   it { is_expected.to have_css("iframe[frameborder=0]") }
   it { is_expected.to have_css("iframe[allow='autoplay; encrypted-media']") }
   it { is_expected.to have_css("iframe[allowfullscreen]") }
+  it { is_expected.to have_css("iframe[enablejsapi=true]") }
 
   describe "validation" do
     context "when the id is not set" do

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -77,6 +77,14 @@ RSpec.feature "content pages check", type: :feature, content: true do
       end
     end
 
+    scenario "ensure all YouTube videos are emebedded using the YouTubeVideoComponent" do
+      @stored_pages.each do |sp|
+        sp.body.css("iframe[src*='youtube']").each do |iframe|
+          expect(iframe.parent).to have_css(".youtube-video")
+        end
+      end
+    end
+
     scenario "there are no absolute adviser URL links" do
       @stored_pages.each do |sp|
         sp.body


### PR DESCRIPTION
### Trello card

[Trello-4617](https://trello.com/c/wM8KZLK0/4617-set-up-tracking-for-video-engagement-in-gtm)

### Context

In order for GTM to listen to YouTube video events (play, pause, etc) we need to specify the `enablejsapi` attribute.

### Changes proposed in this pull request

- Enable tracking of YouTube video interactions

Ensure all markdown files use the `YouTubeVideoComponent` and add a test to prevent manually embedding youtube video iframes (without using the component).

### Guidance to review

