### PR TITLE
Revert "Revert "Config tweak to allow for easier local app+api (#3998…

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -9,6 +9,17 @@
 * Run `bundle exec rails server` to launch the app on http://localhost:3000
 * Run `./bin/shakapacker-dev-server` in a separate shell for faster compilation of assets
 
+### Running the app with a local api
+
+* Build the [get-into-teaching-api](https://github.com/DFE-Digital/get-into-teaching-api) following the documentation in that project. Configure it use a dev CRM instance and docker-based Redis and Postgresql database
+* Run the API on https://localhost:5001/api
+* Run the app using env vars to point to the local API:
+```bash
+GIT_API_ENDPOINT=https://localhost:5001/api  \
+ GIT_API_TOKEN=secret-git  \
+ bundle exec rails server
+```
+
 ## Running the test suites
 
 You need to have the correct version of `chromedriver` installed for the version of Chrome you are running.

--- a/lib/uri_checker.rb
+++ b/lib/uri_checker.rb
@@ -1,0 +1,12 @@
+class URIChecker
+  attr_reader :hostname, :scheme
+
+  def initialize(uri)
+    @hostname = uri.hostname
+    @scheme = uri.scheme
+  end
+
+  def local_https?
+    hostname == "localhost" && scheme == "https"
+  end
+end

--- a/spec/lib/uri_checker_spec.rb
+++ b/spec/lib/uri_checker_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+require "uri_checker"
+
+describe URIChecker do
+  describe "#local_https?" do
+    subject { described_class.new(URI.parse(uri)).local_https? }
+
+    context "with remote http URI" do
+      let(:uri) { "http://production.com:123456/api" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with remote https URI" do
+      let(:uri) { "https://production.com:123456/api" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with local http URI" do
+      let(:uri) { "http://localhost:123456/api" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with local https URI" do
+      let(:uri) { "https://localhost:123456/api" }
+
+      it { is_expected.to be true }
+    end
+  end
+end


### PR DESCRIPTION
Re-apply PR https://github.com/DFE-Digital/get-into-teaching-app/pull/3998

This reverts commit 371cbd8fd38d1197b10ca6168a1098a3e568deb9.

### Trello card

### Context
This PR re-applies PR #3998 which was temporarily reverted in PR #4009

### Changes proposed in this pull request

### Guidance to review

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
