### PR TITLE
Update Educate Group contact details on Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -448,7 +448,7 @@ provider_groups:
     providers:
     - header: Educate Group Initial Teacher Training
       link: https://educate-group.co.uk/initial-teacher-training/
-       name: Educate Group HQ
+      name: Educate Group HQ
       telephone: 01978 281881
       email: aor@educate-group.co.uk
     - header: GORSE SCITT


### PR DESCRIPTION
### Trello card
https://trello.com/c/IYX8aBRJ

### Context
Request received via GIT support team to update the name and contact details for the Educate Group on the Assessment only page.

Also reordered contact details for Xavier Catholic Education Trust to be consistent with other listings.

