### PR TITLE
Move menu button to right on mobile

### DIFF
--- a/app/webpacker/styles/header.scss
+++ b/app/webpacker/styles/header.scss
@@ -8,8 +8,15 @@ body > header {
 
   // mobile (default) layout
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: max-content 1fr;
   grid-auto-rows: auto;
+
+  .extra-navigation {
+    grid-column: 1/3;
+  }
+  nav {
+    grid-column: 1/3;
+  }
 
   @include mq($from: tablet) {
     border-bottom: 1px solid $grey;

--- a/app/webpacker/styles/header/logo.scss
+++ b/app/webpacker/styles/header/logo.scss
@@ -58,6 +58,10 @@
     background-color: $blue;
     z-index: 1000;
 
+    @include mq($until: tablet) {
+      margin-right: 0.3em;
+    }
+
     // position the logo slightly off the left of the page
     // and make sure there's a slight gap beneath the extra nav
     // and that the DfE logo's suitably far away
@@ -66,6 +70,11 @@
     img {
       padding: 1em;
       transform: rotate(3deg);
+
+      @include mq($until: tablet) {
+        margin: 0.3em 0.9em 0 1.3em;
+        padding: 0.5em;
+      }
 
       // use the margin to set the size/aspect ratio of the logo's background
 

--- a/app/webpacker/styles/header/menu-button.scss
+++ b/app/webpacker/styles/header/menu-button.scss
@@ -47,9 +47,9 @@
     }
 
     @include mq($until: tablet) {
-      flex: 1;
-      justify-content: space-between;
-      margin: 1rem $indent-amount $indent-amount;
+      // applies when width < 740px
+      margin-left: 0.1em;
+      margin-right: 0.4em;
     }
 
     &:focus .menu-button__icon {


### PR DESCRIPTION
work in progress

### Trello card
[Relocate menu button on mobile](https://trello.com/c/5tgH9RBw/5042-relocate-menu-button-on-mobile)

### Context
On mobile, the menu button currently uses quite a lot of screen space

### Changes proposed in this pull request
Move the menu button to the top right on mobile

### Guidance to review
Please review on mobile/tablet/desktop in portrait and landscape orientations
