### PR TITLE
Removing Talk to us component from IRP page

### DIFF
--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -11,6 +11,7 @@ promo_content:
 date: "2021-05-27"
 image: "static/content/hero-images/0002.jpg"
 backlink: "../../"
+talk_to_us: false
 inset_text:
   applications-open:
     text: |-


### PR DESCRIPTION
### Trello card

https://trello.com/c/2owkalZE

### Context

The launch of the International Relocation Payment has seen a big increase in contact to the adviser service so we're removing the Talk to us component to reduce this impact temporarily. 

### Changes proposed in this pull request

- removed Talk to us component from the end of the page

### Guidance to review

