### PR TITLE
Experiment with Google Tag menu events

### DIFF
--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -48,6 +48,12 @@ export default class extends Controller {
       if (toggleSecondaryNavigation) {
         this.expandSecondaryNavigation();
       }
+
+      console.log('Expanding menu', item.id);
+      gtag('event', 'expand_menu', {
+        menuItemId: item.id
+      });
+
     } else if (this.toggleIconContracted(item)) {
       this.toggleIconContracted(correspondingItem);
       this.contractAndHideChildMenu(childMenu);
@@ -55,6 +61,11 @@ export default class extends Controller {
       if (toggleSecondaryNavigation) {
         this.contractSecondaryNavigation();
       }
+
+      console.log('Contracting menu', item.id);
+      gtag('event', 'contract_menu', {
+        menuItemId: item.id
+      });
     }
   }
 

--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -48,12 +48,9 @@ export default class extends Controller {
       if (toggleSecondaryNavigation) {
         this.expandSecondaryNavigation();
       }
-
-      console.log('Expanding menu', item.id);
-      gtag('event', 'expand_menu', {
-        menuItemId: item.id
+      window.gtag('event', 'expand_menu', {
+        menuItemId: item.id,
       });
-
     } else if (this.toggleIconContracted(item)) {
       this.toggleIconContracted(correspondingItem);
       this.contractAndHideChildMenu(childMenu);
@@ -61,10 +58,8 @@ export default class extends Controller {
       if (toggleSecondaryNavigation) {
         this.contractSecondaryNavigation();
       }
-
-      console.log('Contracting menu', item.id);
-      gtag('event', 'contract_menu', {
-        menuItemId: item.id
+      window.gtag('event', 'contract_menu', {
+        menuItemId: item.id,
       });
     }
   }


### PR DESCRIPTION
Push expand and contract button click events into GTM

### Trello card
https://trello.com/c/ECzLNq1J/5665-plan-and-set-up-tracking-for-new-menu

### Context
Rather than using CSS selectors to identify buttons in the dropdown menus, instead use javascript to push events to GTM as they happen

### Changes proposed in this pull request

### Guidance to review

### Pre-election period restrictions

* [ ] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
