### PR TITLE
Load new internship providers

### DIFF
--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -17,15 +17,6 @@ fullwidth: true
 content:
   - content/teaching-internship-providers/listing
 provider_groups:
-  East:
-    providers:
-      - header: Thinking Schools Academy Trust
-        link: https://www.tsatrust.org.uk/
-        subjects: chemistry, computing, maths, physics, languages
-        name: Sophie Venables
-        email: s.venables@tsatrust.org.uk
-        areas: Essex
-        applications: Open
   East Midlands:
     providers:
       - header: Bluecoat SCITT Alliance
@@ -40,7 +31,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Claire Amed
         email: Claire.amed@creativeeducationtrust.org.uk
-        areas: North Northamptonshire, Nottingham, West Northmptonshire
+        areas: North Northamptonshire, Nottingham, West Northamptonshire
         applications: Open
       - header: George Spencer Academy
         link: http://www.george-spencer.com/
@@ -112,14 +103,14 @@ provider_groups:
         subjects: chemistry, maths, physics, languages
         name: Susanne Combe
         email: scombe@bestacademies.org.uk
-        areas: Bedford, Central Bendfordshire
+        areas: Bedford, Central Bedfordshire
         applications: Open
       - header: Benfleet Team Supporting All
         link: http://www.btsa.uk/internship-scheme/
         subjects: chemistry, computing, maths, physics, languages
         name: Maxine Howard
         email: mhoward@theappletonschool.org
-        areas: Essex, Southend oin Sea
+        areas: Essex, Southend on Sea
         applications: Open
       - header: Creative Education Trust
         link: https://www.creativeeducationtrust.org.uk/internship
@@ -170,11 +161,11 @@ provider_groups:
         email: vicki.walsh@redborne.com
         areas: Bedford, Central Bedfordshire
         applications: Open
-      - header: South Essex Training and Support Alliance
-        link: https://www.setsa.info/1567/teaching-internship-programme-2023
+      - header: South East Essex Academy Trust (SEEAT)
+        link: https://www.seeat.org/Teaching-Internships/
         subjects: chemistry, computing, maths, physics, languages
-        name: David Struthers
-        email: d.struthers@setsa.info
+        name: Sarah White, Rebecca Geoghegan
+        email: s.white@seeat.org, info@seeat.org
         areas: Essex, Southend-on-Sea
         applications: Open
       - header: The Hertfordshire and Essex High School
@@ -183,6 +174,13 @@ provider_groups:
         name: Claire Ruthven
         email: claire.ruthven@hertsandessex.herts.sch.uk
         areas: Hertfordshire
+        applications: Open
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+        areas: Essex
         applications: Open
   London:
     providers:
@@ -205,7 +203,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Jose Oliveira/Jacqui Aldrich
         email: jose.oliveira@harrisfederation.org.uk / j.aldrich@niot.org.uk
-        areas: Bexley, Brent, Bromley, Croydon, Greenwich, Haringey, Havering, Lambeth, Morton, Newham, Southwark, Sutton, Tower Hamlets, Wandsworth, Westminster
+        areas: Bexley, Brent, Bromley, Croydon, Greenwich, Haringey, Havering, Lambeth, Merton, Newham, Southwark, Sutton, Tower Hamlets, Wandsworth, Westminster
         applications: Open
       - header: LETTA (London East Teacher Training Alliance)
         link: https://letta.org.uk/train/teachinginternships/
@@ -226,21 +224,21 @@ provider_groups:
         subjects: chemistry, maths, physics, languages
         name: Riam Muayad
         email: Riam.Muayad@paddington-academy.org
-        areas: Fulham, Hammershith and Fulham, Lambeth, Westminster
+        areas: Fulham, Hammersmith and Fulham, Lambeth, Westminster
         applications: Open
       - header: Reach Academy Feltham
         link: https://www.reachtraining.org/teaching-internships
         subjects: chemistry, maths, physics, languages
         name: James Foreman
         email: reachteachertraining@reachacademy.org.uk
-        areas: Hounsllow
+        areas: Hounslow
         applications: Open
       - header: St John Southworth Catholic Academy Trust
-        link: "SJSCAT - https://www.sjscat.co.uk/Summer-Teaching-Internship-2024/\r\nCVMS - https://www.cvms.co.uk/Summer-Teaching-Internship-2024/"
+        link: https://www.sjscat.co.uk/Summer-Teaching-Internship-2024/
         subjects: chemistry, computing, maths, physics, languages
         name: Patrick Lanigan
         email: laniganp@cvms.co.uk
-        areas: Brent, Ealing, Hammershith and Fulham, Harrow, Kensington and Chelsea, Wandsworth, West Berkshire, Westminster
+        areas: Brent, Ealing, Hammersmith and Fulham, Harrow, Kensington and Chelsea, Wandsworth, West Berkshire, Westminster
         applications: Open
       - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
         link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2024
@@ -270,7 +268,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah McGee
         email: smcgee@bhcet.org.uk
-        areas: Darlington, Durham, Gateshead, Harlepool, Middlesbrough, Newcastle upon Tyne, North Tyneside, Northumberland, South Tyneside, Stockton on Tees, Sunderland
+        areas: Darlington, Durham, Gateshead, Hartlepool, Middlesbrough, Newcastle upon Tyne, North Tyneside, Northumberland, South Tyneside, Stockton on Tees, Sunderland
         applications: Open
       - header: North East SCITT
         link: https://www.northeastscitt.co.uk/intern
@@ -284,7 +282,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Meriem Lairini
         email: m.lairini@northerneducationtrust.org
-        areas: Gateshead, Hartlepool, Newcastle, Northumbersland, Stockton-on-Tees, Sunderland
+        areas: Gateshead, Hartlepool, Newcastle, Northumberland, Stockton-on-Tees, Sunderland
         applications: Open
       - header: Outwood Institute of Education
         link: https://teachnorth.com/internships
@@ -379,7 +377,7 @@ provider_groups:
         email: j.brierley@brighouse.calderdale.sch.uk
         areas: Calderdale, Kirklees
         applications: Open
-      - header: Wigan and West Lancashire Catholic School Direct 
+      - header: Wigan and West Lancashire Catholic School Direct
         link: https://www.catholicsd.org.uk/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah Holland
@@ -503,7 +501,7 @@ provider_groups:
         areas: Bournemouth Christchurch and Poole, Dorset
         applications: Open
       - header: South West Institute for Teaching (SWIFT)
-        link: www.swiftteachertraining.org.uk/internships
+        link: https://www.swiftteachertraining.org.uk/internships.html
         subjects: chemistry, computing, maths, physics, languages
         name: Abby Spearing
         email: Abby.spearing@sw-ift.org.uk

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -205,8 +205,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Jose Oliveira/Jacqui Aldrich
         email: jose.oliveira@harrisfederation.org.uk / j.aldrich@niot.org.uk
-        areas: Bexley, Brent, Bromley, Croydon, Greenwich, Haringey, Havering, Lambeth,
-        Morton, Newham, Southwark, Sutton, Tower Hamlets, Wandsworth, Westminster
+        areas: Bexley, Brent, Bromley, Croydon, Greenwich, Haringey, Havering, Lambeth, Morton, Newham, Southwark, Sutton, Tower Hamlets, Wandsworth, Westminster
         applications: Open
       - header: LETTA (London East Teacher Training Alliance)
         link: https://letta.org.uk/train/teachinginternships/
