### PR TITLE
Remove some vwo reference from attributes in the secure headers

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -42,7 +42,7 @@ SecureHeaders::Configuration.default do |config|
   gtm_server  = %w[get-into-teaching-staging-gtm.nw.r.appspot.com analytics.getintoteaching.education.gov.uk]
   reddit      = %w[www.redditstatic.com alb.reddit.com]
   clarity     = %w[www.clarity.ms *.clarity.ms]
-  vwo         = %w[*.visualwebsiteoptimizer.com app.vwo.com cdn.pushcrew.com s3.amazonaws.com chart.googleapis.com wingify-assets.s3.amazonaws.com]
+  vwo         = %w[app.vwo.com *.visualwebsiteoptimizer.com]
 
   quoted_unsafe_inline = ["'unsafe-inline'"]
   quoted_unsafe_eval   = ["'unsafe-eval'"]
@@ -71,7 +71,7 @@ SecureHeaders::Configuration.default do |config|
     form_action: self_base.concat(snapchat, facebook, govuk),
     frame_src: self_base.concat(scribble, snapchat, facebook, youtube, google_doubleclick, google_analytics, data, pinterest, optimize, clarity, vwo),
     frame_ancestors: self_base,
-    img_src: self_base.concat(govuk, pinterest, facebook, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, optimize, gtm_server, reddit, clarity, vwo, %w[cx.atdmt.com linkbam.uk]),
+    img_src: self_base.concat(govuk, pinterest, facebook, youtube, twitter, google_supported, google_adservice, google_apis, google_analytics, google_doubleclick, data, lid_pixels, optimize, gtm_server, reddit, clarity, vwo, %w[chart.googleapis.com wingify-assets.s3.amazonaws.com cx.atdmt.com linkbam.uk]),
     manifest_src: self_base,
     media_src: self_base.concat(zendesk).concat(assets),
     script_src: self_base.concat(quoted_unsafe_inline, quoted_unsafe_eval, google_analytics, google_supported, google_apis, lid_pixels, govuk, facebook, jquery, pinterest, scribble, twitter, snapchat, youtube, zendesk, optimize, reddit, clarity, vwo),


### PR DESCRIPTION
### Trello card

[Trello-4887](https://trello.com/c/eVB71yoB/4887-events-provider-portal-is-broken)

### Context

The portal/form used to upload provider and online events to the website, used by the 3rd party supplier Abramis and and the Events team is throwing a 502 error. I.e. the page /internal/events returns 502

### Changes proposed in this pull request

Pinpointed the issue to ```s3.amazonaws.com``` and removed it. Also checked that VWO SmartCode checker works correctly against staging URL.

### Guidance to review

