### PR TITLE
Set autocomplete on signup forms

### DIFF
--- a/app/components/content/adviser_component.html.erb
+++ b/app/components/content/adviser_component.html.erb
@@ -12,9 +12,9 @@
       </p>
 
       <%= form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: teacher_training_adviser_step_path(:identity), scope: :teacher_training_adviser_steps_identity, method: :put do |f| %>
-        <%= f.govuk_text_field :first_name, width: 'two-thirds' %>
-        <%= f.govuk_text_field :last_name, width: 'two-thirds' %>
-        <%= f.govuk_email_field :email, width: 'two-thirds' %>
+        <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
+        <%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
+        <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>
         <%= f.hidden_field :channel_id, value: f.object&.channel_id.presence || params[:channel] %>
         <%= f.hidden_field :sub_channel_id, value: f.object&.sub_channel_id.presence || params[:sub_channel] %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -27,9 +27,9 @@
   color: "grey"
 ) %>
 
-<%= f.govuk_text_field :first_name, width: 'two-thirds' %>
-<%= f.govuk_text_field :last_name, width: 'two-thirds' %>
-<%= f.govuk_email_field :email, width: 'two-thirds' %>
+<%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
+<%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
+<%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>
 <%= f.hidden_field :channel_id, value: f.object.channel_id.presence || params[:channel] %>
 <%= f.hidden_field :sub_channel_id, value: f.object.sub_channel_id.presence || params[:sub_channel] %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>


### PR DESCRIPTION
### Trello card
[Ensure the purpose of the email field in adviser sign up form can be identified programmatically](https://trello.com/c/sbylF98p/5609-ensure-the-purpose-of-the-email-field-in-adviser-sign-up-form-can-be-identified-programmatically)

### Context
To improve accessibility, email and name fields should have an autocomplete attribute so that they can be identified programatically.

### Changes proposed in this pull request
Add autocomplete attributes to common forms

### Guidance to review
Check the `/teacher-training-adviser/sign_up/identity` page now has autocomplete attributes set

