### PR TITLE
Add 'Events' to the extra-navigation component

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,12 +1,22 @@
 <%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }, role: "navigation") do %>
   <ul class="extra-navigation__list">
-    <li class="extra-navigation__link extra-navigation__mail">
-      <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
-      Register your interest<!--
-   --><span class="icon icon-mail" aria-hidden="true"></span>
-      <span class="icon icon-mail-white" aria-hidden="true"></span>
-      <% end %>
-    </li>
+    <span class="extra-navigation__flex">
+      <li class="extra-navigation__link extra-navigation__border">
+        <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
+        Sign up for emails
+        <% end %>
+      </li>
+      <li class="extra-navigation__link extra-navigation__border">
+        <%= link_to("/events", class: "link--black") do %>
+        Events
+        <% end %>
+      </li>
+      <li class="extra-navigation__link">
+        <%= link_to("/teacher-training-adviser/sign_up/identity", class: "link--black") do %>
+        Get an adviser
+        <% end %>
+      </li>
+    </span>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden], data: { "searchbox-target": "label" }) %>
       <%= link_to(search_path, aria: { label: "Search" }, data: { action: "searchbox#toggle" }) do %>
@@ -14,6 +24,6 @@
         <span class="icon icon-close"></span>
       <% end %>
     <% end %>
-  </ul>
+  </ul>  
   <div class="searchbar" data-searchbox-target="searchbar" role="search"></div>
 <% end %>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -15,7 +15,8 @@
       <span class="menu-button__text">Menu</span>
     <% end %>
   </div>
-  <%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Events" }) %>
+  <!--<%= render Header::NavigationComponent.new(extra_resources: { "/events" => "Events" }) %>-->
+  <%= render Header::NavigationComponent.new %>
 </header>
 
 <% if breadcrumbs %>

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -2,7 +2,7 @@
 
 .extra-navigation {
   &__list {
-    font-size: .9rem;
+    font-size: 14px;
     background-color: $grey;
     margin: 0 auto;
     list-style: none;
@@ -11,14 +11,32 @@
     justify-content: flex-end;
   }
 
-  .extra-navigation__mail {
+  .extra-navigation__link {
     margin-bottom: 0;
   }
 
+  &__flex {
+    display: flex;
+
+    @include mq($until: mobile) {
+      margin-right: auto;
+    }
+  }
+
+  &__border::after {
+    content: '';
+    border-right: 1px solid #1d1d1d;
+  }
+
+
   &__link a {
     display: inline-block;
-    padding: .6em $indent-amount;
+    padding: .6em 1.1em;
     line-height: 28px;
+
+    @include mq($until: mobile) {
+      padding: 0.6em 0.8em;
+    }
 
     .icon {
       margin-left: .5em;
@@ -31,7 +49,7 @@
     }
   }
 
-  &__mail a {
+  /*&__mail a {
     &:not(:focus) {
       .icon-mail-white {
         display: none;
@@ -43,7 +61,7 @@
         display: none;
       }
     }
-  }
+  }*/
 
   &__search a {
     background-color: $pink;


### PR DESCRIPTION
### Trello card

[Trello 4791](https://trello.com/c/SPQkrvoI)

### Context

We are rearranging the header following user research which suggests that the removal of 'Events' from the main navigation would benefit the structure and usability of the website.

### Changes proposed in this pull request

Remove 'Events from the main navigation and add this link to the extra-navigation bar, along with a link to 'Get an advisor'.

### Guidance to review

Review the removal of 'Events' from the main navigation and addition of additional links to the extra-navigation bar.