### PR TITLE
Update physics page

### DIFF
--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -90,7 +90,7 @@
 <li>disabled </li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support for non-UK citizens</a>.</p>
+<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support available for non-UK citizens</a>.</p>
 
 <h2>Paid internship</h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching maths, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -90,7 +90,7 @@
 <li>disabled </li>
 </ul>
 <p>Non-UK citizens without indefinite leave to remain in the UK are unlikely to be eligible for funding.</p>
-<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support available for non-UK citizens</a>.</p>
+<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support for non-UK citizens</a>.</p>
 
 <h2>Paid internship</h2>
 <p>If you’re currently doing an undergraduate or master's degree and are interested in teaching maths, you could apply for a <a href="/is-teaching-right-for-me/teaching-internship-providers">paid teaching internship</a>.</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -66,7 +66,7 @@ You could inspire your pupils to consider rewarding professions, from tackling c
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
-<p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
+<p>Find out more about what <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">qualifications you need to train to teach</a>.</p>
 <p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -68,7 +68,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
 <p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
-<p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can check your eligibility to train to teach in England</a>.</p>
+<p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>
   </section>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -83,7 +83,7 @@ a parent or carer</li>
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens are eligible for bursaries and scholarships for physics teacher training courses.</p>
-<p>Find out more about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support available for non-UK trainee teachers</a>.</p>
+<p>Find out more about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support for non-UK trainee teachers</a>.</p>
 </section>
 <section class="col col-space-m col-720">
 <h2>Paid internship</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -83,7 +83,7 @@ a parent or carer</li>
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens are eligible for bursaries and scholarships for physics teacher training courses.</p>
-<p>You can <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">find out more about fees and financial support available for non-UK citizens</a>.</p>
+<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support available for non-UK citizens</a>.</p>
 </section>
 <section class="col col-space-m col-720">
 <h2>Paid internship</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -83,7 +83,7 @@ a parent or carer</li>
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens are eligible for bursaries and scholarships for physics teacher training courses.</p>
-<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support available for non-UK citizens</a>.</p>
+<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support available for non-UK citizens</a>.</p>
 </section>
 <section class="col col-space-m col-720">
 <h2>Paid internship</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -34,7 +34,6 @@ You could inspire your pupils to consider rewarding careers from tackling climat
           <li class="tag">Electricity and electromagnetism</li>
           <li class="tag">Waves and matter</li>
         </ul>
-        <p><a href="https://www.thenational.academy/teachers/programmes/physics-secondary-ks3-higher-aqa/units">Explore what teaching a key stage 3 physics lesson would be like</a>.</p>
       <p>Themes you’ll cover for 14 to 16 year olds (key stage 4) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Energy, forces and wave motion</li>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -83,7 +83,7 @@ a parent or carer</li>
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens are eligible for bursaries and scholarships for physics teacher training courses.</p>
-<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support available for non-UK trainee teachers</a>.</p>
+<p>Find out more about <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">fees and financial support available for non-UK trainee teachers</a>.</p>
 </section>
 <section class="col col-space-m col-720">
 <h2>Paid internship</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -27,14 +27,14 @@ You could inspire your pupils to consider rewarding professions, from tackling c
 <section class="col col-720">
       <h2>What you'll be teaching</h2>
       <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-science-programmes-of-study/national-curriculum-in-england-science-programmes-of-study">national curriculum for physics</a>, with opportunities to develop your pupils' ability to think like physicists and see physics as a solution to many challenges.</p>
-      <p>Themes you'll cover for 11 to 14 year olds (key stage 3) include:</p>
+      <p>Themes you'll cover when you teach 11 to 14 year olds (key stage 3) include:</p>
         <ul class="vertical-tags">
           <li class="tag">Energy</li>
           <li class="tag">Motion and forces</li>
           <li class="tag">Electricity and electromagnetism</li>
           <li class="tag">Waves and matter</li>
         </ul>
