### PR TITLE
Adding holding message to funding pages

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -1,6 +1,6 @@
 <div class="call-to-action call-to-action--funding-widget">
   <div class="call-to-action__content">
-    <h2 class="call-to-action__heading">What funding could I get for teacher training courses starting in 2023?</h2>
+    <h2 class="call-to-action__heading">What funding could I get for teacher training courses starting in the 2023/24 academic year?</h2>
 
     <div class="call-to-action__text">
       <div class="call-to-action__form">

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -1,6 +1,6 @@
 <div class="call-to-action call-to-action--funding-widget">
   <div class="call-to-action__content">
-    <h2 class="call-to-action__heading">What funding could I get for teacher training?</h2>
+    <h2 class="call-to-action__heading">What funding could I get for teacher training courses starting in 2023?</h2>
 
     <div class="call-to-action__text">
       <div class="call-to-action__form">

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -1,6 +1,6 @@
 <div class="call-to-action call-to-action--funding-widget">
   <div class="call-to-action__content">
-    <h2 class="call-to-action__heading">What funding could I get for teacher training courses starting in the 2023/24 academic year?</h2>
+    <h2 class="call-to-action__heading">What funding could I get for teacher training?</h2>
 
     <div class="call-to-action__text">
       <div class="call-to-action__form">

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -1,4 +1,4 @@
-<%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.") %>
+<%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting the following year will be announced in autumn 2023.") %>
 
 <p>You may be eligible for a bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.</p>
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -1,12 +1,10 @@
-<%= render Content::InsetTextComponent.new(text: "The following amounts are for teacher training courses starting in the 2023/24 academic year. Financial support for courses starting in the 2024/25 academic year will be announced in autumn 2023.") %>
+<%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.") %>
 
 <p>You may be eligible for a bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.</p>
 
 <p>Your bursary or scholarship will be paid in a minimum of 10 equal monthly instalments over the duration of your course by your teacher training provider.</p>
 
 <p>Your teacher training provider will confirm the payment dates and amounts.</p>
