### PR TITLE
Fixed breadcrumb pseudo-element issue

### DIFF
--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -12,17 +12,18 @@
 
     .govuk-breadcrumbs__list .govuk-breadcrumbs__list-item {
       &:not(:first-child) {
-        margin-left: 20px;
+        margin-left: 16px;
         padding-left: 20px;
 
         &:before {
-          @extend .fas;
-
-          content: "";
-          border: none;
-          transform: none;
-          font-size: .5em;
-          top: 2px;
+          top: 1px; 
+          width: 6px;
+          height: 6px;
+          margin: auto 0;
+          transform: rotate(45deg);
+          border: solid;
+          border-width: 2px 2px 0 0;
+          border-color: $black;
         }
       }
 

--- a/app/webpacker/styles/components/breadcrumb.scss
+++ b/app/webpacker/styles/components/breadcrumb.scss
@@ -16,7 +16,7 @@
         padding-left: 20px;
 
         &:before {
-          top: 1px; 
+          top: 1px;
           width: 6px;
           height: 6px;
           margin: auto 0;


### PR DESCRIPTION
### Trello card

[Trello 5217](https://trello.com/c/dbccy9Yx)

### Context

On the ‘Teacher training funding’ page, in the breadcrumb trail below the header navigation, there is a separator arrow, added with a CSS ::before pseudo-element, before each link in the breadcrumb trail except the first link. With JAWS screen reader, the virtual cursor silently stops at these elements without announcement.

This affects JAWS screen reader users who encounter an additional unexplained silent stop whilst browsing in context, which could prove confusing to them.

### Changes proposed in this pull request

Ensure that purely decorative content is hidden from assistive technologies.

### Guidance to review

Test the fix using a screenreader. The virtual cursor should no longer recognise the pseudo-element.
