### PR TITLE
Enable azure rbac deployment

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -24,7 +24,7 @@ runs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ inputs.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/destroy_review.yml
+++ b/.github/workflows/destroy_review.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ production-cluster:
 
 get-cluster-credentials: set-azure-account
 	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
 
 edit-local-secrets-aks: install-fetch-config set-azure-account
 	./fetch_config.rb -s azure-key-vault-secret:s189t01-git-local-app-kv/${APPLICATION_SECRETS} -e -d azure-key-vault-secret:s189t01-git-local-app-kv/${APPLICATION_SECRETS} -f yaml -c

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -34,6 +34,15 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }
 
 provider "statuscake" {


### PR DESCRIPTION
### Trello card

https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

Not to be deployed until terraform modules has been updated on Monday Jan 29th.

### Context

Enable azure rbac on deployment (for when it is enabled in the cluster)

### Changes proposed in this pull request

Update Makefile, terraform and workflows to use rbac if configured for the cluster

### Guidance to review

make env terraform-plan
check review app deploys successfully

