### PR TITLE
Validation of Privacy Policy id

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   class InvalidTemplateName < RuntimeError; end
+  class InvalidPrivacyPolicy < RuntimeError; end
 
   before_action :init_funding_widget, only: %i[scholarships_and_bursaries scholarships_and_bursaries_search]
 
@@ -9,12 +10,14 @@ class PagesController < ApplicationController
   ].freeze
 
   PAGE_TEMPLATE_FILTER = %r{\A[a-zA-Z0-9][a-zA-Z0-9_\-/]*(\.[a-zA-Z]+)?\z}
+  PRIVACY_POLICY_ID_FILTER = %r{^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$}
 
   caches_page :cookies
   caches_page :show
 
   before_action :set_welcome_guide_info, if: -> { request.path.start_with?("/welcome") && (params[:subject] || params[:degree_status]) }
   rescue_from *MISSING_TEMPLATE_EXCEPTIONS, with: :rescue_missing_template
+  rescue_from InvalidPrivacyPolicy, with: :rescue_invalid_privacy_policy
 
   PAGE_LAYOUTS = [
     "layouts/home",
@@ -31,6 +34,8 @@ class PagesController < ApplicationController
   def privacy_policy
     @page_title = "Privacy Policy"
     policy_id = params[:id]
+
+    raise InvalidPrivacyPolicy if policy_id && policy_id !~ PRIVACY_POLICY_ID_FILTER
 
     @privacy_policy = if policy_id
                         GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_privacy_policy(policy_id)
@@ -144,6 +149,21 @@ private
 
       format.all do
         render status: :not_found, body: nil
+      end
+    end
+  end
+
+  def rescue_invalid_privacy_policy
+    respond_to do |format|
+      format.html do
+        render \
+          template: "errors/bad_request",
+          layout: "application",
+          status: :bad_request
+      end
+
+      format.all do
+        render status: :bad_request, body: nil
       end
     end
   end

--- a/app/views/errors/bad_request.erb
+++ b/app/views/errors/bad_request.erb
@@ -1,0 +1,19 @@
+<% @fullwidth = @hide_page_helpful_question = true %>
+<% @page_title = "Bad request" %>
+
+<section class="container supplementary">
+  <header>
+    <%= render Content::HeadingComponent.new(
+      heading: @page_title,
+      heading_size: :xxl,
+      caption: "Error 400",
+      caption_size: :xxl,
+      caption_purple: false,
+      caption_bold: false
+    ) %>
+  </header>
+
+  <article class="text-content">
+    <p><a href="#talk-to-us">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
+  </article>
+</section>


### PR DESCRIPTION
### Trello card
[Privacy Policy Id](https://trello.com/c/ThTKr9yV/5652-add-validation-of-privacy-policy-id)

### Context
Privacy Policy IDs were being passed straight to the CRM without validation.

### Changes proposed in this pull request
Add validation to the Policy IDs to ensure they are valid UUIDs.

### Guidance to review