-      <p>Themes you’ll cover for 14 to 16 year olds (key stage 4) include:</p>
+      <p>Themes you’ll cover when you teach 14 to 16 year olds (key stage 4) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Energy, forces and wave motion</li>
         <li class="tag">Electricity, magnetism and electromagnetism</li>
@@ -42,7 +42,7 @@ You could inspire your pupils to consider rewarding professions, from tackling c
         <li class="tag">Atomic structure and space physics</li>
       </ul>
       <p><a href="https://www.thenational.academy/teachers/programmes/physics-secondary-ks4-higher-aqa/units">Explore what teaching a key stage 4 physics lesson would be like</a>.</p>
-      <p>Themes you’ll cover for 16 to 18 year olds (key stage 5) include:</p>
+      <p>Themes you’ll cover when you teach 16 to 18 year olds (key stage 5) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Fields, vectors and scalars</li>
         <li class="tag">Mechanics and mechanical properties of matter</li>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-You could inspire your pupils to consider rewarding careers from tackling climate change to artificial intelligence (AI).
+You could inspire your pupils to consider rewarding professions from tackling climate change to artificial intelligence (AI).
   </p>
   <p>Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee physics teachers.</p>
 

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -61,9 +61,9 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 </section>
   <section class="col col-space-m col-720">
     <h2>Check your qualifications</h2>
-<p>To train to teach in primary and secondary schools in England, you’ll need:</p>
+<p>To train to teach in secondary schools in England, you’ll need:</p>
 <ul>
-<li>GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary)</li>
+<li>GCSEs at grade 4 (C) or above in English and maths</li>
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -66,7 +66,7 @@ You could inspire your pupils to consider rewarding professions, from tackling c
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
-<p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
+<p>Find out more about<a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
 <p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -83,7 +83,7 @@ a parent or carer</li>
 <li>disabled</li>
 </ul>
 <p>Non-UK citizens are eligible for bursaries and scholarships for physics teacher training courses.</p>
-<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support available for non-UK citizens</a>.</p>
+<p>Find out more about<a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees"> fees and financial support available for non-UK trainee teachers</a>.</p>
 </section>
 <section class="col col-space-m col-720">
 <h2>Paid internship</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -69,7 +69,8 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
 
 <p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
-<p>If your training provider thinks you need to top up your physics knowledge, you might need to do a <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">subject knowledge enhancement (SKE) course</a> before you start your teacher training.</p>
+<h3>Subject knowledge enhancement (SKE) course
+<p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>
 <p><a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">Find out more about the qualifications needed to train to teach</a>.</p>
   </section>
   <section class="col col-space-m col-720">

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -26,7 +26,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 </section>
 <section class="col col-720">
       <h2>What you'll be teaching</h2>
-      <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-science-programmes-of-study/national-curriculum-in-england-science-programmes-of-study">national curriculum</a>, with opportunities to develop your pupils' ability to think like physicists and see physics as a solution to many challenges.</p>
+      <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-science-programmes-of-study/national-curriculum-in-england-science-programmes-of-study">national curriculum for physics</a>, with opportunities to develop your pupils' ability to think like physicists and see physics as a solution to many challenges.</p>
       <p>The themes you're likely to cover for 11 to 14 year olds (key stage 3) include:</p>
         <ul class="vertical-tags">
           <li class="tag">Energy</li>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -1,7 +1,7 @@
 <div class="row inset">
 <section class="col col-720">
   <p>
-    Teaching physics is an exciting and rewarding career. Schools need more specialist physics teachers, so it's a great choice of subject.
+    Teaching secondary physics is an exciting and rewarding career. Schools need more specialist physics teachers, so it's a great choice of subject.
   </p>
 
   <p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -67,11 +67,10 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
-
+<p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
 <p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>
-<p><a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">Find out more about the qualifications needed to train to teach</a>.</p>
   </section>
   <section class="col col-space-m col-720">
 <h2>Fund your teacher training</h2>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -74,7 +74,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
   </section>
   <section class="col col-space-m col-720">
 <h2>Fund your teacher training</h2>
