### PR TITLE
Remove references to online events

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -56,7 +56,7 @@
           <% end %>
           <div>
             <h2 class="heading-s">Can't find what you're looking for?</h2>
-            <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }}), class: "link--black") %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
+            <p>You can also take a look at <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
           </div>
         </section>
       <% else %>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -4,7 +4,7 @@
 
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
-    <p> 
+    </p> 
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -1,7 +1,6 @@
 <section class="teaching-events">
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
-
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -4,28 +4,7 @@
 
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
-    </p>
-
-    <details class="teaching-events__descriptions">
-      <summary class="teaching-events__descriptions--summary">Explore the different types of events</summary>
-
-      <dl>
-        <div>
-          <dt>Get Into Teaching events</dt>
-          <dd>Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Online Q&amp;As</dt>
-          <dd>Get answers to your specific questions from an online panel of teacher training advisers. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Training provider events</dt>
-          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-        </div>
-      </dl>
-    </details>
+    <p> 
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,16 +5,7 @@
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
-    
-    <h2 class="heading-s"> Get Into Teaching events</h2>
-    <p>
-      Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).
-    </p>
-
-    <h2 class="heading-s">Training provider events</h2>
-    <p>
-      Find out about local courses and how to apply. Hosted by teacher training providers.
-    </p>
+  </header>
 
   <div class="teaching-events__container">
     <div class="teaching-events__filter">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,27 +5,16 @@
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
+    
+    <h2 class="heading-s"> Get Into Teaching events</h2>
+    <p>
+      Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).
+    </p>
 
-    <details class="teaching-events__descriptions">
-      <summary class="teaching-events__descriptions--summary">Explore the different types of events</summary>
-
-      <dl>
-        <div>
-          <dt>Get Into Teaching events</dt>
-          <dd>Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Online Q&amp;As</dt>
-          <dd>Get answers to your specific questions from an online panel of teacher training advisers. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Training provider events</dt>
-          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-        </div>
-      </dl>
-    </details>
+    <h2 class="heading-s">Training provider events</h2>
+    <p>
+      Find out about local courses and how to apply. Hosted by teacher training providers.
+    </p>
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -1,9 +1,31 @@
 <section class="teaching-events">
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
+
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
+
+    <details class="teaching-events__descriptions">
+      <summary class="teaching-events__descriptions--summary">Explore the different types of events</summary>
+
+      <dl>
+        <div>
+          <dt>Get Into Teaching events</dt>
+          <dd>Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).</dd>
+        </div>
+
+        <div>
+          <dt>Online Q&amp;As</dt>
+          <dd>Get answers to your specific questions from an online panel of teacher training advisers. Run by the Department for Education (DfE).</dd>
+        </div>
+
+        <div>
+          <dt>Training provider events</dt>
+          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
+        </div>
+      </dl>
+    </details>
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -15,7 +15,6 @@
     <p>
       Find out about local courses and how to apply. Hosted by teacher training providers.
     </p>
-  </header>
 
   <div class="teaching-events__container">
     <div class="teaching-events__filter">

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -19,7 +19,6 @@
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
       <%= f.govuk_check_box :type, "git", label: { text: "DfE Get Into Teaching" } %>
-      <%= f.govuk_check_box :type, "onlineqa", label: { text: "DfE Online Q&A" } %>
       <%= f.govuk_check_box :type, "provider", label: { text: "Training provider" } %>
     <% end %>
   </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/pLbpSuaC

### Context

The events team are not running any online Q&A events in the Autumn or Spring terms so we need to remove references to them.

### Changes proposed in this pull request

- removed reference and accordion on events page

### Guidance to review

