### PR TITLE
Set word break on cookies form

### DIFF
--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -129,6 +129,6 @@ form {
   }
 }
 
-form#cookie-preferences-form {
+#cookie-preferences-form {
   word-break: normal;
 }

--- a/app/webpacker/styles/forms.scss
+++ b/app/webpacker/styles/forms.scss
@@ -128,3 +128,7 @@ form {
     border-color: $red;
   }
 }
+
+form#cookie-preferences-form {
+  word-break: normal;
+}


### PR DESCRIPTION
### Trello card
[Fix text wrapping on cookies prefs](https://trello.com/c/kGIg5K2T/5870-fix-text-wrapping-on-cookies-preference-page)

### Context
On iphones the cookie preference text was not rendering correctly

### Changes proposed in this pull request

### Guidance to review

