### PR TITLE
Upgrade zendesk chat widget with the new code snippet

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -47,7 +47,6 @@ export default class extends Controller {
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
-        document.getElementById('webWidget').focus();
         this.chatTarget.textContent = 'Chat online';
       });
     });
@@ -67,7 +66,7 @@ export default class extends Controller {
 
   waitForWebWidget(callback) {
     const interval = setInterval(() => {
-      if (document.getElementById('webWidget')) {
+      if (window.zEACLoaded) {
         clearInterval(interval);
         // Small delay to account for the chat box animating in.
         setTimeout(() => {
@@ -79,23 +78,15 @@ export default class extends Controller {
 
   waitForZendeskScript(callback) {
     const interval = setInterval(() => {
-      if (window.$zopim && window.$zopim.livechat) {
+      if (window.zEACLoaded) {
         clearInterval(interval);
         callback();
       }
-    }, 100);
+    }, 1000);
   }
 
   showWebWidget() {
-    window.$zopim.livechat.window.show();
-    window.$zopim.livechat.window.onHide(() => {
-      // Return focus back to where it was before opening
-      // the chat widget.
-      if (this.previousTarget) {
-        this.previousTarget.focus();
-        this.previousTarget.blur();
-      }
-    });
+    zE('messenger', 'open');
   }
 
   get zendeskScriptLoaded() {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -82,7 +82,7 @@ export default class extends Controller {
         clearInterval(interval);
         callback();
       }
-    }, 1000);
+    }, 100);
   }
 
   showWebWidget() {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -60,7 +60,7 @@ export default class extends Controller {
     const script = document.createElement('script');
     script.setAttribute('id', 'ze-snippet');
     script.src =
-      'https://static.zdassets.com/ekr/snippet.js?key=32605345-0b23-4904-9dc1-db94653c370b';
+      'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
     document.body.appendChild(script);
   }
 

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
     const script = document.createElement('script');
     script.setAttribute('id', 'ze-snippet');
     script.src =
-      'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
+      'https://static.zdassets.com/ekr/snippet.js?key=32605345-0b23-4904-9dc1-db94653c370b';
     document.body.appendChild(script);
   }
 

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -86,7 +86,7 @@ export default class extends Controller {
   }
 
   showWebWidget() {
-    zE('messenger', 'open');
+    window.zE('messenger', 'open');
   }
 
   get zendeskScriptLoaded() {

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -7,7 +7,7 @@ describe('ChatController', () => {
   afterEach(() => jest.useRealTimers());
 
   let chatShowSpy;
-  let chatOnHideSpy;
+  let chatOpenSpy;
 
   const setBody = () => {
     document.body.innerHTML = `
@@ -41,9 +41,10 @@ describe('ChatController', () => {
 
   describe('when the chat is online', () => {
     beforeEach(() => {
-      chatShowSpy = jest.fn();
-      chatOnHideSpy = jest.fn();
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy, onHide: chatOnHideSpy } } } }));
+      chatShowSpy = jest.fn(() => true);
+      chatOpenSpy = jest.fn();
+
+      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ zE: chatOpenSpy, zEACLoaded: chatShowSpy }));
 
       setBody();
       setCurrentTime('2021-01-01 10:00');
@@ -68,7 +69,7 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatShowSpy).toHaveBeenCalled();
+        expect(chatOpenSpy).toHaveBeenCalled();
         expect(getButtonText()).toEqual("Chat online");
       });
     });
@@ -81,7 +82,7 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatShowSpy).toHaveBeenCalled();
+        expect(chatOpenSpy).toHaveBeenCalled();
         expect(button.textContent).toEqual("Chat online");
         button.click();
         expect(button.textContent).toEqual("Chat online");

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -62,7 +62,6 @@ describe('ChatController', () => {
     describe('when clicking the chat button', () => {
       it('appends the Zendesk snippet, shows a loading message and then opens the chat window', () => {
         const button = document.querySelector('a');
-        expect(document.activeElement.id).not.toEqual("webWidget");
         button.click();
         expect(document.querySelector('#ze-snippet')).not.toBeNull();
         expect(getButtonText()).toEqual("Starting chat...");
@@ -71,7 +70,6 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
         expect(chatShowSpy).toHaveBeenCalled();
         expect(getButtonText()).toEqual("Chat online");
-        expect(document.activeElement.id).toEqual("webWidget");
       });
     });
 


### PR DESCRIPTION
### Trello card

[Trello-4847](https://trello.com/c/Qqf05GG1/4847-replace-webchat-widget-with-upgraded-version)

### Context

TPUK have suggested replacing the current Zendesk webchat widget with a later version that is more accessible. The current widget is no longer being maintained by Zendesk.

### Changes proposed in this pull request

### Guidance to review

