### PR TITLE
Fixed quotation mark alignment

### DIFF
--- a/app/webpacker/styles/components/what-theyre-saying.scss
+++ b/app/webpacker/styles/components/what-theyre-saying.scss
@@ -57,13 +57,13 @@
         content: open-quote;
         position: absolute;
         left: -.6em;
-        top: -.3em;
+        top: -.1em;
       }
 
       &:after {
         position: absolute;
         content: close-quote;
-        margin-left: .02em;
+        margin-left: .1em;
         margin-top: -.1em;
       }
     }


### PR DESCRIPTION
### Trello card

[Trello 5242](https://trello.com/c/pkEawlYs)

### Context

The quotation marks don't currently align correctly, as per the style guide.

### Changes proposed in this pull request

Align the quotation marks more consistently to match the style guide.

### Guidance to review

Check that the quotation marks align with the top of the line of text they accompany.