### PR TITLE
Unwind train to be a teacher split test test 12

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -7,8 +7,6 @@
 #   - /
 
 paths:
-  - /landing/train-to-teach
-  - /train-to-be-a-teacher
   - /landing/how-to-become-a-teacher
   - /landing/how-to-become-a-teacher-mailing-list
   - /teacher-training-adviser/sign_up/identity

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -184,8 +184,6 @@ describe ApplicationHelper do
     it "includes pages currently under test" do
       is_expected.to eq({
         paths: [
-          "/landing/train-to-teach",
-          "/train-to-be-a-teacher",
           "/landing/how-to-become-a-teacher",
           "/landing/how-to-become-a-teacher-mailing-list",
           "/teacher-training-adviser/sign_up/identity",


### PR DESCRIPTION
### Trello card

[Trello-4652](https://trello.com/c/MjSg5w7b/4652-unwind-train-to-be-a-teacher-split-test-test-12)

### Context

Once the Train to be a teacher landing page test has finished (Test 12) and we have measured enough sessions to see significant results, we need to unwind the test.

### Changes proposed in this pull request

Remove those 2 pages from the google optimize config

### Guidance to review

