### PR TITLE
Add alerting for backing services and webapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,3 +269,9 @@ edit-app-secrets-aks: install-fetch-config set-azure-account
 
 print-app-secrets-aks: install-fetch-config set-azure-account
 	./fetch_config.rb -s azure-key-vault-secret:${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv/${APPLICATION_SECRETS}  -f yaml
+
+action-group-resources: set-azure-account # make env_aks action-group-resources ACTION_GROUP_EMAIL=notificationemail@domain.com . Must be run before setting enable_monitoring=true for each subscription
+	$(if $(ACTION_GROUP_EMAIL), , $(error Please specify a notification email for the action group))
+	echo ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg
+	az group create -l uksouth -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=Get into teaching website" "Environment=Test" "Service Offering=Teacher services cloud"
+	az monitor action-group create -n ${AZURE_RESOURCE_PREFIX}-get-into-teaching-app -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --short-name ${AZURE_RESOURCE_PREFIX}-git --action email ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}

--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -7,6 +7,8 @@
     "replicas": 6,
     "postgres_enable_high_availability": true,
     "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+    "enable_monitoring": true,
+    "app_webtest_url": "https://getintoteaching.education.gov.uk/healthcheck.json",
     "azure_maintenance_window": {
         "day_of_week": 0,
         "start_hour": 3,

--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -1,0 +1,100 @@
+locals {
+  enable_webtest = var.app_webtest_url != null
+}
+
+data "azurerm_resource_group" "monitoring" {
+  count = local.enable_webtest ? 1 : 0
+
+  name = "${var.azure_resource_prefix}-${var.service_short}-mn-rg"
+}
+
+data "azurerm_monitor_action_group" "main" {
+  count = local.enable_webtest ? 1 : 0
+
+  name                = "${var.azure_resource_prefix}-${var.service_name}"
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
+}
+
+resource "azurerm_log_analytics_workspace" "webtest" {
+  count = local.enable_webtest ? 1 : 0
+
+  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai-log"
+  location            = data.azurerm_resource_group.monitoring[0].location
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_application_insights" "webtest" {
+  count = local.enable_webtest ? 1 : 0
+
+  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai"
+  location            = data.azurerm_resource_group.monitoring[0].location
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
+  workspace_id        = azurerm_log_analytics_workspace.webtest[0].id
+  application_type    = "web"
+  retention_in_days   = 30
+
+  internet_ingestion_enabled = false
+  internet_query_enabled     = false
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_application_insights_standard_web_test" "webtest" {
+  count = local.enable_webtest ? 1 : 0
+
+  name                    = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai-webtest"
+  resource_group_name     = data.azurerm_resource_group.monitoring[0].name
+  location                = data.azurerm_resource_group.monitoring[0].location
+  application_insights_id = azurerm_application_insights.webtest[0].id
+  geo_locations           = ["emea-ru-msa-edge"]
+  enabled                 = true
+
+  request {
+    url = var.app_webtest_url
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "webtest" {
+  count = local.enable_webtest ? 1 : 0
+
+  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai-webtest-alert"
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
+  scopes              = [azurerm_application_insights.webtest[0].id]
+  description         = "Action will be triggered when web test fails"
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name      = "availabilityResults/availabilityPercentage"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 100
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/terraform/aks/statuscake.tf
+++ b/terraform/aks/statuscake.tf
@@ -1,10 +1,13 @@
-module "statuscake" {
-  count = var.enable_monitoring ? 1 : 0
+# Commenting out this module as currently statuscake monitoring for git fails due to a large HTTP header.
+# We will use an App Insights web test monitor until the dev team can decrease the size of the CSP header.
+#
+# module "statuscake" {
+#   count = var.enable_monitoring ? 1 : 0
 
-  source = "./vendor/modules/aks//monitoring/statuscake"
+#   source = "./vendor/modules/aks//monitoring/statuscake"
 
-  uptime_urls = compact([module.web_application.probe_url, var.external_url])
-  ssl_urls    = compact([var.external_url])
+#   uptime_urls = compact([module.web_application.probe_url, var.external_url])
+#   ssl_urls    = compact([var.external_url])
 
-  contact_groups = var.statuscake_contact_groups
-}
+#   contact_groups = var.statuscake_contact_groups
+# }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -85,7 +85,9 @@ variable "postgres_flexible_server_sku" {
 variable "postgres_enable_high_availability" {
   default = false
 }
-
+variable "app_webtest_url" {
+  default = null
+}
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/w1nAr3IF/806-git-add-monitoring-alerts

### Context

Add monitoring alerts for the production env
- web url monitoring via Azure App Insights while statuscake is unavailable.
   currently checks the app every 5 minutes (minimum possible) and alerts if a request fails (via email to infra team)
- backing service monitoring for postgres and redis

### Changes proposed in this pull request

- Add terraform config
- disable statuscake

### Guidance to review

make production_aks terraform-plan-aks
deployed to review app (rm1) and tested alerts trigger on response failure, which should be removed after merge


