### PR TITLE
Revert chat widget commits

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -47,6 +47,7 @@ export default class extends Controller {
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
+        document.getElementById('webWidget').focus();
         this.chatTarget.textContent = 'Chat online';
       });
     });
@@ -66,7 +67,7 @@ export default class extends Controller {
 
   waitForWebWidget(callback) {
     const interval = setInterval(() => {
-      if (window.zEACLoaded) {
+      if (document.getElementById('webWidget')) {
         clearInterval(interval);
         // Small delay to account for the chat box animating in.
         setTimeout(() => {
@@ -78,7 +79,7 @@ export default class extends Controller {
 
   waitForZendeskScript(callback) {
     const interval = setInterval(() => {
-      if (window.zEACLoaded) {
+      if (window.$zopim && window.$zopim.livechat) {
         clearInterval(interval);
         callback();
       }
@@ -86,7 +87,15 @@ export default class extends Controller {
   }
 
   showWebWidget() {
-    window.zE('messenger', 'open');
+    window.$zopim.livechat.window.show();
+    window.$zopim.livechat.window.onHide(() => {
+      // Return focus back to where it was before opening
+      // the chat widget.
+      if (this.previousTarget) {
+        this.previousTarget.focus();
+        this.previousTarget.blur();
+      }
+    });
   }
 
   get zendeskScriptLoaded() {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -27,9 +27,8 @@ export default class extends Controller {
     const closeTime = dayjs().set('hour', 17).set('minute', 30).tz(timeZone);
     const now = dayjs().tz(timeZone);
     const weekend = [6, 0].includes(now.get('day'));
-    const disabled = true; // temporary to disable chat
 
-    return !disabled && !weekend && now >= openTime && now <= closeTime;
+    return !weekend && now >= openTime && now <= closeTime;
   }
 
   start(e) {
@@ -43,12 +42,26 @@ export default class extends Controller {
       this.chatTarget.textContent = 'Starting chat...';
     }
 
+    this.appendZendeskScript();
+
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         this.chatTarget.textContent = 'Chat online';
       });
     });
+  }
+
+  appendZendeskScript() {
+    if (this.zendeskScriptLoaded) {
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.setAttribute('id', 'ze-snippet');
+    script.src =
+      'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
+    document.body.appendChild(script);
   }
 
   waitForWebWidget(callback) {

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[api.smooch.io api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Chat", type: :feature do
     context "when chat is online" do
       let(:date) { Time.zone.local(2021, 1, 1, 9) }
 
-      xscenario "viewing the chat section of the talk to us component" do
+      scenario "viewing the chat section of the talk to us component" do
         visit_on_date root_path
         dismiss_cookies
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -39,7 +39,7 @@ describe('ChatController', () => {
     return document.querySelector('a').textContent;
   }
 
-  xdescribe('when the chat is online', () => {
+  describe('when the chat is online', () => {
     beforeEach(() => {
       chatShowSpy = jest.fn(() => true);
       chatOpenSpy = jest.fn();

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -7,7 +7,7 @@ describe('ChatController', () => {
   afterEach(() => jest.useRealTimers());
 
   let chatShowSpy;
-  let chatOpenSpy;
+  let chatOnHideSpy;
 
   const setBody = () => {
     document.body.innerHTML = `
@@ -41,10 +41,9 @@ describe('ChatController', () => {
 
   describe('when the chat is online', () => {
     beforeEach(() => {
-      chatShowSpy = jest.fn(() => true);
-      chatOpenSpy = jest.fn();
-
-      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ zE: chatOpenSpy, zEACLoaded: chatShowSpy }));
+      chatShowSpy = jest.fn();
+      chatOnHideSpy = jest.fn();
+      jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ $zopim: { livechat: { window: { show: chatShowSpy, onHide: chatOnHideSpy } } } }));
 
       setBody();
       setCurrentTime('2021-01-01 10:00');
@@ -63,14 +62,16 @@ describe('ChatController', () => {
     describe('when clicking the chat button', () => {
       it('appends the Zendesk snippet, shows a loading message and then opens the chat window', () => {
         const button = document.querySelector('a');
+        expect(document.activeElement.id).not.toEqual("webWidget");
         button.click();
         expect(document.querySelector('#ze-snippet')).not.toBeNull();
         expect(getButtonText()).toEqual("Starting chat...");
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(chatShowSpy).toHaveBeenCalled();
         expect(getButtonText()).toEqual("Chat online");
+        expect(document.activeElement.id).toEqual("webWidget");
       });
     });
 
@@ -82,7 +83,7 @@ describe('ChatController', () => {
         jest.runOnlyPendingTimers(); // Timer for script loading,
         jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
         jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-        expect(chatOpenSpy).toHaveBeenCalled();
+        expect(chatShowSpy).toHaveBeenCalled();
         expect(button.textContent).toEqual("Chat online");
         button.click();
         expect(button.textContent).toEqual("Chat online");


### PR DESCRIPTION
### Trello card
No trello card for this specific work, this is reverting the work and release that was done as part of [4847](https://trello.com/c/Qqf05GG1/4847-replace-webchat-widget-with-upgraded-version)

### Context
Release had issues, and so there is a need to revert back.

### Changes proposed in this pull request
No changes, more of a rewind, this PR takes the relevant files back to their previous state.

### Guidance to review
From a code perspective, it is a rewind to a previous state, so preference is to not introduce improvements / refactorings to this as it is code that was once passed, and the aim of this is to accurately rewind to the previous widget with confidence, making additional changes on top of this removes that confidence a bit.

From a functional perspective, ensure widget behaves as expected. Conversations ongoing as to how to do that with production configuration on R101 end.
