### PR TITLE
Allow adviser component to support html intro text

### DIFF
--- a/app/components/content/adviser_component.html.erb
+++ b/app/components/content/adviser_component.html.erb
@@ -8,7 +8,7 @@
   <div class="content">
     <div class="inset">
       <p>
-        <%= intro %>
+        <%= intro || content %>
       </p>
 
       <%= form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: teacher_training_adviser_step_path(:identity), scope: :teacher_training_adviser_steps_identity, method: :put do |f| %>

--- a/app/components/content/adviser_component.rb
+++ b/app/components/content/adviser_component.rb
@@ -2,7 +2,7 @@ module Content
   class AdviserComponent < ViewComponent::Base
     attr_reader :title, :intro, :color, :margin, :heading
 
-    def initialize(title:, intro:, color: "pink", margin: true, heading: :m)
+    def initialize(title:, intro: nil, color: "pink", margin: true, heading: :m)
       super
 
       @title = title

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -11,7 +11,7 @@
         <p>
           <p>If you're thinking about returning to teaching in England, an adviser can help you:</p>
           <ul>
-          <li> get classroom experience</li>
+          <li>get classroom experience</li>
           <li>search for teaching jobs</li>
           <li>support you with the application process.</li>
           </ul>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -16,8 +16,7 @@
           <li>support you with the application process.</li>
           </ul>
         <p>You can talk to an adviser as little or as often as you need.</p>
-        <p>To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to teach in an English state school.<p>
-        </p>
+        <p>To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to teach in an English state school.</p>
 
     <% end %>
     </section>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -14,8 +14,7 @@
           <li> get classroom experience</li>
           <li>search for teaching jobs</li>
           <li>support you with the application process.</li>
-          <ul>
-        
+          </ul>
         <p>You can talk to an adviser as little or as often as you need.</p>
         <p>To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to teach in an English state school.<p>
         </p>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -7,7 +7,6 @@
         margin: false,
         heading: :l
       ) do %>
-      
           <p>If you're thinking about returning to teaching in England, an adviser can help you:</p>
           <ul>
           <li>get classroom experience</li>
@@ -16,7 +15,6 @@
           </ul>
         <p>You can talk to an adviser as little or as often as you need.</p>
         <p>To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to teach in an English state school.</p>
-
     <% end %>
     </section>
   </div>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -9,8 +9,15 @@
       ) do %>
 
         <p>
-          If you're thinking about returning to teaching in England, an adviser can help you get classroom experience, search for teaching jobs and support you with the application process. You can talk to an adviser as little or as often as you need. To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to
-          teach in an English state school.
+          <p>If you're thinking about returning to teaching in England, an adviser can help you:</p>
+          <ul>
+          <li> get classroom experience</li>
+          <li>search for teaching jobs</li>
+          <li>support you with the application process.</li>
+          <ul>
+        
+        <p>You can talk to an adviser as little or as often as you need.</p>
+        <p>To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to teach in an English state school.<p>
         </p>
 
     <% end %>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -7,8 +7,7 @@
         margin: false,
         heading: :l
       ) do %>
-
-        <p>
+      
           <p>If you're thinking about returning to teaching in England, an adviser can help you:</p>
           <ul>
           <li>get classroom experience</li>

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -3,12 +3,17 @@
     <section class="col col-720 col-space-0">
          <%= render Content::AdviserComponent.new(
         title: "Free one-to-one support by phone, text or email",
-        intro: "If you're thinking about returning to teaching in England, an adviser can help you get classroom experience, search for teaching jobs and support you with the application process. You can talk to an adviser as little or as often as you need. To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to
-  teach in an English state school.",
         color: "transparent",
         margin: false,
         heading: :l
-      ) %>
+      ) do %>
+
+        <p>
+          If you're thinking about returning to teaching in England, an adviser can help you get classroom experience, search for teaching jobs and support you with the application process. You can talk to an adviser as little or as often as you need. To be eligible for an adviser, you'll need English qualified teacher status (QTS) and want to
+          teach in an English state school.
+        </p>
+
+    <% end %>
     </section>
   </div>
 </div>


### PR DESCRIPTION
### Trello card
[Allow for additional formatting in adviser component](https://trello.com/c/BFaIseKM/5838-allow-for-additional-formatting-in-the-embedded-adviser-component)

### Context
The adviser component does support generic html content (unlike the mailing list component). Extend this support to the adviser component.

### Changes proposed in this pull request

### Guidance to review

