### PR TITLE
Change-Talk-to-adviser-H3s

### DIFF
--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -10,15 +10,15 @@
         <ul>
           <%= render Categories::CardComponent.new(heading_tag: "h3", card:
             OpenStruct.new(
-              title: "If you're a student and not in your final year of study",
-              description: "An explore teaching adviser can help you find out more about teaching as a career.",
-              path: "/explore-teaching-advisers"
-            )) %>
-          <%= render Categories::CardComponent.new(heading_tag: "h3", card:
-            OpenStruct.new(
               title: "If you already have a degree or you're a final year student",
               description: "A teacher training adviser can help you understand how to get into teaching.",
               path: "/teacher-training-advisers"
+            )) %>
+          <%= render Categories::CardComponent.new(heading_tag: "h3", card:
+            OpenStruct.new(
+              title: "If you're a student and not in your final year of study",
+              description: "An explore teaching adviser can help you find out more about teaching as a career.",
+              path: "/explore-teaching-advisers"
             )) %>
         </ul>
       </nav>

--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -10,8 +10,8 @@
         <ul>
           <%= render Categories::CardComponent.new(heading_tag: "h3", card:
             OpenStruct.new(
-              title: "Explore teaching advisers",
-              description: "If you're a student and not in your final year of study, an adviser can help you find out more about teaching as a career.",
+              title: "If you're a student not in your final year",
+              description: "An explore teaching adviser can help you find out more about teaching as a career.",
               path: "/explore-teaching-advisers"
             )) %>
           <%= render Categories::CardComponent.new(heading_tag: "h3", card:

--- a/app/views/content/help-and-support/_categories.html.erb
+++ b/app/views/content/help-and-support/_categories.html.erb
@@ -10,14 +10,14 @@
         <ul>
           <%= render Categories::CardComponent.new(heading_tag: "h3", card:
             OpenStruct.new(
-              title: "If you're a student not in your final year",
+              title: "If you're a student and not in your final year of study",
               description: "An explore teaching adviser can help you find out more about teaching as a career.",
               path: "/explore-teaching-advisers"
             )) %>
           <%= render Categories::CardComponent.new(heading_tag: "h3", card:
             OpenStruct.new(
-              title: "Teacher training advisers",
-              description: "If you already have a degree or are a final year student, an adviser can help you understand how to get into teaching.",
+              title: "If you already have a degree or you're a final year student",
+              description: "A teacher training adviser can help you understand how to get into teaching.",
               path: "/teacher-training-advisers"
             )) %>
         </ul>


### PR DESCRIPTION
### Trello card
https://trello.com/c/0fAiDmAi/5526-switch-h3s-and-content-round-on-adviser-page-cards-on-help-and-support-category-page

### Context
The H3s on the 2 grey cards in the Talk to an adviser section on the help and support category page are difficult to differentiate between and may cause confusion for users who don’t understand there are different types of adviser.

### Changes proposed in this pull request

- Switch the H3s and the content round so the h3s make it clear which user group they're for
- Switch the order of the cards round so the if you have a degree one comes before the if you're a final year student as it makes more sense this way round.

### Guidance to review

