### PR TITLE
Updating salaries in line with the new pay award

### DIFF
--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,7 +1,7 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
     <h3>Earn at least &pound;30k a year</h3>
-    <p>All recently qualified teachers will now have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
+    <p>All qualified teachers will have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
     <p>Find out more about the <%= link_to("salaries and benefits of teaching", page_path("salaries-and-benefits")) %>.</p>
   <% end %>
 </div>

--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,7 +1,7 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
     <h3>Earn at least &pound;28k a year</h3>
-    <p>All recently qualified teachers will now have a <strong>starting salary of at least £28,000</strong> (or higher in London).</p>
+    <p>All recently qualified teachers will now have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
     <p>Find out more about the <%= link_to("salaries and benefits of teaching", page_path("salaries-and-benefits")) %>.</p>
   <% end %>
 </div>

--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,6 +1,6 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
-    <h3>Earn at least &pound;28k a year</h3>
+    <h3>Earn at least &pound;30k a year</h3>
     <p>All recently qualified teachers will now have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
     <p>Find out more about the <%= link_to("salaries and benefits of teaching", page_path("salaries-and-benefits")) %>.</p>
   <% end %>

--- a/app/views/content/is-teaching-right-for-me/_facts_and_figures.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_facts_and_figures.html.erb
@@ -13,7 +13,7 @@
           },
           {
             icon: "icon-money",
-            value: "£28k",
+            value: "£30k",
             title: "minimum starting salary",
             link: link_to("Salaries and benefits", page_path("salaries-and-benefits")),
           },

--- a/app/views/content/landing/how-much-do-teachers-get-paid.md
+++ b/app/views/content/landing/how-much-do-teachers-get-paid.md
@@ -1,6 +1,6 @@
 ---
 title: "How much do teachers get paid?"
-description: There are great benefits to teaching including a starting salary of at least £28k (or higher in London). Learn more about teachers' salaries and other benefits.
+description: There are great benefits to teaching including a starting salary of at least £30k (or higher in London). Learn more about teachers' salaries and other benefits.
 content:
     - content/landing/how-much-do-teachers-get-paid/header
     - content/landing/how-much-do-teachers-get-paid/collage

