### PR TITLE
Remove the span tag from ul list, update class of list to be the flex container, move margin from being on the right of the span, to the left of the search icon

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,6 +1,5 @@
 <%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }, role: "navigation") do %>
-  <ul class="extra-navigation__list">
-    <span class="extra-navigation__flex">
+  <ul class="extra-navigation__list extra-navigation__flex">
       <li class="extra-navigation__link extra-navigation__mail">
         <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
         Sign up for emails<span class="icon icon-mail" aria-hidden="true"></span><span class="icon icon-mail-white" aria-hidden="true"></span>
@@ -11,7 +10,6 @@
         Find an event<span class="icon icon-calendar" aria-hidden="true"></span><span class="icon icon-calendar-white" aria-hidden="true"></span>
         <% end %>
       </li>
-    </span>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden], data: { "searchbox-target": "label" }) %>
       <%= link_to(search_path, aria: { label: "Search" }, data: { action: "searchbox#toggle" }) do %>

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -17,7 +17,6 @@
 
   &__flex {
     display: flex;
-    margin-right: 1em;
 
     @include mq($until: mobile) {
       margin-right: auto;
@@ -74,6 +73,7 @@
 
   &__search a {
     background-color: $pink;
+    margin-left: 1em;
     padding: .6em $indent-amount / 2;
     line-height: 28px;
 

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -71,22 +71,28 @@
     }
   }
 
-  &__search a {
-    background-color: $pink;
-    margin-left: 1em;
-    padding: .6em $indent-amount / 2;
-    line-height: 28px;
-
-    &:hover {
-      background-color: $pink-dark;
+  &__search {
+    @include mq($until: mobile) {
+      margin-left: auto;
     }
 
-    &:focus {
-      background-color: $black;
-    }
+    a {
+      background-color: $pink;
+      margin-left: 1em;
+      padding: .6em $indent-amount / 2;
+      line-height: 28px;
 
-    .icon {
-      margin: 0;
+      &:hover {
+        background-color: $pink-dark;
+      }
+
+      &:focus {
+        background-color: $black;
+      }
+
+      .icon {
+        margin: 0;
+      }
     }
   }
 

--- a/spec/components/header/extra_navigation_component_spec.rb
+++ b/spec/components/header/extra_navigation_component_spec.rb
@@ -9,8 +9,7 @@ describe Header::ExtraNavigationComponent, type: "component" do
 
   specify "renders the extra navigation container with contents" do
     expect(page).to have_css(".extra-navigation") do |en|
-      expect(en).to have_css("ul.extra-navigation__list > span.extra-navigation__flex > li", count: 2)
-      expect(en).to have_css("ul.extra-navigation__list > li", count: 1)
+      expect(en).to have_css("ul.extra-navigation__list.extra_navigation__flex > li", count: 3)
     end
   end
 

--- a/spec/components/header/extra_navigation_component_spec.rb
+++ b/spec/components/header/extra_navigation_component_spec.rb
@@ -9,7 +9,7 @@ describe Header::ExtraNavigationComponent, type: "component" do
 
   specify "renders the extra navigation container with contents" do
     expect(page).to have_css(".extra-navigation") do |en|
-      expect(en).to have_css("ul.extra-navigation__list.extra_navigation__flex > li", count: 3)
+      expect(en).to have_css("ul.extra-navigation__list.extra-navigation__flex > li", count: 3)
     end
   end
 


### PR DESCRIPTION
### Trello card
[5110](https://trello.com/c/zDW2QhTg/5110-fix-issues-with-list-html-in-bonus-bar)

### Context
Silktide has flagged an accessibility issue with the changes to the bonus bar as their is a `span` tag as a direct descendant of a `ul` tag in the top navigation with the search.

### Changes proposed in this pull request
Removed the `span` tag within the `ul` list, and made the `ul` list act as the flex container. Adjust the margin of the search icon to be the equivalent that was previously on the `span` but in the opposite direction so that it displays with the same spacing as before.

### Guidance to review
Please check on the review apps that it looks and behaves as expected. And inspecting the elements to ensure that the only direct descendants of the `ul` tag are `li` tags and nothing else.
