### PR TITLE
Increase prod redis from C1 to C2

### DIFF
--- a/terraform/aks/config/production_aks.tfvars.json
+++ b/terraform/aks/config/production_aks.tfvars.json
@@ -8,6 +8,7 @@
     "postgres_enable_high_availability": true,
     "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
     "enable_monitoring": true,
+    "redis_cache_capacity": 2,
     "azure_maintenance_window": {
         "day_of_week": 0,
         "start_hour": 3,

--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -34,4 +34,7 @@ module "redis-cache" {
   azure_enable_monitoring   = var.enable_monitoring
   azure_patch_schedule      = [{ "day_of_week" : "Sunday", "start_hour_utc" : 01 }]
   server_version            = "6"
+  azure_capacity            = var.redis_cache_capacity
+  azure_family              = var.redis_cache_family
+  azure_sku_name            = var.redis_cache_sku_name
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -85,6 +85,15 @@ variable "postgres_flexible_server_sku" {
 variable "postgres_enable_high_availability" {
   default = false
 }
+variable "redis_cache_capacity" {
+  default = 1
+}
+variable "redis_cache_family" {
+  default = "C"
+}
+variable "redis_cache_sku_name" {
+  default = "Standard"
+}
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/4muiS8eL/871-git-prod-redis-alert

### Context

Increase production redis cache from a C1 to C2
(increases available memory from 1G to 2.5G)

### Changes proposed in this pull request

Update terraform config

### Guidance to review

make production_aks terraform-plan-aks

