### PR TITLE
updating internships page

### DIFF
--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -68,7 +68,7 @@ provider_groups:
       name: Administrator
       email: interns@diverse-ac.org.uk
   East of England:
-    providers:
+  providers:
     - header: Advanced Learning Partnership
       link: https://www.advancedlearningpartnership.co.uk/
       subjects: chemistry, computing, maths, physics, languages
@@ -453,7 +453,7 @@ provider_groups:
       link: https://ywtt.org.uk/ywtt-paid-internship-programme/
       subjects: chemistry, computing, maths, physics, languages
       name: Sarah Barley
-      email: sarah.barley@theeducationalliance.org.uk --->
+      email: sarah.barley@theeducationalliance.org.uk
 keywords:
   - teaching internship
   - internship

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -453,7 +453,7 @@ provider_groups:
       link: https://ywtt.org.uk/ywtt-paid-internship-programme/
       subjects: chemistry, computing, maths, physics, languages
       name: Sarah Barley
-      email: sarah.barley@theeducationalliance.org.uk
+      email: sarah.barley@theeducationalliance.org.uk --->
 keywords:
   - teaching internship
   - internship

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -68,7 +68,7 @@ provider_groups:
       name: Administrator
       email: interns@diverse-ac.org.uk
   East of England:
-  providers:
+    providers:
     - header: Advanced Learning Partnership
       link: https://www.advancedlearningpartnership.co.uk/
       subjects: chemistry, computing, maths, physics, languages

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -5,7 +5,7 @@
     <div>
       <h2 class="heading-m">Applications for teaching internships are now closed</h2>
 
-      <p>Our explore teaching advisers can let you know when applications open. They can also give helpful advice and insights about getting into teaching. </p>
+      <p>Our explore teaching advisers can let you know when applications re-open for the summer 2024 internships. They can also give helpful advice and insights about getting into teaching.</p>
 
       <p><a class="button button--white" href="/explore-teaching-advisers">Find out about explore teaching advisers</a></p>
     </div>

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -10,7 +10,7 @@
       <p><a class="button button--white" href="/explore-teaching-advisers">Find out about explore teaching advisers</a></p>
     </div>
   </div>
- 
+
 <p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom. You’ll get to experience a range of activities to help you get a feel for school life.</p>
 
 <p>Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
@@ -66,7 +66,6 @@
 </section>
 
 <!--- <h2>How to apply</h2>
-
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>
 

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -64,4 +64,3 @@
     large: false
   ) %>
 </section>
-

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -1,3 +1,16 @@
+<div class="content-alert content-alert--fullwidth">
+    <div>
+      <span class="icon icon-warning" aria-hidden="true"></span>
+    </div>
+    <div>
+      <h2 class="heading-m">Applications for teaching internships are now closed</h2>
+
+      <p>Our explore teaching advisers can let you know when applications open. They can also give helpful advice and insights about getting into teaching. </p>
+
+      <p><a class="button button--white" href="/explore-teaching-advisers">Find out about explore teaching advisers</a></p>
+    </div>
+  </div>
+ 
 <p>If you’re studying for a degree and interested in a career in teaching, an internship could help you to understand what it’s really like in the classroom. You’ll get to experience a range of activities to help you get a feel for school life.</p>
 
 <p>Internships last 3 weeks, start in June and you’ll be paid £300 per week.</p>
@@ -52,7 +65,8 @@
   ) %>
 </section>
 
-<h2>How to apply</h2>
+<!--- <h2>How to apply</h2>
+
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>
 
@@ -62,4 +76,4 @@
 
 <section class="providers-list">
   <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
-</section>
+</section> --->

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -26,7 +26,7 @@
 
 <h2>Internship subjects</h2>
 
-<p>You’ll need to be studying for a related degree and interested in teaching one of these subjects:</p>
+<p>Teaching internships are only available if you're studying for a related degree and interested in teaching certain subjects. In 2023, these included:</p>
 <ul>
   <li>chemistry</li>
   <li>computing</li>
@@ -65,14 +65,3 @@
   ) %>
 </section>
 
-<!-- <h2>How to apply</h2>
-
-<p>You can apply for an internship directly to one of the schools listed below.</p>
-
-<p> To have the best chance of succeeding in your application, <a href="/explore-teaching-advisers"> get help from an adviser</a>. They offer one-to-one support, and are all experienced teachers.</p>
-
-<h3>Find a teaching internship in your region</h3>
-
-<section class="providers-list">
-  <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
-</section> -->

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -65,7 +65,7 @@
   ) %>
 </section>
 
-<!--- <h2>How to apply</h2>
+<!-- <h2>How to apply</h2>
 
 <p>You can apply for an internship directly to one of the schools listed below.</p>
 
@@ -75,4 +75,4 @@
 
 <section class="providers-list">
   <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
-</section> --->
+</section> -->


### PR DESCRIPTION
### Trello card

https://trello.com/c/4waIVkHT

### Context

The teaching internships programme has now closed to applications so we need to update the page to reflect this.

### Changes proposed in this pull request

- Banner added to the top of the page to alert users that applications are now closed
- Provider contacts and details of how to apply have been hidden

### Guidance to review

