### PR TITLE
Update QTS and PGCE references to be consistent with Find

### DIFF
--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -69,7 +69,7 @@ Full-time salaried teacher training will usually last:
 
 Some courses can begin at other points in the year and there may be part-time courses available. 
 
-As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) but you may have to pay an extra fee. 
+Some salaried courses award QTS only. You may have the option to do a salaried course where you can work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) but you may have to pay an extra fee. 
 
 [Find out more about what to expect during your teacher training](/train-to-be-a-teacher/initial-teacher-training). 
 

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -69,7 +69,7 @@ Full-time salaried teacher training will usually last:
 
 Some courses can begin at other points in the year and there may be part-time courses available. 
 
-As well as QTS, you may also be able to work towards a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), but you may have to pay an extra fee. 
+As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), but you may have to pay an extra fee. 
 
 [Find out more about what to expect during your teacher training](/train-to-be-a-teacher/initial-teacher-training). 
 
@@ -81,6 +81,6 @@ It’s usually wise to apply for non-salaried courses as well to increase your c
 
 ### Teach First 
 
-Teach First delivers a 2 year employment-based route to teaching for high performing graduates and career changers. You’ll earn a salary while working towards QTS and a postgraduate certificate in education (PGCE). 
+Teach First delivers a 2 year employment-based route to teaching for high performing graduates and career changers. You’ll earn a salary while working towards QTS with a postgraduate certificate in education (PGCE). 
 
 To apply and find out more, you should [visit the Teach First website](https://www.teachfirst.org.uk/).

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -69,7 +69,7 @@ Full-time salaried teacher training will usually last:
 
 Some courses can begin at other points in the year and there may be part-time courses available. 
 
-As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) or a PGCE, but you may have to pay an extra fee. 
+As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) but you may have to pay an extra fee. 
 
 [Find out more about what to expect during your teacher training](/train-to-be-a-teacher/initial-teacher-training). 
 

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -69,7 +69,7 @@ Full-time salaried teacher training will usually last:
 
 Some courses can begin at other points in the year and there may be part-time courses available. 
 
-As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), but you may have to pay an extra fee. 
+As well as QTS, you may also be able to work towards QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) or a PGCE, but you may have to pay an extra fee. 
 
 [Find out more about what to expect during your teacher training](/train-to-be-a-teacher/initial-teacher-training). 
 

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -81,6 +81,6 @@ It’s usually wise to apply for non-salaried courses as well to increase your c
 
 ### Teach First 
 
-Teach First delivers a 2 year employment-based route to teaching for high performing graduates and career changers. You’ll earn a salary while working towards QTS with a postgraduate certificate in education (PGCE). 
+Teach First delivers a 2 year employment-based route to teaching for high performing graduates and career changers. You’ll earn a salary while working towards QTS with a PGCE. 
 
 To apply and find out more, you should [visit the Teach First website](https://www.teachfirst.org.uk/).

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -43,7 +43,7 @@ You can get help with your application from our [teacher training advisers](/tea
 
 ## What course should I apply for? 
 
-Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts), some QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some a PGCE without QTS.
+Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts), some QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some a PGCE without QTS.
 
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -37,13 +37,13 @@ navigation_description: Find out what you need to include in your teacher traini
 
 ---
 
-Find out what you need to include in your teacher training application and what happens as part of the application process. 
+Find out what you need to include in your primary or secondary teacher training application and what happens as part of the application process. 
 
 You can get help with your application from our [teacher training advisers](/teacher-training-advisers). They have years of teaching experience and can give you free, one-to-one support. 
 
 ## What course should I apply for? 
 
-Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts), some QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some a PGCE without QTS.
+Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) and some QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -43,7 +43,7 @@ You can get help with your application from our [teacher training advisers](/tea
 
 ## What course should I apply for? 
 
-Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts), some a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some both. 
+Make sure you check which qualification you’ll get through your training course. Some will award [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts), some QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some a PGCE without QTS.
 
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
@@ -27,11 +27,11 @@ promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-interviews
 ---
 
-Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.
+Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a primary or secondary teacher training course.
 
 These tips can help you prepare for a successful interview. 
 
-It could be an interview for a course that leads to qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or PGCE without QTS. 
+It could be an interview for a course that leads to qualified teacher status (QTS) or QTS with a postgraduate certificate in education (PGCE). 
 
 The exact interview process will vary depending on the teacher training provider.
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
@@ -31,7 +31,7 @@ Congratulations on being invited for an interview! This is an important stage in
 
 These tips can help you prepare for a successful interview. 
 
