### PR TITLE
removing reference to 5 step guide

### DIFF
--- a/app/views/content/is-teaching-right-for-me/_how_to_become_a_teacher.html.erb
+++ b/app/views/content/is-teaching-right-for-me/_how_to_become_a_teacher.html.erb
@@ -1,9 +1,9 @@
 <div class="row inset">
   <section class="col col-720">
-    <h2>Want to find out how to become a teacher?</h2>
+    <h2>Find out how to become a teacher</h2>
     <p>
-      Get to grips with what you need to do and when in our simple 5 step guide.
+      Plan your next steps into teaching with our guide.
     </p>
-    <p><%= link_to("Steps to become a teacher", page_path("steps-to-become-a-teacher")) %>.</p>
+    <p><%= link_to("How to become a teacher", page_path("steps-to-become-a-teacher")) %>.</p>
   </section>
 </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/y9io0uzo

### Context

Since we have now updated 'Steps' to 'How to become a teacher' we need to update this banner to remove reference to 5 steps.

### Changes proposed in this pull request

- updated H2
- tweaked body copy
- tweaked link copy

### Guidance to review

