### PR TITLE
Change curriculum link on maths page

### DIFF
--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -28,7 +28,7 @@
     <div>
       <h2>What you'll be teaching</h2>
 
-      <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-mathematics-programmes-of-study/national-curriculum-in-england-mathematics-programmes-of-study#key-stage-3">national curriculum</a>.</p>
+      <p>You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-mathematics-programmes-of-study/national-curriculum-in-england-mathematics-programmes-of-study">national curriculum</a>.</p>
       <p>When teaching 11 to 16 year olds (key stage 3 and 4), you can use interactive games with conkers and dice to help your pupils understand algebra. Themes you’ll cover are:</p>
       <ul class="vertical-tags">
         <li class="tag">Numbers</li>


### PR DESCRIPTION
### Trello card
https://trello.com/c/FQgwn44F

### Context
Changing the link to the national curriculum to go to the top of the page rather than the key stage 3 section, to be consistent with other subject pages
