### PR TITLE
Update computing page

### DIFF
--- a/app/views/content/is-teaching-right-for-me/computing.md
+++ b/app/views/content/is-teaching-right-for-me/computing.md
@@ -6,7 +6,7 @@ backlink: "../../"
 subcategory: What to teach
 navigation: 5.43
 navigation_title: Computing
-navigation_description: Discover why teaching computing is vital in helping children from all backgrounds to learn the digital skills they'll need throughout life.
+navigation_description: Discover how computing is vital, helping children learn digital skills they'll need throughout life.
 layout: "layouts/minimal"
 colour: "yellow"
 image: "static/images/content/hero-images/0036.jpg"

--- a/app/views/content/is-teaching-right-for-me/computing.md
+++ b/app/views/content/is-teaching-right-for-me/computing.md
@@ -6,7 +6,7 @@ backlink: "../../"
 subcategory: What to teach
 navigation: 5.43
 navigation_title: Computing
-navigation_description: Discover what it's like to a be computing teacher and how you would encourage pupils to learn new digital skills.
+navigation_description: Discover why teaching computing is vital in helping children from all backgrounds to learn the digital skills they'll need throughout life.
 layout: "layouts/minimal"
 colour: "yellow"
 image: "static/images/content/hero-images/0036.jpg"

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -90,7 +90,7 @@ image_2_alt: "",
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>Find out about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support for non-UK citizens</a>.</p>
+<p>Find out more about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support for non-UK trainee teachers</a>.</p>
 
 <h2>Paid internship </h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching computing, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -48,7 +48,7 @@ image_2_alt: "",
 </ul>
 <p>When you're teaching key stage 4 you'll teach pupils ways to protect their online privacy and identity.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a key stage 4 computing lesson would be like</a>.</p>
-<p>Themes you'll cover for 16 to 18 year olds (key stage 5), A level qualification, include:</p>
+<p>Themes you'll cover when you teach 16 to 18 year olds (key stage 5), A level qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Abstraction</li>
 <li class="tag">Writing programmes to solve problems</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -48,7 +48,7 @@ image_2_alt: "",
 </ul>
 <p>When you're teaching key stage 4 you'll teach pupils ways to protect their online privacy and identity.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a key stage 4 computing lesson would be like</a>.</p>
-<p>Themes you'll cover when you teach 16 to 18 year olds (key stage 5), A level qualification, include:</p>
+<p>Themes you'll cover when you teach 16 to 18 year olds (key stage 5) A level qualification include:</p>
 <ul class="vertical-tags">
 <li class="tag">Abstraction</li>
 <li class="tag">Writing programmes to solve problems</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -76,7 +76,7 @@ image_2_alt: "",
 </ul>
 <p>Computing teacher training courses have had successful applications from candidates with a range of degrees, including business and management, data science, history and economics.</p>
 <p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach.</a>.</p>
-<p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
+<p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <p>If your training provider thinks you need to top up your computing knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
 <h2>Fund your teacher training</h2>
 <p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000</a> are available for eligible trainee computing teachers</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -24,7 +24,7 @@ image_2_alt: "",
 </section>
 <section class="col col-720">
 <h2>What you'll be teaching</h2>
-<p>You'll teach themes from the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
+<p>You'll the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
 <p>Themes you'll cover for 11 to 14 year olds (key stage 3) include:</p>
 <ul class="vertical-tags">
 <li class="tag">Algorithms</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -75,9 +75,9 @@ image_2_alt: "",
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Computing teacher training courses have had successful applications from candidates with a range of degrees, including business and management, data science, history and economics.</p>
+<p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach.</a>.</p>
 <p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
 <p>If your training provider thinks you need to top up your computing knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
-<p><a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">Find out more about the qualifications needed to train to teach</a>.</p>
 <h2>Fund your teacher training</h2>
 <p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee computing teachers</a>.</p>
 <p>You can get a bursary or scholarship alongside a tuition fee and maintenance loan.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -69,9 +69,9 @@ image_2_alt: "",
 
   <section class="col col-720">
     <h2>Check your qualifications</h2>
-<p>To train to teach in primary and secondary schools in England, you’ll need:</p>
+<p>To train to teach in secondary schools in England, you’ll need:</p>
 <ul>