@@ -241,8 +240,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Patrick Lanigan
         email: laniganp@cvms.co.uk
-        areas: Brent, Ealing, Hammershith and Fulham, Harrow, Kensington and Chelsea,
-        Wandsworth, West Berkshire, Westminster
+        areas: Brent, Ealing, Hammershith and Fulham, Harrow, Kensington and Chelsea, Wandsworth, West Berkshire, Westminster
         applications: Open
       - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
         link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2024
@@ -272,8 +270,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah McGee
         email: smcgee@bhcet.org.uk
-        areas: Darlington, Durham, Gateshead, Harlepool, Middlesbrough, Newcastle upon
-        Tyne, North Tyneside, Northumberland, South Tyneside, Stockton on Tees, Sunderland
+        areas: Darlington, Durham, Gateshead, Harlepool, Middlesbrough, Newcastle upon Tyne, North Tyneside, Northumberland, South Tyneside, Stockton on Tees, Sunderland
         applications: Open
       - header: North East SCITT
         link: https://www.northeastscitt.co.uk/intern
@@ -317,8 +314,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics
         name: Hilary Langmead-Jones
         email: admin@scitt.bright-futures.co.uk
-        areas: Bury, Cheshire West and Chester, Manchester, Oldham, Salford, Stockport,
-        Tameside, Trafford, Wigan
+        areas: Bury, Cheshire West and Chester, Manchester, Oldham, Salford, Stockport, Tameside, Trafford, Wigan
         applications: Open
       - header: Chorlton High School
         link: https://chorltonhigh.manchester.sch.uk/working-for-us/Chorlton-High-Teaching-School-Team/school-experience-programme
@@ -374,8 +370,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Graeme Balfour
         email: gbalfour@loreto.ac.uk
-        areas: Bolton, Bury, Manchester, Oldham, Salford, Stockport, Tameside, Trafford,
-        Wigan
+        areas: Bolton, Bury, Manchester, Oldham, Salford, Stockport, Tameside, Trafford, Wigan
         applications: Open late November
       - header: Valley Learning Partnership
         link: "https://www.brighouse.calderdale.sch.uk/join-us/train-with-us/\r\nwww.brighouse.calderdale.sch.uk/join-us/work-for-us"
@@ -389,8 +384,7 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah Holland
         email: hollands267@saintpetershigh.wigan.sch.uk
-        areas: Chorley, Halton, Lancashire, Leigh, Ormskirk, Skelmersdale, Warrington,
-        Wigan
+        areas: Chorley, Halton, Lancashire, Leigh, Ormskirk, Skelmersdale, Warrington, Wigan
         applications: Open
   South East:
     providers:

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -16,6 +16,473 @@ backlink: /
 fullwidth: true
 content:
   - content/teaching-internship-providers/listing
