### PR TITLE
Update message on About GIT events page when no events listed

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -65,7 +65,7 @@
         </section>
 
         <section class="col col-720">
-          <p>In the meantime, take a look at our <%= link_to("online events", events_path({ teaching_events_search: { online: [true] }}), class: "link--black") %> or <%= link_to("events near you", events_path, class: "link--black") %>.</p>
+          <p>In the meantime, take a look at <%= link_to("teacher training provider events", events_path({ teaching_events_search: { type: ["provider"] }}), class: "link--black") %> in your area or online.</p>
         </section>
 
         <section class="col col-720">


### PR DESCRIPTION
### Trello card
https://trello.com/c/qVjndm6G

### Context
When no GIT events are listed on the About GIT events page, we display a message signposting people to other types of events. This message needs updating as we do not currently have DfE online Q&A events.

