### PR TITLE
Include menu level in gtag tracking payload

### DIFF
--- a/app/webpacker/controllers/navigation_controller.js
+++ b/app/webpacker/controllers/navigation_controller.js
@@ -37,6 +37,16 @@ export default class extends Controller {
     );
     const toggleSecondaryNavigation = item.dataset.toggleSecondaryNavigation;
 
+    const containerClassList = item.closest('ol').classList;
+    let menuLevel;
+    if (containerClassList.contains('primary')) {
+      menuLevel = 1;
+    } else if (containerClassList.contains('category-links-list')) {
+      menuLevel = 2;
+    } else if (containerClassList.contains('page-links-list')) {
+      menuLevel = 3;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -50,6 +60,7 @@ export default class extends Controller {
       }
       window.gtag('event', 'expand_menu', {
         menuItemId: item.id,
+        menuLevel: menuLevel,
       });
     } else if (this.toggleIconContracted(item)) {
       this.toggleIconContracted(correspondingItem);
@@ -60,6 +71,7 @@ export default class extends Controller {
       }
       window.gtag('event', 'contract_menu', {
         menuItemId: item.id,
+        menuLevel: menuLevel,
       });
     }
   }


### PR DESCRIPTION
### Trello card
[Setup tracking for new menu](https://trello.com/c/ECzLNq1J/5665-plan-and-set-up-tracking-for-new-menu)

### Context
We would like to track when users click on buttons to expand/contract the new dropdown menus

### Changes proposed in this pull request
Update the tracking payload to include the level of the menu (primary/secondary/tertiary)

### Guidance to review
Tested in google tag by Jess

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
