### PR TITLE
Remove GLF Schools from Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -285,11 +285,6 @@ provider_groups:
       name: Joanna Jones
       telephone: '01483 888070'
       email: contactscitt@georgeabbot.surrey.sch.uk
-    - header: GLF Schools’ Teacher Training
-      link: http://www.glynsurreyscitt.co.uk/846/assessment-only-route
-      name: Helen Shaw
-      telephone: '020 8716 4934'
-      email: info@glftt.org
     - header: i2i Teaching Partnership SCITT
       link: https://www.i2ipartnership.co.uk/
       name: Krissy Taylor


### PR DESCRIPTION
### Trello card
https://trello.com/c/4aeESRju

### Context
Removing GLF Schools from Assessment only page
