### PR TITLE
Add Future Teacher Training to Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -137,7 +137,12 @@ provider_groups:
       link: https://www.bscteach.co.uk/
       name: Derek Boyle
       telephone: 020 8300 6566
-      email: Administrator@gradteach.co.uk     
+      email: Administrator@gradteach.co.uk      
+    - header: Future Teacher Training (Future Academies)
+      link: https://www.futureteachertraining.org/
+      name: Clare Foster
+      telephone: 020 7802 3455
+      email: enquiries@scitt.futureacademies.org    
     - header: Goldsmiths, University of London
       link: https://www.gold.ac.uk/
       name: Lynsey Salt


### PR DESCRIPTION
### Trello card
https://trello.com/c/7xt1iU96

### Context
Request received via GIT support team to add Future Teacher Training to AO page
