### PR TITLE
Update video titles on About GIT events page

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -111,14 +111,14 @@
       <div class="video">
         <%= render Content::YoutubeVideoComponent.new(
           id: "wLfWfIzIRRY",
-          title: "Train to Teach Events: Take your next step towards teaching"
+          title: "A video about how to start your teaching journey at a Get Into Teaching event"
         ) %>
         <p>For everyone thinking of teaching.</p>
       </div>
       <div class="video">
         <%= render Content::YoutubeVideoComponent.new(
           id: "ToOhH06zMQA",
-          title: "Train to Teach Events: Take your next step towards teaching"
+          title: "A video about why you should attend a Get Into Teaching event"
         ) %>
         <p>Get all your questions answered.</p>
       </div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/G4BmLwd6

### Context
The iframe titles for the two videos on the About Get Into Teaching events page are the same, which is confusing for screen reader users.



