### PR TITLE
Update link text for Google Maps on event pages

### DIFF
--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -7,7 +7,7 @@
 
   <ul>
     <li>
-      <%= link_to("Open in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %>
+      <%= link_to("Open venue map in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %>
     </li>
     <% if display_event_provider_info?(@event) && @event.provider_website_url %>
       <li>


### PR DESCRIPTION
### Trello card
https://trello.com/c/TD5dJaXM

### Context
Our accessibility audit highlighted that the link to Google Maps on our event maps could be confusing for screen reader users and needed more context.

