### PR TITLE
Add aria attributes for expandable components and logic to set true/false as needed

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -12,11 +12,11 @@
       </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden], data: { "searchbox-target": "label" }) %>
-      <%= link_to(search_path, aria: { label: "Search" }, data: { action: "searchbox#toggle" }) do %>
+      <%= link_to(search_path, id: "search-toggle", aria: { label: "Search", expanded: false, controls: "search-bar" }, data: { action: "searchbox#toggle" }) do %>
         <span class="icon icon-search"></span>
         <span class="icon icon-close"></span>
       <% end %>
     <% end %>
   </ul>
-  <div class="searchbar" data-searchbox-target="searchbar" role="search"></div>
+  <div id="search-bar" class="searchbar" data-searchbox-target="searchbar" role="search"></div>
 <% end %>

--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -1,4 +1,4 @@
-<nav class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation" role="navigation">
+<nav id="primary-navigation" class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation" role="navigation">
   <ol class="primary" data-navigation-target="primary">
     <% all_resources.each do |resource| %>
       <%= nav_link(resource.title, resource.path) %>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -10,7 +10,7 @@
   <%= render Header::ExtraNavigationComponent.new(search_input_id: "searchbox__input--desktop") %>
   <%= render Header::LogoComponent.new %>
   <div class="menu-button" id="mobile-navigation-menu-button">
-    <%= tag.button(class: "menu-button__button", data: { action: "click->navigation#toggleNav", "navigation-target" => "menu" }) do %>
+    <%= tag.button(class: "menu-button__button", id: 'menu-toggle', aria: { expanded: false, controls: 'primary-navigation'}, data: { action: "click->navigation#toggleNav", "navigation-target" => "menu" }) do %>
       <span class="menu-button__text">Menu</span>
       <span class="menu-button__icon"></span>
     <% end %>

--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -28,8 +28,10 @@ export default class extends Controller {
 
     if (nav.classList.contains(this.navHiddenClass)) {
       this.expandNav();
+      this.menuToggler.ariaExpanded = 'true';
     } else {
       this.collapseNav();
+      this.menuToggler.ariaExpanded = 'false';
     }
   }
 
@@ -74,5 +76,9 @@ export default class extends Controller {
 
   get navHiddenClass() {
     return 'hidden-mobile';
+  }
+
+  get menuToggler() {
+    return document.getElementById('menu-toggle');
   }
 }

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -19,8 +19,10 @@ export default class extends Controller {
 
     if (this.element.classList.contains('open')) {
       this.element.classList.remove('open');
+      this.searchToggler.ariaExpanded = 'false';
     } else {
       this.element.classList.add('open');
+      this.searchToggler.ariaExpanded = 'true';
       this.input.focus();
     }
   }
@@ -160,5 +162,9 @@ export default class extends Controller {
 
   get input() {
     return this.searchbarTarget.querySelector('input');
+  }
+
+  get searchToggler() {
+    return document.getElementById('search-toggle');
   }
 }


### PR DESCRIPTION
### Trello card
[5293](https://trello.com/c/ERhhH5wv/5293-dac-audit-2023-missing-expanded-aria-1-search-bar)
[5243](//trello.com/c/4CjQRgKC/5243-dac-audit-2023-missing-expanded-aria-2-menu-button-on-mobile)

### Context
The accessibility audit showed that these expandable components did not have the correct aria attributes available. These needed to be added and values updated accordingly with user action.

### Changes proposed in this pull request
Add the `role`, `aria-expanded` and `aria-controls` attributes to the relevant html elements, and include logic to adjust accordingly.

### Guidance to review
In the review app ensure html attributes are present and changing as expected in the DOM when each of the toggle elements are clicked by the user.
