### PR TITLE
Remove extra space after register link

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -2,8 +2,8 @@
   <ul class="extra-navigation__list">
     <li class="extra-navigation__link extra-navigation__mail">
       <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
-      Register your interest
-      <span class="icon icon-mail" aria-hidden="true"></span>
+      Register your interest<!--
+   --><span class="icon icon-mail" aria-hidden="true"></span>
       <span class="icon icon-mail-white" aria-hidden="true"></span>
       <% end %>
     </li>


### PR DESCRIPTION
### Trello card

[Trello-4720](https://trello.com/c/9vCE65gS/4720-remove-extra-space-from-register-your-interest-link-in-extra-navigation-bar)

### Context

The Register your interest link in the extra navigation bar in the header has an extra space in the link text.

### Changes proposed in this pull request

Removed the space

### Guidance to review

