### PR TITLE
Change-H1-on-social-mailing-list-landing-page

### DIFF
--- a/app/views/content/landing/mailing-list.md
+++ b/app/views/content/landing/mailing-list.md
@@ -1,5 +1,5 @@
 ---
-title: "Sign up for emails"
+title: "Get personalised guidance"
 description: Free advice and support on how to become a teacher. Get the latest information sent straight to your inbox.
 content:
     - content/landing/mailing-list/header

--- a/app/views/content/landing/mailing-list/_header.html.erb
+++ b/app/views/content/landing/mailing-list/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::CampaignHeroComponent.new(
-  title: ["Sign up for", "emails"],
+  title: ["Get personalised", "guidance"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
   background_colour: "grey"


### PR DESCRIPTION
### Trello card
https://trello.com/c/iTmbB0DO/5683-update-social-mailing-list-landing-page-h1 

### Context
In split testing we’ve seen more conversions with the landing page that has an H1 Get personalised guidance than the landing page titled Sign up for emails

### Changes proposed in this pull request
Update the H1 on the latest version of the mailing list landing page to Get personalised guidance

### Guidance to review

