### PR TITLE
Add-computing-links

### DIFF
--- a/app/views/content/how-to-apply-for-teacher-training/subject-knowledge-enhancement.md
+++ b/app/views/content/how-to-apply-for-teacher-training/subject-knowledge-enhancement.md
@@ -3,8 +3,9 @@ title: Subject knowledge enhancement (SKE)
 related_content:
     Get school experience : "/is-teaching-right-for-me/get-school-experience"
     How to choose a teacher training course : "/train-to-be-a-teacher/how-to-choose-your-teacher-training-course"
-    Teach physics : "/is-teaching-right-for-me/physics"
+    Teach computing : "/is-teaching-right-for-me/computing"
     Teach maths : "/is-teaching-right-for-me/maths"
+    Teach physics : "/is-teaching-right-for-me/physics"
 description: |-
   Find out more about subject knowledge enhancement (SKE) courses which will help you brush up your knowledge on the subject you want to teach.
 external_content:

--- a/app/views/content/is-teaching-right-for-me/teaching-internship-providers.md
+++ b/app/views/content/is-teaching-right-for-me/teaching-internship-providers.md
@@ -8,10 +8,6 @@ date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships
-related_content:
-    Become a computing teacher: "/is-teaching-right-for-me/computing"
-    Become a maths teacher : "/is-teaching-right-for-me/maths"
-    Become a physics teacher : "/is-teaching-right-for-me/physics"
 backlink: /
 fullwidth: true
 navigation: 5.55

--- a/app/views/content/is-teaching-right-for-me/teaching-internship-providers.md
+++ b/app/views/content/is-teaching-right-for-me/teaching-internship-providers.md
@@ -8,6 +8,10 @@ date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships
+related_content:
+    Become a computing teacher: "/is-teaching-right-for-me/computing"
+    Become a maths teacher : "/is-teaching-right-for-me/maths"
+    Become a physics teacher : "/is-teaching-right-for-me/physics"
 backlink: /
 fullwidth: true
 navigation: 5.55

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
         sub_head: "Computing - Secondary"
         funding: "Scholarships of £30,000 and bursaries of £28,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
         next_steps: |-
-          If you have a passion for computing, find out more about <a href="/subjects/computing">becoming a computing teacher</a>.
+          If you have a passion for computing, find out more about <a href="/is-teaching-right-for-me/computing">becoming a computing teacher</a>.
       dance:
         name: "Dance"
         group: "Secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
         sub_head: "Computing - Secondary"
         funding: "Scholarships of £30,000 and bursaries of £28,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
         next_steps: |-
-          If you have a passion for computing, find out more about <a href="/is-teaching-right-for-me/computing">becoming a computing teacher</a>.
+          Find out more about <a href="/is-teaching-right-for-me/computing">how to become a computing teacher</a>.
       dance:
         name: "Dance"
         group: "Secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,8 @@ en:
         group: "Secondary"
         sub_head: "Computing - Secondary"
         funding: "Scholarships of £30,000 and bursaries of £28,000 are available for trainee computing teachers if you’re eligible (non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible)."
+        next_steps: |-
+          If you have a passion for computing, find out more about <a href="/subjects/computing">becoming a computing teacher</a>.
       dance:
         name: "Dance"
         group: "Secondary"


### PR DESCRIPTION
### Trello card
https://trello.com/c/3oliUzpt/5698-add-links-to-computing-page 

### Context
We have a new computing page and we need to add links to it on other pages around the site.

### Changes proposed in this pull request
Add link to computing page on:

- SKE page
- funding widget
- add related links on internships page and also add link to maths and physics pages

### Guidance to review

