### PR TITLE
Clarifying degree you need to teach

### DIFF
--- a/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
+++ b/app/views/content/is-teaching-right-for-me/qualifications-you-need-to-teach.md
@@ -24,7 +24,7 @@ You do not need QTS to [teach in further education](/become-a-further-education-
 To train to teach in primary and secondary schools in England, you’ll need:
 
 * GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary)
-* a bachelor’s degree (this does not have to be in teaching)
+* a bachelor’s degree in any subject
 
 Different training providers may also have specific criteria. For example, some may ask that you have a bachelor’s degree class 2:2 or above.
 
@@ -34,13 +34,13 @@ Talk to your teacher training provider or [find a course](https://www.find-postg
 
 ## What can you teach?
 
-You do not necessarily need a bachelor’s degree in a subject to teach it. It’s up to your teacher training provider to decide if you have the skills and knowledge required.
+Your degree can be in any subject to teach primary or secondary. For secondary courses, your provider will also want to make sure you have a good knowledge of the subject you're applying to teach.
 
-In some cases, you may be able to train to teach a different subject to your degree if:
+This could be through having a degree in the subject, or having:
 
-* you have an A level in the subject
-* your degree is related to but not in the subject – for example, your degree is in engineering but you’d like to teach physics
-* you have an unrelated degree but relevant professional experience
+* an A level in the subject
+* a degree related to but not in the subject – for example, your degree is in engineering but you’d like to teach physics
+* an unrelated degree but relevant professional experience
 
 Talk to your training provider to find out what you can train to teach.
 

--- a/app/views/content/steps-to-become-a-teacher/_step_1_check_your_qualifications.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_1_check_your_qualifications.html.erb
@@ -1,6 +1,6 @@
 <p>To train to teach, you’ll need to have GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary).</p>
 
-<p>You also need a degree to teach primary and secondary – if you have one or an equivalent qualification, you can do postgraduate teacher training.</p>
+<p>You also need a degree in any subject to teach primary and secondary – if you have one or an equivalent qualification, you can do postgraduate teacher training.</p>
 
 <p>If you do not have a degree, you can do undergraduate teacher training to get a degree alongside qualified teacher status (QTS).</p>
 

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -17,7 +17,7 @@ navigation_title: If you do not have a degree
 navigation_description: You need a degree to get qualified teacher status (QTS). If you're not already studying for one, find out more about undergraduate degree courses.
 ---
 
-You need a bachelor’s degree to train to teach in primary, secondary and special schools in England. This does not have to be in teaching.
+You need a bachelor’s degree in any subject to train to teach in primary, secondary and special schools in England. For secondary teacher training, your provider will also want to make sure you have a good knowledge of the subject you’re applying to teach.
 
 If you do not already have one, you can train to be a teacher as part of your bachelor’s degree and get [qualified teacher status (QTS)](/what-is-qts).
 

--- a/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-dont-have-a-degree.md
@@ -17,7 +17,9 @@ navigation_title: If you do not have a degree
 navigation_description: You need a degree to get qualified teacher status (QTS). If you're not already studying for one, find out more about undergraduate degree courses.
 ---
 
-You need a bachelor’s degree in any subject to train to teach in primary, secondary and special schools in England. For secondary teacher training, your provider will also want to make sure you have a good knowledge of the subject you’re applying to teach.
+You need a bachelor’s degree in any subject to train to teach in primary, secondary and special schools in England.
+
+For secondary teacher training, your provider will also want to make sure you have a good knowledge of the subject you’re applying to teach.
 
 If you do not already have one, you can train to be a teacher as part of your bachelor’s degree and get [qualified teacher status (QTS)](/what-is-qts).
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -28,7 +28,7 @@ keywords:
 ---
 
 
-You need a bachelor's degree to teach in primary, secondary and special schools in England. This does not have to be a bachelor's degree in teaching.
+You need a bachelor's degree in any subject to teach in primary, secondary and special schools in England.
 
 You also need to gain qualified teacher status (QTS) to teach in most schools which you get through teacher training.
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -30,6 +30,8 @@ keywords:
 
 You need a bachelor's degree in any subject to teach in primary, secondary and special schools in England.
 
+For secondary teacher training, your provider will want to make sure you have a good knowledge of the subject you’re applying to teach.
+
 You also need to gain qualified teacher status (QTS) to teach in most schools which you get through teacher training.
 
 Teacher training courses usually take 9 months full-time, or 18 to 24 months part-time.


### PR DESCRIPTION
### Trello card

https://trello.com/c/xvQDCKo8/5083-clarify-what-degree-is-needed-to-train-to-teach-primary

### Context

Analysis of the TPUK data for July 2023 flagged that candidates were confused about which degrees they needed to train to teach primary.

We should review whether we need to explicitly mention primary wherever we talk about needing a degree.

### Changes proposed in this pull request

### Guidance to review

