### PR TITLE
Remove teacher-training-adviser/sign_up/identity from the optimize

### DIFF
--- a/config/google_optimize.yml
+++ b/config/google_optimize.yml
@@ -8,5 +8,4 @@
 
 paths:
   - /landing/how-to-become-a-teacher
-  - /teacher-training-adviser/sign_up/identity
   - /landing/train-to-teach-if-you-have-a-degree

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -185,7 +185,6 @@ describe ApplicationHelper do
       is_expected.to eq({
         paths: [
           "/landing/how-to-become-a-teacher",
-          "/teacher-training-adviser/sign_up/identity",
           "/landing/train-to-teach-if-you-have-a-degree",
         ],
       })


### PR DESCRIPTION
### Trello card

[Trello-4674](https://trello.com/c/nvGsBQJZ/4674-once-test-is-finished-unwind-adviser-funnel-test)

### Context

Remove Optimize from /teacher-training-adviser/sign_up/identity

### Changes proposed in this pull request

### Guidance to review

