### PR TITLE
Delete events videos

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -99,29 +99,3 @@
     </figure>
   </section>
 </div>
-
-<div class="row inset">
-  <section class="col col-full-content">
-    <div class="statement">
-      <h2 class="blue xlarge">Why you should attend</h2>
-    </div>
-  </section>
-  <section class="col col-full-content youtube-videos">
-    <div class="wrapper">
-      <div class="video">
-        <%= render Content::YoutubeVideoComponent.new(
-          id: "wLfWfIzIRRY",
-          title: "A video about how to start your teaching journey at a Get Into Teaching event"
-        ) %>
-        <p>For everyone thinking of teaching.</p>
-      </div>
-      <div class="video">
-        <%= render Content::YoutubeVideoComponent.new(
-          id: "ToOhH06zMQA",
-          title: "A video about why you should attend a Get Into Teaching event"
-        ) %>
-        <p>Get all your questions answered.</p>
-      </div>
-    </div>
-  </section>
-</div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/nmsMrcYZ/5296-dac-audit-2023-video-content-event-videos 

### Context
The 2 videos on this page were flagged in the DAC accessibility audit for having content that was missed by screen readers. As the videos weren't getting many views the events team agreed we can remove them.

### Changes proposed in this pull request
Delete the Why you should attend video section on this page https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events

### Guidance to review