-It could be an interview for a course that leads to qualified teacher status (QTS), QTS with postgraduate certificate in education (PGCE), or PGCE without QTS. 
+It could be an interview for a course that leads to qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or PGCE without QTS. 
 
 The exact interview process will vary depending on the teacher training provider.
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
@@ -31,7 +31,7 @@ Congratulations on being invited for an interview! This is an important stage in
 
 These tips can help you prepare for a successful interview. 
 
-It could be an interview for a course that leads to qualified teacher status (QTS), a postgraduate certificate in education (PGCE), or both. 
+It could be an interview for a course that leads to qualified teacher status (QTS), QTS with postgraduate certificate in education (PGCE), or PGCE without QTS. 
 
 The exact interview process will vary depending on the teacher training provider.
 

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,4 +1,4 @@
-<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS) or QTS with a postgraduate certificate in education (PGCE).</p>
 
 <p>You need QTS to teach in most primary and secondary schools in England but you do not need a PGCE to teach.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,4 +1,4 @@
-<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or PGCE without QTS.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
 
 <p>You need QTS to teach in most primary and secondary schools in England but you do not need a PGCE to teach.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,4 +1,4 @@
-<p>Through teacher training, you can get qualified teacher status (QTS), QTS with postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
 
 <p>You need QTS to teach in most primary and secondary schools in England but you do not need a PGCE to teach.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,4 +1,4 @@
-<p>Through teacher training, you can get qualified teacher status (QTS), a postgraduate certificate in education (PGCE), or both.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or PGCE without QTS.</p>
 
 <p>You need QTS to teach in most primary and secondary schools in England but you do not need a PGCE to teach.</p>
 

--- a/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_4_find_a_teacher_training_course.html.erb
@@ -1,4 +1,4 @@
-<p>Through teacher training, you can get qualified teacher status (QTS), QTS with a postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
+<p>Through teacher training, you can get qualified teacher status (QTS), QTS with postgraduate certificate in education (PGCE), or a PGCE without QTS.</p>
 
 <p>You need QTS to teach in most primary and secondary schools in England but you do not need a PGCE to teach.</p>
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -62,7 +62,7 @@ If your application is successful, the training provider may be able to help you
 
 Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
-Most teacher training courses will award QTS, but some will award QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
+Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
 
 If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -60,7 +60,7 @@ If your application is successful, the training provider may be able to help you
 
 ## The qualifications awarded by the course
 
-Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
+Most primary and secondary schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
 Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -62,7 +62,7 @@ If your application is successful, the training provider may be able to help you
 
 Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
-Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
+Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
 If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -62,7 +62,7 @@ If your application is successful, the training provider may be able to help you
 
 Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
-Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
+Most teacher training courses will award QTS, but some will award QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
 
 If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -62,7 +62,7 @@ If your application is successful, the training provider may be able to help you
 
 Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
-Most teacher training courses will award QTS, but some will just award a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce), and some will award both. 
+Most teacher training courses will award QTS, but some will award QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award PGCE without QTS.
 
 If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -24,7 +24,7 @@ keywords:
 
 ---
 
-All postgraduate teacher training courses include time spent in school placements with some theoretical learning. 
+All primary and secondary postgraduate teacher training courses include time spent in school placements with some theoretical learning. 
 
 The main differences between courses are: 
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -62,7 +62,7 @@ If your application is successful, the training provider may be able to help you
 
 Most schools in England need you to have [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) to teach. Without QTS you may not be fully qualified to teach in your chosen school and will not receive the same pay and support when you start teaching.
 
-Most teacher training courses will award QTS, but some will award QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award PGCE without QTS.
+Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce) and some will award a PGCE without QTS.
 
 If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
 

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
@@ -8,7 +8,7 @@
   <div class="right">
     <h2 class="heading-m heading--margin-top-0">Find your teacher training course</h2>
     <p>
-      You can search for postgraduate teacher training courses to get a PGCE.
+      You can search for postgraduate teacher training courses to get QTS with PGCE.
     </p>
 
     <p>

--- a/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
+++ b/app/views/content/train-to-be-a-teacher/promos/_find-your-course-pgce.html.erb
@@ -8,7 +8,7 @@
   <div class="right">
     <h2 class="heading-m heading--margin-top-0">Find your teacher training course</h2>
     <p>
