### PR TITLE
Add redirect for London event

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -57,6 +57,7 @@ redirects:
   "/explore-my-options/return-to-teaching/events": "/events"
   "/node/478": "/events"
   "/presentations": "/events/about-get-into-teaching-events"
+  "/events/240518-get-into-teaching-london-eventutm(*event)": "/events/240518-get-into-teaching-london-event"
 
   # School Experience
   "/get-school-experience/get-school-experience": "/is-teaching-right-for-me/get-school-experience"


### PR DESCRIPTION
### Trello card
https://trello.com/c/b6nnn2H0

### Context
Adding a redirect as an incorrect link was included in an email