-<p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee physics teachers</a>.</p>
+<p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 </a>are available for eligible trainee physics teachers.</p>
 <p>You can get a bursary or scholarship alongside a tuition fee loan and maintenance loan.</p>
 
 <p>You may also be able to get <a href="/funding-and-support">extra funding and support</a> if you're:</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -75,9 +75,9 @@ You could inspire your pupils to consider rewarding careers from tackling climat
   <section class="col col-space-m col-720">
 <h2>Fund your teacher training</h2>
 <p><a href="/funding-and-support/scholarships-and-bursaries">Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee physics teachers</a>.</p>
-<p>You can get a bursary or scholarship alongside a tuition fee and maintenance loan.</p>
+<p>You can get a bursary or scholarship alongside a tuition fee loan and maintenance loan.</p>
 
-<p>You may also be able to get <a href="/funding-and-support">extra funding support</a> if you're:</p>
+<p>You may also be able to get <a href="/funding-and-support">extra funding and support</a> if you're:</p>
 <ul>
   <li>
 a parent or carer</li>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -34,6 +34,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
           <li class="tag">Electricity and electromagnetism</li>
           <li class="tag">Waves and matter</li>
         </ul>
+        <p><a href="https://www.thenational.academy/teachers/programmes/physics-secondary-ks3-higher-aqa/units">Explore what teaching a key stage 3 physics lesson would be like</a>.</p>
       <p>Themes you’ll cover for 14 to 16 year olds (key stage 4) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Energy, forces and wave motion</li>
@@ -41,6 +42,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
         <li class="tag">The structure of matter</li>
         <li class="tag">Atomic structure and space physics</li>
       </ul>
+      <p><a href="https://www.thenational.academy/teachers/programmes/physics-secondary-ks4-higher-aqa/units">Explore what teaching a key stage 4 physics lesson would be like</a>.</p>
       <p>Themes you’ll cover for 16 to 18 year olds (key stage 5) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Fields, vectors and scalars</li>
@@ -49,12 +51,11 @@ You could inspire your pupils to consider rewarding careers from tackling climat
         <li class="tag">Matter, quantum and nuclear physics</li>
       </ul>
     </p>
-<p><a href="https://www.thenational.academy/teachers/programmes/physics-secondary-ks4-higher-aqa/units">Explore what teaching a physics lesson would be like</a>.</p>
     </section>
    <section class="col col-720">
   <%= render Content::QuoteComponent.new(
     text: "It's inspiring getting 'wow, that's how it works' from pupils as they grasp a subject they thought was hard.",
-    name: "Jane Doran, physics and robotics teacher, West Midlands",
+    name: "Jane, physics and robotics teacher",
     large: true
   ) %>
 </section>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -66,7 +66,7 @@ You could inspire your pupils to consider rewarding professions, from tackling c
 <li>a bachelor’s degree in any subject</li>
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
-<p>Find out more about<a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
+<p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
 <p>Non-UK citizens can <a href="/non-uk-teachers/non-uk-qualifications">check your eligibility to train to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-You could inspire your pupils to consider rewarding professions from tackling climate change to artificial intelligence (AI).
+You could inspire your pupils to consider rewarding professions, from tackling climate change to artificial intelligence (AI).
   </p>
   <p>Tax-free bursaries of £28,000 or scholarships of £30,000 are available for eligible trainee physics teachers.</p>
 

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -1,7 +1,7 @@
 <div class="row inset">
 <section class="col col-720">
   <p>
-    Teaching secondary physics is an exciting and rewarding career. Schools need more specialist physics teachers, so it's a great choice of subject.
+    Teaching secondary physics is an exciting and worthwhile career. Schools need more specialist physics teachers, so it's a great choice of subject.
   </p>
 
   <p>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -68,7 +68,7 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 </ul>
 <p>Physics teacher training courses have had successful applications from candidates with a range of degrees, including maths, geology, business studies and finance.</p>
 <p>Find out more about <a href="/is-teaching-right-for-me/qualifications-you-need-to-teach">what qualifications you need to train to teach</a>.</p>
