### PR TITLE
Update content in homepage salary component

### DIFF
--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,7 +1,7 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
-    <h2 class="call-to-action__heading">Earn at least &pound;30k a year</h2>
-    <p>All qualified teachers will have a <strong>starting salary of at least £30,000</strong> (or higher in London).</p>
+    <h2 class="call-to-action__heading">Earn a minimum of &pound;30k a year</h2>
+    <p>All qualified teachers get a <strong>minimum starting salary of £30k</strong> (or higher in London). So it pays to do what you love. And with lots of opportunities to progress, you could <strong>earn over £41k within 5 years</strong>.</p>
     <p><%= link_to("Find out more about teacher pay and benefits", page_path("is-teaching-right-for-me/teacher-pay-and-benefits")) %>.</p>
   <% end %>
 </div>

--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,7 +1,8 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
     <h2 class="call-to-action__heading">Earn a minimum of &pound;30k a year</h2>
-    <p>All qualified teachers get a <strong>minimum starting salary of £30k</strong> (or higher in London). So it pays to do what you love. And with lots of opportunities to progress, you could <strong>earn over £41k within 5 years</strong>.</p>
+    <p>All qualified teachers get a <strong>minimum starting salary of £30k</strong> (or higher in London), so it pays to do what you love.</p>
+    <p>And with lots of opportunities to progress, you could <strong>earn over £41k within 5 years</strong>.</p>
     <p><%= link_to("Find out more about teacher pay and benefits", page_path("is-teaching-right-for-me/teacher-pay-and-benefits")) %>.</p>
   <% end %>
 </div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/44SRZhfh/5480-tweak-content-in-salary-component-on-homepage-to-align-with-campaign-messaging-language

### Context
We need to make updates to the website to align messaging with the new creative campaign launching on 15 January 2024

### Changes proposed in this pull request
Tweak the wording in the salary component to align with the wording in the messaging matrix.

### Guidance to review