--- a/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_collage.html.erb
@@ -9,7 +9,7 @@
 
         <%= render Content::ChecklistCollageComponent.new(
           checklist: [
-            "You'll earn at least £28k (or more in London) if you're just starting as a teacher.",
+            "You'll earn at least £30k (or more in London) if you're just starting as a teacher.",
             "The average salary for a classroom teacher in England is £39,500 a year."
           ],
           image_paths: [

--- a/app/views/content/landing/how-much-do-teachers-get-paid/_content.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_content.html.erb
@@ -8,8 +8,8 @@
       </p>
 
       <ul>
-        <li>teachers who make a sustained contribution to their school could expect to earn over £40k</li>
-        <li>headteachers are usually the highest paid people in a school and can expect to earn around £50k to £131k depending on the school and location</li>
+        <li>teachers who make a sustained contribution to their school could expect to earn over £43k</li>
+        <li>headteachers are usually the highest paid people in a school and can expect to earn around £53k to £139k depending on the school and location</li>
       </ul>
       <p><%= link_to("Find out more about teaching salaries and benefits", page_path("salaries-and-benefits")) %>.</p>
     </div>

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -102,7 +102,7 @@ When you plan your training, bear in mind that:
 living costs, to train (depending on your immigration status and the subject you train to teach, you may get some financial support)
 - training lasts one academic year full-time, or longer part-time
 - you can apply for paid teaching jobs as soon as you successfully complete your training
-- you'll earn at least £28,000 a year (or more in London) when you qualify as a teacher
+- you'll earn at least £30,000 a year (or more in London) when you qualify as a teacher
 - you can update, extend or switch your visa to live and work in the UK long-term
 
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -110,10 +110,10 @@ The teacher pay scales for leading practitioners are:
 
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
-| England (excluding London)     | £44,523 | £67,685 |
-| London fringe                            | £45,749 | £68,913 |
-| Outer London                             | £48,055 | £71,220 |
-| Inner London                             | £52,936 | £76,104 |
+| England (excluding London)     | £47,417 | £72,085 |
+| London fringe                            | £48,723 | £73,393 |
+| Outer London                             | £51,179 | £75,850 |
+| Inner London                             | £56,377 | £81,051 |
 
 ### Headteacher salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -66,7 +66,7 @@ Figures are for the 2023/24 academic year.
 
 ## Primary and secondary teaching salaries
 
-All qualified primary and secondary teachers will have a starting salary of at least £28,000. This will be higher for teachers working in London. 
+All qualified primary and secondary teachers will have a starting salary of at least £30,000. This will be higher for teachers working in London. 
 
 ### Qualified teacher salary
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -76,10 +76,10 @@ The teacher pay scales for qualified teachers are:
 
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
-| England (excluding London)     | £28,000 | £38,810 |
-| London fringe                            | £29,344 | £40,083 |
-| Outer London                             | £32,407 | £43,193 |
-| Inner London                             | £34,502 | £44,756 |
+| England (excluding London)     | £30,000 | £41,333 |
+| London fringe                            | £31,350 | £42,689 |
+| Outer London                             | £34,514 | £46,001 |
+| Inner London                             | £36,745 | £47,666 |
 
 Most established teachers will earn more than this maximum by progressing onto the upper pay range for teachers, or by becoming a leading practitioner.
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -18,7 +18,7 @@ related_content:
 inset_text:
   new-salaries:
     text: |-
-      These figures are for the 2022/23 academic year. Figures for the 2023/24 academic year will be updated on this page shortly.
+      The pay award for 2023/24 is subject to a statutory consultation process and cannot be confirmed until the final School Teachers’ Pay and Conditions Document is published.
 keywords:
   - Salary
   - Salaries

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -95,10 +95,10 @@ The upper pay ranges for teachers are:
 
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
-| England (excluding London)     | £40,625 | £43,685 |
-| London fringe                            | £41,858 | £44,919 |
-| Outer London                             | £44,687 | £48,055 |
-| Inner London                             | £49,320 | £53,482 |
+| England (excluding London)     | £43,266 | £46,525 |
+| London fringe                            | £44,579 | £47,839 |
+| Outer London                             | £47,592 | £51,179 |
+| Inner London                             | £52,526 | £56,959 |
 
 ### Leading practitioner salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -2,7 +2,7 @@
 title: "Teacher salaries and pay scales"
 heading: "Salaries and benefits"
 description: |-
-  All qualified teachers will have a starting salary of at least £28,000 (or higher in London). Find out about teacher pay scales and more benefits of teaching.
+  All qualified teachers will have a starting salary of at least £30,000 (or higher in London). Find out about teacher pay scales and more benefits of teaching.
 date: "2021-06-24"
 image: "static/content/hero-images/0008.jpg"
 backlink: "../../"

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -18,7 +18,7 @@ related_content:
 inset_text:
   new-salaries:
     text: |-
-      The pay award for 2023/24 is subject to a statutory consultation process and cannot be confirmed until the final School Teachers’ Pay and Conditions Document is published.
+      The new pay award for 2023/24 is subject to a statutory consultation period and your school can choose how to implement it.
 keywords:
   - Salary
   - Salaries

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -125,10 +125,10 @@ The salary ranges for headteachers are:
 
 | Area                                     | Minimum | Maximum  |
 | -------                                  | -----   | -----    |
-| England (excluding London)     | £50,122 | £123,057 |
-| London fringe                            | £51,347 | £124,274 |
-| Outer London                             | £53,637 | £126,539 |
-| Inner London                             | £58,501 | £131,353 |
+| England (excluding London)     | £53,380 | £131,056 |
+| London fringe                            | £54,685 | £132,352 |
+| Outer London                             | £57,124 | £134,765 |
+| Inner London                             | £62,304 | £139,891 |
 
 ### Other payments
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -62,7 +62,7 @@ These salaries apply to maintained primary, secondary and special schools in Eng
 
 Other types of schools (for example, academies) can set their own pay scales.
 
-Figures are for the 2022/23 academic year.
+Figures are for the 2023/24 academic year.
 
 ## Primary and secondary teaching salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -138,12 +138,13 @@ These payments are called ‘teaching and learning responsibility’ (TLR) payme
 
 * progressing the education of people beyond your assigned pupils
 * leading, developing and enhancing the teaching practice of others
-* TLR payments come in 2 main pay ranges (TLR 1 and TLR 2) depending on your responsibilities
+* TLR payments come in 3 main pay ranges (TLR 1, 2 and 3) depending on your responsibilities
 
 | Level         | Minimum | Maximum|
 | -------       | -----   | -----  |
-| TLR 1         | £8,706  | £14,732|
-| TLR 2         | £3,017  | £7,368 |
+| TLR 1         | £9,272  | £15,690|
+| TLR 2         | £3,214  | £7,847 |
+| TLR 3         | £639    | £3,169 |
 
 ### Unqualified teacher salaries
 

--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -155,10 +155,10 @@ The unqualified teacher salary ranges are:
 
 | Area                                     | Minimum | Maximum |
 | -------                                  | -----   | -----   |
-| England (excluding London)     | £19,340 | £30,172 |
-| London fringe                            | £20,594 | £31,421  |
-| Outer London                             | £22,924 | £33,759 |
-| Inner London                             | £24,254 | £35,081 |
+| England (excluding London)     | £20,598 | £32,134 |
+| London fringe                            | £21,933 | £33,464 |
+| Outer London                             | £24,415 | £35,954 |
+| Inner London                             | £25,831 | £37,362 |
 
 ## Holidays
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/DP4nUHdx/4779-update-salaries-information-for-new-pay-award

### Context

We need to update the salary information around our site in line with the new pay award (which is subject to a statutory consultation process and cannot be confirmed until the final School Teachers’ Pay and Conditions Document is published.)

### Changes proposed in this pull request

### Guidance to review

