### PR TITLE
Match search icon size to other icons in bonus bar

### DIFF
--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -34,8 +34,8 @@
 
     .icon {
       margin-left: .5em;
-      width: 20px;
-      height: 20px;
+      width: 24px;
+      height: 24px;
 
       &.icon-close {
         display: none;


### PR DESCRIPTION
### Trello card

[Trello 5247](https://trello.com/c/8C8cv78m)

### Context

Whilst working on the above ticket, I noticed that the search icon in the bonus bar was significantly smaller than the other icons in this component. Increasing the size of this icon to match others is likely to improve the visibility of this button.

### Changes proposed in this pull request

Increase the size of the search icon to 24px x 24px, matching other icons in the bonus bar.

### Guidance to review

Check that the search icon is the same size as the other icons.