### PR TITLE
Updated grouped-cards.scss to improve readability

### DIFF
--- a/app/webpacker/styles/components/grouped-cards.scss
+++ b/app/webpacker/styles/components/grouped-cards.scss
@@ -45,8 +45,21 @@
       &__fields p {
         @include font-size(xsmall);
         white-space: normal;
+        margin-bottom: 1em;
 
-        a { overflow-wrap: break-word; }
+        a { 
+          overflow-wrap: break-word;
+          color: $blue-dark;
+        }
+      }
+
+      &__fields:last-child,
+      &__fields p:last-child {
+        margin-bottom: 0;
+      }
+
+      &__fields span:first-child {
+        font-weight: bold;
       }
     }
   }


### PR DESCRIPTION
### Trello card

[Trello 5121](https://trello.com/c/idaI96lL)

### Context

The internships team asked for additional information to be added to their listings for the 2024 programme. However, as a result, the listings are harder to read.

### Changes proposed in this pull request

Increase spacing and embolden headings to improve readability.

### Guidance to review

Check that the headings of each row are now bold and that each new row has a gap of at least 12px to the next.

