### PR TITLE
Update maths scholarship link

### DIFF
--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -105,7 +105,7 @@ Scholarships are offered by independent institutions. They set their own eligibi
 * [the Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry)
 * [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
 * [British Council](https://www.britishcouncil.org/education/he-science/opportunities/ltts) (languages -- French, German and Spanish only)
-* [the Institute of Mathematics and its Applications](https://teachingmathsscholars.org/home) (maths)
+* [the Institute of Mathematics and its Applications, in partnership with 5 other maths organisations](https://teachingmathsscholars.org/home) (maths)
 * [the Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
 
 Each scholarship body will have its own deadline for applications. You can find these on their individual websites.

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -105,7 +105,7 @@ Scholarships are offered by independent institutions. They set their own eligibi
 * [the Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry)
 * [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
 * [British Council](https://www.britishcouncil.org/education/he-science/opportunities/ltts) (languages -- French, German and Spanish only)
-* [the Institute of Mathematics and its Applications, in partnership with 5 other maths organisations](https://teachingmathsscholars.org/home) (maths)
+* [the Institute of Mathematics and its Applications, and partners](https://teachingmathsscholars.org/home) (maths)
 * [the Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
 
 Each scholarship body will have its own deadline for applications. You can find these on their individual websites.

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -114,7 +114,7 @@
     <p>Scholarships of £30,000 or bursaries of £28,000 are available if you start your maths teacher training course between September 2024 and July 2025.</p>
 
     <p><a href="/funding-and-support/scholarships-and-bursaries">Check your eligibility for bursaries and scholarships</a>.</p>
-    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications, and partners.</a>.</p>
+    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications, and partners</a>.</p>
 
     <h2 class="heading-s">Experience school life</h2>
 

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -114,7 +114,7 @@
     <p>Scholarships of £30,000 or bursaries of £28,000 are available if you start your maths teacher training course between September 2024 and July 2025.</p>
 
     <p><a href="/funding-and-support/scholarships-and-bursaries">Check your eligibility for bursaries and scholarships</a>.</p>
-    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications</a>.</p>
+    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications, provided in partnership with 5 other maths organisations</a>.</p>
 
     <h2 class="heading-s">Experience school life</h2>
 

--- a/app/views/content/subjects/maths/_article.html.erb
+++ b/app/views/content/subjects/maths/_article.html.erb
@@ -114,7 +114,7 @@
     <p>Scholarships of £30,000 or bursaries of £28,000 are available if you start your maths teacher training course between September 2024 and July 2025.</p>
 
     <p><a href="/funding-and-support/scholarships-and-bursaries">Check your eligibility for bursaries and scholarships</a>.</p>
-    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications, provided in partnership with 5 other maths organisations</a>.</p>
+    <p>You can <a href="https://teachingmathsscholars.org/home">find out more about the maths scholarship from The Institute of Mathematics and its Applications, and partners.</a>.</p>
 
     <h2 class="heading-s">Experience school life</h2>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/eHti5UjQ/5289-update-scholarships-link-and-wording-on-maths-subject-page 

### Context
Louisa Cooper in the ITT team has forwarded a request from Vanessa Thorogood from the IMA (Institute of Maths and its Applications). She’s asked we make it clear that scholarships they offer are delivered in conjunction with 5 other maths organisations.

### Changes proposed in this pull request
We need to update link content on the following pages:
https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries
https://getintoteaching.education.gov.uk/subjects/maths

### Guidance to review

