### PR TITLE
Remove duplicated links from the footer

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="site-footer-bottom">
       <div class="site-footer-bottom__logo-container">
-        <%= image_pack_tag 'static/dfelogo-white.svg', alt: "Department for Education", size: "124x73" %>
+        <%= image_pack_tag 'static/dfelogo-white.svg', alt: "Department for Education logo", size: "124x73" %>
       </div>
       <div class="site-footer-bottom__links-container">
         <%= link_to("Search", search_path) %>

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -37,13 +37,8 @@
           <span class="visually-hidden">Youtube - opens in a new tab</span>
         </a>
       </div>
-      <div class="site-footer-top__links-container">
-      </div>
     </div>
     <div class="site-footer-bottom">
-      <div class="site-footer-bottom__logo-container">
-        <%= image_pack_tag 'static/dfelogo-white.svg', alt: "Department for Education logo", size: "124x73" %>
-      </div>
       <div class="site-footer-bottom__links-container">
         <%= link_to("Search", search_path) %>
         <a target="_blank" rel="noopener" href="https://forms.office.com/e/zVfV4SZeVn">Feedback</a>
@@ -52,6 +47,9 @@
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>
         <a target="_blank" rel="noopener" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
         <div class="site-footer-bottom__links-container__license">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0,</a> except where otherwise stated.</div>
+      </div>
+      <div class="site-footer-bottom__logo-container">
+        <%= image_pack_tag 'static/dfelogo-white.svg', alt: "Department for Education logo", size: "124x73" %>
       </div>
     </div>
   </div>

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -38,12 +38,6 @@
         </a>
       </div>
       <div class="site-footer-top__links-container">
-        <% helpers.navigation_resources.each do |resource| %>
-          <a href="<%= resource.path %>"><%= resource.title %></a>
-        <% end %>
-        <%= link_to "Find an event near you", events_path %>
-        <%= link_to "Sign up for updates", "/mailinglist/signup/name" %>
-        <%= link_to("Search", search_path) %>
       </div>
     </div>
     <div class="site-footer-bottom">
@@ -51,6 +45,7 @@
         <%= image_pack_tag 'static/dfelogo-white.svg', alt: "Department for Education", size: "124x73" %>
       </div>
       <div class="site-footer-bottom__links-container">
+        <%= link_to("Search", search_path) %>
         <a target="_blank" rel="noopener" href="https://forms.office.com/e/zVfV4SZeVn">Feedback</a>
         <%= link_to "Cookies", cookies_path %>
         <%= link_to "Privacy notice", privacy_policy_path %>

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -18,7 +18,7 @@ footer.site-footer {
     }
 
     &__links-container {
-      flex: 66% 0 0%;
+      flex: 75% 0 0%;
 
       display: flex;
       flex-wrap: wrap;
@@ -52,14 +52,13 @@ footer.site-footer {
 
   .site-footer-top {
     display: flex;
-    padding-bottom: 2em;
 
     .icon {
       @include font-size(large);
     }
 
     &__social {
-      flex: 33% 0 0;
+      flex: 25% 0 0;
       display: flex;
       margin-right: 1em;
 
@@ -91,7 +90,7 @@ footer.site-footer {
     padding-top: 2em;
 
     &__logo-container {
-      flex: 50% 0 0;
+      flex: 25% 0 0;
       flex-direction: column;
 
       display: flex;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -18,7 +18,7 @@ footer.site-footer {
     }
 
     &__links-container {
-      flex: 75% 0 0%;
+      flex: 66% 0 0%;
 
       display: flex;
       flex-wrap: wrap;
@@ -58,7 +58,7 @@ footer.site-footer {
     }
 
     &__social {
-      flex: 25% 0 0;
+      flex: 33% 0 0;
       display: flex;
       margin-right: 1em;
 
@@ -90,7 +90,7 @@ footer.site-footer {
     padding-top: 2em;
 
     &__logo-container {
-      flex: 25% 0 0;
+      flex: 50% 0 0;
       flex-direction: column;
 
       display: flex;

--- a/app/webpacker/styles/footer.scss
+++ b/app/webpacker/styles/footer.scss
@@ -13,12 +13,16 @@ footer.site-footer {
     display: flex;
 
     @include mq($until: tablet) {
-      flex-direction: column-reverse;
+      flex-direction: column;
       // gap: 2em;
     }
 
     &__links-container {
-      flex: 66% 0 0%;
+      flex: 70% 0 0%;
+
+      @include mq($from: 1800px) {
+        flex: 50% 0 0%;
+      }
 
       display: flex;
       flex-wrap: wrap;
@@ -89,9 +93,17 @@ footer.site-footer {
     margin-top: 2em;
     padding-top: 2em;
 
+    @include mq($from: tablet) {
+      flex-direction: row-reverse;
+    }
+
     &__logo-container {
-      flex: 50% 0 0;
+      flex: 30% 0 0;
       flex-direction: column;
+
+      @include mq($from: 1800px) {
+        flex: 50% 0 0;
+      }
 
       display: flex;
       align-content: center;


### PR DESCRIPTION
### Trello card

[Trello 5087](https://trello.com/c/LGgaAufv)

### Context

The footer currently features a list of links that are duplicates of the top navigation. These links are rarely clicked and present issues through their duplication. Removing these links will clean up the footer and remove any issues associated with this duplication.

The only link from this list that should not be removed is ‘Search’. This is due to accessibility issues. As such, this link will be added to the list of links in the bottom half of the footer instead.

### Changes proposed in this pull request

Remove the duplicated links from the top half of the footer and add the 'Search' link to the list of links in the bottom half of the footer.

### Guidance to review

Check that the links in the top half of the footer have been removed and that 'Search' is now located alongside the links in the bottom half of the footer.

