### PR TITLE
Move order of keys to create change in order of markdown output

### DIFF
--- a/lib/internship_provider.rb
+++ b/lib/internship_provider.rb
@@ -26,10 +26,10 @@ class InternshipProvider
       if @full
         h["status"] = "Course full"
       else
-        h["name"] = @contact_name.strip
-        h["email"] = @contact_email.strip
         h["areas"] = @areas.strip if @areas
         h["applications"] = @applications.strip if @applications
+        h["name"] = @contact_name.strip
+        h["email"] = @contact_email.strip
       end
     end
   end


### PR DESCRIPTION
### Trello card
[5135](https://trello.com/c/PxcxSHoo/5135-reorder-internship-listings-and-upload-revised-details)

### Context
Need to change the order information is displayed in the page, and therefore change the order things are displayed in the markdown.

### Changes proposed in this pull request
Updating key setting order. Wanted a more elegant solution than this originally however, would require more thinking / changes of the models and code. So for now, I am going for the easiest thing, and may look to update this further as part of the other changes I will make as part of the CSV to markdown process improvements.

### Guidance to review
No changes on screen yet with this PR, changes to order in the markdown and therefore on the pages will be reflected at the next CSV upload (Scheduled for 12th Oct). If you want to test locally, run the csv_to_yaml rake task and check the output, keys will be in the required order.

