### PR TITLE
Fix category page padding issue 

### DIFF
--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -1,5 +1,6 @@
 .category {
   background-color: $white;
+  margin-bottom: 3.5em;
 
   &__hero {
     margin: 0;
@@ -106,7 +107,6 @@
 
     &__container {
       border-top: 1px solid $grey;
-      margin-top: 3.5em;
     }
   }
 


### PR DESCRIPTION
### Trello card

[Trello 5183](https://trello.com/c/oTwTbRuf)

### Context

Now that we are removing the lower sections from our category pages, there is not much space between the last nav card and the footer. This needs to be fixed.

### Changes proposed in this pull request

Add 3.5em of margin below the category page.

### Guidance to review

Check that there is a sizeable gap between the lowest card(s) on any category page and whatever component (usually the footer) is below it/them.