### PR TITLE
Change start date so 2023 is removed from the list of teacher training years in adviser funnel

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -90,7 +90,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def date_to_drop_current_year
-      Date.new(current_year, 9, 7)
+      Date.new(current_year, 9, 3)
     end
 
     def current_year

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -90,7 +90,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def date_to_drop_current_year
-      Date.new(current_year, 9, 3)
+      Date.new(current_year, 9, 4)
     end
 
     def current_year

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     context "when its between 24th June and 3th September of the current year (2022)" do
       around do |example|
-        travel_to(Date.new(2022, 9, 2)) { example.run }
+        travel_to(Date.new(2022, 9, 3)) { example.run }
       end
 
       it "returns 'Not sure', and the current year plus next 2 years" do
@@ -159,7 +159,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 2 years if first year and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:first_year]
-      travel_to(Date.new(2022, 9, 2)) do
+      travel_to(Date.new(2022, 9, 3)) do
         expect(instance.inferred_year_id).to eq(12_922)
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 1 years if second year and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:second_year]
-      travel_to(Date.new(2022, 9, 2)) do
+      travel_to(Date.new(2022, 9, 3)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end
@@ -187,7 +187,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 1 years if other and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:other]
-      travel_to(Date.new(2022, 9, 2)) do
+      travel_to(Date.new(2022, 9, 3)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its between 24th June and 6th September of the current year (2022)" do
+    context "when its between 24th June and 4th September of the current year (2022)" do
       around do |example|
-        travel_to(Date.new(2022, 9, 6)) { example.run }
+        travel_to(Date.new(2022, 9, 2)) { example.run }
       end
 
       it "returns 'Not sure', and the current year plus next 2 years" do
@@ -159,7 +159,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 2 years if first year and before 7th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:first_year]
-      travel_to(Date.new(2022, 9, 6)) do
+      travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_922)
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 1 years if second year and before 7th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:second_year]
-      travel_to(Date.new(2022, 9, 6)) do
+      travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end
@@ -187,7 +187,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
 
     it "returns current calendar year + 1 years if other and before 7th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:other]
-      travel_to(Date.new(2022, 9, 6)) do
+      travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its between 24th June and 4th September of the current year (2022)" do
+    context "when its between 24th June and 3th September of the current year (2022)" do
       around do |example|
         travel_to(Date.new(2022, 9, 2)) { example.run }
       end
@@ -82,9 +82,9 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its after 6th September of the current year (2022)" do
+    context "when its after 3th September of the current year (2022)" do
       around do |example|
-        travel_to(Date.new(2022, 9, 7)) { example.run }
+        travel_to(Date.new(2022, 9, 4)) { example.run }
       end
 
       it "returns 'Not sure', and the next 3 years" do
@@ -157,51 +157,51 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:studying]
     end
 
-    it "returns current calendar year + 2 years if first year and before 7th September" do
+    it "returns current calendar year + 2 years if first year and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:first_year]
       travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_922)
       end
     end
 
-    it "returns current calendar year + 3 years if first year and on or after 7th September" do
+    it "returns current calendar year + 3 years if first year and on or after 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:first_year]
-      travel_to(Date.new(2022, 9, 7)) do
+      travel_to(Date.new(2022, 9, 4)) do
         expect(instance.inferred_year_id).to eq(12_923)
       end
     end
 
-    it "returns current calendar year + 1 years if second year and before 7th September" do
+    it "returns current calendar year + 1 years if second year and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:second_year]
       travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end
 
-    it "returns current calendar year + 2 year if second year and on or after 7th September" do
+    it "returns current calendar year + 2 year if second year and on or after 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:second_year]
-      travel_to(Date.new(2022, 9, 7)) do
+      travel_to(Date.new(2022, 9, 4)) do
         expect(instance.inferred_year_id).to eq(12_922)
       end
     end
 
-    it "returns current calendar year + 1 years if other and before 7th September" do
+    it "returns current calendar year + 1 years if other and before 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:other]
       travel_to(Date.new(2022, 9, 2)) do
         expect(instance.inferred_year_id).to eq(12_921)
       end
     end
 
-    it "returns current calendar year + 2 year if other and on or after 7th September" do
+    it "returns current calendar year + 2 year if other and on or after 4th September" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:other]
-      travel_to(Date.new(2022, 9, 7)) do
+      travel_to(Date.new(2022, 9, 4)) do
         expect(instance.inferred_year_id).to eq(12_922)
       end
     end
 
     it "returns nil if final year" do
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:final_year]
-      travel_to(Date.new(2022, 9, 7)) do
+      travel_to(Date.new(2022, 9, 4)) do
         expect(instance.inferred_year_id).to be_nil
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
     it "returns nil if not studying" do
       wizardstore["degree_options"] = TeacherTrainingAdviser::Steps::HaveADegree::DEGREE_OPTIONS[:yes]
       wizardstore["degree_status_id"] = TeacherTrainingAdviser::Steps::StageOfDegree::NOT_FINAL_YEAR[:first_year]
-      travel_to(Date.new(2022, 9, 7)) do
+      travel_to(Date.new(2022, 9, 4)) do
         expect(instance.inferred_year_id).to be_nil
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-4965](https://trello.com/c/u5vUNbgK/4965-ensure-that-2023-is-removed-from-the-list-of-teacher-training-years-in-adviser-funnel)

### Context

The adviser funnel asks users when they want to start their teacher training. Once the recruitment cycle is closed at the beginning of September, we need to ensure that the list does not contain the current year (2023).

### Changes proposed in this pull request

### Guidance to review

