### PR TITLE
Fix 'Get help and support' formatting

### DIFF
--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
-  <section class="category col-space-m" style="margin-bottom: 4em;">
-    <section class="container category__cards main-section promo--border-bottom">
+  <section class="category col-space-m">
+    <section class="container category__cards main-section">
       <h2 class="heading--box-blue">Talk to an adviser</h2>
       <div class="inset">
         <p>Get free, one-to-one support from an adviser with years of teaching experience before you apply for teacher training. Chat by phone, text or email, as little or as often as you need.</p>

--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
-  <section class="category col-space-m">
-    <section class="container category__cards main-section">
+  <section class="category col-space-m" style="margin-bottom: 4em;">
+    <section class="container category__cards main-section promo--border-bottom">
       <h2 class="heading--box-blue">Talk to an adviser</h2>
       <div class="inset">
         <p>Get free, one-to-one support from an adviser with years of teaching experience before you apply for teacher training. Chat by phone, text or email, as little or as often as you need.</p>

--- a/app/views/content/help-and-support/_mailing_list.html.erb
+++ b/app/views/content/help-and-support/_mailing_list.html.erb
@@ -1,13 +1,17 @@
-<div class="row inset">
-  <section class="col col-640">
-    <h2 class="heading-l heading--margin-top-0">Get tailored guidance in your inbox</h2>
+<div class="row">
+  <section class="col col-full-content">
+    <div class="promo promo--border-top">
+      <div class="col col-640" style="margin-bottom: 0;">
+        <h2 class="heading-l heading--margin-top-0">Get tailored guidance in your inbox</h2>
 
-    <p>
-      Answer just a few questions and we'll send you helpful advice and insights, including how
-      to apply for teacher training and tips from trainees
-      and teachers.
-    </p>
+        <p>
+          Answer just a few questions and we'll send you helpful advice and insights, including how
+          to apply for teacher training and tips from trainees
+          and teachers.
+        </p>
 
-    <%= link_to("Get advice in your inbox", mailing_list_steps_path) %>.
+        <%= link_to("Get advice in your inbox", mailing_list_steps_path) %>.
+      </div>
+    </div>
   </section>
 </div>


### PR DESCRIPTION
### Trello card

[Trello 5149](https://trello.com/c/NFIfmtbT)

### Context

We improved the category page design, but this had an unintended knock-on effect on the 'Get help and support' page.

The mailing list section on the 'Get help and support' page now appears to be part of the 'Talk to an adviser' section (even though the heading structure is correct).

### Changes proposed in this pull request

Add a border and padding/margin above the 'Get tailored guidance in your inbox' module.

### Guidance to review

Check to see that there is a border above and below the 'Get tailored guidance in your inbox' module.

