### PR TITLE
Change salary block heading from h3 to h2

### DIFF
--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,6 +1,6 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
-    <h3>Earn at least &pound;30k a year</h3>
+    <h2 class="call-to-action__heading">Earn at least &pound;30k a year</h2>
     <p>All qualified teachers will have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
     <p><%= link_to("Find out more about teacher pay and benefits", page_path("is-teaching-right-for-me/teacher-pay-and-benefits")) %>.</p>
   <% end %>

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -45,6 +45,13 @@
     display: none;
   }
 
+  @include mq($until: tablet) {
+    #salary-banner .call-to-action__content h2 {
+      font-size: 24px;
+      line-height: 25px;
+    }
+  }
+
   @media (max-width: 1000px) {
     #salary-banner picture {
       display: none;

--- a/app/webpacker/styles/home.scss
+++ b/app/webpacker/styles/home.scss
@@ -30,21 +30,15 @@
   }
 
   #salary-banner .call-to-action__content {
-    padding: 30px 30px 10px;
+    padding: 30px 30px 11px;
   }
 
-  #salary-banner .call-to-action__content h3 {
-    font-size: 24px;
-    line-height: 30px;
+  #salary-banner .call-to-action__content h2 {
     margin-top: 0;
-    margin-bottom: 20px;
   }
 
   #salary-banner .call-to-action__content p {
-    font-size: 19px;
-    line-height: 25px;
     margin-top: 0;
-    margin-bottom: 20px;
   }
 
   #salary-banner p.call-to-action__text {
@@ -57,21 +51,15 @@
     }
 
     #salary-banner .call-to-action__content {
-      padding: 20px 20px 5px;
+      padding: 20px 20px 4px;
     }
 
-    #salary-banner .call-to-action__content h3 {
-      font-size: 18px;
-      line-height: 20px;
+    #salary-banner .call-to-action__content h2 {
       margin-top: 0;
-      margin-bottom: 15px;
     }
 
     #salary-banner .call-to-action__content p {
-      font-size: 16px;
-      line-height: 20px;
       margin-top: 0;
-      margin-bottom: 15px;
     }
 
     #salary-banner p.call-to-action__text {


### PR DESCRIPTION
### Trello card

[Trello 5224](https://trello.com/c/1GbQj4Yz)

### Context

There are heading levels on the page which do not accurately reflect the visual relationships within the content.

There is a heading level 3 (Earn at least £30k a year) which is presented programmatically as a sub-heading of the H2 (Online and in-person events), despite being visually unrelated with each being their own distinct section.

As screen reader users use headings to quickly identify content and structure of the page, headings should observe a logical and hierarchical structure, ensuring that visual relationships are preserved programmatically, so as not to present an inaccurate representation of relationships between content on the page.

### Changes proposed in this pull request

Headings provide context to the information they introduce and indicate page regions. Ensure that the correct heading levels are used to reflect the contents hierarchy.

As the heading (Earn at least £30k a year) is not a subheading of the h2 (Online and in-person events), the heading markup must be amended to accurately reflect the heading level; in this instance the h3 should be implemented as an h2.

### Guidance to review

Check that the source code and CSS complies with the above.



