### PR TITLE
Update-career-progression-links

### DIFF
--- a/app/views/content/is-teaching-right-for-me/teacher-pay-and-benefits.md
+++ b/app/views/content/is-teaching-right-for-me/teacher-pay-and-benefits.md
@@ -123,6 +123,8 @@ Their role is wide ranging, but includes leading and motivating teachers, and en
 | Outer London                             | £57,124 | £134,765 |
 | Inner London                             | £62,304 | £139,891 |
 
+Find out more about [how to move up the career ladder in teaching](/is-teaching-right-for-me/career-progression).
+
 ## If you do not have qualified teacher status (QTS)
 
 You need qualified teacher status (QTS) to work in maintained primary, secondary and special schools in England. 

--- a/app/views/content/landing/grow/_content.html.erb
+++ b/app/views/content/landing/grow/_content.html.erb
@@ -19,7 +19,7 @@
 
       </p>
 
-      <p><%= link_to("Find out more about career progression", page_path("is-teaching-right-for-me/teacher-pay-and-benefits", anchor: "career-progression")) %>.</p>
+      <p><%= link_to("Find out more about career progression", page_path("is-teaching-right-for-me/career-progression")) %>.</p>
     </div>
   </section>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/PHOKEHZb/5524-update-links-to-new-career-prospects-page

### Context
We’ve created a new career prospects page to tie in with the new campaign messaging. So it makes sense to update some links where we direct users to the pay page to this page instead where it’s more relevant.

### Changes proposed in this pull request

- Update campaign landing page link https://getintoteaching.education.gov.uk/landing/grow
- Add link in to teacher pay page at the end of the career progression section https://getintoteaching.education.gov.uk/is-teaching-right-for-me/teacher-pay-and-benefits

(Link in Buzzfeed landing page has already been added)

### Guidance to review

