### PR TITLE
Update govuk frontend to 5.3.0

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -12,7 +12,7 @@
 
 <%= render Footer::CookieAcceptanceComponent.new %>
 
-<footer class="site-footer" role="contentinfo">
+<footer class="site-footer">
   <div class="site-footer__wrapper limit-content-width">
     <div class="site-footer-top">
       <div class="site-footer-top__social">

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<header class="limit-content-width" data-controller="navigation" role="banner" data-module="govuk-header">
+<header class="limit-content-width" data-controller="navigation" data-module="govuk-header">
   <%= render Header::ExtraNavigationComponent.new(search_input_id: "searchbox__input--desktop") %>
   <%= render Header::LogoComponent.new %>
   <div class="menu-button" id="mobile-navigation-menu-button">

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,6 @@ module ApplicationHelper
 
   def main_tag(attributes = {}, &block)
     attributes[:id] = "main-content"
-    attributes[:role] = "main"
 
     tag.main(**attributes, &block)
   end

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination" aria-label="pager" role="navigation">
+  <nav class="pagination" aria-label="pager">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dayjs": "^1.11.10",
     "file-loader": "^6.2.0",
     "flatpickr": "^4.6.13",
-    "govuk-frontend": "^5.2.0",
+    "govuk-frontend": "^5.3.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.5",
     "lazysizes": "^5.3.2",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,7 +18,6 @@ describe ApplicationHelper do
   describe "#main_tag" do
     subject { main_tag(class: "homepage") { tag.hr } }
 
-    it { is_expected.to have_css "main[role=main]" }
     it { is_expected.to have_css "main[id=main-content]" }
     it { is_expected.to have_css "main.homepage" }
     it { is_expected.to have_css "body hr" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,10 +4154,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.2.0.tgz#f8e0bf98b771b8ee1501fd45bbba24a091f3846d"
-  integrity sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==
+govuk-frontend@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.3.0.tgz#f9a2b405925beada90d074e17939f9d8ddcd256e"
+  integrity sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
Update libraries, remove redundant `role` from `main`, `header`, `footer` and `nav` tags

### Trello card
[Bump GOV.UK Frontend to v5.3.0 on GIT website](https://trello.com/c/KCIMpfKP/5837-bump-govuk-frontend-to-v530-on-git-website)

### Context
Regular update of GOV.UK Frontend library

### Changes proposed in this pull request
Library updates plus removal of redundant code

### Guidance to review
Test in accessible browsers