-
-<p>Figures are for courses starting in the 2023/24 academic year.</p>
 
 <%= render Content::InsetTextComponent.new(
   text: "If you’re a non-UK citizen without <a href=\"https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk\">indefinite leave to remain in the UK</a>, you will not usually be eligible for a bursary or scholarship,

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -1,4 +1,4 @@
-<%= render Content::InsetTextComponent.new(text: "The following amounts are for teacher training courses starting in 2023. Financial support for courses starting in 2024 will be announced in autumn 2023.") %>
+<%= render Content::InsetTextComponent.new(text: "The following amounts are for teacher training courses starting in the 2023/24 academic year. Financial support for courses starting in the 2024/25 academic year will be announced in autumn 2023.") %>
 
 <p>You may be eligible for a bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.</p>
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -1,3 +1,5 @@
+<%= render Content::InsetTextComponent.new(text: "The following amounts are for teacher training courses starting in 2023. Financial support for courses starting in 2024 will be announced in autumn 2023.") %>
+
 <p>You may be eligible for a bursary or scholarship when training to teach. These are tax-free amounts of money you receive to train in certain subjects. You do not need to pay them back.</p>
 
 <p>Your bursary or scholarship will be paid in a minimum of 10 equal monthly instalments over the duration of your course by your teacher training provider.</p>

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -2,6 +2,8 @@
   <section class="col col-720">
     <h2 class="heading--box-blue">How can I fund my teacher training?</h2>
 
+    <%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.") %>
+
     <div class="inset">
       <h3>Postgraduate bursaries and scholarships</h3>
 

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_content.html.erb
@@ -2,7 +2,7 @@
   <section class="col col-720">
     <h2 class="heading--box-blue">How can I fund my teacher training?</h2>
 
-    <%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.") %>
+    <%= render Content::InsetTextComponent.new(text: "The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting the following year will be announced in autumn 2023.") %>
 
     <div class="inset">
       <h3>Postgraduate bursaries and scholarships</h3>

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -18,7 +18,7 @@ backlink: "../../"
 inset_text:
   funding-holding-message:
     text: |-
-      The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.
+      The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting the following year will be announced in autumn 2023.
 keywords:
   - International
   - Overseas

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -15,6 +15,10 @@ navigation_description: Learn more about teacher training fees in England and fi
 date: "2021-05-27"
 image: "static/content/hero-images/0002.jpg"
 backlink: "../../"
+inset_text:
+  funding-holding-message:
+    text: |-
+      The following amounts are for teacher training courses starting in 2023. Financial support for courses starting in 2024 will be announced in autumn 2023.
 keywords:
   - International
   - Overseas
@@ -57,6 +61,8 @@ keywords:
   - European
   - Settlement Scheme
 ---
+
+$funding-holding-message$
 
 If you’re applying for teacher training as a non-UK citizen, you may be able to get some financial support from the UK government.
 

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -18,7 +18,7 @@ backlink: "../../"
 inset_text:
   funding-holding-message:
     text: |-
-      The following amounts are for teacher training courses starting in the 2023/24 academic year. Financial support for courses starting in the 2024/25 academic year will be announced in autumn 2023.
+      The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting between September 2024 and July 2025 will be announced in autumn 2023.
 keywords:
   - International
   - Overseas

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -18,7 +18,7 @@ backlink: "../../"
 inset_text:
   funding-holding-message:
     text: |-
-      The following amounts apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting the following year will be announced in autumn 2023.
+      The bursary and scholarship amounts on this page apply if you're starting your teacher training course between September 2023 and July 2024. Financial support for courses starting the following year will be announced in autumn 2023.
 keywords:
   - International
   - Overseas

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -18,7 +18,7 @@ backlink: "../../"
 inset_text:
   funding-holding-message:
     text: |-
-      The following amounts are for teacher training courses starting in 2023. Financial support for courses starting in 2024 will be announced in autumn 2023.
+      The following amounts are for teacher training courses starting in the 2023/24 academic year. Financial support for courses starting in the 2024/25 academic year will be announced in autumn 2023.
 keywords:
   - International
   - Overseas

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -130,6 +130,10 @@
     </p>
 
     <p>
+      Financial support for courses starting the following year will be announced in autumn 2023.
+    </p>
+
+    <p>
       <a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for bursaries and scholarships</a>.
     </p>
 

--- a/app/views/content/subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/subjects/engineers-teach-physics/_article.html.erb
@@ -126,7 +126,7 @@
     <h2 class="heading-s">Funding for teaching physics</h2>
 
     <p>
-      Scholarships of £29,000 or bursaries of £27,000 are available for trainee physics teachers starting their teacher training course in the 2023/24 academic year.
+      Scholarships of £29,000 or bursaries of £27,000 are available for trainee physics teachers starting their teacher training course between September 2023 and July 2024.
     </p>
 
     <p>

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -137,7 +137,7 @@
     <h2 class="heading-s">Funding for teaching maths</h2>
 
     <p>
-    Scholarships of £29,000 or bursaries of £27,000 are available for trainee maths teachers starting their teacher training course in the 2023/24 academic year.
+    Scholarships of £29,000 or bursaries of £27,000 are available for trainee maths teachers starting their teacher training course between September 2023 and July 2024.
     </p>
 
     <p>

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -137,7 +137,7 @@
     <h2 class="heading-s">Funding for teaching maths</h2>
 
     <p>
-    Scholarships of £29,000 or bursaries of £27,000 are available for trainee maths teachers starting their teacher training course between September 2023 and July 2024.
+    Scholarships of £29,000 or bursaries of £27,000 are available if you start your maths teacher training course between September 2023 and July 2024.
     </p>
 
     <p>

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -141,6 +141,10 @@
     </p>
 
     <p>
+    Financial support for courses starting the following year will be announced in autumn 2023.
+    </p>
+
+    <p>
       <a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for bursaries and scholarships</a>.
     </p>
   </section>

--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-    If you train to teach physics, you could also be eligible to receive a scholarship or bursary of up to £29,000.
+    If you train to teach physics, you could also be eligible to receive a scholarship or bursary of up to £29,000 if you start your teacher training course between September 2023 and July 2024.
   </p>
   </section>
 
@@ -134,7 +134,7 @@
   <section class="col col-space-m col-720">
     <h3>Fund your training to teach physics</h3>
     <p>
-      You could receive a scholarship of £29,000 from the Institute of Physics or a bursary of £27,000, if you train to teach in the 2023/24 academic year.
+      You could receive a scholarship of £29,000 from the Institute of Physics or a bursary of £27,000, if you start your teacher training course between September 2023 and July 2024.
     </p>
     <p><a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for scholarships and bursaries</a>.</p>
     <p>You can <a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships">find out more about the physics scholarship from the Institute of Physics</a>.</p>
@@ -153,7 +153,7 @@
 </p>
 
 <p>
-  You could also be eligible for a scholarship of £29,000 or a bursary of £27,000.
+  You could also be eligible for a scholarship of £29,000 or a bursary of £27,000 if you start your teacher training between September 2023 and July 2024.
 </p>
 
 <p>

--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -134,7 +134,7 @@
   <section class="col col-space-m col-720">
     <h3>Fund your training to teach physics</h3>
     <p>
-      Scholarships of £29,000 are available from the Institute of Physics. Alternatively, bursaries of £27,000 are available for trainee physics teachers starting their teacher training course from September 2023.
+      You could receive a scholarship of £29,000 from the Institute of Physics or a bursary of £27,000, if you train to teach in the 2023/24 academic year.
     </p>
     <p><a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for scholarships and bursaries</a>.</p>
     <p>You can <a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships">find out more about the physics scholarship from the Institute of Physics</a>.</p>

--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -7,6 +7,10 @@
   <p>
     You could also be eligible to receive a scholarship or bursary of up to £29,000 if you start your physics teacher training course between September 2023 and July 2024.
   </p>
+
+  <p>
+    Financial support for courses starting the following year will be announced in autumn 2023.
+  </p>
   </section>
 
    <section class="col col-space-s col-content-max">
@@ -136,6 +140,11 @@
     <p>
       You could receive a scholarship of £29,000 from the Institute of Physics or a bursary of £27,000, if you start your teacher training course between September 2023 and July 2024.
     </p>
+
+    <p>
+      Financial support for courses starting the following year will be announced in autumn 2023.
+    </p>
+
     <p><a href="/funding-and-support/scholarships-and-bursaries">Find out about your eligibility for scholarships and bursaries</a>.</p>
     <p>You can <a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships">find out more about the physics scholarship from the Institute of Physics</a>.</p>
   </section>
@@ -154,6 +163,10 @@
 
 <p>
   You could also be eligible for a scholarship of £29,000 or a bursary of £27,000 if you start your teacher training between September 2023 and July 2024.
+</p>
+
+<p>
+  Financial support for courses starting the following year will be announced in autumn 2023.
 </p>
 
 <p>

--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-    If you train to teach physics, you could also be eligible to receive a scholarship or bursary of up to £29,000 if you start your teacher training course between September 2023 and July 2024.
+    You could also be eligible to receive a scholarship or bursary of up to £29,000 if you start your physics teacher training course between September 2023 and July 2024.
   </p>
   </section>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/gAOMPYPa/5053-add-holding-message-to-scholarships-and-bursaries-page

### Context

We should make it clear on the website that current funding amounts apply to the 2023/24 academic year.

### Changes proposed in this pull request

### Guidance to review

