### PR TITLE
Updated 'Apply' module link

### DIFF
--- a/app/views/content/train-to-be-a-teacher/promos/_apply-for-your-course.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_apply-for-your-course.html.erb
@@ -12,7 +12,7 @@
     </p>
 
     <p>
-      <a class="button" href="https://www.apply-for-teacher-training.service.gov.uk">Apply for a course</a>
+      <a class="button" href="https://www.gov.uk/apply-for-teacher-training">Apply for a course</a>
     </p>
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6436,15 +6436,15 @@ selfsigned@^2.1.1:
   dependencies:
     node-forge "^1"
 
-semver@6.3.1, semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8:
   version "7.3.8"


### PR DESCRIPTION
### Trello card

[Trello 4742](https://trello.com/c/zWKCy8w8)

### Context

We received feedback from the adviser conference that, ”Users struggle to find the links to Find and Apply.” So, we wish to create a new 'Apply' module in order to remedy this.

### Changes proposed in this pull request

Update the new 'Apply' module link.

### Guidance to review

Review the link from the 'Apply' module which should be going here - [Apply for teacher training](https://www.gov.uk/apply-for-teacher-training)

