### PR TITLE
Focus on chat widget once loaded

### DIFF
--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,9 +48,11 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
+
         chat.focus();
         chat.setAttribute('role', 'dialog');
         chat.setAttribute('aria-modal', 'true');
+
         this.chatTarget.textContent = 'Chat online';
       });
     });

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,6 +48,7 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
+        chat.focus();
         chat.setAttribute('role', 'dialog');
         chat.setAttribute('aria-modal', 'true');
         this.chatTarget.textContent = 'Chat online';

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,7 +48,8 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
-        this.focusOnChat(chat);
+        chat.tabIndex = 1;
+        // this.focusOnChat(chat);
         this.chatTarget.textContent = 'Chat online';
       });
     });
@@ -89,23 +90,6 @@ export default class extends Controller {
 
   showWebWidget() {
     window.zE('messenger', 'open');
-  }
-
-  focusOnChat(chatWidget) {
-    var focusInterval = 10; // ms, time between function calls
-    var focusTotalRepetitions = 10; // number of repetitions
-
-    chatWidget.setAttribute('tabindex', '0');
-    chatWidget.blur();
-
-    var focusRepetitions = 0;
-    var interval = window.setInterval(function () {
-      chatWidget.focus();
-      focusRepetitions++;
-      if (focusRepetitions >= focusTotalRepetitions) {
-        window.clearInterval(interval);
-      }
-    }, focusInterval);
   }
 
   get zendeskScriptLoaded() {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,7 +48,8 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
-        chat.tabIndex = 1;
+        chat.role = 'dialog';
+        chat.setAttribute('aria-modal', 'true');
         this.chatTarget.textContent = 'Chat online';
       });
     });

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -49,7 +49,6 @@ export default class extends Controller {
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
         chat.tabIndex = 1;
-        // this.focusOnChat(chat);
         this.chatTarget.textContent = 'Chat online';
       });
     });

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -47,6 +47,8 @@ export default class extends Controller {
     this.waitForZendeskScript(() => {
       this.showWebWidget();
       this.waitForWebWidget(() => {
+        const chat = document.querySelector('[title="Messaging window"]');
+        chat.focus();
         this.chatTarget.textContent = 'Chat online';
       });
     });

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,7 +48,7 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
-        chat.focus();
+        this.focusOnChat(chat);
         this.chatTarget.textContent = 'Chat online';
       });
     });
@@ -89,6 +89,23 @@ export default class extends Controller {
 
   showWebWidget() {
     window.zE('messenger', 'open');
+  }
+
+  focusOnChat(chatWidget) {
+    var focusInterval = 10; // ms, time between function calls
+    var focusTotalRepetitions = 10; // number of repetitions
+
+    chatWidget.setAttribute('tabindex', '0');
+    chatWidget.blur();
+
+    var focusRepetitions = 0;
+    var interval = window.setInterval(function () {
+      chatWidget.focus();
+      focusRepetitions++;
+      if (focusRepetitions >= focusTotalRepetitions) {
+        window.clearInterval(interval);
+      }
+    }, focusInterval);
   }
 
   get zendeskScriptLoaded() {

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -48,7 +48,7 @@ export default class extends Controller {
       this.showWebWidget();
       this.waitForWebWidget(() => {
         const chat = document.querySelector('[title="Messaging window"]');
-        chat.role = 'dialog';
+        chat.setAttribute('role', 'dialog');
         chat.setAttribute('aria-modal', 'true');
         this.chatTarget.textContent = 'Chat online';
       });


### PR DESCRIPTION
### Trello card
[5253](https://trello.com/c/kk7otptb/5253-fix-webchat-widget-focus-for-screen-readers)

### Context
On launch of the chat widget, the focus for the page and screen readers should go to the chat widget, currently the focus stays on the page in the background, so tabbing through the page continues on from top instead of from the chat widget.

### Changes proposed in this pull request
On loading of the widget, the focus is sent to the loaded widget, and so tabbing through the page from that point on goes through the chat widget, and not the page behind.

### Guidance to review
Check it works as expected on review app.

