### PR TITLE
Add Gloucestershire Initial Teacher Education Partnership to Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -363,6 +363,11 @@ provider_groups:
       name: Lex Blake
       telephone: '01872 305728'
       email: scitt@truro-penwith.ac.uk
+    - header: Gloucestershire Initial Teacher Education Partnership
+      link: https://gitep.org.uk/
+      name: Becky Rose
+      telephone: '01242 505945'
+      email: admin@gitep.org.uk
     - header: Mid Somerset Consortium for Teacher Training
       link: https://www.mscitt.org.uk/Routes/Assessment-only/
       name: Sarah Lewis


### PR DESCRIPTION
### Trello card
https://trello.com/c/bGmLz5on

### Context
Request via the GIT support team to add GITEP to the Assessment only page


