### PR TITLE
updating still time to apply page

### DIFF
--- a/app/views/content/landing/still-time-to-apply/_content.html.erb
+++ b/app/views/content/landing/still-time-to-apply/_content.html.erb
@@ -4,7 +4,7 @@
       <p class="inset">
         Every day, people are being accepted onto teacher training courses starting this September. Places fill up quickly at this time of year so don’t miss your opportunity to join a course while there’s still time to apply.
       </p>
-      
+    
     </div>
     </section>
 

--- a/app/views/content/landing/still-time-to-apply/_content.html.erb
+++ b/app/views/content/landing/still-time-to-apply/_content.html.erb
@@ -4,7 +4,6 @@
       <p class="inset">
         Every day, people are being accepted onto teacher training courses starting this September. Places fill up quickly at this time of year so don’t miss your opportunity to join a course while there’s still time to apply.
       </p>
-    
     </div>
     </section>
 

--- a/app/views/content/landing/still-time-to-apply/_content.html.erb
+++ b/app/views/content/landing/still-time-to-apply/_content.html.erb
@@ -4,21 +4,9 @@
       <p class="inset">
         Every day, people are being accepted onto teacher training courses starting this September. Places fill up quickly at this time of year so don’t miss your opportunity to join a course while there’s still time to apply.
       </p>
+      
     </div>
     </section>
-
-  <section class="col col-720">
-    <h2 class="heading--box-blue">Find a teacher training course</h2>
-    <div class="inset">
-      <p>
-      Teacher training courses usually take 9 months full-time, or 18 to 24 months part-time.
-      </p>
-      <p>
-      Most courses involve school placements with some theoretical learning.
-      </p>
-      <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training</a>.
-    </div>
-  </section>
 
   <section class="col col-720">
     <h2 class="heading--box-blue">Get help to apply on time</h2>
@@ -36,6 +24,19 @@
       </ul>
 
       <p><%= link_to("Get a teacher training adviser", page_path("teacher-training-advisers")) %>.</p>
+    </div>
+  </section>
+
+    <section class="col col-720">
+    <h2 class="heading--box-blue">Find a teacher training course</h2>
+    <div class="inset">
+      <p>
+      Teacher training courses usually take 9 months full-time, or 18 to 24 months part-time.
+      </p>
+      <p>
+      Most courses involve school placements with some theoretical learning.
+      </p>
+      <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training</a>.
     </div>
   </section>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/FctRYu1S

### Context

GA data suggests fewer users are using the adviser link on the 'Still time to apply' page. 

Moving the adviser section higher up the page may help more users to access the support. 

### Changes proposed in this pull request

Moved the 'Get help to apply on time' section up the page.

### Guidance to review