-      You can search for postgraduate teacher training courses to get QTS with PGCE.
+      You can search for postgraduate teacher training courses to get QTS with a PGCE.
     </p>
 
     <p>

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -49,14 +49,16 @@ Many teacher training courses also offer you a postgraduate qualification such a
 You can do a teacher training course that leads to:
 
 * QTS only
-* PGCE only
 * QTS with PGCE
+* PGCE without QTS
 
-Getting QTS only means that you’re qualified to teach in most schools in England. It may also mean that your course fees are lower, you submit fewer assignments, and the course could be shorter.
+## Benefits of having QTS
 
-Getting PGCE only means you will not be qualified to teach in most primary, secondary and special schools in England, although some schools will employ teachers without QTS.
+Getting QTS means you’re qualified to teach in most schools in England. It may also mean that your course fees are lower, you submit fewer assignments, and the course could be shorter.
 
-A PGCE alone will also not entitle you to the same benefits during your training and career as QTS. For example, better pay and support when you start teaching.
+Getting a PGCE without QTS means you will not be qualified to teach in most primary, secondary and special schools in England, although some schools will employ teachers without QTS.
+
+A PGCE without QTS will also not entitle you to the same benefits during your training and career as a PGCE with QTS. For example, better pay and support when you start teaching.
 
 [Read about Nathan who chose to get QTS with PGCE](/blog/salaried-teacher-training-classroom-learning).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -70,7 +70,7 @@ You may want to do a master’s in education, for example, for your professional
 
 ## Types of PGCE courses
 
-You can get QTS with a PGCE in primary and secondary education. Your course will involve both school placements and academic theory.
+You can get QTS with a PGCE in primary or secondary education. Your course will involve both school placements and academic theory.
 
 You can do this through a school-led, university-led, or an apprenticeship teacher training programme.
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -21,6 +21,8 @@ keywords:
   - PGCE
   - Post-graduate
   - Post-grad
+  - Postgraduate
+  - Postgrad
   - Certificate
   - Education
   - QTS

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -58,7 +58,7 @@ If you get a PGCE without QTS you will also not be entitled to the same benefits
 
 [Read about Nathan who chose to get QTS with PGCE](/blog/salaried-teacher-training-classroom-learning).
 
-## Benefits of having a PGCE
+## Benefits of having QTS with PGCE
 
 A PGCE can give you a better understanding of teaching practices, educational research and theory.
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -52,10 +52,6 @@ You can do a teacher training course that leads to:
 * QTS with PGCE
 * PGCE without QTS
 
-## Benefits of having QTS
-
-Getting QTS means you’re qualified to teach in most schools in England. It may also mean that your course fees are lower, you submit fewer assignments, and the course could be shorter.
-
 Getting a PGCE without QTS means you will not be qualified to teach in most primary, secondary and special schools in England, although some schools will employ teachers without QTS.
 
 If you get a PGCE without QTS you will also not be entitled to the same benefits during your training and career as QTS with PGCE. For example, better pay and support when you start teaching.
@@ -74,11 +70,13 @@ You may want to do a master’s in education, for example, for your professional
 
 ## Types of PGCE courses
 
-You can get a PGCE in primary education, secondary education, or further/adult education. Your course will involve both school placements and academic theory.
+You can get QTS with a PGCE in primary and secondary education. Your course will involve both school placements and academic theory.
 
 You can do this through a school-led, university-led, or an apprenticeship teacher training programme.
 
 You can do a full or part-time PGCE course.
+
+You can also do a PGCE without QTS in [further education](/is-teaching-right-for-me/become-a-further-education-teacher).
 
 As part of selecting your course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -58,7 +58,7 @@ Getting QTS means you’re qualified to teach in most schools in England. It may
 
 Getting a PGCE without QTS means you will not be qualified to teach in most primary, secondary and special schools in England, although some schools will employ teachers without QTS.
 
-A PGCE without QTS will also not entitle you to the same benefits during your training and career as a PGCE with QTS. For example, better pay and support when you start teaching.
+A PGCE without QTS will also not entitle you to the same benefits during your training and career as QTS with PGCE. For example, better pay and support when you start teaching.
 
 [Read about Nathan who chose to get QTS with PGCE](/blog/salaried-teacher-training-classroom-learning).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -76,9 +76,9 @@ You can do this through a school-led, university-led, or an apprenticeship teach
 
 You can do a full or part-time PGCE course.
 
