### PR TITLE
Update govuk frontend 5.4.0

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -11,10 +11,10 @@ $govuk-new-typography-scale: false;
 
 // Only import the used parts of the GOV.UK frontend.
 @import "~govuk-frontend/dist/govuk/base";
-@import "~govuk-frontend/dist/govuk/core/all";
-@import "~govuk-frontend/dist/govuk/objects/all";
-@import "~govuk-frontend/dist/govuk/utilities/all";
-@import "~govuk-frontend/dist/govuk/overrides/all";
+@import "~govuk-frontend/dist/govuk/core/index";
+@import "~govuk-frontend/dist/govuk/objects/index";
+@import "~govuk-frontend/dist/govuk/utilities/index";
+@import "~govuk-frontend/dist/govuk/overrides/index";
 @import "~govuk-frontend/dist/govuk/components/back-link/index";
 @import "~govuk-frontend/dist/govuk/components/button/index";
 @import "~govuk-frontend/dist/govuk/components/checkboxes/index";

--- a/app/webpacker/styles/internal.scss
+++ b/app/webpacker/styles/internal.scss
@@ -11,7 +11,7 @@ $govuk-include-default-font-face: false;
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
-@import "~govuk-frontend/dist/govuk/all";
+@import "~govuk-frontend/dist/govuk/index";
 @import "~trix";
 @import "~flatpickr";
 @import "colours";

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dayjs": "^1.11.10",
     "file-loader": "^6.2.0",
     "flatpickr": "^4.6.13",
-    "govuk-frontend": "^5.3.1",
+    "govuk-frontend": "^5.4.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.5",
     "lazysizes": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,10 +4180,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.3.1.tgz#d63e2078b0d94a119bfe322431218f04024668a2"
-  integrity sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ==
+govuk-frontend@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.4.0.tgz#8f2e0b55ef7c7552a1efe68c7b40ff1b4a393e72"
+  integrity sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
### Trello card
[Upgrade GOVUK Frontend to 5.4.0](https://trello.com/c/lrGlZqyM/6045-bump-govuk-frontend-to-v540-on-git-website)

### Context
Regular update of GOVUK Frontend Library

### Changes proposed in this pull request

### Guidance to review
No visible changes to the site

### Pre-election period "purdah" restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
