### PR TITLE
Adding new steps to how to become a teacher

### DIFF
--- a/app/views/content/steps-to-become-a-teacher.md
+++ b/app/views/content/steps-to-become-a-teacher.md
@@ -22,6 +22,12 @@
           partial: content/steps-to-become-a-teacher/step_4_find_a_teacher_training_course
         Apply for teacher training:
           partial: content/steps-to-become-a-teacher/step_5_apply_for_teacher_training
+        Start your teacher training:
+          partial: content/steps-to-become-a-teacher/step_6_start_your_teacher_training
+        Apply for a teaching role:
+          partial: content/steps-to-become-a-teacher/step_7_apply_for_a_teaching_role
+        Start your career:
+          partial: content/steps-to-become-a-teacher/step_8_start_your_career
   how_to:
     Check your qualifications:
       id: "step-1"
@@ -48,6 +54,21 @@
       image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
       directions:
         - You can usually start applying in October, the year before your course starts.
+    Start your teacher training:
+      id: "step-6"
+      image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
+      directions:
+        - Teacher training involves classroom placements in at least 2 schools, with some theoretical learning.
+    Apply for a teaching role:
+      id: "step-7"
+      image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
+      directions:
+        - Schools start to advertise their vacancies from January.
+    Start your career:
+      id: "step-8"
+      image: "static/content/hero-images/M_DFE_Southfeilds_Room_A360_10445.jpg"
+      directions:
+        - For your first 2 years as an early career teacher, you'll receive a package of support to help you find your feet.
   keywords:
     - QTS
     - Qualified Teacher Status

--- a/app/views/content/steps-to-become-a-teacher/_step_1_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_1_check_your_qualifications.html.erb
@@ -1,9 +1,7 @@
-<p>If you have a degree or equivalent qualification, you can do postgraduate primary or secondary teacher training.</p>
+<p>To train to teach, you’ll need to have GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary).</p>
 
-<p>If you do not have a degree and are not studying for one, you can do undergraduate teacher training.</p>
+<p>You also need a degree to teach primary and secondary – if you have one or an equivalent qualification, you can do postgraduate teacher training.</p>
 
-<p>To train to teach, you’ll need to have GCSEs at grade 4 (C) or above in English and maths.</p>
-
-<p>If you want to teach primary, you will also need a GCSE at grade 4 (C) or above in science.</p>
+<p>If you do not have a degree, you can do undergraduate teacher training to get a degree alongside QTS.</p>
 
 <p><a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">Find out more about the qualifications you need to teach</a>.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,7 +1,7 @@
-<p>Full-time postgraduate teacher training courses usually take 9 months, while part-time courses can take from 18 to 24.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS), a postgraduate certificate in education (PGCE), or both.</p>
 
-<p>Whichever course you choose, they all involve school placements with some theoretical learning.</p>
+<p>You do not need a PGCE to teach, but you do need QTS to teach in many primary and secondary schools.</p>
 
-<p>You can <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">search for postgraduate teaching courses in England</a> to study for qualified teacher status (QTS).</p>
+<p>You can <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">find postgraduate teacher training courses in England</a>.</p>
 
-<p>If you do not have a degree and are not studying for one, you can do <a href="/train-to-be-a-teacher/if-you-dont-have-a-degree">undergraduate teacher training</a>. These courses usually take 4 years to complete.</p>
+<p>Or take a look at <a href="https://digital.ucas.com/search">undergraduate teacher training courses</a>.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_5_apply_for_teacher_training.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_5_apply_for_teacher_training.html.erb
@@ -1,5 +1,7 @@
-<p>You can usually start applying for postgraduate training in October, the year before your course starts. You can apply any time throughout the year, but some courses do fill up quickly.</p>
+<p>You can usually start applying for postgraduate training in October and undergraduate training in May, the calendar year before your course starts.</p>
+
+<p>You can apply throughout the year, but some courses do fill up quickly.</p>
 
 <p><a href="/train-to-be-a-teacher/how-to-apply-for-teacher-training">Get tips on making a great application</a> including finding the right references and writing a personal statement.</p>
 
-<p><a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training</a>.</p>
+<p><a href="https://www.gov.uk/apply-for-teacher-training">Apply for postgraduate teacher training</a>.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_6_start_your_teacher_training.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_6_start_your_teacher_training.erb
@@ -1,0 +1,7 @@
+<p>All postgraduate training involves classroom placements in at least 2 schools, with some theoretical learning – this might be in a different location to your placements.</p>
+
+<p>Most postgraduate courses start in September, with full-time courses taking 9 months and part-time courses taking 18 to 24.</p>
+
+<p>Undergraduate courses usually take 4 years.</p>
+
+<p><a href="/train-to-be-a-teacher/initial-teacher-training">Find out more about what teacher training is like</a>.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_7_apply_for_a_teaching_role.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_7_apply_for_a_teaching_role.erb
@@ -1,0 +1,5 @@
+<p>Some teacher training providers recommend you start thinking about job applications quite early in your teacher training year.</p>
+
+<p>Schools start to advertise their vacancies from January.</p>
+
+<p>But don't worry – you can get tips on <a href="https://teaching-vacancies.campaign.gov.uk/application-advice/">how to apply for teaching jobs</a>.</p>

--- a/app/views/content/steps-to-become-a-teacher/_step_8_start_your_career.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_8_start_your_career.erb
@@ -1,0 +1,7 @@
+<p>Congratulations – you're a qualified teacher!</p>
+
+<p>Now that you’ve started your first teaching job, you’ll be an early career teacher (ECT) – this used to be called newly qualified teacher (NQT).</p>
+
+<p>For your first 2 years as an early career teacher, you’ll receive a package of support to help you find your feet.</p>
+
+<p><a href="/support-for-early-career-teachers">Find out more about support for early career teachers (ECT)</a>.</p>

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -19,7 +19,7 @@
           <div class="col col-full-content">
             <%= render Content::PurpleBoxComponent.new(
               heading: "Get free one-to-one support",
-              text: "An adviser with years of teaching experience can help you with your application. Chat through phone, text or email as little or often as you need.",
+              text: "An adviser with years of teaching experience can help you with your teacher training application. Chat through phone, text or email as little or often as you need.",
               cta: {
                 text: "Find out more about advisers",
                 path: "/teacher-training-advisers",


### PR DESCRIPTION
### Trello card

https://trello.com/c/pr7Sr2iK/4580-add-steps-beyond-teacher-training-to-steps-page

### Context

UR found that users expected the steps in How to become a teacher to go beyond applying for teacher training.

They expected to see information on:

- the teacher training year
- finding a teaching job
- what happens once they're in post

We should expand the steps on the page to include some of this content and further support users on their journey into teaching.

### Changes proposed in this pull request

### Guidance to review