-You can also do a PGCE without QTS in [further education](/is-teaching-right-for-me/become-a-further-education-teacher).
-
 As part of selecting your course, you will need to decide if you want to train to teach at a primary or secondary level. [Learn about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
+
+You can also do a PGCE without QTS in [further education](/is-teaching-right-for-me/become-a-further-education-teacher).
 
 ### Entry requirements
 

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -58,7 +58,7 @@ Getting QTS means you’re qualified to teach in most schools in England. It may
 
 Getting a PGCE without QTS means you will not be qualified to teach in most primary, secondary and special schools in England, although some schools will employ teachers without QTS.
 
-A PGCE without QTS will also not entitle you to the same benefits during your training and career as QTS with PGCE. For example, better pay and support when you start teaching.
+If you get a PGCE without QTS you will also not be entitled to the same benefits during your training and career as QTS with PGCE. For example, better pay and support when you start teaching.
 
 [Read about Nathan who chose to get QTS with PGCE](/blog/salaried-teacher-training-classroom-learning).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -66,7 +66,7 @@ You can get QTS through undergraduate or postgraduate initial teacher training. 
 
 You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 
-You can also get a postgraduate qualification through teacher training such as a QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
+You can also get a postgraduate qualification through teacher training such as QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
 [Find out how to get QTS through teacher training](/train-to-be-a-teacher).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -66,7 +66,7 @@ You can get QTS through undergraduate or postgraduate initial teacher training. 
 
 You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 
-You can also get a postgraduate qualification through teacher training such as a QTS with a[postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
+You can also get a postgraduate qualification through teacher training such as a QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
 [Find out how to get QTS through teacher training](/train-to-be-a-teacher).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -66,7 +66,7 @@ You can get QTS through undergraduate or postgraduate initial teacher training. 
 
 You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 
-You can also get a postgraduate qualification through teacher training such as a QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce). 
+You can also get a postgraduate qualification through teacher training such as a QTS with a[postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce). 
 
 Some courses just offer a PGCE without QTS, but this means you may not be fully qualified to teach in your chosen school or entitled to the same benefits.
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -23,8 +23,9 @@ inset_text:
     color: grey
 keywords:
   - PGCE
+  - Postgraduate
+  - Postgrad
   - Post-graduate
-  - Post-grad
   - Certificate
   - Diploma
   - Education

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -66,9 +66,7 @@ You can get QTS through undergraduate or postgraduate initial teacher training. 
 
 You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 
-You can also get a postgraduate qualification through teacher training such as a QTS with a[postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce). 
-
-Some courses just offer a PGCE without QTS, but this means you may not be fully qualified to teach in your chosen school or entitled to the same benefits.
+You can also get a postgraduate qualification through teacher training such as a QTS with a[postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
 [Find out how to get QTS through teacher training](/train-to-be-a-teacher).
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -65,7 +65,7 @@ You can get QTS through undergraduate or postgraduate initial teacher training. 
 
 You can apply for either a primary or secondary teacher training course awarding QTS. [Find out more about deciding who to teach](/is-teaching-right-for-me/who-do-you-want-to-teach).
 
-You can also get a postgraduate qualification through teacher training such as a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce). 
+You can also get a postgraduate qualification through teacher training such as a QTS with [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce). 
 
 Some courses just offer a PGCE without QTS, but this means you may not be fully qualified to teach in your chosen school or entitled to the same benefits.
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/csqPMYEh/5616-ensure-that-references-to-pgce-being-in-addition-to-qts-are-consistent-with-find

### Context
Candidates can be confused about whether they need QTS or PGCE to teach in England. We refer to this differently across GIT and Find so we have agreed on consistent terminology and need to update the content to align on some of our pages.

### Changes proposed in this pull request
We need to update the references to QTS/PGCE on the following pages:
https://getintoteaching.education.gov.uk/steps-to-become-a-teacher
https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-choose-your-teacher-training-course
https://getintoteaching.education.gov.uk/train-to-be-a-teacher/what-is-qts
https://getintoteaching.education.gov.uk/train-to-be-a-teacher/what-is-a-pgce
https://getintoteaching.education.gov.uk/funding-and-support/salaried-teacher-training
https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-application
https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-interview

### Guidance to review

