### PR TITLE
Add NOSONAR comment

### DIFF
--- a/app/components/events/card_component.html.erb
+++ b/app/components/events/card_component.html.erb
@@ -1,3 +1,4 @@
+<!-- This <li> element is dynamically generated within a parent template that includes the surrounding <ul>. -->
 <!-- //NOSONAR --><li class="category__nav-card">
   <%= link_to(path, class: "link--black") do %>
     <div class="category__nav-card--content">

--- a/app/components/events/card_component.html.erb
+++ b/app/components/events/card_component.html.erb
@@ -1,4 +1,4 @@
-<li class="category__nav-card">
+<!-- //NOSONAR --><li class="category__nav-card">
   <%= link_to(path, class: "link--black") do %>
     <div class="category__nav-card--content">
       <%= content_tag(heading_tag, title) %>

--- a/app/components/events/card_component.html.erb
+++ b/app/components/events/card_component.html.erb
@@ -1,5 +1,5 @@
 <!-- This <li> element is dynamically generated within a parent template that includes the surrounding <ul>. -->
-<!-- //NOSONAR --><li class="category__nav-card">
+<li class="category__nav-card">
   <%= link_to(path, class: "link--black") do %>
     <div class="category__nav-card--content">
       <%= content_tag(heading_tag, title) %>

--- a/app/components/events/card_component.html.erb
+++ b/app/components/events/card_component.html.erb
@@ -1,5 +1,5 @@
 <!-- This <li> element is dynamically generated within a parent template that includes the surrounding <ul>. -->
-<li class="category__nav-card">
+<!-- //NOSONAR --><li class="category__nav-card">
   <%= link_to(path, class: "link--black") do %>
     <div class="category__nav-card--content">
       <%= content_tag(heading_tag, title) %>


### PR DESCRIPTION
### Trello card
[Fix sonarcloud issue with new event card component](https://trello.com/c/HVT5YP2m/5290-fix-sonarcloud-issue-with-new-event-card-component)

### Context
SonarCloud code analysis is incorrectly identifying a code snippet as invalid as it does not appear to have a wrapping `<ul>` container - in the fact the element _is_ wrapped by a `<ul>` generated in a parent template

### Changes proposed in this pull request
Mark the `<li>` element as ignored for analysis in SonarCloud

### Guidance to review
Verify there are no errors raised in SonarCloud

