### PR TITLE
Adding context to salaries pages re maintained schools

### DIFF
--- a/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
@@ -9,7 +9,7 @@
 
         <%= render Content::ChecklistCollageComponent.new(
           checklist: [
-            "You'll earn at least £28k (or more in London) if you're just starting as a teacher in a maintained primary, secondary or special school in England (schools funded by local authorities).",
+            "You'll earn at least £28k (or more in London) if you're just starting as a teacher.",
             "The average salary for a classroom teacher in England is £39,500 a year."
           ],
           image_paths: [

--- a/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
@@ -9,7 +9,7 @@
 
         <%= render Content::ChecklistCollageComponent.new(
           checklist: [
-            "You will earn at least £28k (or more in London) if you're just starting as a teacher.",
+            "You'll earn at least £28k (or more in London) if you're just starting as a teacher in a maintained primary, secondary or special school in England (schools funded by local authorities).",
             "The average salary for a classroom teacher in England is £39,500 a year."
           ],
           image_paths: [

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -52,9 +52,11 @@ keywords:
 
 For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
 
-Figures are for the 2022/23 academic year and apply to maintained primary, secondary and special schools in England (schools funded by local authorities).
+These salaries apply to maintained primary, secondary and special schools in England (schools funded by local authorities).
 
-Other schools (for example, academies) can set their own pay scales.
+Other types of schools (for example, academies) can set their own pay scales.
+
+Figures are for the 2022/23 academic year.
 
 ## Primary and secondary teaching salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -52,7 +52,9 @@ keywords:
 
 For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
 
-Figures are for the 2022/23 academic year and apply to maintained primary, secondary and special schools in England (schools funded by local authorities). Other schools (for example, academies) can set their own pay scales.
+Figures are for the 2022/23 academic year and apply to maintained primary, secondary and special schools in England (schools funded by local authorities).
+
+Other schools (for example, academies) can set their own pay scales.
 
 ## Primary and secondary teaching salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -52,7 +52,7 @@ keywords:
 
 For helping to shape the next generation, you’re entitled to a competitive salary, generous holidays, and a substantial pension.
 
-Figures are for the 2022/23 academic year.
+Figures are for the 2022/23 academic year and apply to maintained primary, secondary and special schools in England (schools funded by local authorities). Other schools (for example, academies) can set their own pay scales.
 
 ## Primary and secondary teaching salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -56,7 +56,7 @@ Figures are for the 2022/23 academic year and apply to maintained primary, secon
 
 ## Primary and secondary teaching salaries
 
-All qualified primary and secondary teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London.
+All qualified primary and secondary teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London. 
 
 ### Qualified teacher salary
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/mI6qifQQ/4773-add-content-around-maintained-schools-on-salaries-pages

### Context

We don't highlight on our salaries pages that the figures apply to maintained schools - schools such as academies can set their own pay scales. We should make this clear to users.

### Changes proposed in this pull request

### Guidance to review

