### PR TITLE
Fix alignment of mailing list title

### DIFF
--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -2,7 +2,12 @@
   <div class="home-mailing-list">
     <div class="col col-full-content">
       <div>
-        <h2><i class="icon icon-arrow-black icon--on-yellow"></i> Sign up for our emails</h2>
+
+        <h2 class="mailing-list-title">
+          <i class="icon icon-arrow-black icon--on-yellow"></i>
+          <span>Sign up for our emails</span>
+        </h2>
+
         <p>
           Everything you need to know to start a career in teaching sent straight into your inbox.
           Tailored to your own situation, you'll get all the latest information as well as advice and support.

--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -2,7 +2,6 @@
   <div class="home-mailing-list">
     <div class="col col-full-content">
       <div>
-
         <h2 class="mailing-list-title">
           <i class="icon icon-arrow-black icon--on-yellow"></i>
           <span>Sign up for our emails</span>

--- a/app/webpacker/styles/components/mailing-list.scss
+++ b/app/webpacker/styles/components/mailing-list.scss
@@ -36,6 +36,7 @@
 
     & > span {
       display: inline-block;
+      padding-left: 20px;
     }
   }
 

--- a/app/webpacker/styles/components/mailing-list.scss
+++ b/app/webpacker/styles/components/mailing-list.scss
@@ -36,7 +36,7 @@
 
     & > span {
       display: inline-block;
-      padding-left: 20px;
+      padding-left: .95em;
     }
   }
 

--- a/app/webpacker/styles/components/mailing-list.scss
+++ b/app/webpacker/styles/components/mailing-list.scss
@@ -36,7 +36,7 @@
 
     & > span {
       display: inline-block;
-      padding-left: .95em;
+      padding-left: .3em;
     }
   }
 

--- a/app/webpacker/styles/components/mailing-list.scss
+++ b/app/webpacker/styles/components/mailing-list.scss
@@ -25,6 +25,20 @@
     position: relative;
   }
 
+  h2.mailing-list-title {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+
+    & > i {
+      flex-basis: auto;
+    }
+
+    & > span {
+      display: inline-block;
+    }
+  }
+
   h2::before {
     content: "";
     background-image: url("../images/content/homepage/dashed-lineV2.svg");


### PR DESCRIPTION
### Trello card
[Amend Sign up to emails icon CSS to fix text wrapping on home page](https://trello.com/c/fzREucy9/6023-amend-sign-up-to-emails-icon-css-to-fix-text-wrapping-on-home-page)

### Context
The mailing list title wraps on to a new line past the icon

### Changes proposed in this pull request
This uses a flex-box layout to force the wrapping to be more consistent

### Guidance to review

