### PR TITLE
Remove online Q&A events

### DIFF
--- a/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_after-accordion.md
+++ b/app/views/content/non-uk-teachers/return-to-england-after-teaching-overseas/_after-accordion.md
@@ -25,7 +25,6 @@ learn more.
 
 To find out more about returning to England to teach, you can:
 
-* sign up for an [online Q&A](/events?teaching_events_search[type][]=onlineqa) for returners
 * email us at teach.inengland@education.gov.uk
 * [find us on Facebook](https://www.facebook.com/getintoteaching)
 * [discover us on Instagram](https://www.instagram.com/get_into_teaching/)

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -56,7 +56,7 @@
           <% end %>
           <div>
             <h2 class="heading-s">Can't find what you're looking for?</h2>
-            <p>You can also take a look at our <%= link_to("online Q&A events", events_path({ teaching_events_search: { type: ["onlineqa"] }}), class: "link--black") %> or <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
+            <p>You can also take a look at <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area.</p>
           </div>
         </section>
       <% else %>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -6,8 +6,6 @@
 
   </header>
 
-  
-
   <div class="teaching-events__container">
     <div class="teaching-events__filter">
       <%= render partial: "teaching_events/index/filter" %>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -2,18 +2,11 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
-    <p>
-      Find out more about getting into teaching at a free event where you can get all your questions answered.
-    </p>
-
-    <h2 class="heading-s">Get Into Teaching events</h2>
-
-    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching. Run by the Department for Education (DfE).</p>
-
-    <h2 class="heading-s">Training provider events</h2>
-<p>Find out about local courses and how to apply. Hosted by teacher training providers.</p>
+    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching at Get into Teaching events run by the Department for Education (DfE). You can also find out about local courses and how to apply at events run by teacher training providers.</p>
 
   </header>
+
+  
 
   <div class="teaching-events__container">
     <div class="teaching-events__filter">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
     <p>Choose from 2 types of free events:</p>
-    
+
     <p><strong>Get Into Teaching events</strong> where you can talk to expert advisers, a range of local training providers and current and former teachers.</p>
 
     <p><strong>Training provider events</strong> where specific teacher training providers will talk about the courses they offer.</p>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,6 +5,14 @@
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
+    
+    <h3 class="heading-s">Get Into Teaching events</h3>
+    
+    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching. Run by the Department for Education (DfE).</p>
+    
+    <h3 class="heading-s">Training provider events</h3>
+<p>Find out about local courses and how to apply. Hosted by teacher training providers.</p>
+
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,11 +5,11 @@
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
-    
+
     <h3 class="heading-s">Get Into Teaching events</h3>
-    
+ 
     <p>Get expert advice, meet training providers and talk to teachers about a career in teaching. Run by the Department for Education (DfE).</p>
-    
+
     <h3 class="heading-s">Training provider events</h3>
 <p>Find out about local courses and how to apply. Hosted by teacher training providers.</p>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -2,7 +2,7 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
-    <p>Get expert advice, meet training providers, and talk to teachers at Get into Teaching events.</p>
+    <p>Get expert advice, meet training providers, and talk to teachers at Get Into Teaching events.</p>
 
     <p>You can also find out about local courses and how to apply at teacher training provider events.</p>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -2,7 +2,9 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
-    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching at Get into Teaching Events. You can also find out about local courses and how to apply at events run by teacher training providers.</p>
+    <p>Get expert advice, meet training providers, and talk to teachers at Get into Teaching events.</p>
+
+    <p>You can also find out about local courses and how to apply at teacher training provider events.</p>
 
   </header>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -6,11 +6,11 @@
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
 
-    <h3 class="heading-s">Get Into Teaching events</h3>
+    <h2 class="heading-s">Get Into Teaching events</h2>
 
     <p>Get expert advice, meet training providers and talk to teachers about a career in teaching. Run by the Department for Education (DfE).</p>
 
-    <h3 class="heading-s">Training provider events</h3>
+    <h2 class="heading-s">Training provider events</h2>
 <p>Find out about local courses and how to apply. Hosted by teacher training providers.</p>
 
   </header>

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -2,7 +2,7 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
-    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching at Get into Teaching events run by the Department for Education (DfE). You can also find out about local courses and how to apply at events run by teacher training providers.</p>
+    <p>Get expert advice, meet training providers and talk to teachers about a career in teaching at Get into Teaching Events. You can also find out about local courses and how to apply at events run by teacher training providers.</p>
 
   </header>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -2,9 +2,11 @@
   <header>
     <h1 class="heading-l heading--box-yellow">Events</h1>
 
-    <p>Get expert advice, meet training providers, and talk to teachers at Get Into Teaching events.</p>
+    <p>Choose from 2 types of free events:</p>
+    
+    <p><strong>Get Into Teaching events</strong> where you can talk to expert advisers, a range of local training providers and current and former teachers.</p>
 
-    <p>You can also find out about local courses and how to apply at teacher training provider events.</p>
+    <p><strong>Training provider events</strong> where specific teacher training providers will talk about the courses they offer.</p>
 
   </header>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -4,7 +4,7 @@
 
     <p>Choose from 2 types of free events:</p>
 
-    <p><strong>Get Into Teaching events</strong> where you can talk to expert advisers, a range of local training providers and current and former teachers.</p>
+    <p><strong>Get Into Teaching events</strong> where you can talk to expert advisers, a range of local training providers and experienced teachers.</p>
 
     <p><strong>Training provider events</strong> where specific teacher training providers will talk about the courses they offer.</p>
 

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -5,27 +5,6 @@
     <p>
       Find out more about getting into teaching at a free event where you can get all your questions answered.
     </p>
-
-    <details class="teaching-events__descriptions">
-      <summary class="teaching-events__descriptions--summary">Explore the different types of events</summary>
-
-      <dl>
-        <div>
-          <dt>Get Into Teaching events</dt>
-          <dd>Get expert advice, talk to teachers and connect with people like you considering a career in teaching. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Online Q&amp;As</dt>
-          <dd>Get answers to your specific questions from an online panel of teacher training advisers. Run by the Department for Education (DfE).</dd>
-        </div>
-
-        <div>
-          <dt>Training provider events</dt>
-          <dd>Find out about local courses and how to apply. Hosted by teacher training providers.</dd>
-        </div>
-      </dl>
-    </details>
   </header>
 
   <div class="teaching-events__container">

--- a/app/views/teaching_events/index.html.erb
+++ b/app/views/teaching_events/index.html.erb
@@ -7,7 +7,7 @@
     </p>
 
     <h3 class="heading-s">Get Into Teaching events</h3>
- 
+
     <p>Get expert advice, meet training providers and talk to teachers about a career in teaching. Run by the Department for Education (DfE).</p>
 
     <h3 class="heading-s">Training provider events</h3>

--- a/app/views/teaching_events/index/_filter.html.erb
+++ b/app/views/teaching_events/index/_filter.html.erb
@@ -19,7 +19,6 @@
   <div class="teaching-events__filter--group">
     <%= f.govuk_check_boxes_fieldset(:type, legend: { text: "Event type", tag: nil }) do %>
       <%= f.govuk_check_box :type, "git", label: { text: "DfE Get Into Teaching" } %>
-      <%= f.govuk_check_box :type, "onlineqa", label: { text: "DfE Online Q&A" } %>
       <%= f.govuk_check_box :type, "provider", label: { text: "Training provider" } %>
     <% end %>
   </div>

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
         .map { |e| e.attr("value") }
         .flat_map { |qp| qp.split(",") }
 
-      expect(params).to match_array(Crm::EventType::QUERY_PARAM_NAMES.keys)
+      expect(params).to match_array(Crm::EventType::QUERY_PARAM_NAMES.keys.reject { |a| a == "onlineqa" })
     end
   end
 
@@ -159,17 +159,6 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expected_type_ids = Crm::EventType.lookup_by_names("Get Into Teaching event")
 
       check "DfE Get Into Teaching"
-      click_on "Update results"
-
-      expect(fake_api).to have_received(:search_teaching_events).with(hash_including(type_ids: expected_type_ids)).once
-    end
-
-    scenario "searching for online forum events" do
-      visit events_path
-
-      expected_type_ids = [Crm::EventType.online_event_id]
-
-      check "DfE Online Q&A"
       click_on "Update results"
 
       expect(fake_api).to have_received(:search_teaching_events).with(hash_including(type_ids: expected_type_ids)).once


### PR DESCRIPTION
### Trello card

https://trello.com/c/pLbpSuaC

### Context

Events team are not offering online Q&A events during Autumn and Spring so we need to remove them from the frontend of the website.

### Changes proposed in this pull request

 - removed types of events accordion from events page
 - removed filter from type of events

### Guidance to review

