### PR TITLE
Increase spacing between page numbers

### DIFF
--- a/app/webpacker/styles/components/pagination.scss
+++ b/app/webpacker/styles/components/pagination.scss
@@ -11,7 +11,7 @@
 
   .prev,
   .first {
-    padding-right: 8px;
+    padding-right: 15px;
   }
 
   .next,
@@ -28,5 +28,23 @@
 
   .current {
     font-weight: bold;
+  }
+
+  @include mq($until: mobile) {
+    .prev,
+    .first {
+      padding-right: 12px;
+    }
+  
+    .next,
+    .last {
+      padding-left: 12px;
+    }
+
+    .page a,
+    .current,
+    .gap {
+      margin: 0 4px;
+    }  
   }
 }

--- a/app/webpacker/styles/components/pagination.scss
+++ b/app/webpacker/styles/components/pagination.scss
@@ -16,14 +16,14 @@
 
   .next,
   .last {
-    padding-left: 8px;
+    padding-left: 15px;
   }
 
   .page a,
   .current,
   .gap {
     padding: 0 8px;
-    margin: 0 4px;
+    margin: 0 7px;
   }
 
   .current {

--- a/app/webpacker/styles/components/pagination.scss
+++ b/app/webpacker/styles/components/pagination.scss
@@ -23,7 +23,7 @@
   .current,
   .gap {
     padding: 0 8px;
-    margin: 0 4px
+    margin: 0 4px;
   }
 
   .current {

--- a/app/webpacker/styles/components/pagination.scss
+++ b/app/webpacker/styles/components/pagination.scss
@@ -23,6 +23,7 @@
   .current,
   .gap {
     padding: 0 8px;
+    margin: 0 4px
   }
 
   .current {

--- a/app/webpacker/styles/components/pagination.scss
+++ b/app/webpacker/styles/components/pagination.scss
@@ -12,11 +12,19 @@
   .prev,
   .first {
     padding-right: 15px;
+
+    @include mq($until: mobile) {
+      padding-right: 12px;
+    }
   }
 
   .next,
   .last {
     padding-left: 15px;
+
+    @include mq($until: mobile) {
+      padding-left: 12px;
+    }
   }
 
   .page a,
@@ -24,27 +32,13 @@
   .gap {
     padding: 0 8px;
     margin: 0 7px;
+
+    @include mq($until: mobile) {
+      margin: 0 4px;
+    }
   }
 
   .current {
     font-weight: bold;
-  }
-
-  @include mq($until: mobile) {
-    .prev,
-    .first {
-      padding-right: 12px;
-    }
-  
-    .next,
-    .last {
-      padding-left: 12px;
-    }
-
-    .page a,
-    .current,
-    .gap {
-      margin: 0 4px;
-    }  
   }
 }


### PR DESCRIPTION
### Trello card

[Trello 5116](https://trello.com/c/DlPHB0ig)

### Context

Silktide has identified that our page numbers are too close together on pages like /events and /blog. We therefore need to increase the spacing.

### Changes proposed in this pull request

Add margin to the page numbers in order to increase the spacing between them.

### Guidance to review

Check that the page numbers no have 4px margin either side. Or, comparing against the live site, visually check that you can see an increase in the spacing between each page number.

