### PR TITLE
Remove double space from Step 2 of How to become a teacher

### DIFF
--- a/app/views/content/steps-to-become-a-teacher/_step_2_understand_funding.html.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_2_understand_funding.html.erb
@@ -2,6 +2,6 @@
 
 <p>You can apply for tuition fee and maintenance loans, even if you already have a student loan.</p>
 
-<p>If you're interested in teaching certain subjects, you might be able to get up to £30k tax-free  to support you while you're training. This money does not have to be paid back.</p>
+<p>If you're interested in teaching certain subjects, you might be able to get up to £30k tax-free to support you while you're training. This money does not have to be paid back.</p>
 
 <p><a href="/funding-and-support"> Find out how to fund your training</a>.</p>


### PR DESCRIPTION
### Context
Removing a double-space spotted during a review of salary and bursary variables