-<li>GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary)</li>
+<li>GCSEs at grade 4 (C) or above in English and maths</li>
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Computing teacher training courses have had successful applications from candidates with a range of degrees, including business and management, data science, history and economics.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -62,7 +62,7 @@ image_2_alt: "",
 <section class="col col-720">
   <%= render Content::QuoteComponent.new(
     text: "Every lesson presents an opportunity to delve into the latest advancements in the field and inspire students to become innovators. Teaching computing is about fostering a deep understanding of technology while enabling students to develop the skills and resilience to thrive in this digital age.",
-    name: "Shiulee Begum, Curriculum lead for computing and business",
+    name: "Shiulee, Curriculum lead for computing and business",
     large: true
   ) %>
 </section>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -48,7 +48,7 @@ image_2_alt: "",
 </ul>
 <p>When you're teaching key stage 4 you'll teach pupils ways to protect their online privacy and identity.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a key stage 4 computing lesson would be like</a>.</p>
-<p>Themes you'll cover when you teach 16 to 18 year olds (key stage 5) A level qualification include:</p>
+<p>Themes you'll cover when you teach 16 to 18 year olds (key stage 5) computer science as an A level qualification include:</p>
 <ul class="vertical-tags">
 <li class="tag">Abstraction</li>
 <li class="tag">Writing programmes to solve problems</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -75,7 +75,7 @@ image_2_alt: "",
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Computing teacher training courses have had successful applications from candidates with a range of degrees, including business and management, data science, history and economics.</p>
-<p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach.</a>.</p>
+<p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach</a>.</p>
 <p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <h3> Subject knowledge enhancement course (SKE)
 <p>If your training provider thinks you need to top up your computing knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -88,6 +88,7 @@ image_2_alt: "",
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
 <p>Find out about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support for non-UK citizens</a>.</p>
+
 <h2>Paid internship </h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching computing, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>
 <p>The 3-week programme could help you to understand what it’s really like in the classroom and get a feel for school life.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -80,8 +80,8 @@ image_2_alt: "",
 <p>If your training provider thinks you need to top up your computing knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
 <h2>Fund your teacher training</h2>
 <p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee computing teachers</a>.</p>
-<p>You can get a bursary or scholarship alongside a tuition fee and maintenance loan.</p>
-<p>You may also be able to get <a href="/funding-and-support">extra funding support</a> if you're:</p>
+<p>You can get a bursary or scholarship alongside a tuition fee loan and maintenance loan.</p>
+<p>You may also be able to get <a href="/funding-and-support">extra funding and support</a> if you're:</p>
 <ul>
 <li>a parent or carer</li>
 <li>disabled</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -1,7 +1,7 @@
 <div class="row inset">
   <section class="col col-720">
-<p>As a computing teacher you'll help pupils become responsible and confident users of information and technology in an increasingly digital world.</p>
-<p>Whether it's teaching your pupils about artificial intelligence (AI) or creating apps, you could inspire them to look at a future role in technology.</p>
+<p>As a secondary computing teacher you'll help pupils become responsible and confident users of information and technology in an increasingly digital world.</p>
+<p>Whether it's teaching your pupils about artificial intelligence (AI) or creating apps, you could inspire them to look at a future role in tech.</p>
 <p>Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee computing teachers.</p>
 </section>
   <section class="col col-space-s col-content-max">

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -79,7 +79,7 @@ image_2_alt: "",
 <p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
 <p>If your training provider thinks you need to top up your computing knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
 <h2>Fund your teacher training</h2>
-<p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee computing teachers</a>.</p>
+<p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000</a> are available for eligible trainee computing teachers</a>.</p>
 <p>You can get a bursary or scholarship alongside a tuition fee loan and maintenance loan.</p>
 <p>You may also be able to get <a href="/funding-and-support">extra funding and support</a> if you're:</p>
 <ul>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -87,7 +87,7 @@ image_2_alt: "",
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>You can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a> as a non-UK citizen.</p>
+<p>Find out about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support for non-UK citizens</a>.</p>
 <h2>Paid internship </h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching computing, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>
 <p>The 3-week programme could help you to understand what it’s really like in the classroom and get a feel for school life.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -36,7 +36,7 @@ image_2_alt: "",
 <li class="tag">Online safety </li>
 </ul>
 <p>When you're teaching key stage 3 you could use interactive exercises during your lessons, like creating a robot car.</p>
