### PR TITLE
Remove nodejs pkg version from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apk update
 
 RUN apk add --no-cache \
   "procps-ng=4.0.4-r0" \
-  "libproc2=4.0.4-r0" \
-  "nodejs=18.17.1-r0"
+  "libproc2=4.0.4-r0"
 
 RUN apk add --no-cache build-base tzdata shared-mime-info nodejs yarn git \
         chromium chromium-chromedriver postgresql-libs postgresql-dev && rm -rf /var/lib/apt/lists/*
@@ -92,9 +91,7 @@ RUN apk add --no-cache tzdata shared-mime-info postgresql-libs postgresql-dev &&
 
 RUN apk add --no-cache \
   "procps-ng=4.0.4-r0" \
-  "libproc2=4.0.4-r0" \
-  "nodejs=18.17.1-r0"
-
+  "libproc2=4.0.4-r0"
 
 COPY --from=release-build /app /app
 COPY --from=release-build /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
### Trello card

n/a

### Context

Build failing due to hardcoded nodejs pkg version

### Changes proposed in this pull request

Remove hardcoded version from Dockerfile

### Guidance to review

Check build runs ok

