### PR TITLE
Fix alignment issues on landing page headers

### DIFF
--- a/app/webpacker/styles/components/campaign-hero.scss
+++ b/app/webpacker/styles/components/campaign-hero.scss
@@ -79,6 +79,8 @@
       @include font-size(xxlarge);
 
       padding: .05rem .7rem;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
 
     span:last-of-type {


### PR DESCRIPTION
### Trello card

[Trello 5160](https://trello.com/c/kUc0q2DV)

### Context

H1s on the alternate template pages are misaligned when wrapping is involved.

### Changes proposed in this pull request

Fix the alignment issue by using the `box-decoration-break` property.

### Guidance to review

Check that the alignment issue is no longer present on alternate template pages such as /subjects/maths and /landing/how-much-do-teachers-get-paid.