+provider_groups:
+  East Midlands:
+    providers:
+      - header: Bluecoat SCITT Alliance
+        link: https://www.bluecoatscittalliance.uk.com/vacancies/paid-graduate-internship/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Julie Hefferman
+        email: itt@bluecoat.uk.com
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Amed
+        email: Claire.amed@creativeeducationtrust.org.uk
+      - header: George Spencer Academy
+        link: http://www.george-spencer.com/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Tammy Elward
+        email: tammyelward@satrust.com
+      - header: Learners First Schools Partnership
+        link: https://www.learnersfirst.net/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Garbutt/Georgia Osborne
+        email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
+      - header: Leicestershire Secondary SCITT
+        link: https://www.leicestershiresecondaryscitt.org/events-information/teaching-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Laura Wharton
+        email: lwharton@rushey-tmet.uk
+      - header: Lionheart Teach
+        link: https://www.lionheartteach.org.uk/opportunities/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Emma Lowe
+        email: info@lionheartteach.org.uk
+      - header: Nottingham Catholic ITT Partnership
+        link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Vanessa Scott
+        email: v.scott@becketonline.co.uk
+      - header: Nottinghamshire Torch SCITT
+        link: https://www.teachnottinghamshire.co.uk/internships.php
+        subjects: chemistry, computing, maths, physics, languages
+        name: Rebecca Morgan-Jones
+        email: contact@teachnottinghamshire.co.uk 
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: George W. Robson
+        email: teachnorth@oie.outwood.com
+      - header: Tuxford Academy
+        link: https://www.diverseassociation.org.uk/get-into-teaching/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Administrator
+        email: interns@diverse-ac.org.uk
+  East of England:
+    providers:
+      - header: Advanced Learning Partnership
+        link: https://www.advancedlearningpartnership.co.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Nicola Nicolaou
+        email: nicolaoun@damealiceowens.herts.sch.uk
+      - header: Bedfordshire Schools Trust
+        link: https://www.bestteachingschool.org.uk/
+        subjects: chemistry, maths, physics, languages
+        name: Susanne Combe
+        email: scombe@bestacademies.org.uk
+      - header: Benfleet Team Supporting All
+        link: http://www.btsa.uk/internship-scheme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Maxine Howard
+        email: mhoward@theappletonschool.org
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Amed
+        email: Claire.amed@creativeeducationtrust.org.uk
+      - header: Debden Park High School (TKAT Teacher Training)
+        link: https://scitt.tkat.org/842/internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jo Fogg
+        email: jo.fogg@tkat.org
+      - header: Farlingaye High School
+        link: https://www.eastscitt.co.uk/Undergraduate-Internships/
+        subjects: maths,physics
+        name: Peter Smith
+        email: psmith@farlingaye.suffolk.sch.uk
+      - header: Harris Initial Teacher Education
+        link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jose Oliveira/Shona Findlay
+        email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
+      - header: Northgate High School,Ipswich
+        link: https://www.northgate.suffolk.sch.uk/staff/training-to-teach/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Miss Mary Hallett
+        email: mch@northgate.suffolk.sch.uk
+      - header: Ormiston Academies Trust
+        link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jemma Sherwood
+        email: internships@ormistonacademies.co.uk
+      - header: Redborne Teaching Partnership
+        link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
+        subjects: chemistry, computing, maths, physics, languages
+        name: Vicki Walsh
+        email: vicki.walsh@redborne.com
+      - header: Saffron Walden County High School
+        link: https://www.swchs.net/page/?title=Teaching+Internship+Programme+%2D+June+2023&pid=417
+        subjects: chemistry, computing, maths, physics, languages
+        name: Angela Rodda
+        email: arodda@swchs.net
+      - header: South Essex Training and Support Alliance
+        link: https://www.setsa.info/1567/teaching-internship-programme-2023
+        subjects: chemistry, computing, maths, physics, languages
+        name: David Struthers
+        email: d.struthers@setsa.info
+      - header: The Hertfordshire and Essex High School
+        link: https://www.hertsandessex.herts.sch.uk/teaching-internships/60636.html
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Ruthven
+        email: claire.ruthven@hertsandessex.herts.sch.uk
+  London:
+    providers:
+      - header: Debden Park High School (TKAT Teacher Training)
+        link: https://scitt.tkat.org/842/internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jo Fogg
+        email: jo.fogg@tkat.org
+      - header: GLF Teacher Training
+        link: https://www.glfscitt.org/259/teaching-internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Blackburn
+        email: k.blackburn@glfschools.org
+      - header: Harris Initial Teacher Education
+        link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jose Oliveira/Shona Findlay
+        email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
+      - header: LETTA (London East Teacher Training Alliance)
+        link: https://letta.org.uk/train/teachinginternships/
+        subjects: maths, physics
+        name: Ben Sperring
+        email: train@letta.org.uk
+      - header: New River Teaching Alliance
+        link: https://nrta.co.uk/train-to-teach/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Kate Dowling
+        email: kdowling@alexandrapark.school
+        areas: Haringey
+        applications: Open
+      - header: Paddington Academy
+        link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
+        subjects: chemistry, maths, physics, languages
+        name: Riam Muayad
+        email: Riam.Muayad@paddington-academy.org
+      - header: Reach Academy Feltham
+        link: https://www.reachtraining.org/teaching-internships
+        subjects: chemistry, maths, physics, languages
+        name: James Foreman
+        email: reachteachertraining@reachacademy.org.uk
+      - header: St John Southworth Catholic Academy Trust
+        link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Patrick Lanigan
+        email: laniganp@cvms.co.uk
+      - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
+        link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2023
+        subjects: computing, maths
+        name: Claire Lane
+        email: c.lane@waldegravesch.org
+      - header: Xavier Teach SouthEast
+        link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Cornforth
+        email: k.cornforth@xaviercet.org.uk
+  North East:
+    providers:
+      - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
+        link: https://www.centreforteaching.com/initial-teacher-training/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Anna Herdman
+        email: aherdman@bwcet.com
+      - header: Carmel Teacher Training Partnership
+        link: https://carmelteachertraining.com/teaching-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sarah McGee
+        email: smcgee@bhcet.org.uk
+      - header: North East SCITT
+        link: https://www.northeastscitt.co.uk/intern
+        subjects: chemistry, computing, maths, physics, languages
+        name: Susan Ingram
+        email: Susan.ingram@nelt.co.uk
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: George W. Robson
+        email: teachnorth@oie.outwood.com
+      - header: Stockton Teacher Training Partnership
+        link: https://stocktonscitt.uk/paid-teaching-internship/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Kirsten Webber
+        email: Kirsten.Webber@stockton.gov.uk
+  North West:
+    providers:
+      - header: Associated Merseyside Partnership SCITT
+        link: https://www.amp-scitt.lydiatelearningtrust.co.uk/teaching-internship/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Alison Brady
+        email: a.brady@ampscitt.co.uk
+      - header: Bright Futures SCITT
+        link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/our-programmes/paid-undergraduate-internship-scheme/
+        subjects: chemistry, computing, maths, physics
+        name: Hilary Langmead-Jones
+        email: admin@scitt.bright-futures.co.uk
+        areas: Trafford, Bury, Cheshire West, Chester, Manchester, Oldham, Salford, Stockport,
+          Tameside, Wigan
+        applications: Open - November 2023
+      - header: Chorlton High School
+        link: https://chorltonhigh.manchester.sch.uk/working-for-us/Chorlton-High-Teaching-School-Team/school-experience-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: Fazia Chowdhury
+        email: F.Chowdhury@chorltonhigh.manchester.sch.uk
+      - header: Co-op Academies Trust 
+        link: https://www.coopacademies.co.uk/teaching-internship/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Andy Gibson 
+        email: andy.gibson@coopacademies.co.uk
+      - header: Cumbria Education Trust
+        link: https://www.williamhoward.cumbria.sch.uk/teaching-internship-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katy Birks
+        email: kbirks@williamhoward.cumbria.sch.uk
+      - header: Great Schools Trust
+        link: https://www.greatschoolstrust.org/train-with-us/internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Diane Lloyd
+        email: d.lloyd@greatschoolstrust.com
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+      - header: Ormiston Academies Trust
+        link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jemma Sherwood
+        email: internships@ormistonacademies.co.uk
+      - header: Teach Manchester
+        link: https://teachmanchester.com/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Graeme Balfour
+        email: gbalfour@loreto.ac.uk
+      - header: Valley Learning Partnership
+        link: https://www.brighouse.calderdale.sch.uk/join-us/train-with-us/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Janet Brierley
+        email: j.brierley@brighouse.calderdale.sch.uk
+      - header: Wigan and West Lancashire Catholic School Direct 
+        link: https://www.catholicsd.org.uk/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sarah Holland
+        email: hollands267@saintpetershigh.wigan.sch.uk
+  South East:
+    providers:
+      - header: Debden Park High School (TKAT Teacher Training)
+        link: https://scitt.tkat.org/842/internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jo Fogg
+        email: jo.fogg@tkat.org
+      - header: GLF Teacher Training
+        link: https://www.glfscitt.org/259/teaching-internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Blackburn
+        email: k.blackburn@glfschools.org
+      - header: George Abbot School in partnership with George Abbot SCITT
+        link: https://georgeabbottraining.co.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Joanna Jones
+        email: jjones@georgeabbot.surrey.sch.uk
+      - header: Northfleet Technology College
+        link: https://ntc.kent.sch.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Michael Jones
+        email: jonesm@ntc.kent.sch.uk
+      - header: Ringwood School
+        link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Clare Adams
+        email: cadams@ringwood.hants.sch.uk
+      - header: Teach Maidenhead
+        link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
+        subjects: chemistry, computing, maths, physics, languages
+        name: Maria Avellano
+        email: maria.avellano@furzeplatt.net
+      - header: The Cherwell School
+        link: https://www.cherwell.oxon.sch.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Emma Rapson
+        email: erapson@cherwellschool.org
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+      - header: Xavier Teach SouthEast
+        link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Cornforth
+        email: k.cornforth@xaviercet.org.uk
+      - header: i2i Teaching Partnership
+        link: https://www.i2ipartnership.co.uk/1243/undergraduate-teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: Liz Wylie
+        email: lwylie@i2ipartnership.co.uk
+  South West:
+    providers:
+      - header: Excalibur
+        link: https://www.stjohns.excalibur.org.uk/about-us/recruitment/train-to-teach/teaching-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Emma Hawes
+        email: ehawes@stjohns.excalibur.org.uk
+      - header: GLF Teacher Training
+        link: https://www.glfscitt.org/259/teaching-internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Blackburn
+        email: k.blackburn@glfschools.org
+      - header: Odyssey Teaching School Hub
+        link: https://www.patesgs.org/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Tim Connole
+        email: tconnole@patesgs.org
+      - header: Ringwood School
+        link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Clare Adams
+        email: cadams@ringwood.hants.sch.uk
+      - header: South West Institute for Teaching (SWIFT)
+        link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
+        subjects: chemistry, computing, maths, physics, languages
+        name: Abby Spearing
+        email: Abby.spearing@sw-ift.org.uk
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+      - header: West Country Internships
+        link: https://exetermathematicsschool.ac.uk/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Kerry Burnham
+        email: kburnham@exeterms.ac.uk
+  West Midlands:
+    providers:
+      - header: Arthur Terry SCITT
+        link: https://arthurterryteachingschool.atlp.org.uk/teaching-internship-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Robert Bloomfield
+        email: rbloomfield@arthurterry.bham.sch.uk
+      - header: Barr Beacon SCITT
+        link: https://bbscitt.co.uk/teaching-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Michael Eszrenyi
+        email: meszrenyi@matrixacademytrust.co.uk
+        areas: Walsall, Birmingham, Staffordshire, Wolverhampton
+        applications: Open
+      - header: Bishop Challoner Training School
+        link: https://www.bctsa.org/605/teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: Angela Hodgkin
+        email: trainingschool@bishopchalloner.bham.sch.uk
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Amed
+        email: Claire.amed@creativeeducationtrust.org.uk
+      - header: Ormiston Academies Trust
+        link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jemma Sherwood
+        email: internships@ormistonacademies.co.uk
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: George W. Robson
+        email: teachnorth@oie.outwood.com
+      - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
+          School Hub
+        link: https://www.princehenrys.worcs.sch.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Andy Duffy
+        email: ad@princehenrys.worcs.sch.uk
+      - header: St Joseph's College
+        link: https://www.sjcscitt.co.uk/page/?title=DfE+Teaching+Internships&pid=26
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sam Chater
+        email: schater@stjosephsmail.com
+      - header: St Peter's Catholic School Solihull
+        link: https://www.st-peters.solihull.sch.uk/teaching-school/
+        subjects: chemistry, computing, maths, physics
+        name: Anthony Jones
+        email: jonesa@st-peters.solihull.sch.uk
+      - header: The Coventry SCITT
+        link: https://www.coventryscitt.org.uk/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Katie Williams
+        email: scittadmin@sidneystringeracademy.org.uk
+      - header: The Polesworth School
+        link: https://www.thecatinstitute.org/page/?title=Internships&pid=110
+        subjects: chemistry, computing, maths, physics, languages
+        name: Michelle Borders
+        email: mborders@catschools.uk
+      - header: Windsor Academy Trust
+        link: https://www.windsoracademytrust.org.uk/professional-learning/teaching-internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Nathalie Gotting
+        email: ngotting@kingswinford.windsoracademytrust.org.uk
+  Yorkshire and the Humber:
+    providers:
+      - header: Learners First Schools Partnership
+        link: https://www.learnersfirst.net/internships/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Garbutt/Georgia Osborne
+        email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
+      - header: Northern Education Trust
+        link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Meriem Lairini
+        email: m.lairini@northerneducationtrust.org
+      - header: Northern Star Academies Trust
+        link: https://www.northernlightsscitt.com/our-programmes/teaching-internships1/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Helen Smith
+        email: training@northernlightsscitt.com
+      - header: Outwood Institute of Education
+        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        subjects: chemistry, computing, maths, physics, languages
+        name: George W. Robson
+        email: teachnorth@oie.outwood.com
+      - header: Scarborough Teaching Alliance - Coast and Vale Learning Trust
+        link: https://www.scarboroughteachingalliance.co.uk/events/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Ashleigh Southall
+        email: a.southall@coastandvale.academy
+      - header: Sheffield SCITT
+        link: https://www.sheffieldscitt.org.uk/internship
+        subjects: chemistry, computing, maths, physics, languages
+        name: Stacey Wooliscroft
+        email: hallamtsa@notredame-high.co.uk
+      - header: St Mary's College
+        link: https://www.scrcat.org/vacancies
+        subjects: chemistry, computing, maths, physics, languages
+        name: Laura Fillingham
+        email: schooldirect@smchull.org
+      - header: Wolds Learning Partnership Trust
+        link: https://www.woldgate.net/jobs.html
+        subjects: chemistry, maths, physics, languages
+        name: Kirsten Russell
+        email: krussell@WLP.education
+      - header: Yorkshire Wolds Teacher Training
+        link: https://ywtt.org.uk/ywtt-paid-internship-programme/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sarah Barley
+        email: sarah.barley@theeducationalliance.org.uk
 
 keywords:
   - teaching internship

