### PR TITLE
Revert the various PR changes to chat widget back to state before release of new widget

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[api.smooch.io api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Chat", type: :feature do
     context "when chat is online" do
       let(:date) { Time.zone.local(2021, 1, 1, 9) }
 
-      xscenario "viewing the chat section of the talk to us component" do
+      scenario "viewing the chat section of the talk to us component" do
         visit_on_date root_path
         dismiss_cookies
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -7,7 +7,7 @@ describe('ChatController', () => {
   afterEach(() => jest.useRealTimers());
 
   let chatShowSpy;
-  let chatOpenSpy;
+  let chatOnHideSpy;
 
   const setBody = () => {
     document.body.innerHTML = `
@@ -39,12 +39,11 @@ describe('ChatController', () => {
     return document.querySelector('a').textContent;
   }
 
-  xdescribe('when the chat is online', () => {
+  describe('when the chat is online', () => {
     beforeEach(() => {
-      chatShowSpy = jest.fn(() => true);
-      chatOpenSpy = jest.fn();
-
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ zE: chatOpenSpy, zEACLoaded: chatShowSpy }));
+      chatShowSpy = jest.fn();
+      chatOnHideSpy = jest.fn();
+      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy, onHide: chatOnHideSpy } } } }));
 
       setBody();
       setCurrentTime('2021-01-01 10:00');
@@ -69,7 +68,7 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(chatShowSpy).toHaveBeenCalled();
         expect(getButtonText()).toEqual("Chat online");
       });
     });
@@ -82,7 +81,7 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(chatShowSpy).toHaveBeenCalled();
         expect(button.textContent).toEqual("Chat online");
         button.click();
         expect(button.textContent).toEqual("Chat online");


### PR DESCRIPTION
### Trello card
No trello card for this specific work, this is reverting the work and release that was done as part of [4847](https://trello.com/c/Qqf05GG1/4847-replace-webchat-widget-with-upgraded-version)

### Context
Release had issues, and so there is a need to revert back.

### Changes proposed in this pull request
No changes, more of a rewind, this PR takes the relevant files back to their previous state.

### Guidance to review
From a code perspective, it is a rewind to a previous state, so preference is to not introduce improvements / refactorings to this as it is code that was once passed, and the aim of this is to accurately rewind to the previous widget with confidence, making additional changes on top of this removes that confidence a bit.

From a functional perspective, ensure widget behaves as expected. Conversations ongoing as to how to do that with production configuration on R101 end.

