### PR TITLE
Adding information about what you can teach

### DIFF
--- a/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
+++ b/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
@@ -46,7 +46,7 @@ Talk to your training provider to find out what you can train to teach.
 
 You could also receive a scholarship or bursary of up to £29,000 to train to teach certain subjects. [Find out more about your eligibility for a scholarship or bursary](/funding-and-support/scholarships-and-bursaries).
 
-You may have the opportunity to teach other subjects in your career and can train to teach more than one subject.
+You may also have the opportunity to teach other subjects in your career and can train to teach more than one subject.
 
 ## Do a subject knowledge enhancement (SKE) course
 

--- a/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
+++ b/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
@@ -34,9 +34,9 @@ Talk to your teacher training provider or [find a course](https://www.find-postg
 
 ## What can you teach?
 
-You do not necessarily need a bachelor’s degree in a subject to teach it. It’s up to your teacher training provider to decide if you have the skills and knowledge required to teach a specific subject.
+You do not necessarily need a bachelor’s degree in a subject to teach it. It’s up to your teacher training provider to decide if you have the skills and knowledge required.
 
-For example, in some cases you may be able to teach a different subject to your degree if:
+In some cases, you may be able to train to teach a different subject to your degree if:
 
 * you have an A level in the subject
 * your degree is related to but not in the subject – for example, your degree is in engineering but you’d like to teach physics
@@ -45,6 +45,12 @@ For example, in some cases you may be able to teach a different subject to your 
 Talk to your training provider to find out what you can train to teach.
 
 You could also receive a scholarship or bursary of up to £29,000 to train to teach certain subjects. [Find out more about your eligibility for a scholarship or bursary](/funding-and-support/scholarships-and-bursaries).
+
+The subject you train in is not the only one you’ll have the opportunity to teach.
+
+You may be asked to teach others related to your subject – for example, if you’re a trained physics teacher, you may teach other sciences. 
+
+Or, if you have an A level in another subject, you might get the opportunity to teach that, too. 
 
 ## Do a subject knowledge enhancement (SKE) course
 

--- a/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
+++ b/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
@@ -46,11 +46,7 @@ Talk to your training provider to find out what you can train to teach.
 
 You could also receive a scholarship or bursary of up to £29,000 to train to teach certain subjects. [Find out more about your eligibility for a scholarship or bursary](/funding-and-support/scholarships-and-bursaries).
 
-The subject you train in is not the only one you’ll have the opportunity to teach.
-
-You may be asked to teach others related to your subject – for example, if you’re a trained physics teacher, you may teach other sciences. 
-
-Or, if you have an A level in another subject, you might get the opportunity to teach that, too. 
+You may have the opportunity to teach other subjects in your career and can train to teach more than one subject.
 
 ## Do a subject knowledge enhancement (SKE) course
 

--- a/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
+++ b/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
@@ -17,7 +17,7 @@ You need qualified teacher status (QTS) to teach in maintained primary, secondar
 
 You do not need QTS to [teach in further education](/become-a-further-education-teacher) or to [teach in early years](/early-years-teaching-training).
 
-[Find out more about qualified teacher status (QTS)](/what-is-qts).
+[Find out more about qualified teacher status (QTS)](/what-is-qts). 
 
 ## What qualifications do you need to train?
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/fcvSpS2Z/4893-update-qualifications-page-about-what-you-can-teach

### Context

Advisers pointed out at the conference that if you train to teach a specific subject, that doesn’t mean that’s the only thing you can teach (and rarely ever is).

We should consider adding guidance around this to our qualifications page, and anywhere else relevant on the site.

### Changes proposed in this pull request

### Guidance to review

