### PR TITLE
Changed font colour from white to black in non-CTA components

### DIFF
--- a/app/components/content/adviser_component.rb
+++ b/app/components/content/adviser_component.rb
@@ -2,7 +2,7 @@ module Content
   class AdviserComponent < ViewComponent::Base
     attr_reader :title, :intro, :color, :margin, :heading
 
-    def initialize(title:, intro:, color: "purple", margin: true, heading: :m)
+    def initialize(title:, intro:, color: "pink", margin: true, heading: :m)
       super
 
       @title = title

--- a/app/components/content/mailing_list_component.rb
+++ b/app/components/content/mailing_list_component.rb
@@ -2,7 +2,7 @@ module Content
   class MailingListComponent < ViewComponent::Base
     attr_reader :title, :intro, :color, :margin, :heading
 
-    def initialize(title:, intro:, color: "purple", margin: true, heading: :m)
+    def initialize(title:, intro:, color: "pink", margin: true, heading: :m)
       super
 
       @title = title

--- a/app/components/content/talk_to_us_component.html.erb
+++ b/app/components/content/talk_to_us_component.html.erb
@@ -1,6 +1,6 @@
 <div class="talk-to-us-content">
   <div class="heading-container">
-    <h2 class="heading-m heading--box-purple">Talk to us</h2>
+    <h2 class="heading-m heading--box-pink">Talk to us</h2>
   </div>
 
   <div class="content">

--- a/app/components/footer/talk_to_us_component.html.erb
+++ b/app/components/footer/talk_to_us_component.html.erb
@@ -2,7 +2,7 @@
   <div class="talk-to-us">
     <section class="container">
       <div>
-        <h2 class="heading-m heading--box-purple heading--overlap" id="talk-to-us">Talk to us</h2>
+        <h2 class="heading-m heading--box-pink heading--overlap" id="talk-to-us">Talk to us</h2>
         <div class="content">
           <div class="contact">
             <div class="options">

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -247,7 +247,7 @@
 
     .call-to-action__heading {
       color: $black;
-      background: $purple;
+      background: $pink;
       display: inline-block;
       padding: .5em 1.25em;
       margin-left: -22px;

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -246,7 +246,7 @@
     }
 
     .call-to-action__heading {
-      color: white;
+      color: $black;
       background: $purple;
       display: inline-block;
       padding: .5em 1.25em;

--- a/app/webpacker/styles/components/photo-quote-list.scss
+++ b/app/webpacker/styles/components/photo-quote-list.scss
@@ -102,7 +102,7 @@ ol.photo-quote-list {
       }
 
       h3 {
-        @extend .heading--highlight-white-on-purple;
+        @extend .heading--highlight-pink;
       }
     }
 

--- a/app/webpacker/styles/components/quote-list.scss
+++ b/app/webpacker/styles/components/quote-list.scss
@@ -12,7 +12,7 @@ ol.quote-list {
     grid-template-rows: 50% 50%;
 
     h3 {
-      @extend .heading--highlight-white-on-purple;
+      @extend .heading--highlight-pink;
       grid-area: 1 / 1 / span 2 / span 1;
       margin-left: 2.5rem;
     }

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -157,7 +157,7 @@
   @include highlight-text($purple, $black);
 }
 