--- a/app/views/content/teaching-internship-providers.md
+++ b/app/views/content/teaching-internship-providers.md
@@ -17,6 +17,15 @@ fullwidth: true
 content:
   - content/teaching-internship-providers/listing
 provider_groups:
+  East:
+    providers:
+      - header: Thinking Schools Academy Trust
+        link: https://www.tsatrust.org.uk/
+        subjects: chemistry, computing, maths, physics, languages
+        name: Sophie Venables
+        email: s.venables@tsatrust.org.uk
+        areas: Essex
+        applications: Open
   East Midlands:
     providers:
       - header: Bluecoat SCITT Alliance
@@ -24,51 +33,71 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Julie Hefferman
         email: itt@bluecoat.uk.com
+        areas: Derby, Derbyshire, Nottingham, Nottinghamshire
+        applications: Open
       - header: Creative Education Trust
         link: https://www.creativeeducationtrust.org.uk/internship
         subjects: chemistry, computing, maths, physics, languages
         name: Claire Amed
         email: Claire.amed@creativeeducationtrust.org.uk
+        areas: North Northamptonshire, Nottingham, West Northmptonshire
+        applications: Open
       - header: George Spencer Academy
         link: http://www.george-spencer.com/
         subjects: chemistry, computing, maths, physics, languages
         name: Tammy Elward
         email: tammyelward@satrust.com
-      - header: Learners First Schools Partnership
+        areas: Derbyshire, Nottingham, Nottinghamshire
+        applications: Open
+      - header: Learners First Schools Partnership (Wickersley School & Sports College)
         link: https://www.learnersfirst.net/internships/
         subjects: chemistry, computing, maths, physics, languages
-        name: Claire Garbutt/Georgia Osborne
-        email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
+        name: Stacey Williams
+        email: Teachertraining@learnersfirst.org
+        areas: Derbyshire
+        applications: Open
       - header: Leicestershire Secondary SCITT
         link: https://www.leicestershiresecondaryscitt.org/events-information/teaching-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Laura Wharton
         email: lwharton@rushey-tmet.uk
+        areas: Leicestershire
+        applications: Open
       - header: Lionheart Teach
         link: https://www.lionheartteach.org.uk/opportunities/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Emma Lowe
         email: info@lionheartteach.org.uk
+        areas: Leicester, Leicestershire
+        applications: Open
       - header: Nottingham Catholic ITT Partnership
         link: https://www.ololcatholicmat.co.uk/itt/paid-summer-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Vanessa Scott
         email: v.scott@becketonline.co.uk
+        areas: Bassetlaw, Derby, Lincolnshire, Nottingham, Nottinghamshire
+        applications: Open
       - header: Nottinghamshire Torch SCITT
         link: https://www.teachnottinghamshire.co.uk/internships.php
         subjects: chemistry, computing, maths, physics, languages
         name: Rebecca Morgan-Jones
-        email: contact@teachnottinghamshire.co.uk 
+        email: contact@teachnottinghamshire.co.uk
+        areas: Nottingham, Nottinghamshire
+        applications: Open
       - header: Outwood Institute of Education
-        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        link: https://teachnorth.com/internships
         subjects: chemistry, computing, maths, physics, languages
-        name: George W. Robson
-        email: teachnorth@oie.outwood.com
+        name: Emma Sikora
+        email: e.sikora@outwood.com
+        areas: Lincolnshire, Nottinghamshire
+        applications: Open
       - header: Tuxford Academy
         link: https://www.diverseassociation.org.uk/get-into-teaching/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Administrator
         email: interns@diverse-ac.org.uk
+        areas: Bassetlaw, Lincolnshire, Nottingham, Nottinghamshire
+        applications: Open
   East of England:
     providers:
       - header: Advanced Learning Partnership
@@ -76,66 +105,85 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Nicola Nicolaou
         email: nicolaoun@damealiceowens.herts.sch.uk
+        areas: Barnet, Hertfordshire
+        applications: Open
       - header: Bedfordshire Schools Trust
         link: https://www.bestteachingschool.org.uk/
         subjects: chemistry, maths, physics, languages
         name: Susanne Combe
         email: scombe@bestacademies.org.uk
