### PR TITLE
Missing expanded aria search

### DIFF
--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -1,4 +1,4 @@
-<nav id="primary-navigation" class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation" role="navigation">
+<nav class="hidden-mobile" data-navigation-target="nav" aria-label="Primary navigation" role="navigation">
   <ol class="primary" data-navigation-target="primary">
     <% all_resources.each do |resource| %>
       <%= nav_link(resource.title, resource.path) %>

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -10,7 +10,7 @@
   <%= render Header::ExtraNavigationComponent.new(search_input_id: "searchbox__input--desktop") %>
   <%= render Header::LogoComponent.new %>
   <div class="menu-button" id="mobile-navigation-menu-button">
-    <%= tag.button(class: "menu-button__button", id: 'menu-toggle', aria: { expanded: false, controls: 'primary-navigation'}, data: { action: "click->navigation#toggleNav", "navigation-target" => "menu" }) do %>
+    <%= tag.button(class: "menu-button__button", data: { action: "click->navigation#toggleNav", "navigation-target" => "menu" }) do %>
       <span class="menu-button__text">Menu</span>
       <span class="menu-button__icon"></span>
     <% end %>

--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -28,10 +28,8 @@ export default class extends Controller {
 
     if (nav.classList.contains(this.navHiddenClass)) {
       this.expandNav();
-      this.menuToggler.ariaExpanded = 'true';
     } else {
       this.collapseNav();
-      this.menuToggler.ariaExpanded = 'false';
     }
   }
 
@@ -76,9 +74,5 @@ export default class extends Controller {
 
   get navHiddenClass() {
     return 'hidden-mobile';
-  }
-
-  get menuToggler() {
-    return document.getElementById('menu-toggle');
   }
 }


### PR DESCRIPTION
### Trello card
[5293](https://trello.com/c/ERhhH5wv/5293-dac-audit-2023-missing-expanded-aria-1-search-bar)

### Context
The accessibility audit showed that these expandable components did not have the correct aria attributes available. These needed to be added and values updated accordingly with user action.

### Changes proposed in this pull request
Add the role, aria-expanded and aria-controls attributes to the relevant html elements, and include logic to adjust accordingly.

### Guidance to review
In the review app ensure html attributes are present and changing as expected in the DOM when each of the toggle elements are clicked by the user.
