### PR TITLE
Create separate Events card component

### DIFF
--- a/app/components/events/card_component.html.erb
+++ b/app/components/events/card_component.html.erb
@@ -1,0 +1,8 @@
+<li class="category__nav-card">
+  <%= link_to(path, class: "link--black") do %>
+    <div class="category__nav-card--content">
+      <%= content_tag(heading_tag, title) %>
+      <%= tag.p(helpers.safe_html_format(description)) %>
+    </div>
+  <% end %>
+</li>

--- a/app/components/events/card_component.rb
+++ b/app/components/events/card_component.rb
@@ -1,0 +1,12 @@
+class Events::CardComponent < ViewComponent::Base
+  attr_reader :title, :description, :path, :heading_tag
+
+  def initialize(card:, heading_tag: "h3")
+    @title       = card.title
+    @description = card.description
+    @path        = card.path
+    @heading_tag = heading_tag
+
+    super
+  end
+end

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -51,7 +51,7 @@
         <section id="events" class="category__cards">
           <%= tag.nav(class: "category__nav-cards") do %>
             <ul class="one-column horizontal">
-              <%= render(Categories::CardComponent.with_collection(categorise_events(@git_events))) %>
+              <%= render(Events::CardComponent.with_collection(categorise_events(@git_events))) %>
             </ul>
           <% end %>
           <div>


### PR DESCRIPTION
### Trello card

[Trello 5220](https://trello.com/c/PlOQWjcb)

### Context

Headings had been used in a way that did not relay the relationships correctly to screen reader users. The ‘Events in your region’ heading introduces the headings ‘East of England’, ‘North East’, ‘London’ and ‘North West’, but the same heading level has been applied i.e. h2.

### Changes proposed in this pull request

Create a new card component for the 'About Get Into Teaching Events' page which allows us to change the headings from h2s to h3s.

### Guidance to review

Check the headers on the card component on the /events/about-get-into-teaching-events page are h3s.