+        areas: Bedford, Central Bendfordshire
+        applications: Open
       - header: Benfleet Team Supporting All
         link: http://www.btsa.uk/internship-scheme/
         subjects: chemistry, computing, maths, physics, languages
         name: Maxine Howard
         email: mhoward@theappletonschool.org
+        areas: Essex, Southend oin Sea
+        applications: Open
       - header: Creative Education Trust
         link: https://www.creativeeducationtrust.org.uk/internship
         subjects: chemistry, computing, maths, physics, languages
         name: Claire Amed
         email: Claire.amed@creativeeducationtrust.org.uk
+        areas: Norfolk
+        applications: Open
       - header: Debden Park High School (TKAT Teacher Training)
         link: https://scitt.tkat.org/842/internships
         subjects: chemistry, computing, maths, physics, languages
         name: Jo Fogg
         email: jo.fogg@tkat.org
+        areas: Essex
+        applications: Open
       - header: Farlingaye High School
         link: https://www.eastscitt.co.uk/Undergraduate-Internships/
-        subjects: maths,physics
-        name: Peter Smith
-        email: psmith@farlingaye.suffolk.sch.uk
+        subjects: maths, physics
+        name: Ellie Colton
+        email: ecolton@farlingaye.suffolk.sch.uk
+        areas: Suffolk
+        applications: Open
       - header: Harris Initial Teacher Education
         link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
         subjects: chemistry, computing, maths, physics, languages
-        name: Jose Oliveira/Shona Findlay
-        email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
-      - header: Northgate High School,Ipswich
+        name: Jose Oliveira/Jacqui Aldrich
+        email: jose.oliveira@harrisfederation.org.uk / j.aldrich@niot.org.uk
+        areas: Thurrock
+        applications: Open
+      - header: Northgate High School, Ipswich
         link: https://www.northgate.suffolk.sch.uk/staff/training-to-teach/
         subjects: chemistry, computing, maths, physics, languages
         name: Miss Mary Hallett
         email: mch@northgate.suffolk.sch.uk
+        areas: Suffolk
+        applications: Open December
       - header: Ormiston Academies Trust
         link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
         subjects: chemistry, computing, maths, physics, languages
         name: Jemma Sherwood
         email: internships@ormistonacademies.co.uk
+        areas: Norfolk, Suffolk
+        applications: Open
       - header: Redborne Teaching Partnership
         link: https://www.redbornecommunitycollege.com/page/?title=Paid+Internship+Programme&pid=179
-        subjects: chemistry, computing, maths, physics, languages
+        subjects: chemistry, maths, physics, languages
         name: Vicki Walsh
         email: vicki.walsh@redborne.com
-      - header: Saffron Walden County High School
-        link: https://www.swchs.net/page/?title=Teaching+Internship+Programme+%2D+June+2023&pid=417
-        subjects: chemistry, computing, maths, physics, languages
-        name: Angela Rodda
-        email: arodda@swchs.net
+        areas: Bedford, Central Bedfordshire
+        applications: Open
       - header: South Essex Training and Support Alliance
         link: https://www.setsa.info/1567/teaching-internship-programme-2023
         subjects: chemistry, computing, maths, physics, languages
         name: David Struthers
         email: d.struthers@setsa.info
+        areas: Essex, Southend-on-Sea
+        applications: Open
       - header: The Hertfordshire and Essex High School
         link: https://www.hertsandessex.herts.sch.uk/teaching-internships/60636.html
         subjects: chemistry, computing, maths, physics, languages
         name: Claire Ruthven
         email: claire.ruthven@hertsandessex.herts.sch.uk
+        areas: Hertfordshire
+        applications: Open
   London:
     providers:
       - header: Debden Park High School (TKAT Teacher Training)
@@ -143,53 +191,73 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Jo Fogg
         email: jo.fogg@tkat.org
+        areas: Bromley
+        applications: Open
       - header: GLF Teacher Training
-        link: https://www.glfscitt.org/259/teaching-internships
+        link: https://www.inspiringfutureteachers.org/
         subjects: chemistry, computing, maths, physics, languages
         name: Katie Blackburn
         email: k.blackburn@glfschools.org
+        areas: Croydon
+        applications: Open 16 October
       - header: Harris Initial Teacher Education
         link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
         subjects: chemistry, computing, maths, physics, languages
-        name: Jose Oliveira/Shona Findlay
-        email: jose.oliveira@harrisfederation.org.uk / shona.findlay@harrisfederation.org.uk
+        name: Jose Oliveira/Jacqui Aldrich
+        email: jose.oliveira@harrisfederation.org.uk / j.aldrich@niot.org.uk
+        areas: Bexley, Brent, Bromley, Croydon, Greenwich, Haringey, Havering, Lambeth,
+        Morton, Newham, Southwark, Sutton, Tower Hamlets, Wandsworth, Westminster
+        applications: Open
       - header: LETTA (London East Teacher Training Alliance)
         link: https://letta.org.uk/train/teachinginternships/
         subjects: maths, physics
         name: Ben Sperring
         email: train@letta.org.uk
+        areas: Tower Hamlets
+        applications: Open
       - header: New River Teaching Alliance
         link: https://nrta.co.uk/train-to-teach/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Kate Dowling
         email: kdowling@alexandrapark.school
-        areas: Haringey
-        applications: Open
+        areas: Barnet, Enfield, Haringey
+        applications: Open December
       - header: Paddington Academy
         link: https://www.paddington-academy.org/recruitment/summer-teaching-internship
         subjects: chemistry, maths, physics, languages
         name: Riam Muayad
         email: Riam.Muayad@paddington-academy.org
+        areas: Fulham, Hammershith and Fulham, Lambeth, Westminster
+        applications: Open
       - header: Reach Academy Feltham
         link: https://www.reachtraining.org/teaching-internships
         subjects: chemistry, maths, physics, languages
         name: James Foreman
         email: reachteachertraining@reachacademy.org.uk
+        areas: Hounsllow
+        applications: Open
       - header: St John Southworth Catholic Academy Trust
-        link: https://www.sjscat.co.uk/Maths-Physics-and-Computing-Undergraduate-Summer-I/
+        link: "SJSCAT - https://www.sjscat.co.uk/Summer-Teaching-Internship-2024/\r\nCVMS - https://www.cvms.co.uk/Summer-Teaching-Internship-2024/"
         subjects: chemistry, computing, maths, physics, languages
         name: Patrick Lanigan
         email: laniganp@cvms.co.uk
+        areas: Brent, Ealing, Hammershith and Fulham, Harrow, Kensington and Chelsea,
+        Wandsworth, West Berkshire, Westminster
+        applications: Open
       - header: Waldegrave Training Alliance and Orleans Park Teaching Alliance
-        link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2023
+        link: https://www.waldegrave.richmond.sch.uk/923/paid-teaching-internships-summer-2024
         subjects: computing, maths
         name: Claire Lane
         email: c.lane@waldegravesch.org
+        areas: Richmond upon Thames
+        applications: Open
       - header: Xavier Teach SouthEast
         link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
         subjects: chemistry, computing, maths, physics, languages
