### PR TITLE
Enable AKS production

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -3,8 +3,8 @@
     "namespace": "git-production",
     "environment": "production",
     "internet_hostnames": [ "getintoteaching" ],
-    "basic_auth": 0,
-    "replicas": 0,
+    "basic_auth": 1,
+    "replicas": 6,
     "postgres_enable_high_availability": true,
     "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
     "azure_maintenance_window": {


### PR DESCRIPTION
### Trello card

n/a

### Context

Start the AKS prod environment
Has basic_auth enabled to prevent real users, crawlers, etc

### Changes proposed in this pull request

Update production_aks settings

### Guidance to review

make production_aks terraform-plan-aks

