### PR TITLE
Update extra-navigation.scss

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -11,6 +11,10 @@
     justify-content: flex-end;
   }
 
+  .extra-navigation__mail {
+    margin-bottom: 0;
+  }
+
   &__link a {
     display: inline-block;
     padding: .6em $indent-amount;


### PR DESCRIPTION
### Trello card

[Trello-1478](https://trello.com/c/HzAq7clD)

### Context

There is a small gap below the search button in the extra navigation bar at the top of the website which shouldn’t be there. This creates a disconnect between the button and the search bar when it’s active.

### Changes proposed in this pull request

CSS change.

### Guidance to review

Review the extra-navigation bar.