### PR TITLE
Change national curriculum link on maths page

### DIFF
--- a/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
+++ b/app/views/content/is-teaching-right-for-me/maths/_article.html.erb
@@ -35,7 +35,7 @@
   <section class="col col-720">
     <h2>What you'll be teaching</h2>
     <p>
-      You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-mathematics-programmes-of-study/national-curriculum-in-england-mathematics-programmes-of-study#key-stage-3">national curriculum for maths</a>.
+      You'll teach the <a href="https://www.gov.uk/government/publications/national-curriculum-in-england-mathematics-programmes-of-study/national-curriculum-in-england-mathematics-programmes-of-study">national curriculum for maths</a>.
     </p>
     <p>
       Themes you’ll cover when you teach 11 to 16 year olds (key stage 3 and 4) include:


### PR DESCRIPTION
### Trello card
https://trello.com/c/FQgwn44F

### Context
Changing link to national curriculum on maths page to go to the top of the page rather than anchored at key stage 3, to be consistent with other subject pages

