### PR TITLE
Add html html attributes for accessibility audit for screen readers

### DIFF
--- a/app/components/footer/cookie_acceptance_component.html.erb
+++ b/app/components/footer/cookie_acceptance_component.html.erb
@@ -1,4 +1,4 @@
-<div class="cookie-acceptance" data-controller="cookie-acceptance" data-cookie-acceptance-target="modal" role="complementary">
+<div class="cookie-acceptance" data-controller="cookie-acceptance" data-cookie-acceptance-target="modal" role="dialog" aria-modal="true">
   <div class="dialog" data-cookie-acceptance-target="overlay">
     <div class="dialog__background"></div>
     <div class="dialog__content">


### PR DESCRIPTION
### Trello card
[5227](https://trello.com/c/pviWctFJ/5227-dac-audit-2023-cookie-modal-focus-escaping)

### Context
Screen reader does not focus correctly on cookie modal.

### Changes proposed in this pull request
Add `role="dialog"` and `aria-modal="true"` html attributes to the element to ensure screen reader picks it up.

### Guidance to review
Use a screen reader like voice over on your phone, and swipe through page once the cookies modal appears, it should first step through the elements on the cookie modal, not the page behind.
