### PR TITLE
Remove a non-breaking space from docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Development
+# Development
 
 ## Setting up the app in development
 


### PR DESCRIPTION
Copied from duncanjbrown:fix-non-breaking-space to be able to build the docker image
See https://github.com/DFE-Digital/get-into-teaching-app/pull/3384