### PR TITLE
Exclude file types from compression for aks

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,7 +5,11 @@ require_relative 'config/environment'
 require 'prometheus/middleware/exporter'
 require_relative 'lib/rack/deflater_with_exclusions'
 
-EXTENSIONS_TO_EXCLUDE = %w(.jpg .jpeg .png .gif .pdf).freeze
+if ENV.has_key?("VCAP_APPLICATION")
+  EXTENSIONS_TO_EXCLUDE = %w(.jpg .jpeg .png .gif .pdf).freeze
+else
+  EXTENSIONS_TO_EXCLUDE = %w(.jpg .jpeg .png .gif .pdf .jp2 .webp .svg .ttf).freeze
+end
 
 use Rack::DeflaterWithExclusions, exclude: proc { |env|
   File.extname(env["PATH_INFO"]).in?(EXTENSIONS_TO_EXCLUDE)


### PR DESCRIPTION
### Trello card

https://trello.com/c/gcc9mz47/746-fix-for-compressed-files-using-frontdoor

### Context

Some file types won't download correctly from a web browser (compressed/HTTP 206) for AKS envs if using Azure front door

### Changes proposed in this pull request

Add file types to the deflater exclude list if not a PaaS environment (i.e. AKS)

### Guidance to review

Check review apps work as expected

