### PR TITLE
Upgrade GovUK Frontend v5.2.0

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -2,6 +2,10 @@
 
 $git-font-family: sans-serif;
 $govuk-font-family: $git-font-family;
+// NB: enabling the new typography scale will affect text rendering at lower
+// resolutions. Consider waiting to upgrade until v6.
+// https://design-system.service.gov.uk/get-started/new-type-scale/
+$govuk-new-typography-scale: false;
 
 @import "./git";
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dayjs": "^1.11.10",
     "file-loader": "^6.2.0",
     "flatpickr": "^4.6.13",
-    "govuk-frontend": "^5.1.0",
+    "govuk-frontend": "^5.2.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.5",
     "lazysizes": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4181,10 +4181,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.1.0.tgz#55e520940b587ddd023e96251efaa076acc9bd5f"
-  integrity sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==
+govuk-frontend@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.2.0.tgz#f8e0bf98b771b8ee1501fd45bbba24a091f3846d"
+  integrity sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
### Trello card
[Bump GOV.UK Frontend to 5.2.0](https://trello.com/c/NRM6QvIq/5727-bump-govuk-frontend-to-520-for-get-into-teaching)

### Context
Upgrade frontend library from v5.1.0 to v5.2.0

### Changes proposed in this pull request
Not enabling new responsive typeface for now

### Guidance to review

