### PR TITLE
Add hidden fields for channel and sub_channel in order to enable attribute sign-ups in the reporting

### DIFF
--- a/app/components/content/mailing_list_component.html.erb
+++ b/app/components/content/mailing_list_component.html.erb
@@ -15,6 +15,8 @@
         <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
         <%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
         <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>
+        <%= f.hidden_field :channel_id, value: params[:channel] || f.object&.channel_id.presence %>
+        <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id.presence %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
         <p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>

--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -19,6 +19,8 @@
         <%= f.govuk_text_field :first_name, autocomplete: "given-name" %>
         <%= f.govuk_text_field :last_name, autocomplete: "family-name" %>
         <%= f.govuk_email_field :email, autocomplete: "email" %>
+        <%= f.hidden_field :channel_id, value: params[:channel] || f.object&.channel_id.presence %>
+        <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id.presence %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
         <% button_text = "Next step <span></span>" %>


### PR DESCRIPTION
### Trello card

### Context

BAM, the on campus agency, drive students to the GIT website via QR codes linking to specific pages.

The QR codes contain query parameters ?channel=xxx. The channel ids are captured in CRM which enables us to attribute sign-ups in our reporting.

### Changes proposed in this pull request

### Guidance to review

