### PR TITLE
improve adviser completion page for international callbacks

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -31,45 +31,56 @@
 
   <p>Or <%= link_to("find out more about teaching in England if you trained outside the UK", "/non-uk-teachers/teach-in-england-if-you-trained-overseas") %>.</p>
   <% elsif @callback_booked %>
+  <h1 class="heading-l heading--box-green"><%= @first_name %>, we'll give you a call</h1>
+
+  <h2 class="govuk-heading-m">What happens next?</h2>
   <p>
-    We've booked a call. We will be in contact with you at the time you selected.
+    We'll give you a call at the time you selected. We need to check you have the right qualifications before we can sign you up for an adviser.
   </p>
   <p>
-    If we are unable to contact you at this time, we will try to contact you a further 2 times. If we are still unable to contact you, you will have to sign up again.
+    If we're unable to contact you at this time, we'll try again twice. If we're still unable to contact you, you will have to sign up again.
   </p>
 
+  <h2 class="govuk-heading-m">Have any questions?</h2>
   <p>
-    If you have any questions or you need to update any of the information you provided, call us on <a href="tel:08003892500">0800 389 2500</a> Monday to Friday between 8:30am and 5:30pm, except on <%= link_to("bank holidays", "https://www.gov.uk/bank-holidays") %>.
+    Call us on <a href="tel:08003892500">0800 389 2500</a> Monday to Friday between 8:30am and 5:30pm, except on <%= link_to("bank holidays", "https://www.gov.uk/bank-holidays") %>.
   </p>
 
-  <h2 class="govuk-heading-m">Explore teaching in England</h2>
+  <h2 class="govuk-heading-m">Find out more about teaching in England</h2>
 
-  <p>If you're not a UK citizen, you can find out <%= link_to "how to train to teach in England as an international student", "/train-to-teach-in-england-as-an-international-student" %>.</p>
-
-  <p>Get help and guidance on:</p>
+  <p>If you're not a UK citizen, you can read guidance on:</p>
 
   <ul>
     <li>your qualifications</li>
     <li>funding your training</li>
     <li>getting a visa</li>
   </ul>
+
+<p>Find out more about <%= link_to "training to teach in England as a non-UK citizen", "/train-to-teach-in-england-as-an-international-student" %>.</p>
   <% elsif @equivalent %>
+  <h1 class="heading-l heading--box-green"><%= @first_name %>, give us a call</h1>
+
+  <h2 class="govuk-heading-m">What happens next?</h2>
   <p>Please give us a call so that we can check your degree.</p>
 
   <p>You can call us on <a href="tel:08003892500">0800 389 2500</a> Monday to Friday between 8:30am and 5:30pm, except on <%= link_to("bank holidays", "https://www.gov.uk/bank-holidays") %>.</p>
 
-  <h2 class="govuk-heading-m">Explore teaching in England</h2>
+  <h2 class="govuk-heading-m">Find out more about teaching in England</h2>
 
-  <p>If you're not a UK citizen, you can find out <%= link_to "how to train to teach in England as an international student", "/train-to-teach-in-england-as-an-international-student" %>.</p>
-
-  <p>Get help and guidance on:</p>
+  <p>If you're not a UK citizen, you can read guidance on:</p>
 
   <ul>
     <li>your qualifications</li>
     <li>funding your training</li>
     <li>getting a visa</li>
   </ul>
+
+<p>Find out more about <%= link_to "training to teach in England as a non-UK citizen", "/train-to-teach-in-england-as-an-international-student" %>.</p>
   <% else %>
+  <h1 class="heading-l heading--box-green"><%= @first_name %>, you're signed up.</h1>
+
+  <h2 class="govuk-heading-m">What happens next?</h2>
+
   <p>An adviser will email you within 3 working days. Make sure you check your junk or spam folders.</p>
 
   <p>You need to reply to the email to be assigned an adviser.</p>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,11 +1,12 @@
 <% @page_title = "Sign up complete" %>
 
 <section class="registration__teacher-training-adviser" data-sub-channel-id="<%= session.dig("sign_up", "sub_channel_id") %>">
+
+  <% if @returner %>
   <h1 class="heading-l heading--box-green"><%= @first_name %>, you're signed up.</h1>
 
   <h2 class="govuk-heading-m">What happens next?</h2>
 
-  <% if @returner %>
   <p>
     A return to teaching adviser will email you within 3 working days to outline your next steps. Make sure you check your junk or spam folders.
   </p>

--- a/spec/features/teacher_training_adviser/sign_up_spec.rb
+++ b/spec/features/teacher_training_adviser/sign_up_spec.rb
@@ -307,8 +307,8 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       click_on "Complete sign up"
 
-      expect(page).to have_css "h1", text: "John, you're signed up."
-      expect(page).to have_text "We've booked a call."
+      expect(page).to have_css "h1", text: "John, we'll give you a call"
+      expect(page).to have_text "We'll give you a call."
     end
 
     scenario "with an equivalent degree (UK)" do
@@ -436,7 +436,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
         click_on "Complete sign up"
 
-        expect(page).to have_css "h1", text: "John, you're signed up."
+        expect(page).to have_css "h1", text: "John, give us a call"
         expect(page).to have_text "Please give us a call so that we can check your degree"
       end
 

--- a/spec/features/teacher_training_adviser/sign_up_spec.rb
+++ b/spec/features/teacher_training_adviser/sign_up_spec.rb
@@ -308,7 +308,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Complete sign up"
 
       expect(page).to have_css "h1", text: "John, we'll give you a call"
-      expect(page).to have_text "We'll give you a call."
+      expect(page).to have_text "We'll give you a call at the time you selected."
     end
 
     scenario "with an equivalent degree (UK)" do
@@ -371,8 +371,8 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       click_on "Complete sign up"
 
-      expect(page).to have_css "h1", text: "John, you're signed up."
-      expect(page).to have_text "We've booked a call."
+      expect(page).to have_css "h1", text: "John, we'll give you a call"
+      expect(page).to have_text "We'll give you a call at the time you selected"
     end
 
     context "when there are no callback slots available" do
@@ -498,7 +498,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
         click_on "Complete sign up"
 
-        expect(page).to have_css "h1", text: "John, you're signed up."
+        expect(page).to have_css "h1", text: "John, give us a call"
         expect(page).to have_text "Please give us a call so that we can check your degree"
       end
     end
@@ -1016,7 +1016,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
 
       click_on "Complete sign up"
 
-      expect(page).to have_css "h1", text: "John, you're signed up."
+      expect(page).to have_css "h1", text: "John, we'll give you a call"
     end
 
     scenario "skipping pre-filled optional steps" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/B29cZRt3

### Context

We need to improve the content of the adviser sign up completion page to make it clearer that international candidates need to wait for a call back. 

### Changes proposed in this pull request

- moving header into conditional sections

### Guidance to review

