### PR TITLE
Delete Yorkshire and Humber Teacher Training from Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -478,11 +478,6 @@ provider_groups:
     - header: The Sheffield SCITT
       link: https://www.sheffieldscitt.org.uk/
       email: admin@sheffieldscitt.org.uk
-    - header: Yorkshire and Humber Teacher Training
-      link: https://www.yhtt.co.uk
-      name: Kirstin Hilgenfeldt
-      telephone: 01482 686699
-      email: admin@yhtt.ac.uk
   National:
     providers:
     - header: TES Institute


### PR DESCRIPTION
### Trello card
https://trello.com/c/CMZ8hkvn

### Context
Request to remove Yorkshire and Humber Teacher Training from Assessment only page received via GIT support team

