### PR TITLE
Remove paas DNS validation domains

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -11,13 +11,7 @@
         ],
         "environment_short": "pd",
         "origin_hostname": "get-into-teaching-app-production.teacherservices.cloud",
-        "null_host_header": false,
-        "cnames": {
-          "_868153fdedc73d7ab612304d7f6c2644": {
-            "target": "_892e06be392d6d72139b4e9efdc23796.zjfbrrwmzc.acm-validations.aws",
-            "ttl": 86400
-          }
-        }
+        "null_host_header": false
       }
     }
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/sJjGP3s7/840-code-clean-up-git-website

### Context

Remove PaaS validation domain after migration

### Changes proposed in this pull request

Remove cname from terraform config

### Guidance to review

make production domains-plan


