### PR TITLE
Remove a non-breaking space from docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Development
+# Development
 
 ## Setting up the app in development
 


### PR DESCRIPTION
Noticed when working on https://github.com/DFE-Digital/teacher-services-tech-docs/pull/46!