-<p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can find out more about training to teach in England</a>.</p>
+<p><a href="/non-uk-teachers/train-to-teach-in-england-as-an-international-student">Non-UK citizens can check your eligibility to train to teach in England</a>.</p>
 <h3>Subject knowledge enhancement (SKE) course
 <p>If your training provider thinks you need to top up your physics knowledge, you might need to do an <a href="/how-to-apply-for-teacher-training/subject-knowledge-enhancement">SKE course</a> before you start your teacher training.</p>
   </section>

--- a/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/physics/_article.html.erb
@@ -27,25 +27,21 @@ You could inspire your pupils to consider rewarding careers from tackling climat
 <section class="col col-720">
       <h2>What you'll be teaching</h2>
       <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-science-programmes-of-study/national-curriculum-in-england-science-programmes-of-study">national curriculum for physics</a>, with opportunities to develop your pupils' ability to think like physicists and see physics as a solution to many challenges.</p>
-      <p>The themes you're likely to cover for 11 to 14 year olds (key stage 3) include:</p>
+      <p>Themes you'll cover for 11 to 14 year olds (key stage 3) include:</p>
         <ul class="vertical-tags">
           <li class="tag">Energy</li>
           <li class="tag">Motion and forces</li>
           <li class="tag">Electricity and electromagnetism</li>
           <li class="tag">Waves and matter</li>
         </ul>
-      <p>
-        Themes you’ll cover for 14 to 16 year olds (key stage 4):
-      </p>
+      <p>Themes you’ll cover for 14 to 16 year olds (key stage 4) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Energy, forces and wave motion</li>
         <li class="tag">Electricity, magnetism and electromagnetism</li>
         <li class="tag">The structure of matter</li>
         <li class="tag">Atomic structure and space physics</li>
       </ul>
-      <p>
-        Themes you’ll cover for 16 to 18 year olds (key stage 5):
-      </p>
+      <p>Themes you’ll cover for 16 to 18 year olds (key stage 5) include:</p>
        <ul class="vertical-tags">
         <li class="tag">Fields, vectors and scalars</li>
         <li class="tag">Mechanics and mechanical properties of matter</li>

--- a/config/images.yml
+++ b/config/images.yml
@@ -273,7 +273,7 @@
     - "static/images/content/hero-images/0037--tablet.jpg"
 
 "static/images/content/hero-images/physics_1383.jpg":
-  alt: "A physics teacher talking about gravity with balls in the classroom."
+  alt: "A physics teacher demonstrating how gravity works by juggling balls at the front of the classroom."
   variants:
     - "static/images/content/hero-images/physics_1383-mobile.jpg"
     - "static/images/content/hero-images/physics_1383-tablet.jpg"    

--- a/config/images.yml
+++ b/config/images.yml
@@ -608,6 +608,6 @@
 
 # subjects
 "static/images/content/subjects/rotna-roy.jpeg":
-  alt: "Rotna Roy, maths teacher"
+  alt: "Rotna, maths teacher"
 
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/0QcjxnRh/5757-improve-physics-subject-page-following-user-research

### Context
We need to make some updates to the physics page to make sure it's consistent with the maths and computing pages.

### Changes proposed in this pull request

- ensure meta description includes become a physics teacher
- update bursary and scholarship link
- update non-UK qualifications link to go to non-UK qualifications page
- update nav card description
- include physics in national curriculum link
- delete references to primary in qualifications section
- add reference to secondary in intro section
- change 'receive this alongside a tuition fee and maintenance loan' to receive a bursary or scholarship...
- add loan after tuition fee in the sentence above
- make themes you'll cover wording consistent in all sections
- update wording in Fund your teacher training section to You may also be able to get extra funding **and **support if you're:
- delete surname and location if applicable from quotes
- add links to ks3 and ks4 lesson plans where available for both under the relevant sections

### Guidance to review

