### PR TITLE
Enable optimise on train-to-teach-if-you-have-a-degree page

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -12,3 +12,4 @@ paths:
   - /landing/how-to-become-a-teacher
   - /landing/how-to-become-a-teacher-mailing-list
   - /teacher-training-adviser/sign_up/identity
+  - /train-to-teach-if-you-have-a-degree

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -189,6 +189,7 @@ describe ApplicationHelper do
           "/landing/how-to-become-a-teacher",
           "/landing/how-to-become-a-teacher-mailing-list",
           "/teacher-training-adviser/sign_up/identity",
+          "/train-to-teach-if-you-have-a-degree",
         ],
       })
     end


### PR DESCRIPTION
### Trello card

[Trello-4615](https://trello.com/c/pa4AeR8w/4615-test-14-test-new-content-and-social-proofing-on-landing-train-to-teach-if-you-have-a-degree)

### Context

- We want to iterate our existing landing page template to see if we can increase sign ups to the mailing list.
- We want to test tweaking the content on /landing/train-to-teach-if-you-have-a-degree and adding social proofing to see if this impacts sign ups.

### Changes proposed in this pull request

Enable Google Optimize

### Guidance to review

