### PR TITLE
Fix styling spacing

### DIFF
--- a/app/components/calls_to_action/homepage_component.html.erb
+++ b/app/components/calls_to_action/homepage_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div(class: %w[call-to-action call-to-action--homepage]) do %>
-    <%= tag.div(icon, class: "call-to-action__icon__container") %>
+    <%= tag.div(icon) %>
     <%= tag.div(class: "call-to-action__content") do %>
       <%= render Content::HeadingComponent.new(
         heading: title,

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -126,26 +126,11 @@
     overflow: visible;
 
     &:last-child .call-to-action__image {
-      background-position: 70%;
+      background-position: 100%;
     }
 
     .badge {
       transform: translate(-50%, -50%);
-    }
-
-    .call-to-action__icon__container {
-      @include reset;
-
-      grid-area: 1 / 1 / 3 / 2;
-
-      margin: 1em auto auto 0;
-      padding-left: .2em;
-      background-color: $yellow;
-      display: inline-block;
-
-      .call-to-action__icon {
-        background: transparent;
-      }
     }
 
     .call-to-action__heading {
@@ -171,10 +156,10 @@
 
     .call-to-action__image {
       @include reset;
-      grid-area: 2 / 2 / 5 / 3;
+      grid-area: 1 / 2 / 6 / 5;
       background-position: center;
       background-size: cover;
-      margin: 30px 0;
+      margin: 0px 0;
     }
 
     @include mq($until: tablet) {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -192,13 +192,6 @@
 
       .call-to-action__action {
         grid-area: 3 / 1 / 4 / 3;
-
-        a {
-          margin: 1em;
-          display: flex;
-          white-space: pre-wrap;
-          flex-direction: row;
-        }
       }
 
       .call-to-action__image {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  &__photo {
+  &__photo .call-to-action__icon {
     > picture img,
     > img {
       width: 8em;
@@ -166,6 +166,10 @@
       grid-template-rows: 12em 1fr auto;
       grid-template-columns: .8fr 1.2fr;
 
+      .call-to-action__icon {
+        display: none;
+      }
+
       .call-to-action__icon__container {
         grid-area: 1 / 1 / 2 / 2;
         align-self: center;
@@ -182,7 +186,7 @@
         margin: 1em auto 0 0;
 
         .call-to-action__heading {
-          @include font-size("small");
+          @include font-size("large");
         }
       }
 
@@ -191,11 +195,12 @@
 
         a {
           margin: 1em;
+          display: flex;
         }
       }
 
       .call-to-action__image {
-        grid-area: 1 / 2 / 2 / 3;
+        grid-area: 1 / 1 / 2 / 3;
         margin: 0;
       }
     }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -119,9 +119,9 @@
   &--homepage {
     display: grid;
     margin-bottom: 0;
-    gap: .6em;
+    gap: .1em;
 
-    grid-template-rows: 1em 1fr 2fr .8fr 1em;
+    grid-template-rows: 1em .7fr 2fr .8fr 1em;
     grid-template-columns: 1.2fr .8fr;
     overflow: visible;
 
@@ -186,7 +186,7 @@
         margin: 1em auto 0 0;
 
         .call-to-action__heading {
-          @include font-size("large");
+          @include font-size("xlarge");
         }
       }
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -159,7 +159,7 @@
       grid-area: 1 / 2 / 6 / 5;
       background-position: center;
       background-size: cover;
-      margin: 0px 0;
+      margin: 0;
     }
 
     @include mq($until: tablet) {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -196,6 +196,8 @@
         a {
           margin: 1em;
           display: flex;
+          white-space: pre-wrap;
+          flex-direction: row;
         }
       }
 

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -125,10 +125,6 @@
     grid-template-columns: 1.2fr .8fr;
     overflow: visible;
 
-    &:last-child .call-to-action__image {
-      background-position: 100%;
-    }
-
     .badge {
       transform: translate(-50%, -50%);
     }

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -182,7 +182,8 @@
         margin: 1em auto 0 0;
 
         .call-to-action__heading {
-          @include font-size("xlarge");
+          font-size: 24px;
+          line-height: 25px;
         }
       }
 


### PR DESCRIPTION
### Trello card

[Trello-4724](https://trello.com/c/kaZhQCwt/4724-various-padding-and-spacing-issues-on-the-homepage-feature-blocks-for-events-and-advisers)

### Context

The homepage-feature blocks are displaying in an inconsistent manner on the homepage on both desktop and mobile. For example, the yellow icons boxes are different sizes and the top two icons sit 19px from the top of their containers.


### Changes proposed in this pull request

### Guidance to review

