### PR TITLE
Fix hostname for test front door origin group

### DIFF
--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -10,7 +10,7 @@
           "/packs/*"
         ],
         "environment_short": "ts",
-        "origin_hostname": "get-into-teaching-test.test.teacherservices.cloud"
+        "origin_hostname": "get-into-teaching-app-test.test.teacherservices.cloud"
       }
     }
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/ADGjNHqy/730-fix-test-fd-domain

### Context

Origin hostname incorrect for test env front door

### Changes proposed in this pull request

Update to correct hostname

### Guidance to review

make test_aks domains-plan (already applied)
check test url works 