-        name: Katie Cornforth
-        email: k.cornforth@xaviercet.org.uk
+        name: Emily Bertolone
+        email: e.bertolone@xaviercet.org.uk
+        areas: Kensington and Chelsea, Southwark
+        applications: Open
   North East:
     providers:
       - header: Bishop Wilkinson Catholic Education Trust - Centre for Teaching
@@ -197,31 +265,44 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Anna Herdman
         email: aherdman@bwcet.com
+        areas: County Durham, Durham, Gateshead, Northumberland, Sunderland
+        applications: Open
       - header: Carmel Teacher Training Partnership
         link: https://carmelteachertraining.com/teaching-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah McGee
         email: smcgee@bhcet.org.uk
+        areas: Darlington, Durham, Gateshead, Harlepool, Middlesbrough, Newcastle upon
+        Tyne, North Tyneside, Northumberland, South Tyneside, Stockton on Tees, Sunderland
+        applications: Open
       - header: North East SCITT
         link: https://www.northeastscitt.co.uk/intern
         subjects: chemistry, computing, maths, physics, languages
         name: Susan Ingram
         email: Susan.ingram@nelt.co.uk
+        areas: County Durham, Durham, Northumberland, Sunderland
+        applications: Open
       - header: Northern Education Trust
         link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
         subjects: chemistry, computing, maths, physics, languages
         name: Meriem Lairini
         email: m.lairini@northerneducationtrust.org
+        areas: Gateshead, Hartlepool, Newcastle, Northumbersland, Stockton-on-Tees, Sunderland
+        applications: Open
       - header: Outwood Institute of Education
-        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        link: https://teachnorth.com/internships
         subjects: chemistry, computing, maths, physics, languages
-        name: George W. Robson
-        email: teachnorth@oie.outwood.com
+        name: Emma Sikora
+        email: e.sikora@outwood.com
+        areas: Middlesbrough, Redcar and Cleveland, Stockton on Tees
+        applications: Open
       - header: Stockton Teacher Training Partnership
         link: https://stocktonscitt.uk/paid-teaching-internship/
         subjects: chemistry, computing, maths, physics, languages
         name: Kirsten Webber
         email: Kirsten.Webber@stockton.gov.uk
+        areas: Stockton-on-Tees
+        applications: Open
   North West:
     providers:
       - header: Associated Merseyside Partnership SCITT
@@ -229,148 +310,225 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Alison Brady
         email: a.brady@ampscitt.co.uk
+        areas: Halton, Liverpool, Sefton, Wirral
+        applications: Open
       - header: Bright Futures SCITT
         link: https://www.bright-futures.co.uk/professional-development-institute/bright-futures-scitt/our-programmes/paid-undergraduate-internship-scheme/
         subjects: chemistry, computing, maths, physics
         name: Hilary Langmead-Jones
         email: admin@scitt.bright-futures.co.uk
-        areas: Trafford, Bury, Cheshire West, Chester, Manchester, Oldham, Salford, Stockport,
-          Tameside, Wigan
-        applications: Open - November 2023
+        areas: Bury, Cheshire West and Chester, Manchester, Oldham, Salford, Stockport,
+        Tameside, Trafford, Wigan
+        applications: Open
       - header: Chorlton High School
         link: https://chorltonhigh.manchester.sch.uk/working-for-us/Chorlton-High-Teaching-School-Team/school-experience-programme
         subjects: chemistry, computing, maths, physics, languages
         name: Fazia Chowdhury
         email: F.Chowdhury@chorltonhigh.manchester.sch.uk
-      - header: Co-op Academies Trust 
-        link: https://www.coopacademies.co.uk/teaching-internship/
+        areas: Manchester
+        applications: Open
+      - header: Co-op Academies Trust
+        link: https://www.coopacademies.co.uk/page/?title=Paid+Teaching+Internship&pid=42
         subjects: chemistry, computing, maths, physics, languages
-        name: Andy Gibson 
+        name: Andy Gibson
         email: andy.gibson@coopacademies.co.uk
+        areas: Manchester, Oldham, Salford
+        applications: Open
       - header: Cumbria Education Trust
         link: https://www.williamhoward.cumbria.sch.uk/teaching-internship-programme/
         subjects: chemistry, computing, maths, physics, languages
         name: Katy Birks
         email: kbirks@williamhoward.cumbria.sch.uk
+        areas: Cumbria
+        applications: Open
       - header: Great Schools Trust
         link: https://www.greatschoolstrust.org/train-with-us/internships
         subjects: chemistry, computing, maths, physics, languages
         name: Diane Lloyd
         email: d.lloyd@greatschoolstrust.com
+        areas: Bolton, Liverpool, Warrington
+        applications: Open
       - header: Northern Education Trust
         link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
         subjects: chemistry, computing, maths, physics, languages
         name: Meriem Lairini
         email: m.lairini@northerneducationtrust.org
+        areas: Bolton
+        applications: Open
       - header: Ormiston Academies Trust
         link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
         subjects: chemistry, computing, maths, physics, languages
         name: Jemma Sherwood
         email: internships@ormistonacademies.co.uk
+        areas: Halton
+        applications: Open
+      - header: Outwood Institute of Education
+        link: https://teachnorth.com/internships
+        subjects: chemistry, computing, maths, physics, languages
+        name: Emma Sikora
+        email: e.sikora@outwood.com
+        areas: St Helens, Wigan
+        applications: Open
       - header: Teach Manchester
         link: https://teachmanchester.com/
         subjects: chemistry, computing, maths, physics, languages
         name: Graeme Balfour
         email: gbalfour@loreto.ac.uk
+        areas: Bolton, Bury, Manchester, Oldham, Salford, Stockport, Tameside, Trafford,
+        Wigan
+        applications: Open late November
       - header: Valley Learning Partnership
-        link: https://www.brighouse.calderdale.sch.uk/join-us/train-with-us/
+        link: "https://www.brighouse.calderdale.sch.uk/join-us/train-with-us/\r\nwww.brighouse.calderdale.sch.uk/join-us/work-for-us"
         subjects: chemistry, computing, maths, physics, languages
         name: Janet Brierley
         email: j.brierley@brighouse.calderdale.sch.uk
+        areas: Calderdale, Kirklees
+        applications: Open
       - header: Wigan and West Lancashire Catholic School Direct 
         link: https://www.catholicsd.org.uk/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah Holland
         email: hollands267@saintpetershigh.wigan.sch.uk
+        areas: Chorley, Halton, Lancashire, Leigh, Ormskirk, Skelmersdale, Warrington,
+        Wigan
+        applications: Open
   South East:
     providers:
+      - header: Creative Education Trust
+        link: https://www.creativeeducationtrust.org.uk/internship
+        subjects: chemistry, computing, maths, physics, languages
+        name: Claire Amed
+        email: Claire.amed@creativeeducationtrust.org.uk
+        areas: Milton Keynes
+        applications: Open
       - header: Debden Park High School (TKAT Teacher Training)
         link: https://scitt.tkat.org/842/internships
         subjects: chemistry, computing, maths, physics, languages
         name: Jo Fogg
         email: jo.fogg@tkat.org
+        areas: East Sussex, Hampshire, Kent, West Sussex
+        applications: Open
       - header: GLF Teacher Training
-        link: https://www.glfscitt.org/259/teaching-internships
+        link: https://www.inspiringfutureteachers.org/
         subjects: chemistry, computing, maths, physics, languages
         name: Katie Blackburn
         email: k.blackburn@glfschools.org
