### PR TITLE
Updated .logo__image background colour

### DIFF
--- a/app/webpacker/styles/colours.scss
+++ b/app/webpacker/styles/colours.scss
@@ -1,5 +1,5 @@
 $black: #1d1d1b;
-$blue: #2781be;
+$blue: #2881be;
 $blue-dark: #0076bd;
 $blue-dark-90: rgba($blue-dark, .9);
 $green: #159964;

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -55,7 +55,7 @@
 
   &__image {
     @include rotated-block;
-    background-color: $green-dark;
+    background-color: $blue;
     z-index: 1000;
 
     // position the logo slightly off the left of the page


### PR DESCRIPTION
### Trello card

[Trello 4841](https://trello.com/c/NvkWOpyV)

### Context

The 'Teaching' logo in the header currently clashes with CTAs throughout the website as it employs the same green background colour. This possibly causes accessibility and/or usability issues, particularly on mobile.

### Changes proposed in this pull request

To change the background colour of the 'Teaching' logo to the blue brand colour specified in the style guide (#2881BE).

### Guidance to review

Check if the background colour of the logo is now GIT brand blue (#2881BE).

