### PR TITLE
Change page titles to match the category

### DIFF
--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support as a parent or carer"
 heading: "Funding and support if you're a parent or carer"
-subcategory: Additional help to train to teach
+subcategory: Extra support
 description: |-
   Find out what extra grants and schemes are available when completing your teacher training if you have children or other caring responsibilities.
 related_content:

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support as a parent or carer"
-heading: "Get support training to teach if you're a parent or carer"
-subcategory: Get extra support
+heading: "Funding and support if you're a parent or carer"
+subcategory: Additional funding and support
 description: |-
   Find out what extra grants and schemes are available when completing your teacher training if you have children or other caring responsibilities.
 related_content:
@@ -13,7 +13,7 @@ related_content:
 promo_content:
     - content/funding-and-support/promos/get-adviser-support-promo
 navigation: 20.30
-navigation_title: If you're a parent or carer
+navigation_title: Funding and support if you're a parent or carer
 navigation_description: Find out what extra grants and schemes are available if you have children or other caring responsibilities.
 keywords:
     - Bursaries

--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support as a parent or carer"
 heading: "Funding and support if you're a parent or carer"
-subcategory: Additional funding and support
+subcategory: Additional help to train to teach
 description: |-
   Find out what extra grants and schemes are available when completing your teacher training if you have children or other caring responsibilities.
 related_content:

--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're a veteran"
 heading: "Funding and support if you're a veteran"
-subcategory: Additional funding and support
+subcategory: Additional help to train to teach
 description: |-
     Find out how to get support training to teach if you're a veteran transitioning from or you've already left the armed forces.
 related_content:

--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're a veteran"
-heading: "Get support training to teach if you're a veteran"
-subcategory: Get extra support
+heading: "Funding and support if you're a veteran"
+subcategory: Additional funding and support
 description: |-
     Find out how to get support training to teach if you're a veteran transitioning from or you've already left the armed forces.
 related_content:
@@ -11,7 +11,7 @@ related_content:
 promo_content:
     - content/funding-and-support/promos/get-adviser-veterans-promo
 navigation: 20.35
-navigation_title: If you're a veteran
+navigation_title: Funding and support if you're a veteran
 navigation_description: Find out how to get support training to teach if you're a veteran transitioning from or you've already left the armed forces.
 calls_to_action:
   chat:

--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're a veteran"
 heading: "Funding and support if you're a veteran"
-subcategory: Additional help to train to teach
+subcategory: Extra support
 description: |-
     Find out how to get support training to teach if you're a veteran transitioning from or you've already left the armed forces.
 related_content:

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're disabled"
-heading: "Get support training to teach if you're disabled"
-subcategory: Get extra support
+heading: "Funding and support if you're disabled"
+subcategory: Additional funding and support
 description: |-
     Find out about the support you can get while training to teach if you're disabled.
 related_content:
@@ -11,7 +11,7 @@ related_content:
 promo_content:
     - content/funding-and-support/promos/get-adviser-support-promo
 navigation: 20.25
-navigation_title: If you're disabled
+navigation_title: Funding and support if you're disabled
 navigation_description: Find out about the support you can get while training to teach if you're disabled.
 keywords:
     - Disability

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're disabled"
 heading: "Funding and support if you're disabled"
-subcategory: Additional help to train to teach
+subcategory: Extra support
 description: |-
     Find out about the support you can get while training to teach if you're disabled.
 related_content:

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -1,7 +1,7 @@
 ---
 title: "Get support if you're disabled"
 heading: "Funding and support if you're disabled"
-subcategory: Additional funding and support
+subcategory: Additional help to train to teach
 description: |-
     Find out about the support you can get while training to teach if you're disabled.
 related_content:


### PR DESCRIPTION
### Trello card

https://trello.com/c/LjWCLsUK/5120-change-the-titles-of-pages-so-they-match-the-theme-of-their-category

### Context

We've reviewed page titles based on the feedback from user research and are updating some of them to better align the title with the content.

### Changes proposed in this pull request

 - updated page titles on parent and carer, veteran and if you're disabled pages 
- updated navigation headings for parent and carer, veteran and if you're disabled pages

### Guidance to review



