### PR TITLE
Fix events card component issue

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -48,7 +48,7 @@
       ) %>
 
       <% if @git_events.any? %>
-        <section class="category__cards">
+        <section id="events" class="category__cards">
           <%= tag.nav(class: "category__nav-cards") do %>
             <ul class="one-column horizontal">
               <%= render(Categories::CardComponent.with_collection(categorise_events(@git_events))) %>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -217,3 +217,11 @@
     margin-bottom: 0;
   }
 }
+
+#events .category__nav-cards {
+  margin-bottom: 3em;
+}
+
+#events .category__nav-card {
+  background: $white;
+}


### PR DESCRIPTION
### Trello card

[Trello 5184](https://trello.com/c/OKViRkAg)

### Context

As a result of improving the category card design, we inadvertently affected the event listing on the About GIT events page [https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events](https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events). We therefore need to apply a fix for the category cards on this page.

### Changes proposed in this pull request

Change the background back to white for this page only.

### Guidance to review

Check that the category cards on this page are white, as before.
