### PR TITLE
image change for campus mailing list page to new campaign image

### DIFF
--- a/app/views/content/landing/campus-mailing-list.md
+++ b/app/views/content/landing/campus-mailing-list.md
@@ -4,7 +4,7 @@ description: Free advice and support on how to become a teacher. Get the latest 
 content:
     - content/landing/campus-mailing-list/header
     - content/landing/campus-mailing-list/mailing-list
-image: "static/images/content/campus-mailing-list/campus-mailing-list.jpeg"
+image: "static/images/content/hero-images/0030.jpg"
 colour: "pink"
 layout: "layouts/minimal"
 talk_to_us: false


### PR DESCRIPTION
### (https://trello.com/c/541k0Gqz/5631-replace-image-on-on-campus-mailing-list-landing-page)

### Context
The advertising team have confirmed that the licence for the image we are using on https://getintoteaching.education.gov.uk/landing/campus-mailing-list has expired

### Changes proposed in this pull request
Change image to new campaign image



