### PR TITLE
Removing full stop from link on Ukraine page

### DIFF
--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -49,7 +49,7 @@ If you're coming to the UK from Ukraine, [check what you need to do before you t
 
 The international relocation payment (IRP) is a single payment of £10,000 which the UK government is making available to non-UK trainees and teachers of languages and physics. To be eligible, you must be coming to England to work or train in the 2023 to 2024 academic year. 
 
-[Learn more about the international relocation payment.](/non-uk-teachers/get-an-international-relocation-payment)
+[Learn more about the international relocation payment](/non-uk-teachers/get-an-international-relocation-payment).
 
 
 ### Check the status of your visa


### PR DESCRIPTION
### Trello card

### Context

There's a full stop in the IRP link on the Ukraine page that we should take out.

### Changes proposed in this pull request

### Guidance to review

