### PR TITLE
Update links in inset text component to be consistent colour with other site links

### DIFF
--- a/app/webpacker/styles/components/inset-text.scss
+++ b/app/webpacker/styles/components/inset-text.scss
@@ -7,6 +7,12 @@ section.inset-text {
   &.yellow {
     background-color: $yellow-light;
     border-left-color: $black;
+
+    @at-root (with: rule) {
+      a {
+        @extend .link--black;
+      }
+    }
   }
 
   &.grey {
@@ -28,9 +34,5 @@ section.inset-text {
   h2,
   p {
     @include font-size("small");
-  }
-
-  a {
-    @extend .link--black;
   }
 }


### PR DESCRIPTION
### Trello card

[Trello-4633](https://trello.com/c/ARcORfwl/4633-update-links-in-inset-text-component-to-be-consistent-colour-with-other-site-links)

### Context

The links in our inset text component are a different colour from the other links on our site

### Changes proposed in this pull request

Update the links in our inset component to be blue font and underline for consistency. Although, if the background of the inset_text element is yellow then it's still set to standard text colour to meet accessibility guidelines

### Guidance to review

Links on yellow background will have standard font colour i.e. https://review-get-into-teaching-app-3336.london.cloudapps.digital/non-uk-teachers/teach-in-england-if-you-trained-overseas:
<table><tr><td><img width="400" alt="Screenshot 2023-06-01 at 13 59 40" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/77098906/20759258-cd01-42f3-bbfb-7f17a07c4c5f"></td></tr></table>

Links on white background will be blue as everywhere else i.e. https://review-get-into-teaching-app-3336.london.cloudapps.digital/steps-to-become-a-teacher:
<table><tr><td><img width="400" alt="Screenshot 2023-06-01 at 13 56 37" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/77098906/1468a67e-a4ce-4c86-b4cf-ac555f723ce1"></td></tr></table>
