### PR TITLE
Update naming convention for variables already in prod

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -534,7 +534,7 @@ The assessment programme takes up to 12 weeks.
 
 ## How much does assessment only QTS cost?
 
-Fees range from about $fees_assessment-only_low$ to $fees_assessment-only_high$, but vary between provider so it’s best to check with them for more information.
+Fees range from about $fees_assessmentonly_low$ to $fees_assessmentonly_high$, but vary between provider so it’s best to check with them for more information.
 
 Fees may be paid by you or your school at the start of the programme. If you’re currently working in a school, talk to your employer about your funding options.
 

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts/descriptions/_teacher-training-providers-offering-assessment-only-qts-to-international-teachers.md
@@ -3,7 +3,7 @@ Teachers outside the UK who do not have a teaching qualification, but [meet the 
 
 You will not have to visit or train in England. However, you will need to be assessed at your place of work by an examiner from your teaching training provider. Your teacher training provider can explain what type of school you must be working in to undergo assessment only QTS.
 
-Fees may be substantially more than $fees_assessment-only_high$ if you’re outside the UK. Check with individual providers for more details.
+Fees may be substantially more than $fees_assessmentonly_high$ if you’re outside the UK. Check with individual providers for more details.
 
 Assessment only training providers cannot give you advice about:
 

--- a/config/values/fees.yml
+++ b/config/values/fees.yml
@@ -1,5 +1,5 @@
 fees:
-  assessment-only:
+  assessmentonly:
     low: £1,500
     high: £4,000
   iQTS:
@@ -7,12 +7,11 @@ fees:
     high: £9,950
   ## to implement below this line
   pgitt:
-    domestic-full-time: £9,250
-    domestic-part-time: £6,935
-    international-average: £14,765
-    international-max-full-time: £36,000
-    international-max-part-time: £17,500
+    domesticfulltime: £9,250
+    domesticparttime: £6,935
+    internationalaverage: £14,765
+    internationalmaxfulltime: £36,000
+    internationalmaxparttime: £17,500
   ugitt: £9,250
   eyitt: £9,250
-  pgitt-and-ugitt: £9,250
-
+  pgittandugitt: £9,250


### PR DESCRIPTION
### Trello card

N/A

### Context

We're updating the naming convention for how we define variables in the codebase, we're removing hyphens. This PR removes hyphens for those that are already implemented in producation.

### Changes proposed in this pull request

No visual changes, but here are some screenshots of the values that have updated, and that they still render correctly:

These are from this page, the only page that uses this updated variable set https://get-into-teaching-app-review-4012.test.teacherservices.cloud/train-to-be-a-teacher/assessment-only-route-to-qts

<img width="1263" alt="image" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/35870975/47c057ab-5c15-43c7-b123-ae5cc8d5c0f8">


<img width="1139" alt="image" src="https://github.com/DFE-Digital/get-into-teaching-app/assets/35870975/9f1c10ee-c53d-4485-96fe-6deddaf2fe5d">

### Guidance to review

Does this all look ok?

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
