### PR TITLE
Fix secrets for dependabot review apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,7 @@ jobs:
     needs: [ build_release ]
     if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
+    continue-on-error: true
     concurrency: Review_aks_${{github.event.number}}
     environment:
        name: review_aks
@@ -464,16 +465,24 @@ jobs:
         with:
           var_file: .github/common_environment_aks.yml
 
+      - name: Setup Environment Variables
+        if: github.actor == 'dependabot[bot]'
+        id: variables
+        shell: bash
+        run: |
+             secret_suffix="_AKS_REVIEW"
+             echo "SECRET_SUFFIX=$secret_suffix" >> $GITHUB_ENV
+
       - uses: Azure/login@v1
         with:
-            creds: ${{ secrets.AZURE_CREDENTIALS }}
+            creds: ${{ secrets[format('AZURE_CREDENTIALS{0}', env.SECRET_SUFFIX)] }}
 
       - name: Fetch secrets from key vault
         uses: azure/CLI@v1
         id: keyvault-yaml-secret
         with:
           inlineScript: |
-            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.KEY_VAULT}}" --query "value" -o tsv)
+            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets[format('KEY_VAULT{0}', env.SECRET_SUFFIX)] }}" --query "value" -o tsv)
             echo "::add-mask::$SLACK_WEBHOOK"
             echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
 
@@ -484,9 +493,9 @@ jobs:
           environment: review_aks
           sha:  ${{ github.sha }}
           pr:   ${{github.event.number}}
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          KEY_VAULT:         ${{ secrets.KEY_VAULT }}
-          ARM_ACCESS_KEY:    ${{ secrets.ARM_ACCESS_KEY }}
+          AZURE_CREDENTIALS: ${{ secrets[format('AZURE_CREDENTIALS{0}', env.SECRET_SUFFIX)] }}
+          KEY_VAULT:         ${{ secrets[format('KEY_VAULT{0}', env.SECRET_SUFFIX)] }}
+          ARM_ACCESS_KEY:    ${{ secrets[format('ARM_ACCESS_KEY{0}', env.SECRET_SUFFIX)] }}
 
       - name: Post sticky pull request comment
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
### Trello card

https://trello.com/c/F1AJ1jdj/719-fix-aks-review-apps-for-dependabot-prs

### Context

AKS review apps fail if run by dependabot, due to missing secrets

### Changes proposed in this pull request

Add a suffix to the secrets if the workflow is being run by dependabot, so it can pick up AKS secrets

### Guidance to review

Check workflow