+        areas: Surrey, West Sussex
+        applications: Open 16 October
       - header: George Abbot School in partnership with George Abbot SCITT
         link: https://georgeabbottraining.co.uk/
         subjects: chemistry, computing, maths, physics, languages
         name: Joanna Jones
         email: jjones@georgeabbot.surrey.sch.uk
+        areas: Surrey
+        applications: Open
+      - header: Harris Initial Teacher Education
+        link: https://www.harristraintoteach.com/187/news/post/108/paid-internship-programme-2023
+        subjects: chemistry, computing, maths, physics, languages
+        name: Jose Oliveira/Jacqui Aldrich
+        email: jose.oliveira@harrisfederation.org.uk / j.aldrich@niot.org.uk
+        areas: West Berkshire
+        applications: Open
       - header: Northfleet Technology College
         link: https://ntc.kent.sch.uk/
         subjects: chemistry, computing, maths, physics, languages
-        name: Michael Jones
-        email: jonesm@ntc.kent.sch.uk
+        name: Miriam Hayes
+        email: HayesM@ntc.kent.sch.uk
+        areas: Bromley, Greenwich, Kent, Lewisham, Medway
+        applications: Open
       - header: Ringwood School
         link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Clare Adams
         email: cadams@ringwood.hants.sch.uk
+        areas: Hampshire
+        applications: Open
       - header: Teach Maidenhead
         link: https://www.furzeplatt.com/page/?title=INTERNSHIPS+AVAILABLE+for+Physics%2C+Maths%2C+Chemistry%2C+Computing+and+Languages+%2D+APPLICATIONS+NOW+OPEN&pid=536
         subjects: chemistry, computing, maths, physics, languages
         name: Maria Avellano
         email: maria.avellano@furzeplatt.net
+        areas: Windsor and Maidenhead
+        applications: Open
       - header: The Cherwell School
         link: https://www.cherwell.oxon.sch.uk/
         subjects: chemistry, computing, maths, physics, languages
         name: Emma Rapson
         email: erapson@cherwellschool.org
+        areas: Oxfordshire
+        applications: Open
       - header: Thinking Schools Academy Trust
         link: https://www.tsatrust.org.uk/
         subjects: chemistry, computing, maths, physics, languages
         name: Sophie Venables
         email: s.venables@tsatrust.org.uk
+        areas: Kent, Medway, Portsmouth
+        applications: Open
       - header: Xavier Teach SouthEast
         link: https://www.teachsoutheast.co.uk/page/?title=Undergraduate+teaching+internship&pid=17
         subjects: chemistry, computing, maths, physics, languages
-        name: Katie Cornforth
-        email: k.cornforth@xaviercet.org.uk
+        name: Emily Bertolone
+        email: e.bertolone@xaviercet.org.uk
+        areas: Slough, Surrey
+        applications: Open
       - header: i2i Teaching Partnership
         link: https://www.i2ipartnership.co.uk/1243/undergraduate-teaching-internship-programme
         subjects: chemistry, computing, maths, physics, languages
         name: Liz Wylie
         email: lwylie@i2ipartnership.co.uk
+        areas: Hampshire, Surrey
+        applications: Open
   South West:
     providers:
-      - header: Excalibur
+      - header: Excalibur Academies Trust
         link: https://www.stjohns.excalibur.org.uk/about-us/recruitment/train-to-teach/teaching-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Emma Hawes
         email: ehawes@stjohns.excalibur.org.uk
+        areas: Bristol, West Berkshire, Wiltshire
+        applications: Open
       - header: GLF Teacher Training
-        link: https://www.glfscitt.org/259/teaching-internships
+        link: https://www.inspiringfutureteachers.org/
         subjects: chemistry, computing, maths, physics, languages
         name: Katie Blackburn
         email: k.blackburn@glfschools.org
+        areas: Dorset
+        applications: Open 16 October
       - header: Odyssey Teaching School Hub
         link: https://www.patesgs.org/
         subjects: chemistry, computing, maths, physics, languages
         name: Tim Connole
         email: tconnole@patesgs.org
+        areas: Gloucestershire, South Gloucestershire, Wiltshire
+        applications: Open
       - header: Ringwood School
         link: https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Clare Adams
         email: cadams@ringwood.hants.sch.uk
+        areas: Bournemouth Christchurch and Poole, Dorset
+        applications: Open
       - header: South West Institute for Teaching (SWIFT)
-        link: https://teachertraining.sw-ift.org.uk/teaching-internships.html
+        link: www.swiftteachertraining.org.uk/internships
         subjects: chemistry, computing, maths, physics, languages
         name: Abby Spearing
         email: Abby.spearing@sw-ift.org.uk
+        areas: Devon, Plymouth
+        applications: Open
       - header: Thinking Schools Academy Trust
         link: https://www.tsatrust.org.uk/
         subjects: chemistry, computing, maths, physics, languages
         name: Sophie Venables
         email: s.venables@tsatrust.org.uk
+        areas: Devon, Plymouth, Torbay
+        applications: Open
       - header: West Country Internships
         link: https://exetermathematicsschool.ac.uk/internships/
         subjects: chemistry, computing, maths, physics, languages
-        name: Kerry Burnham
-        email: kburnham@exeterms.ac.uk
+        name: Sophie Brown
+        email: sophiebrown@exeterms.ac.uk
+        areas: Devon, Plymouth, Somerset, Torbay
+        applications: Open
   West Midlands:
     providers:
       - header: Arthur Terry SCITT
@@ -378,111 +536,143 @@ provider_groups:
         subjects: chemistry, computing, maths, physics, languages
         name: Robert Bloomfield
         email: rbloomfield@arthurterry.bham.sch.uk
+        areas: Birmingham, Staffordshire, Warwickshire
+        applications: Open
       - header: Barr Beacon SCITT
         link: https://bbscitt.co.uk/teaching-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Michael Eszrenyi
         email: meszrenyi@matrixacademytrust.co.uk
-        areas: Walsall, Birmingham, Staffordshire, Wolverhampton
+        areas: Birmingham, Staffordshire, Walsall, Wolverhampton
         applications: Open
       - header: Bishop Challoner Training School
         link: https://www.bctsa.org/605/teaching-internship-programme
         subjects: chemistry, computing, maths, physics, languages
-        name: Angela Hodgkin
+        name: Angela Hodgin
         email: trainingschool@bishopchalloner.bham.sch.uk
+        areas: Birmingham, Solihull
+        applications: Open
       - header: Creative Education Trust
         link: https://www.creativeeducationtrust.org.uk/internship
         subjects: chemistry, computing, maths, physics, languages
         name: Claire Amed
         email: Claire.amed@creativeeducationtrust.org.uk
+        areas: Staffordshire, Warwickshire
+        applications: Open
       - header: Ormiston Academies Trust
         link: https://www.ormistonacademiestrust.co.uk/careers-and-training/teaching-internships-programme/
         subjects: chemistry, computing, maths, physics, languages
         name: Jemma Sherwood
         email: internships@ormistonacademies.co.uk
-      - header: Outwood Institute of Education
-        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
-        subjects: chemistry, computing, maths, physics, languages
-        name: George W. Robson
-        email: teachnorth@oie.outwood.com
-      - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching
-          School Hub
+        areas: Sandwell, Stoke on Trent
+        applications: Open
+      - header: Prince Henry’s and South Worcestershire SCITT / Prince Henry’s Teaching School Hub
         link: https://www.princehenrys.worcs.sch.uk/
         subjects: chemistry, computing, maths, physics, languages
         name: Andy Duffy
         email: ad@princehenrys.worcs.sch.uk
