### PR TITLE
Updated category page styling

### DIFF
--- a/app/components/categories/card_component.html.erb
+++ b/app/components/categories/card_component.html.erb
@@ -2,10 +2,7 @@
   <%= link_to(path, class: "link--black") do %>
     <div class="category__nav-card--content">
       <%= content_tag(heading_tag, title) %>
-
       <%= tag.p(helpers.safe_html_format(description)) %>
     </div>
-
-    <div class="category__nav-card--icon"></div>
   <% end %>
 </li>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -75,7 +75,7 @@
     }
 
     &:hover {
-      background-color: #e6e6e6;
+      border-color: $blue;
 
       h2,
       h3 {

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -1,7 +1,5 @@
 .category {
 
-  &__hero
-
   &__hero {
     margin: 0;
     background: $yellow;
@@ -63,6 +61,7 @@
       h2,
       h3 {
         color: $blue-dark;
+        text-decoration: underline;
       }
 
       &:focus h2 {
@@ -74,13 +73,13 @@
       }
     }
 
-    h2,
-    h3 {
-      text-decoration: none;
-    }
-
     &:hover {
-      border-color: $blue-dark;
+      background-color: #e6e6e6;
+
+      h2,
+      h3 {
+        text-decoration: none;
+      }
     }
 
     &--content {

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -1,4 +1,5 @@
 .category {
+  background-color: $white;
 
   &__hero {
     margin: 0;

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -1,5 +1,6 @@
 .category {
-  background-color: $grey;
+
+  &__hero
 
   &__hero {
     margin: 0;
@@ -11,14 +12,13 @@
   }
 
   &__cards {
-    padding-bottom: 2em;
     width: 100%;
   }
 
   &__nav-cards ul {
     display: grid;
     grid-template-columns: 1fr;
-    margin-block: 2em;
+    margin-block: 1em;
     padding: 0;
     gap: 1.2em;
     list-style: none;
@@ -48,23 +48,39 @@
   }
 
   &__nav-card {
-    background: white;
-    box-shadow: 0 6px 5px 0 rgba(0, 0, 0, .15);
+    background: $grey;
     display: flex;
+    margin-bottom: 0;
+    border-bottom: 4px solid $grey-light;
 
     a {
-      padding: 2em;
+      padding: 1.25em;
       text-decoration: none;
       display: flex;
       gap: 1.5em;
       width: 100%;
+
+      h2,
+      h3 {
+        color: $blue-dark;
+      }
+
+      &:focus h2 {
+        color: $white;
+      }
+
+      &:focus h3 {
+        color: $white;
+      }
+    }
+
+    h2,
+    h3 {
+      text-decoration: none;
     }
 
     &:hover {
-      box-shadow: 0 12px 9px 0 rgba(0, 0, 0, .15);
-
-      h2,
-      h3 { text-decoration: underline; }
+      border-color: $blue-dark;
     }
 
     &--content {
@@ -75,19 +91,6 @@
         @extend .heading-m, .heading--margin-0;
       }
     }
-
-    &--icon {
-      flex: 1;
-      text-align: right;
-
-      &:after {
-        display: inline-block;
-        content: "\276F";
-        background: $blue;
-        color: white;
-        padding: 0 .5em;
-      }
-    }
   }
 
   &__questions {
@@ -95,11 +98,16 @@
     flex-direction: column;
     gap: 3em;
     background: $white;
-    padding-bottom: 4em;
+    padding: 2.5em 0 4em;
 
     @include mq($from: tablet) {
       flex-direction: row;
       gap: 2em;
+    }
+
+    &__container {
+      border-top: 1px solid $grey;
+      margin-top: 3.5em;
     }
   }
 

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -61,7 +61,6 @@
 
       h2,
       h3 {
-        color: $blue-dark;
         text-decoration: underline;
       }
 

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -171,18 +171,6 @@ $mobile-cutoff: 800px;
     background-color: $yellow-dark;
   }
 
-  &.blend-content {
-    padding-bottom: 4em;
-
-    @include mq($from: tablet) {
-      padding-bottom: 5em;
-    }
-
-    & + .main-section {
-      margin-top: -4em;
-    }
-  }
-
   &__title {
     z-index: 20;
   }

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -87,6 +87,12 @@ $mobile-cutoff: 800px;
       margin-top: 2em;
     }
 
+    @include mq($until: tablet) {
+      &__paragraph {
+        padding: 0 1.5em;
+      }
+    }
+
     &__subtitle {
       align-items: center;
       margin: 0 auto 2em 1.5em;
@@ -266,6 +272,6 @@ $mobile-cutoff: 800px;
   }
 
   .hero.blend-content {
-    padding-bottom: 4.5em;
+    padding-bottom: 2em;
   }
 }

--- a/spec/components/categories/card_component_spec.rb
+++ b/spec/components/categories/card_component_spec.rb
@@ -37,10 +37,6 @@ describe Categories::CardComponent, type: "component" do
     end
   end
 
-  specify "the link has an icon" do
-    expect(subject).to have_css("a > .category__nav-card--icon")
-  end
-
   context "when the heading_tag is overridden" do
     let(:custom_heading_tag) { "h4" }
 


### PR DESCRIPTION
### Trello card

[Trello 5044](https://trello.com/c/DtljVpEA)

### Context

As part of the restructuring of the website, we are redesigning the category pages to make it easier for users to find exactly what they’re looking for.

### Changes proposed in this pull request

Various changes have been implemented, including:

- Reducing the amount of wasted whitespace
- Tightening up the cards and giving them a rollover state that's more consistent with other component on the website
- Making the header of each card look more like a link
- Removing the arrow icons as the entire card is clickable
- Changing the background from grey to white
- Removing the blend from the hero into the category cards

### Guidance to review

CSS and HTML changes.

