### PR TITLE
Added quote to SEND page

### DIFF
--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -38,7 +38,7 @@ This will enable you to work in a range of settings throughout your career.
 >
 > They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the Autistic Spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified.
 >
->_Jane Wilkinson, former teacher and teacher training adviser._
+>_Jane Wilkinson, former teacher and teacher training adviser_
 
 ## Teach pupils with sensory impairments
 

--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -25,7 +25,6 @@ quote:
   q-jane-wilkinson:
     text: "I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs. They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the autistic spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified."
     name: "Jane Wilkinson, former teacher and teacher training adviser"
-    job_title: "former teacher and teacher training adviser"
 ---
 Most disabled pupils and pupils with special educational needs learn in mainstream schools.
 
@@ -40,7 +39,6 @@ As you train and teach you'll get the skills you need to work with disabled pupi
 This will enable you to work in a range of settings throughout your career.
 
 $q-jane-wilkinson$
-
 
 ## Teach pupils with sensory impairments
 

--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -24,7 +24,7 @@ keywords:
 quote:
   q-jane-wilkinson:
     text: "I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs. They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the autistic spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified."
-    name: "Jane Wilkinson"
+    name: "Jane Wilkinson, former teacher and teacher training adviser"
     job_title: "former teacher and teacher training adviser"
 ---
 Most disabled pupils and pupils with special educational needs learn in mainstream schools.

--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -23,7 +23,7 @@ keywords:
   - special school
 quote:
   q-jane-wilkinson:
-    text: "I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs. They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the Autistic Spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified."
+    text: "I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs. They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the autistic spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified."
     name: "Jane Wilkinson"
     job_title: "former teacher and teacher training adviser"
 ---

--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -9,7 +9,7 @@ image: "static/content/hero-images/0023.jpg"
 navigation: 5.40
 navigation_title: How can I teach children with special educational needs?
 navigation_description: Find out more about teaching pupils with special educational needs and disabilities.
-article_classes: ['longform']
+article_classes: ['longform', 'blog']
 promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-send
 keywords:
@@ -33,6 +33,12 @@ However, it’s not essential to do a course specialising in SEND.
 As you train and teach you'll get the skills you need to work with disabled pupils and pupils with special educational needs.
 
 This will enable you to work in a range of settings throughout your career.
+
+> I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs.
+>
+> They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the Autistic Spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified.
+>
+>_Jane Wilkinson, former teacher and teacher training adviser._
 
 ## Teach pupils with sensory impairments
 

--- a/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
+++ b/app/views/content/is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs.md
@@ -9,7 +9,7 @@ image: "static/content/hero-images/0023.jpg"
 navigation: 5.40
 navigation_title: How can I teach children with special educational needs?
 navigation_description: Find out more about teaching pupils with special educational needs and disabilities.
-article_classes: ['longform', 'blog']
+article_classes: ['longform']
 promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-send
 keywords:
@@ -21,6 +21,11 @@ keywords:
   - teaching
   - teacher
   - special school
+quote:
+  q-jane-wilkinson:
+    text: "I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs. They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the Autistic Spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified."
+    name: "Jane Wilkinson"
+    job_title: "former teacher and teacher training adviser"
 ---
 Most disabled pupils and pupils with special educational needs learn in mainstream schools.
 
@@ -34,11 +39,8 @@ As you train and teach you'll get the skills you need to work with disabled pupi
 
 This will enable you to work in a range of settings throughout your career.
 
-> I specifically wanted to work with children identified with Special Educational Needs and Disabilities (SEND). I was fortunate to find a teacher training course provider that was able to allow me to practice in a mainstream school that also hosted a hearing impairment unit. And another school that offered support for children with a variety of learning needs.
->
-> They were great at teaching me and letting me practice my classroom management skills early on. I was able to research and understand ways to differentiate resources for children who were on the Autistic Spectrum. And I was able to create and implement a scheme of work to reflect on and evaluate for later use once qualified.
->
->_Jane Wilkinson, former teacher and teacher training adviser_
+$q-jane-wilkinson$
+
 
 ## Teach pupils with sensory impairments
 


### PR DESCRIPTION
### Trello card

[Trello 5260](https://trello.com/c/EjpVrFa7)

### Context

Following our [review of the blog](https://trello.com/c/pC75AtVz/4846-review-blogs-to-identify-which-should-be-deleted-and-which-converted-to-informational-pages), we identified a number of pages that should be removed and redirected to existing pages.

We have deleted the blog post on [https://getintoteaching.education.gov.uk/blog/choosing-the-right-teacher-training-course-provider](https://getintoteaching.education.gov.uk//blog/choosing-the-right-teacher-training-course-provider) and moved any relevant content into the page https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-choose-your-teacher-training-course

As part of this we have identified a strong quote around teaching children with special educational needs and want to reuse it on the SEND page.

### Changes proposed in this pull request

Add the quote outlined by @MaxineCl to the SEND page as requested.

### Guidance to review

Check that the quote appears on the /is-teaching-right-for-me/teach-disabled-pupils-and-pupils-with-special-educational-needs page.