### PR TITLE
Add env variable for enabling / disabling of analytics on development environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.x.structured_data.event = true
   config.x.structured_data.how_to = true
 
-  config.x.dfe_analytics = true
+  config.x.dfe_analytics = ENV["DFE_ANALYTICS"]
 
   # Allow access from Codespaces
   config.hosts << /[a-z0-9\-]+\.(preview\.app\.github|githubpreview)\.dev/

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -10,5 +10,5 @@ Rails.application.configure do
 
   config.x.display_content_errors = true
 
-  config.x.dfe_analytics = true
+  config.x.dfe_analytics = ENV["DFE_ANALYTICS"]
 end


### PR DESCRIPTION
### Trello card
None, this is an adhoc fix for an issue that has come up.

### Context
Review apps and the development environment share a database, which means when a PR makes a change to the database but isn't merged yet, it blocks other PRs and all deployments because the dev build step fails as DfE Analytics complains that the database doesn't align to the config available in a given branch. This PR adds an env variable to allow the analytics to be temporarily disabled in the dev environment when needed, specifically when a PR with database changes is present, so as to not block other PRs and deployments.

### Changes proposed in this pull request
Instead of defaulting to true for enabling analytics, introduce a control on the dev environment to allow it to be enabled and disabled as needed.

### Guidance to review
Ensure review apps work as expected, and that CI build steps work and build despite the differences between the database and analytics config.
