### PR TITLE
Update email signup header

### DIFF
--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -4,7 +4,7 @@
       <div>
         <h2 class="mailing-list-title">
           <i class="icon icon-arrow-black icon--on-yellow"></i>
-          <span>Sign up for our emails</span>
+          <span>Start your teaching journey today</span>
         </h2>
 
         <p>


### PR DESCRIPTION
### Trello card

https://trello.com/c/aJLMxOvn/6071-change-sign-up-to-emails-header-copy-on-home-page

### Context

We split test a variation of the email sign up header and saw a significant increase in users clicking the CTA button and signing up to emails. We now want to make the variant permanent. 

### Changes proposed in this pull request

Change email sign up header from 'Sign up to our emails' to 'Start your teaching journey today'

### Guidance to review
