### PR TITLE
Update healthchecks_controller.rb

### DIFF
--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -1,5 +1,9 @@
 class HealthchecksController < ApplicationController
-  def show
+   def show
+     # De-activate the CSP header on the healthcheck page, to allow the system
+     # to be monitored without over-sized CSP headers
+    SecureHeaders::opt_out_of_header(request, 'csp')
+
     @healthcheck = Healthcheck.new
     Rails.logger.info("HealthCheck: #{@healthcheck.to_h}")
     render json: @healthcheck


### PR DESCRIPTION
De-activate the CSP header on the healthcheck page, to allow the system to be monitored without over-sized CSP headers

### Trello card
[5209](https://trello.com/c/5QRmY2Jz/5209-investigate-header-size-which-is-preventing-statuscake-monitoring)

### Context

The Content Security Policy (CSP) headers of the site were causing the monitoring system (StatusCake) to error as they were oversized (> 17k). 

### Changes proposed in this pull request

De-activate the CSP headers on the monitoring page https://getintoteaching.education.gov.uk/healthcheck.json

As a separate task, we will review which headers are still required and try and trim down the list

### Guidance to review

In the review app, navigate to the /healthcheck.json endpoint and verify there are no CSP headers being returned.
