### PR TITLE
Reconfigured spacing in hero banners sitewide

### DIFF
--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -270,8 +270,7 @@ $mobile-cutoff: 800px;
   }
 }
 
-@media only screen 
-and (max-device-width: 767px) { 
+@media only screen and (max-device-width: 767px) {
   .hero {
     padding-bottom: 2em;
     grid-template-rows: 8em 4em repeat(2, minmax(0, max-content));

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -83,7 +83,7 @@ $mobile-cutoff: 800px;
     &__content,
     &__paragraph {
       grid-area: 4 / 1 / 5 / 5;
-      padding: 0 2em 2em;
+      padding: 2em 2em 0;
     }
 
     &__subtitle {
@@ -112,7 +112,7 @@ $mobile-cutoff: 800px;
           4,
           minmax(100px, 1fr)
         );
-      grid-template-rows: 2em repeat(5, fit-content(0)) 2em;
+      grid-template-rows: repeat(5, fit-content(0)) 3em;
 
       &__title {
         grid-area: 3 / 1 / 5 / 5;
@@ -220,6 +220,10 @@ $mobile-cutoff: 800px;
       }
     }
   }
+}
+
+.hero h1 {
+  margin-bottom: 0;
 }
 
 .hero__mailing-strip {

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -83,7 +83,8 @@ $mobile-cutoff: 800px;
     &__content,
     &__paragraph {
       grid-area: 4 / 1 / 5 / 5;
-      padding: 2em 2em 0;
+      padding: 0 2em;
+      margin-top: 2em;
     }
 
     &__subtitle {
@@ -174,7 +175,7 @@ $mobile-cutoff: 800px;
     padding-bottom: 4em;
 
     @include mq($from: tablet) {
-      padding-bottom: 6em;
+      padding-bottom: 5em;
     }
 
     & + .main-section {
@@ -266,5 +267,17 @@ $mobile-cutoff: 800px;
         padding: .2em .5em;
       }
     }
+  }
+}
+
+@media only screen 
+and (max-device-width: 767px) { 
+  .hero {
+    padding-bottom: 2em;
+    grid-template-rows: 8em 4em repeat(2, minmax(0, max-content));
+  }
+
+  .hero.blend-content {
+    padding-bottom: 4.5em;
   }
 }


### PR DESCRIPTION
### Trello card

[Trello 4895](https://trello.com/c/HAW5FBja)

### Context

There is currently a lot of excess padding in the hero banners across the site, much of which only serves to push content further down the page. Reconfiguring the padding and margin properties of the hero banner and its contents would help to move content back up the page as well as tightening up the look and feel of the website.

### Changes proposed in this pull request

Reconfiguring the padding and margin properties of the hero banner and its contents.

### Guidance to review

Check the hero banners across the website on mobile, tablet and desktop, ensuring that they are rendering correctly.