### PR TITLE
Emboldened service proposition paragraph

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,6 +1,7 @@
 ---
 EnableDefaultLinters: true
 exclude:
+  - 'app/components/content/hero_component.html.erb'
   - 'app/views/sections/_head.html.erb'
 linters:
   ErbSafety:

--- a/app/components/content/hero_component.html.erb
+++ b/app/components/content/hero_component.html.erb
@@ -19,9 +19,7 @@
     </div>
   <% end %>
 
-  <% if paragraph.present? %>
-    <div class="hero__paragraph">
-      <%= paragraph %>
-    </div>
-  <% end %>
+  <div class="hero__paragraph">
+    <%= paragraph&.html_safe %>
+  </div>
 <% end %>

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -5,7 +5,7 @@
     Explore how to get into teaching with official Department for Education guidance on training courses, finding funding, and what teaching is really like.
   fullwidth: true
   date: "2023-04-19"
-  title_paragraph: "Nobody knows teaching like we do. Whether you're just thinking about it or ready to apply, we offer free advice and support to decide if teaching in a primary or secondary school in England is right for you."
+  title_paragraph: "Nobody knows teaching like we do. Whether you're just thinking about it or ready to apply, we offer <strong>free advice and support</strong> to decide if <strong>teaching in a primary or secondary school</strong> in England is right for you."
   image: "static/content/hero-images/0012.jpg"
   hero_content_width: even
   hero_bg_color: yellow


### PR DESCRIPTION
### Trello card

[Trello 4636](https://trello.com/c/ub0y069h)

### Context

Users rarely read the service proposition, and instead are drawn to the navigation bar to tell them what the rest of the website is about.

### Changes proposed in this pull request

Embolden important portions of the service proposition in order to more effectively catch the eye.

### Guidance to review

Check that 'free advice and support' and 'teaching in a primary or secondary school' is bold.

