### PR TITLE
updating no events message

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -61,7 +61,7 @@
         </section>
       <% else %>
         <section class="col col-720 col-space-m">
-          <p><strong>Our Get Into Teaching events are now closed. Details of our next events will be published on this page soon.</strong></p>
+          <p><strong>We do not have any Get Into Teaching events open for registration right now. We'll update this page with new Get Into Teaching events soon.</strong></p>
         </section>
 
         <section class="col col-720">

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -61,7 +61,7 @@
         </section>
       <% else %>
         <section class="col col-720 col-space-m">
-          <p><strong>Our autumn Get Into Teaching events are now closed. Details of our spring events will be published on this page in early January 2023.</strong></p>
+          <p><strong>Our Get Into Teaching events are now closed. Details of our next events will be published on this page soon.</strong></p>
         </section>
 
         <section class="col col-720">

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -101,7 +101,7 @@ describe "teaching events", type: :request do
       context "when there are no GiT events" do
         let(:events) { [] }
 
-        it { is_expected.to include("Our autumn Get Into Teaching events are now closed.") }
+        it { is_expected.to include("Our Get Into Teaching events are now closed.") }
       end
     end
 

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -101,7 +101,7 @@ describe "teaching events", type: :request do
       context "when there are no GiT events" do
         let(:events) { [] }
 
-        it { is_expected.to include("Our Get Into Teaching events are now closed.") }
+        it { is_expected.to include("We do not have any Get Into Teaching events open for registration right now.") }
       end
     end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/IxPbkiS5

### Context

An automated message is displayed when there are no Get Into Teaching events because the programme is closed. This message currently refers to the autumn programme so needs to be updated.

### Changes proposed in this pull request

Amended the message to make it generic to avoid the need for a manual update in future. 

### Guidance to review

