### PR TITLE
Updating events block on homepage

### DIFF
--- a/app/views/content/home/_calls-to-action.html.erb
+++ b/app/views/content/home/_calls-to-action.html.erb
@@ -12,8 +12,8 @@
     icon: "icon-calendar",
     title: "Online and in-person events",
     text: "Get advice on training to teach, talk to teachers, meet training course providers and connect with others considering a career in teaching.",
-    link_text: "Find an event",
-    link_target: "/events",
+    link_text: "Get Into Teaching events",
+    link_target: "/events/about-get-into-teaching-events",
     image: "static/content/homepage/here-to-help.jpg")
   %>
 </div>

--- a/app/views/content/home/_directory.html.erb
+++ b/app/views/content/home/_directory.html.erb
@@ -27,7 +27,7 @@
   ) do %>
     <ul>
       <li><a href="/teacher-training-adviser/sign_up/identity">Get an adviser</a></li>
-      <li><a href="/events">Go to an event</a></li>
+      <li><a href="/events">Find an event</a></li>
       <li><a href="/mailinglist/signup/name">Sign up for personalised updates</a></li>
       <li><a href="/train-to-be-a-teacher/get-school-experience">Get school experience</a></li>
     </ul>


### PR DESCRIPTION
### Trello card

https://trello.com/c/5GoU0pKA/5023-remove-events-from-nav-bar-and-update-home-page-block

### Context

We need to update the events block on the homepage so that it is linking to the /events/about-get-into-teaching-events page rather than /events and tweak the link text so it's not the same as in the bonus bar.

### Changes proposed in this pull request

### Guidance to review

