### PR TITLE
Adding the ske link to physics page

### DIFF
--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -149,6 +149,11 @@
     <p>You can <a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships">find out more about the physics scholarship from the Institute of Physics</a>.</p>
   </section>
   <section class="col col-space-m col-720">
+  <h3>Improving your physics subject knowledge</h3>
+  <p> If you need to brush up on your physics knowledge before you become a teacher, you can do a subject knowledge enhancement course.</p>
+  <p><a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">Find out about subject knowledge enhancement courses</a>.</p>
+  </section>
+  <section class="col col-space-m col-720">
     <h3>Engineers teach physics</h3>
     <p>
       If you're an engineer considering a career as a physics teacher, there is a teacher training course designed especially with your experience and skills in mind.

--- a/app/views/content/subjects/physics/_article.html.erb
+++ b/app/views/content/subjects/physics/_article.html.erb
@@ -149,7 +149,7 @@
     <p>You can <a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships">find out more about the physics scholarship from the Institute of Physics</a>.</p>
   </section>
   <section class="col col-space-m col-720">
-  <h3>Improving your physics subject knowledge</h3>
+  <h3>Improve your physics subject knowledge</h3>
   <p> If you need to brush up on your physics knowledge before you become a teacher, you can do a subject knowledge enhancement course.</p>
   <p><a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">Find out about subject knowledge enhancement courses</a>.</p>
   </section>


### PR DESCRIPTION
### Trello card

https://trello.com/c/OC1dss0J

### Context

Other subject pages include information on subject knowledge enhancement (SKE) courses but this needs to be added to the physics page.

### Changes proposed in this pull request

- adding SKE information the physics page

### Guidance to review

Link to updated page: https://review-get-into-teaching-app-3563.london.cloudapps.digital/subjects/physics
