### PR TITLE
Fixing error on salaries page

### DIFF
--- a/app/views/content/salaries-and-benefits.md
+++ b/app/views/content/salaries-and-benefits.md
@@ -138,7 +138,8 @@ These payments are called ‘teaching and learning responsibility’ (TLR) payme
 
 * progressing the education of people beyond your assigned pupils
 * leading, developing and enhancing the teaching practice of others
-* TLR payments come in 3 main pay ranges (TLR 1, 2 and 3) depending on your responsibilities
+
+TLR payments come in 3 main pay ranges (TLR 1, 2 and 3) depending on your responsibilities.
 
 | Level         | Minimum | Maximum|
 | -------       | -----   | -----  |


### PR DESCRIPTION
### Trello card

### Context

Noticed an error on the salaries page where a sentence is in a bullet point but should be a stand alone sentence.

### Changes proposed in this pull request

### Guidance to review