+        areas: Herefordshire, Worcestershire
+        applications: Open
       - header: St Joseph's College
         link: https://www.sjcscitt.co.uk/page/?title=DfE+Teaching+Internships&pid=26
         subjects: chemistry, computing, maths, physics, languages
         name: Sam Chater
         email: schater@stjosephsmail.com
+        areas: Cheshire East, Cheshire West and Chester, Staffordshire, Stoke-on-Trent
+        applications: Open
       - header: St Peter's Catholic School Solihull
         link: https://www.st-peters.solihull.sch.uk/teaching-school/
         subjects: chemistry, computing, maths, physics
         name: Anthony Jones
         email: jonesa@st-peters.solihull.sch.uk
+        areas: Birmingham, Solihull
+        applications: Open
       - header: The Coventry SCITT
         link: https://www.coventryscitt.org.uk/internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Katie Williams
         email: scittadmin@sidneystringeracademy.org.uk
+        areas: Coventry, Warwickshire
+        applications: Open
       - header: The Polesworth School
         link: https://www.thecatinstitute.org/page/?title=Internships&pid=110
         subjects: chemistry, computing, maths, physics, languages
         name: Michelle Borders
         email: mborders@catschools.uk
+        areas: Sandwell, Staffordshire, Warwickshire
+        applications: Open
       - header: Windsor Academy Trust
         link: https://www.windsoracademytrust.org.uk/professional-learning/teaching-internships/
         subjects: chemistry, computing, maths, physics, languages
         name: Nathalie Gotting
         email: ngotting@kingswinford.windsoracademytrust.org.uk
+        areas: Dudley, Staffordshire
+        applications: Open
   Yorkshire and the Humber:
     providers:
-      - header: Learners First Schools Partnership
+      - header: Learners First Schools Partnership (Wickersley School & Sports College)
         link: https://www.learnersfirst.net/internships/
         subjects: chemistry, computing, maths, physics, languages
-        name: Claire Garbutt/Georgia Osborne
-        email: cgarbutt@learnersfirst.org / gosborne@learnersfirst.org
+        name: Stacey Williams
+        email: Teachertraining@learnersfirst.org
+        areas: Barnsley, Doncaster, Rotherham, Sheffield
+        applications: Open
       - header: Northern Education Trust
         link: https://www.northerneducationtrust.org/2023/01/19/teaching-internships-programme-summer-2023/?highlight=internships
         subjects: chemistry, computing, maths, physics, languages
         name: Meriem Lairini
         email: m.lairini@northerneducationtrust.org
+        areas: Barnsley
+        applications: Open
       - header: Northern Star Academies Trust
         link: https://www.northernlightsscitt.com/our-programmes/teaching-internships1/
         subjects: chemistry, computing, maths, physics, languages
-        name: Helen Smith
-        email: training@northernlightsscitt.com
+        name: "Helen Smith\r\nGinette Hawkins"
+        email: "training@northernlightsscitt.com\r\ninfo@nsat.org.uk"
+        areas: Bradford, Harrogate, North Yorkshire
+        applications: Open
       - header: Outwood Institute of Education
-        link: https://oie.outwood.com/latest-news/2023/2/8/outwood-institute-of-education-opens-applications-for-teaching-internship-programme
+        link: https://teachnorth.com/internships
         subjects: chemistry, computing, maths, physics, languages
-        name: George W. Robson
-        email: teachnorth@oie.outwood.com
+        name: Emma Sikora
+        email: e.sikora@outwood.com
+        areas: Barnsley, Doncaster, North Lincolnshire, North Yorkshire, Sheffield, Wakefield
+        applications: Open
       - header: Scarborough Teaching Alliance - Coast and Vale Learning Trust
         link: https://www.scarboroughteachingalliance.co.uk/events/
         subjects: chemistry, computing, maths, physics, languages
         name: Ashleigh Southall
         email: a.southall@coastandvale.academy
+        areas: North Yorkshire, York
+        applications: Open
       - header: Sheffield SCITT
         link: https://www.sheffieldscitt.org.uk/internship
         subjects: chemistry, computing, maths, physics, languages
         name: Stacey Wooliscroft
         email: hallamtsa@notredame-high.co.uk
+        areas: Barnsley, Doncaster, Rotherham, Sheffield
+        applications: Open
       - header: St Mary's College
         link: https://www.scrcat.org/vacancies
         subjects: chemistry, computing, maths, physics, languages
-        name: Laura Fillingham
-        email: schooldirect@smchull.org
+        name: Nikki Hawxwell
+        email: nhawxwell@smchull.org
+        areas: Hull
+        applications: Open
       - header: Wolds Learning Partnership Trust
-        link: https://www.woldgate.net/jobs.html
+        link: https://wlp.education/internship-progamme/
         subjects: chemistry, maths, physics, languages
         name: Kirsten Russell
         email: krussell@WLP.education
+        areas: East Riding of Yorkshire, North Yorkshire
+        applications: Open
       - header: Yorkshire Wolds Teacher Training
         link: https://ywtt.org.uk/ywtt-paid-internship-programme/
         subjects: chemistry, computing, maths, physics, languages
         name: Sarah Barley
         email: sarah.barley@theeducationalliance.org.uk
+        areas: East Riding of Yorkshire
+        applications: Open
 
 keywords:
   - teaching internship

--- a/app/views/content/teaching-internship-providers/_listing.html.erb
+++ b/app/views/content/teaching-internship-providers/_listing.html.erb
@@ -64,3 +64,9 @@
     large: false
   ) %>
 </section>
+
+<h2>How to apply</h2>
+<p>You can apply for an internship directly to one of the schools listed below.</p>
+<section class="providers-list">
+  <%= render GroupedCards::ListingComponent.new @front_matter["provider_groups"] %>
+</section>

--- a/lib/internship_provider.rb
+++ b/lib/internship_provider.rb
@@ -11,6 +11,8 @@ class InternshipProvider
       @contact_name = d["contact_name"]
       @contact_email = d["contact_email"]
       @subjects = d["subjects"]
+      @areas = d["local_areas"]
+      @applications = d["applications_open"]
       @full = ActiveModel::Type::Boolean.new.cast(d["full"])
     end
   end
@@ -26,6 +28,8 @@ class InternshipProvider
       else
         h["name"] = @contact_name.strip
         h["email"] = @contact_email.strip
+        h["areas"] = @areas.strip if @areas
+        h["applications"] = @applications.strip if @applications
       end
     end
   end

--- a/lib/internship_provider.rb
+++ b/lib/internship_provider.rb
@@ -11,8 +11,8 @@ class InternshipProvider
       @contact_name = d["contact_name"]
       @contact_email = d["contact_email"]
       @subjects = d["subjects"]
-      @areas = d["local_areas"]
-      @applications = d["applications_open"]
+      @areas = d["areas"]
+      @applications = d["applications"]
       @full = ActiveModel::Type::Boolean.new.cast(d["full"])
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-5077](https://trello.com/c/am1Tf2Jw/5077-enhance-the-internships-page-listings-for-the-2024-programme-and-upload-the-new-listings)

### Context

The internships team want to launch the 2024 internships programme in early October

The internships team would like the following changes:
 - additional information added to the listings
 - the 2024 listings uploaded
 
### Changes proposed in this pull request


### Guidance to review

