### PR TITLE
Add simple feature flag for feedback that can be enabled / disabled per env

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -41,7 +41,7 @@
     <div class="site-footer-bottom">
       <div class="site-footer-bottom__links-container">
         <%= link_to("Search", search_path) %>
-        <%= link_to "Feedback", feedback_steps_path %>
+        <%= link_to "Feedback", feedback_steps_path if Rails.application.config.x.feature_flags.feedback_enabled %>
         <%= link_to "Cookies", cookies_path %>
         <%= link_to "Privacy notice", privacy_policy_path %>
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>

--- a/app/controllers/feedback/steps_controller.rb
+++ b/app/controllers/feedback/steps_controller.rb
@@ -5,6 +5,7 @@ module Feedback
     include GITWizard::Controller
     self.wizard_class = Feedback::Wizard
 
+    before_action :check_feature_flag!
     before_action :set_step_page_title, only: %i[show update]
     before_action :set_completed_page_title, only: [:completed]
 
@@ -15,6 +16,10 @@ module Feedback
     end
 
   private
+
+    def check_feature_flag!
+      redirect_to "/" unless Rails.application.config.x.feature_flags.feedback_enabled
+    end
 
     def first_step_class
       wizard_class.steps.first

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,6 +71,8 @@ Rails.application.configure do
 
   config.x.dfe_analytics = true
 
+  config.x.feature_flags.feedback_enabled = true
+
   # Allow access from Codespaces
   config.hosts << /[a-z0-9\-]+\.(preview\.app\.github|githubpreview)\.dev/
 end

--- a/config/environments/pagespeed.rb
+++ b/config/environments/pagespeed.rb
@@ -2,6 +2,8 @@
 require File.expand_path("production.rb", __dir__)
 
 Rails.application.configure do
+  config.x.feature_flags.feedback_enabled = true
+
   # Override any production defaults here
   config.x.git_api_endpoint = \
     "https://getintoteachingapi-test.test.teacherservices.cloud/api"

--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -18,4 +18,6 @@ Rails.application.configure do
   config.view_component.show_previews = true
 
   config.x.dfe_analytics = true
+
+  config.x.feature_flags.feedback_enabled = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -141,6 +141,8 @@ Rails.application.configure do
 
   config.x.dfe_analytics = true
 
+  config.x.feature_flags.feedback_enabled = false
+
   # Ensure beta redirect happens before static page cache.
   config.middleware.insert_before ActionDispatch::Static, Rack::HostRedirect, {
     "beta-getintoteaching.education.gov.uk" => "getintoteaching.education.gov.uk",

--- a/config/environments/rolling.rb
+++ b/config/environments/rolling.rb
@@ -11,4 +11,6 @@ Rails.application.configure do
   config.x.display_content_errors = true
 
   config.x.dfe_analytics = true
+
+  config.x.feature_flags.feedback_enabled = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,4 +55,5 @@ Rails.application.configure do
   config.x.integration_credentials = { username: ENV["HTTP_USERNAME"], password: ENV["HTTP_PASSWORD"] }
   config.x.mailsac_api_key = ENV["MAILSAC_API_KEY"]
   config.x.dfe_analytics = true
+  config.x.feature_flags.feedback_enabled = true
 end


### PR DESCRIPTION
### Trello card
[4926](https://trello.com/c/nMIiZhyX/4926-support-paas-migration-of-git-website)

### Context
A migration of the production environment from PAAS to AKS will take place next week. For this, we want to temporarily disable anyone accessing or using the feedback pages.

### Changes proposed in this pull request
Add a simple feature flag that can be set per environment to enable / disable access to the feedback pages.

### Guidance to review
Currently development (and therefore also review apps) are set with the feature flag turned on, so testing should be that you are able to use the feedback functionality with no issues, if you would like to test what will happen when it is turned off, please let me know and I can push a change that turns it off for the development environment as well (which I will revert before merging).

