### PR TITLE
Add focus state to menu button

### DIFF
--- a/app/webpacker/images/icon-arrow-down-white.svg
+++ b/app/webpacker/images/icon-arrow-down-white.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="38" height="38" viewBox="0 0 38 38">
+  <defs>
+    <style>
+      .cls-1 {
+        clip-path: url(#clip-Icon-arrow-down-white);
+      }
+
+      .cls-2 {
+        fill: #fff;
+      }
+    </style>
+    <clipPath id="clip-Icon-arrow-down-white">
+      <rect width="38" height="38"/>
+    </clipPath>
+  </defs>
+  <g id="Icon-arrow-down-white" class="cls-1">
+    <path id="Union_1" data-name="Union 1" class="cls-2" d="M0,33.251,14.25,19,0,4.75,4.751,0l19,19-19,19Z" transform="translate(38 7.125) rotate(90)"/>
+  </g>
+</svg>

--- a/app/webpacker/styles/header/menu-button.scss
+++ b/app/webpacker/styles/header/menu-button.scss
@@ -16,20 +16,17 @@
     margin-left: 1em;
     padding: .8em 1em;
 
-    &:focus {
-      background-color: $white;
-      color: $green;
-      box-shadow: none;
-    }
-
     &:active {
       background-color: $white;
       box-shadow: none;
     }
 
     &:hover {
-      background-color: $white;
       cursor: pointer;
+    }
+
+    &:focus {
+      border-color: $black;
     }
 
     &.open {
@@ -37,8 +34,7 @@
       color: $white;
 
       &:focus {
-        background-color: $green;
-        box-shadow: none;
+        background-color: $black;
       }
 
       &:focus .menu-button__icon {

--- a/app/webpacker/styles/header/menu-button.scss
+++ b/app/webpacker/styles/header/menu-button.scss
@@ -53,7 +53,7 @@
     }
 
     &:focus .menu-button__icon {
-      background-image: url("../images/icon-arrow-down.svg");
+      background-image: url("../images/icon-arrow-down-white.svg");
     }
 
     .menu-button__text {


### PR DESCRIPTION
### Trello card

[Trello 5109](https://trello.com/c/LtjoZ68z)

### Context

Silktide has flagged an accessibility issue with the new menu button on mobile. It doesn't change state on focus.

### Changes proposed in this pull request

Add a focus state to the menu button.

### Guidance to review

Tab through the homepage with the website rendered as if on mobile or tablet and check that, when the menu button is in a focused state, it has a black background, white text and icon and a pink underline.

