### PR TITLE
Fix failing integration test

### DIFF
--- a/spec/integration/teacher_training_adviser_spec.rb
+++ b/spec/integration/teacher_training_adviser_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Sign up", :integration, type: :feature, js: true do
     )
     submit_uk_callback_step("123456789")
     submit_review_answers_step
-    expect(page).to have_text("you're signed up")
+
+    expect(page).to have_text("we'll give you a call")
   end
 end


### PR DESCRIPTION
### Context

It's failing integration test, because the expected text changed from ```you're signed up``` to ```we'll give you a call```

### Changes proposed in this pull request

### Guidance to review