-<p>Themes you'll cover 14 to 16 year olds (key stage 4) computer science as a GCSE qualification, teaching pupils ways to protect their online privacy and identity. include:</p>
+<p>Themes you'll cover for 14 to 16 year olds (key stage 4), computer science as a GCSE qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Computational thinking</li>
 <li class="tag">Digital media and information technology</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -25,7 +25,7 @@ image_2_alt: "",
 <section class="col col-720">
 <h2>What you'll be teaching</h2>
 <p>You'll teach themes from the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
-<p>When teaching 11 to 14 year olds (key stage 3), you could use interactive exercises during your lessons, like creating a robot car. Themes you might cover include:</p>
+<p>Themes you'll cover for 11 to 14 year olds (key stage 3) include:</p>
 <ul class="vertical-tags">
 <li class="tag">Algorithms</li>
 <li class="tag">Programming and debugging</li>
@@ -35,7 +35,8 @@ image_2_alt: "",
 <li class="tag">Uses of technology</li>
 <li class="tag">Online safety </li>
 </ul>
-<p>You'll teach 14 to 16 year olds (key stage 4) computer science as a GCSE qualification, teaching pupils ways to protect their online privacy and identity. Themes you might cover include:</p>
+<p>When you're teaching key stage 3 you could use interactive exercises during your lessons, like creating a robot car.</p>
+<p>Themes you'll cover 14 to 16 year olds (key stage 4) computer science as a GCSE qualification, teaching pupils ways to protect their online privacy and identity. include:</p>
 <ul class="vertical-tags">
 <li class="tag">Computational thinking</li>
 <li class="tag">Digital media and information technology</li>
@@ -44,7 +45,8 @@ image_2_alt: "",
 <li class="tag">Data representation</li>
 <li class="tag">Digital technology</li>
 </ul>
-<p>For 16 to 18 year olds (key stage 5), you'll teach computer science as an A level qualification, helping pupils to develop websites and prepare them for further learning or employment. Themes you might cover include:</p>
+<p>When you're teaching key stage 4 you'll teach pupils ways to protect their online privacy and identity.</p>
+<p>Themes you'll cover for 16 to 18 year olds (key stage 5), A level qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Abstraction</li>
 <li class="tag">Writing programmes to solve problems</li>
@@ -53,7 +55,7 @@ image_2_alt: "",
 <li class="tag">Systems architecture</li>
 <li class="tag">Computing related mathematics</li>
 </ul>
-
+<p>When you're teaching key stage 5 you'll help pupils to develop websites and prepare them for further learning or employment.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a computer lesson would be like</a>.</p>
 </section>
 <section class="col col-720">

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -25,7 +25,7 @@ image_2_alt: "",
 <section class="col col-720">
 <h2>What you'll be teaching</h2>
 <p>You'll the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
-<p>Themes you'll cover for 11 to 14 year olds (key stage 3) include:</p>
+<p>Themes you'll cover when you teach 11 to 14 year olds (key stage 3) include:</p>
 <ul class="vertical-tags">
 <li class="tag">Algorithms</li>
 <li class="tag">Programming and debugging</li>
@@ -37,7 +37,7 @@ image_2_alt: "",
 </ul>
 <p>When you're teaching key stage 3 you could use interactive exercises during your lessons, like creating a robot car.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks3-l/units">Explore what teaching a key stage 3 computing lesson would be like</a>.</p>
-<p>Themes you'll cover for 14 to 16 year olds (key stage 4), computer science as a GCSE qualification, include:</p>
+<p>Themes you'll cover when you teach 14 to 16 year olds (key stage 4), computer science as a GCSE qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Computational thinking</li>
 <li class="tag">Digital media and information technology</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -77,7 +77,8 @@ image_2_alt: "",
 <p>Computing teacher training courses have had successful applications from candidates with a range of degrees, including business and management, data science, history and economics.</p>
 <p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach.</a>.</p>
 <p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
-<p>If your training provider thinks you need to top up your computing knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
+<h3> Subject knowledge enhancement course (SKE)
+<p>If your training provider thinks you need to top up your computing knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>
 <h2>Fund your teacher training</h2>
 <p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000</a> are available for eligible trainee computing teachers</a>.</p>
 <p>You can get a bursary or scholarship alongside a tuition fee loan and maintenance loan.</p>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -36,6 +36,7 @@ image_2_alt: "",
 <li class="tag">Online safety </li>
 </ul>
 <p>When you're teaching key stage 3 you could use interactive exercises during your lessons, like creating a robot car.</p>
