### PR TITLE
Delete Uni of Bedfordshire from Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -76,11 +76,6 @@ provider_groups:
       name: Jackie Atkin
       telephone: '01234 907896'
       email: jatkin@pilgrimpartnership.org
-    - header: University of Bedfordshire
-      link: https://www.beds.ac.uk/
-      name: Bedford Admissions
-      telephone: 01234 793279
-      email: admission@beds.ac.uk
     - header: University of Hertfordshire
       link: https://www.herts.ac.uk/apply/schools-of-study/education/initial-teacher-training/assessment-only-route
       name: AO Administration Team


### PR DESCRIPTION
### Trello card
https://trello.com/c/srj3qR6j

### Context
Request via the GIT support team to delete the University of Bedfordshire from the assessment only page
