### PR TITLE
Add Bishop Challoner to Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -377,7 +377,12 @@ provider_groups:
       email: WSTP@poolehigh.poole.sch.uk
   West Midlands:
     providers:
-    - header: Birmingham City University
+    - header: Bishop Challoner Training School
+      link: https://www.bctsa.org/1299/assessment-only-qts
+      name: Emily Giubertoni
+      telephone: 07714 672398
+      email: e.giubertoni@bishopchalloner.bham.sch.uk
+   - header: Birmingham City University
       link: https://www.bcu.ac.uk/
       name: Programme Leader
       telephone: 0121 331 4627

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -382,7 +382,7 @@ provider_groups:
       name: Emily Giubertoni
       telephone: 07714 672398
       email: e.giubertoni@bishopchalloner.bham.sch.uk
-   - header: Birmingham City University
+    - header: Birmingham City University
       link: https://www.bcu.ac.uk/
       name: Programme Leader
       telephone: 0121 331 4627

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -377,16 +377,16 @@ provider_groups:
       email: WSTP@poolehigh.poole.sch.uk
   West Midlands:
     providers:
-    - header: Bishop Challoner Training School
-      link: https://www.bctsa.org/1299/assessment-only-qts
-      name: Emily Giubertoni
-      telephone: 07714 672398
-      email: e.giubertoni@bishopchalloner.bham.sch.uk
     - header: Birmingham City University
       link: https://www.bcu.ac.uk/
       name: Programme Leader
       telephone: 0121 331 4627
       email: assessmentonlyqts@bcu.ac.uk
+    - header: Bishop Challoner Training School
+      link: https://www.bctsa.org/1299/assessment-only-qts
+      name: Emily Giubertoni
+      telephone: 07714 672398
+      email: e.giubertoni@bishopchalloner.bham.sch.uk
     - header: Haybridge Alliance SCITT
       link: https://www.teachwithhaybridge.co.uk
       email: tforward@haybridge.worcs.sch.uk


### PR DESCRIPTION
### Trello card
https://trello.com/c/BmmXUXnB

### Context
Request via ITT Accreditation team to add Bishop Challoner Training School to the Assessment only page

