### PR TITLE
Remove the feedback component from the website

### DIFF
--- a/app/components/footer_component.rb
+++ b/app/components/footer_component.rb
@@ -1,5 +1,5 @@
 class FooterComponent < ViewComponent::Base
-  def initialize(talk_to_us: true, feedback: true)
+  def initialize(talk_to_us: true, feedback: false)
     super
 
     @talk_to_us = talk_to_us

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -111,7 +111,7 @@ module ApplicationHelper
   end
 
   def content_footer_kwargs(front_matter)
-    defaults = { talk_to_us: true, feedback: true }
+    defaults = { talk_to_us: true, feedback: false }
     defaults.merge(front_matter.symbolize_keys.slice(:talk_to_us, :feedback))
   end
 end

--- a/app/views/content/help-and-support.md
+++ b/app/views/content/help-and-support.md
@@ -7,7 +7,7 @@ description: |-
   Contact Get Into Teaching by phone or live chat and find out how to get dedicated support from an adviser, attend an event, or sign up for tailored emails.
 navigation: 40
 layout: "layouts/minimal"
-feedback: true
+feedback: false
 talk_to_us: false
 content:
   - content/help-and-support/header

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -13,7 +13,7 @@ describe FooterComponent, type: "component" do
   end
 
   specify "renders the 'Feedback bar' by default" do
-    expect(page).to have_css(feedback_selector)
+    expect(page).not_to have_css(feedback_selector)
   end
 
   specify "renders the 'Talk To Us' section by default" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -233,7 +233,7 @@ describe ApplicationHelper do
 
     subject { content_footer_kwargs(front_matter) }
 
-    it { is_expected.to eq({ talk_to_us: true, feedback: true }) }
+    it { is_expected.to eq({ talk_to_us: true, feedback: false }) }
 
     context "when overriden in the front_matter" do
       let(:front_matter) { { talk_to_us: false, feedback: false, other: false } }


### PR DESCRIPTION
### Trello card

[Trello 5049](https://trello.com/c/fjUSFOIS/5049-remove-the-feedback-component-from-the-website)

### Context

The current feedback component (located just above the footer), is simply a link to the feedback form and is duplicated in the footer. We have decided to remove the component but retain the footer link as this is a more typical location for such a feature.

### Changes proposed in this pull request

Removal of the feedback component across the website.

### Guidance to review

Check for the presence of the feedback component above the footer on various page layouts. If it's visible, further changes will be required.

