### PR TITLE
Changed quotation marks colour to improve contrast

### DIFF
--- a/app/webpacker/styles/components/what-theyre-saying.scss
+++ b/app/webpacker/styles/components/what-theyre-saying.scss
@@ -50,7 +50,7 @@
       &:before,
       &:after {
         @include font-size(xlarge);
-        color: $pink-dark;
+        color: $black;
       }
 
       &:before {


### PR DESCRIPTION
### Trello card

[Trello 5242](https://trello.com/c/pkEawlYs)

### Context

On the [Get Into Teaching events](https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events) page, the colour contrast difference between the pink quotation marks (#D34491) and the yellow background (#FBBA20) is 2.42:1. This does not meet the AA standard of 3:1.

### Changes proposed in this pull request

Ensure that where possible all text achieves a ratio as high as possible. We will therefore match the colour of the quotation marks to the quotation itself, which is #0B0C0C.

### Guidance to review

Check that the quotation marks are now black (#0B0C0C).