-.heading--highlight-white-on-purple {
+.heading--highlight-black-on-purple {
   @include highlight-text($purple, $black);
 }
 

--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -102,7 +102,7 @@
 }
 
 .heading--box-green {
-  @include box-heading($green, $white);
+  @include box-heading($green, $black);
 }
 
 .heading--box-grey {
@@ -114,7 +114,7 @@
 }
 
 .heading--box-purple {
-  @include box-heading($purple, $white);
+  @include box-heading($purple, $black);
 }
 
 .heading--box-pink {
@@ -158,7 +158,7 @@
 }
 
 .heading--highlight-white-on-purple {
-  @include highlight-text($purple, $white);
+  @include highlight-text($purple, $black);
 }
 
 .heading--highlight-blue {

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -2,7 +2,7 @@ $slightly-darker-grey: darken($grey, 10%);
 $icon-size: 3rem;
 
 @mixin get-into-teaching-event-box {
-  border: 2px solid $purple;
+  border: 3px solid $yellow;
   padding: 3rem 1rem 1rem;
 
   &:after {
@@ -11,7 +11,7 @@ $icon-size: 3rem;
     content: "Get Into Teaching event";
     right: 5%;
     top: -1em;
-    background: $purple url("../images/icon-git-white.svg") no-repeat left center;
+    background: $yellow url("../images/icon-git-white.svg") no-repeat left center;
     background-size: 1.2em;
     background-position: .4em;
     color: $black;
@@ -152,7 +152,7 @@ $icon-size: 3rem;
     margin: 0;
     position: relative;
     background: white;
-    border: 2px solid $slightly-darker-grey;
+    border: 3px solid $slightly-darker-grey;
     padding: 0;
 
     &__info {
@@ -596,7 +596,7 @@ $icon-size: 3rem;
   }
 
   &--message {
-    background: $purple;
+    background: $yellow;
     color: $black;
     flex-basis: 60%;
 

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -14,7 +14,7 @@ $icon-size: 3rem;
     background: $purple url("../images/icon-git-white.svg") no-repeat left center;
     background-size: 1.2em;
     background-position: .4em;
-    color: $white;
+    color: $black;
     font-weight: bold;
     padding: .4em 1em .4em 2.5em;
   }
@@ -597,7 +597,7 @@ $icon-size: 3rem;
 
   &--message {
     background: $purple;
-    color: $white;
+    color: $black;
     flex-basis: 60%;
 
     p {

--- a/app/webpacker/styles/vertical-tags.scss
+++ b/app/webpacker/styles/vertical-tags.scss
@@ -19,7 +19,7 @@
     display: inline-block;
     margin-left: -2em;
 
-    color: $white;
+    color: $black;
     border: 1px solid $purple;
     background: $purple;
   }

--- a/app/webpacker/styles/vertical-tags.scss
+++ b/app/webpacker/styles/vertical-tags.scss
@@ -20,7 +20,7 @@
     margin-left: -2em;
 
     color: $black;
-    border: 1px solid $purple;
-    background: $purple;
+    border: 1px solid $blue;
+    background: $blue;
   }
 }

--- a/spec/components/content/adviser_component_spec.rb
+++ b/spec/components/content/adviser_component_spec.rb
@@ -11,7 +11,7 @@ describe Content::AdviserComponent, type: :component do
   let(:heading) { :m }
   let(:component) { described_class.new(title: "title", intro: "intro", color: color, heading: heading, margin: margin) }
 
-  it { is_expected.to have_css("h2.heading-m.heading--box-purple", text: "title") }
+  it { is_expected.to have_css("h2.heading-m.heading--box-pink", text: "title") }
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--purple") }
   it { is_expected.to have_css("form") }

--- a/spec/components/content/mailing_list_component_spec.rb
+++ b/spec/components/content/mailing_list_component_spec.rb
@@ -11,7 +11,7 @@ describe Content::MailingListComponent, type: :component do
   let(:heading) { :m }
   let(:component) { described_class.new(title: "title", intro: "intro", color: color, heading: heading, margin: margin) }
 
-  it { is_expected.to have_css("h2.heading-m.heading--box-purple", text: "title") }
+  it { is_expected.to have_css("h2.heading-m.heading--box-pink", text: "title") }
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--purple") }
   it { is_expected.to have_css("form") }


### PR DESCRIPTION
### Trello card

[Trello 5414](https://trello.com/c/uwgNl4bg)

### Context

We are replacing our colours with refreshed brand colours supplied by Havas. Our h2s have changed from darker blue background with white font to be lighter blue with dark font - dark font is more in keeping with the brand

We want to reconsider where we are still using white font in other places as we want to keep white font just for CTAs as a principle.

### Changes proposed in this pull request

All text on a coloured background that is non-CTA should change from being white to black, as per the brand guidelines.

### Guidance to review

Check all non-CTA headers that have a coloured background (such as h2s) and ensure the font colour is black, not white.