### PR TITLE
Fix Next Step button when javascript is disabled

### DIFF
--- a/app/components/content/adviser_component.html.erb
+++ b/app/components/content/adviser_component.html.erb
@@ -23,7 +23,7 @@
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 
-        <% button_text = "Next step <span></span>" %>
+        <% button_text = helpers.safe_html_format("Next step <span></span>") %>
         <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
       <% end %>
     </div>

--- a/app/components/content/mailing_list_component.html.erb
+++ b/app/components/content/mailing_list_component.html.erb
@@ -23,7 +23,7 @@
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 
-        <% button_text = "Next step <span></span>" %>
+        <% button_text = helpers.safe_html_format("Next step <span></span>") %>
         <%= f.button button_text, class: "call-to-action-button button", data: { "prevent-double-click": true, "disable-with": button_text } %>
       <% end %>
     </div>

--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -23,7 +23,7 @@
         <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id.presence %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
-        <% button_text = "Next step <span></span>" %>
+        <% button_text = helpers.safe_html_format("Next step <span></span>") %>
         <%= f.button button_text, class: "button", data: { "prevent-double-click": true, "disable-with": button_text } %>
       <% end %>
     </div>


### PR DESCRIPTION
### Trello card
[Fix sign-up button on homepage when javascript is disabled](https://trello.com/c/IktpkoPt/5610-sign-up-next-step-button-on-homepage-when-javascript-turned-off)

### Context
When javascript is disabled, the sign up button displays "<span></span>" at the end

### Changes proposed in this pull request
Marks this as html-safe code

### Guidance to review
Disable javascript and check the signup button renders correctly

