### PR TITLE
Fixed search bar accessibility issue

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -147,6 +147,11 @@
       width: 100%;
       background-color: $white;
       margin: 0;
+      padding: 5px 8px;
+      background-image: url("../images/icon-search-black.svg");
+      background-repeat: no-repeat;
+      background-position: center right 8px;
+      background-size: 24px 24px;
     }
 
     @include mq($from: tablet) {


### PR DESCRIPTION
### Trello card

[Trello 5247](https://trello.com/c/8C8cv78m)

### Context

On the ‘Get into Teaching’ homepage, when the search bar is visible, the search input is visually labelled by use of the placeholder text ‘Search’.

The issue with relying on placeholder text for labelling the input is that, upon entry into the input field, the placeholder text disappears.

This can affect all sighted users but could prove more challenging to cognitive users if they are required to remember what the placeholder had said before it vanished. With the only way to see the placeholder prompt again is to delete your entry and then recall what the previous deleted entry had been to re-enter it again.

### Changes proposed in this pull request

Ensure there is a persistent visible label for any input control, identifying its purpose. Consider adding a visible label to the search field identifying it (see screenshot 2).

In doing so, the visually hidden label (actually located just before the search bar open and close icon, after the ‘Find an event’ link) would no longer be required, as the visible label, programmatically associated with the search input, would cater to all user groups.

Alternatively, consider that, in the case of search, it would be deemed acceptable that the meaning of the standard magnifying glass icon, to represent search, is universally recognised and is a reasonable substitute for the text ‘Search’ (see screenshot 3).

In this case, the visually hidden ‘Search’ label would be retained for screen reader users.

We have opted for the latter option.

### Guidance to review

Check that there is a magnifying glass icon present in the input field, even when a search is started.

