### PR TITLE
Update Chemistry scholarship link on bursaries page

### DIFF
--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -102,7 +102,7 @@ They offer more than just financial benefits, including:
 
 Scholarships are offered by independent institutions. They set their own eligibility criteria and you’ll need to apply through the relevant scholarship body:
 
-* [the Royal Society of Chemistry](https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/) (chemistry)
+* [the Royal Society of Chemistry](https://www.rsc.org/prizes-funding/funding/find-funding/teacher-training-scholarships/) (chemistry)
 * [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
 * [British Council](https://www.britishcouncil.org/education/he-science/opportunities/ltts) (languages -- French, German and Spanish only)
 * [the Institute of Mathematics and its Applications, and partners](https://teachingmathsscholars.org/home) (maths)


### PR DESCRIPTION
### Trello card
https://trello.com/c/3Kl1QctS

### Context
The Royal Society of Chemistry has moved its page on teacher training scholarships so we need to update our link

