### PR TITLE
Remove code that starts and appends chat widget to the DOM

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -42,20 +42,12 @@ export default class extends Controller {
       this.chatTarget.textContent = 'Starting chat...';
     }
 
-    this.appendZendeskScript();
-
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         this.chatTarget.textContent = 'Chat online';
       });
     });
-  }
-
-  appendZendeskScript() {
-    if (this.zendeskScriptLoaded) {
-      return;
-    }
   }
 
   waitForWebWidget(callback) {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -26,9 +26,10 @@ export default class extends Controller {
     const openTime = dayjs().set('hour', 8).set('minute', 30).tz(timeZone);
     const closeTime = dayjs().set('hour', 17).set('minute', 30).tz(timeZone);
     const now = dayjs().tz(timeZone);
-    const weekend = true;
+    const weekend = [6, 0].includes(now.get('day'));
+    const disabled = true; // temporary to disable chat
 
-    return !weekend && now >= openTime && now <= closeTime;
+    return !disabled && !weekend && now >= openTime && now <= closeTime;
   }
 
   start(e) {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -56,12 +56,6 @@ export default class extends Controller {
     if (this.zendeskScriptLoaded) {
       return;
     }
-
-    const script = document.createElement('script');
-    script.setAttribute('id', 'ze-snippet');
-    script.src =
-      'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
-    document.body.appendChild(script);
   }
 
   waitForWebWidget(callback) {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
     const openTime = dayjs().set('hour', 8).set('minute', 30).tz(timeZone);
     const closeTime = dayjs().set('hour', 17).set('minute', 30).tz(timeZone);
     const now = dayjs().tz(timeZone);
-    const weekend = [6, 0].includes(now.get('day'));
+    const weekend = true;
 
     return !weekend && now >= openTime && now <= closeTime;
   }

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Chat", type: :feature do
     context "when chat is online" do
       let(:date) { Time.zone.local(2021, 1, 1, 9) }
 
-      scenario "viewing the chat section of the talk to us component" do
+      xscenario "viewing the chat section of the talk to us component" do
         visit_on_date root_path
         dismiss_cookies
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -39,7 +39,7 @@ describe('ChatController', () => {
     return document.querySelector('a').textContent;
   }
 
-  describe('when the chat is online', () => {
+  xdescribe('when the chat is online', () => {
     beforeEach(() => {
       chatShowSpy = jest.fn(() => true);
       chatOpenSpy = jest.fn();
@@ -57,7 +57,7 @@ describe('ChatController', () => {
 
     it('displays the chat online button', () => {
       const button = document.querySelector('[data-chat-target="online"]')
-      // expect(button.classList.contains('hidden')).toBe(false)
+      expect(button.classList.contains('hidden')).toBe(false)
     })
   })
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -59,36 +59,6 @@ describe('ChatController', () => {
       const button = document.querySelector('[data-chat-target="online"]')
       expect(button.classList.contains('hidden')).toBe(false)
     })
-
-    describe('when clicking the chat button', () => {
-      it('appends the Zendesk snippet, shows a loading message and then opens the chat window', () => {
-        const button = document.querySelector('a');
-        button.click();
-        expect(document.querySelector('#ze-snippet')).not.toBeNull();
-        expect(getButtonText()).toEqual("Starting chat...");
-        jest.runOnlyPendingTimers(); // Timer for script loading,
-        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
-        jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
-        expect(getButtonText()).toEqual("Chat online");
-      });
-    });
-
-    describe('when clicking the chat button twice', () => {
-      it('only appends the Zendesk snippet once and does not show the loading message for the second click', () => {
-        const button = document.querySelector('a');
-        button.click();
-        expect(button.textContent).toEqual("Starting chat...");
-        jest.runOnlyPendingTimers(); // Timer for script loading,
-        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
-        jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
-        expect(button.textContent).toEqual("Chat online");
-        button.click();
-        expect(button.textContent).toEqual("Chat online");
-        expect(document.querySelectorAll('#ze-snippet').length).toEqual(1);
-      });
-    });
   })
 
   describe("when the chat is offline (too early)", () => {

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -59,6 +59,36 @@ describe('ChatController', () => {
       const button = document.querySelector('[data-chat-target="online"]')
       expect(button.classList.contains('hidden')).toBe(false)
     })
+
+    describe('when clicking the chat button', () => {
+      it('appends the Zendesk snippet, shows a loading message and then opens the chat window', () => {
+        const button = document.querySelector('a');
+        button.click();
+        expect(document.querySelector('#ze-snippet')).not.toBeNull();
+        expect(getButtonText()).toEqual("Starting chat...");
+        jest.runOnlyPendingTimers(); // Timer for script loading,
+        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
+        jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
+        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(getButtonText()).toEqual("Chat online");
+      });
+    });
+
+    describe('when clicking the chat button twice', () => {
+      it('only appends the Zendesk snippet once and does not show the loading message for the second click', () => {
+        const button = document.querySelector('a');
+        button.click();
+        expect(button.textContent).toEqual("Starting chat...");
+        jest.runOnlyPendingTimers(); // Timer for script loading,
+        jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
+        jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
+        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(button.textContent).toEqual("Chat online");
+        button.click();
+        expect(button.textContent).toEqual("Chat online");
+        expect(document.querySelectorAll('#ze-snippet').length).toEqual(1);
+      });
+    });
   })
 
   describe("when the chat is offline (too early)", () => {

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -57,7 +57,7 @@ describe('ChatController', () => {
 
     it('displays the chat online button', () => {
       const button = document.querySelector('[data-chat-target="online"]')
-      expect(button.classList.contains('hidden')).toBe(false)
+      // expect(button.classList.contains('hidden')).toBe(false)
     })
   })
 


### PR DESCRIPTION
Hotfix to stop the script being pulled from zendesk, to stop the chat widget from being appended to the DOM, and to stop the chat button from appearing at all.

