### PR TITLE
Adding-inital-teacher-training-page-to-nav

### DIFF
--- a/app/views/content/train-to-be-a-teacher.md
+++ b/app/views/content/train-to-be-a-teacher.md
@@ -11,9 +11,6 @@ navigation: 15
 navigation_title: Train to be a teacher
 navigation_path: "/train-to-be-a-teacher"
 layout: "layouts/category"
-content:
-    - content/train-to-be-a-teacher/questions
-    - content/train-to-be-a-teacher/why-teach
 image: "static/content/hero-images/0007.jpg"
 hero_bg_color: yellow
 title_bg_color: white

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -6,7 +6,7 @@ description: |-
   Find out what initial teacher training (ITT) is like, from your classroom placements and theoretical learning, to how you'll be assessed.
 navigation: 20.30
 navigation_title: What to expect in teacher training
-navigation_description: Find out more about what your teacher training will be like, what you'll learn, and what classroom experience you'll get.
+navigation_description: Find out what your teacher training will be like, what you'll learn, and what classroom experience you'll get.
 related_content:
     Diary of a trainee teacher : "/blog/a-diary-of-a-trainee-teacher"
     Choosing the right teacher training course provider : "/blog/choosing-the-right-teacher-training-course-provider"

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -1,8 +1,12 @@
 ---
 title: "Teacher training"
 heading: "Teacher training"
+subcategory: Postgraduate teacher training
 description: |-
   Find out what initial teacher training (ITT) is like, from your classroom placements and theoretical learning, to how you'll be assessed.
+navigation: 20.30
+navigation_title: What to expect in teacher training
+navigation_description: Find out more about what your teacher training will be like, what you'll learn, and what classroom experience you'll get.
 related_content:
     Diary of a trainee teacher : "/blog/a-diary-of-a-trainee-teacher"
     Choosing the right teacher training course provider : "/blog/choosing-the-right-teacher-training-course-provider"

--- a/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
+++ b/app/views/content/train-to-be-a-teacher/initial-teacher-training.md
@@ -1,6 +1,6 @@
 ---
-title: "Teacher training"
-heading: "Teacher training"
+title: "What to expect in teacher training"
+heading: "What to expect in teacher training"
 subcategory: Postgraduate teacher training
 description: |-
   Find out what initial teacher training (ITT) is like, from your classroom placements and theoretical learning, to how you'll be assessed.


### PR DESCRIPTION
### Trello card

https://trello.com/c/SQlCnlQh


### Context

We want to move the Initial teacher training year to be a nav card on Train to be a teacher

We also want to remove the lower sections on the category page (questions section and Why teach section) as part of navigation improvements

### Changes proposed in this pull request

- removing the components on Train to be a teacher
- creating a nav card for the Inital teacher training page
- updating the page title for the Inital teacher training page

### Guidance to review

