### PR TITLE
Remove message re holiday response time on adviser funnel completed page

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -11,8 +11,6 @@
     A return to teaching adviser will email you within 3 working days to outline your next steps. Make sure you check your junk or spam folders.
   </p>
 
-  <p>It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can. Thank you for your patience.</p>
-
   <p> You need to reply to the email to be assigned an adviser.
   </p>
 
@@ -85,8 +83,6 @@
   <h2 class="govuk-heading-m">What happens next?</h2>
 
   <p>An adviser will email you within 3 working days. Make sure you check your junk or spam folders.</p>
-
-  <p>It may take us longer to respond to you during the holiday period until early January. We’ll be in touch as soon as we can. Thank you for your patience.</p>
 
   <p>You need to reply to the email to be assigned an adviser.</p>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/D6pncfaN

### Context
Removing message about possible slower response times from advisers over the festive period

