### PR TITLE
Updated checklist tick icon colour contrast

### DIFF
--- a/app/components/content/checklist_collage_component.html.erb
+++ b/app/components/content/checklist_collage_component.html.erb
@@ -2,7 +2,7 @@
   <div>
     <ul>
       <% checklist.each do |item| %>
-        <%= tag.li(safe_join([helpers.fa_icon("check"), tag.strong(item)])) %>
+        <%= tag.li(safe_join([tag.strong(item)])) %>
       <% end %>
     </ul>
     <%= link_to(cta[:text], cta[:link], class: "button") if cta.present? %>

--- a/app/webpacker/styles/blog.scss
+++ b/app/webpacker/styles/blog.scss
@@ -65,6 +65,11 @@
 
     li {
       background-color: $grey;
+      margin-bottom: 0;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
 
       a {
         display: block;

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -37,7 +37,7 @@
         position: absolute;
         margin-left: -4rem;
         border: solid 4px $black;
-        top: 7px;
+        top: -5px;
       }
     }
   }

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -17,27 +17,27 @@
   ul {
     position: relative;
     list-style: none;
-    padding-left: 2rem;
+    padding-left: 4rem;
+    margin-top: 0;
     margin-bottom: 2 * $indent-amount;
 
     li {
       position: relative;
-      margin: $indent-amount 0;
+      margin: 0 0 2em;
 
-      &:not(:first-child) {
-        margin-top: 3.5em;
-      }
-
-      .fa-check {
+      &:before {
+        content: "";
+        background-image: url("../images/icon-tick.svg");
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 40px 40px;
+        display: block;
+        width: 30px;
+        height: 30px;
         position: absolute;
-        color: $white;
-        left: -2rem;
-        top: 0;
-        width: 22px;
-        height: 20px;
-        background-color: $yellow;
-        text-align: center;
-        border-top: 3px solid $yellow;
+        margin-left: -4rem;
+        border: solid 4px $black;
+        top: 7px;
       }
     }
   }

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -17,7 +17,7 @@
   ul {
     position: relative;
     list-style: none;
-    padding-left: 4rem;
+    padding-left: 3.5rem;
     margin-top: 0;
     margin-bottom: 2 * $indent-amount;
 
@@ -35,7 +35,7 @@
         width: 30px;
         height: 30px;
         position: absolute;
-        margin-left: -4rem;
+        margin-left: -3.5rem;
         border: solid 4px $black;
         top: -5px;
       }

--- a/app/webpacker/styles/header/extra-navigation.scss
+++ b/app/webpacker/styles/header/extra-navigation.scss
@@ -25,11 +25,11 @@
 
   &__link a {
     display: inline-block;
-    padding: .6em 1em;
-    line-height: 28px;
+    padding: .75em 1em;
+    line-height: 24px;
 
     @include mq($until: mobile) {
-      padding: .6em .8em;
+      padding: .75em .8em;
     }
 
     .icon {
@@ -79,8 +79,8 @@
     a {
       background-color: $pink;
       margin-left: 1em;
-      padding: .6em $indent-amount / 2;
-      line-height: 28px;
+      padding: .75em;
+      line-height: 24px;
 
       &:hover {
         background-color: $pink-dark;

--- a/spec/components/content/checklist_collage_component_spec.rb
+++ b/spec/components/content/checklist_collage_component_spec.rb
@@ -35,7 +35,7 @@ describe Content::ChecklistCollageComponent, type: :component do
   it { is_expected.to have_css("p", text: "content") }
   it { is_expected.to have_css(".images.images-3") }
 
-  it "renders the checlist items" do
+  it "renders the checklist items" do
     checklist.each do |item|
       is_expected.to have_css("ul li", text: item)
     end


### PR DESCRIPTION
### Trello card

[Trello 5249](https://trello.com/c/UHOCStIW)
[Trello 5250](https://trello.com/c/zNHGTbJC)

### Context

The colour contrast difference between the non-text element’s white colour (#FFFFFF) and the yellow background (#FBBA20) is 1.72:1. This does not meet the AA standard of 3:1.

Also, the colour contrast difference between the non-text element’s yellow colour (#FBBA20) and the grey background (#F0F0F0) is 1.51:1. This does not meet the AA standard of 3:1.

### Changes proposed in this pull request

Replace the current tick icon - which, as a rounded Font Awesome icon, does not match the styling of other ticks on the website - with the same tick icon as is used in the GIT logo. Also, remove the yellow background as this only serves to complicate the colour contrast issue.

### Guidance to review

Check that the rounded tick in a yellow box has been replaced by a sharper tick in a box, to match the icon in the GIT logo.

