### PR TITLE
Revert "Remove code that starts and appends chat widget to the DOM"

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -27,9 +27,8 @@ export default class extends Controller {
     const closeTime = dayjs().set('hour', 17).set('minute', 30).tz(timeZone);
     const now = dayjs().tz(timeZone);
     const weekend = [6, 0].includes(now.get('day'));
-    const disabled = true; // temporary to disable chat
 
-    return !disabled && !weekend && now >= openTime && now <= closeTime;
+    return !weekend && now >= openTime && now <= closeTime;
   }
 
   start(e) {
@@ -43,12 +42,26 @@ export default class extends Controller {
       this.chatTarget.textContent = 'Starting chat...';
     }
 
+    this.appendZendeskScript();
+
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         this.chatTarget.textContent = 'Chat online';
       });
     });
+  }
+
+  appendZendeskScript() {
+    if (this.zendeskScriptLoaded) {
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.setAttribute('id', 'ze-snippet');
+    script.src =
+      'https://static.zdassets.com/ekr/snippet.js?key=34a8599c-cfec-4014-99bd-404a91839e37';
+    document.body.appendChild(script);
   }
 
   waitForWebWidget(callback) {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -200,8 +200,3 @@ body a.govuk-back-link {
     display: inline-block;
   }
 }
-
-// Default Zendesk chat button (hidden as we use our own).
-#launcher {
-  display: none;
-}

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[wss://api.eu-1.smootch.io/faye api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -28,7 +28,7 @@ SecureHeaders::Configuration.default do |config|
   google_doubleclick = %w[*.doubleclick.net *.googleads.g.doubleclick.net *.ad.doubleclick.net *.fls.doubleclick.net stats.g.doubleclick.net]
   google_apis        = %w[*.googleapis.com googleapis.com https://fonts.googleapis.com]
 
-  zendesk     = %w[wss://api.eu-1.smootch.io/faye api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
+  zendesk     = %w[wss://api.eu-1.smooch.io/faye api.eu-1.smooch.io *.zendesk.com static.zdassets.com https://*.zopim.com wss://*.zopim.com dfesupport-tpuk.zendesk.com ekr.zdassets.com]
   facebook    = %w[*.facebook.com *.facebook.net *.connect.facebook.net]
   govuk       = %w[*.gov.uk www.gov.uk]
   jquery      = %w[code.jquery.com]

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Chat", type: :feature do
     context "when chat is online" do
       let(:date) { Time.zone.local(2021, 1, 1, 9) }
 
-      xscenario "viewing the chat section of the talk to us component" do
+      scenario "viewing the chat section of the talk to us component" do
         visit_on_date root_path
         dismiss_cookies
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -39,7 +39,7 @@ describe('ChatController', () => {
     return document.querySelector('a').textContent;
   }
 
-  xdescribe('when the chat is online', () => {
+  describe('when the chat is online', () => {
     beforeEach(() => {
       chatShowSpy = jest.fn(() => true);
       chatOpenSpy = jest.fn();


### PR DESCRIPTION
### Trello card

[4847](https://trello.com/c/Qqf05GG1/4847-replace-webchat-widget-with-upgraded-version)

### Changes proposed in this pull request

Reverts DFE-Digital/get-into-teaching-app#3630

Reinstates code to allow the widget to display.

Adds websocket endpoint to whitelist to enable messaging.