+<p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks3-l/units">Explore what teaching a key stage 3 computing lesson would be like</a>.</p>
 <p>Themes you'll cover for 14 to 16 year olds (key stage 4), computer science as a GCSE qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Computational thinking</li>

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -47,6 +47,7 @@ image_2_alt: "",
 <li class="tag">Digital technology</li>
 </ul>
 <p>When you're teaching key stage 4 you'll teach pupils ways to protect their online privacy and identity.</p>
+<p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a key stage 4 computing lesson would be like</a>.</p>
 <p>Themes you'll cover for 16 to 18 year olds (key stage 5), A level qualification, include:</p>
 <ul class="vertical-tags">
 <li class="tag">Abstraction</li>
@@ -57,7 +58,6 @@ image_2_alt: "",
 <li class="tag">Computing related mathematics</li>
 </ul>
 <p>When you're teaching key stage 5 you'll help pupils to develop websites and prepare them for further learning or employment.</p>
-<p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks4-l/units">Explore what teaching a computer lesson would be like</a>.</p>
 </section>
 <section class="col col-720">
   <%= render Content::QuoteComponent.new(

--- a/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/computing/_article.html.erb
@@ -24,7 +24,7 @@ image_2_alt: "",
 </section>
 <section class="col col-720">
 <h2>What you'll be teaching</h2>
-<p>You'll the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
+<p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">national curriculum for computing</a>, with opportunities to develop your pupils' computational thinking.</p>
 <p>Themes you'll cover when you teach 11 to 14 year olds (key stage 3) include:</p>
 <ul class="vertical-tags">
 <li class="tag">Algorithms</li>
@@ -37,7 +37,7 @@ image_2_alt: "",
 </ul>
 <p>When you're teaching key stage 3 you could use interactive exercises during your lessons, like creating a robot car.</p>
 <p><a href="https://www.thenational.academy/teachers/programmes/computing-secondary-ks3-l/units">Explore what teaching a key stage 3 computing lesson would be like</a>.</p>
-<p>Themes you'll cover when you teach 14 to 16 year olds (key stage 4), computer science as a GCSE qualification, include:</p>
+<p>Themes you'll cover when you teach 14 to 16 year olds (key stage 4) computer science as a GCSE qualification include:</p>
 <ul class="vertical-tags">
 <li class="tag">Computational thinking</li>
 <li class="tag">Digital media and information technology</li>

--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -90,7 +90,7 @@
 <li>disabled </li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support available for non-UK citizens</a>.</p>
+<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support for non-UK trainee teachers</a>.</p>
 
 <h2>Paid internship</h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching maths, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -90,7 +90,7 @@
 <li>disabled </li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support for non-UK trainee teachers</a>.</p>
+<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support available for non-UK citizens</a>.</p>
 
 <h2>Paid internship</h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching maths, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/physics.md
+++ b/app/views/content/is-teaching-right-for-me/physics.md
@@ -5,7 +5,7 @@ description: |-
 subcategory: What to teach
 navigation: 5.48
 navigation_title: Physics
-navigation_description: Find out how to become a physics teacher and what teaching pupils a wide range of experiments would be like.
+navigation_description: Find out how to become a physics teacher and inspire the next generation of scientists, engineers and innovators.
 layout: "layouts/minimal"
 colour: "yellow"
 image: "static/images/content/hero-images/physics_1383.jpg"


### PR DESCRIPTION
### Trello card
https://trello.com/c/NoXzVwDW/5758-improve-computing-subject-page-following-user-research

### Context
We need to make some updates to the computing page to make sure it's consistent with the maths and physics pages

### Changes proposed in this pull request

- ensure meta description includes become a computing teacher
- update bursary and scholarship link
- update non-UK qualifications link to go to non-UK qualifications page
- update nav card description (this has been done in the physics PR)
- include computing in national curriculum link
- delete references to primary in qualifications section
- add reference to secondary in intro section
- change 'receive this alongside a tuition fee and maintenance loan' to receive a bursary or scholarship...
- add loan after tuition fee in the sentence above
- make themes you'll cover wording consistent in all sections
- update wording in Fund your teacher training section to You may also be able to get extra funding **and **support if you're:
- delete surname and location if applicable from quotes
- add links to ks3 and ks4 lesson plans where available for both under the relevant sections

### Guidance to review

