### PR TITLE
re-parse the output of components for values

### DIFF
--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -51,14 +51,24 @@ module TemplateHandlers
       autolink_html render_markdown
     end
 
-    # rubocop:disable Style/PerlBackrefs
+
     def markdown
       # use $1 rather than a block argument here because gsub assigns the
       # entire placeholder to the arg (including dollar symbols) but we only
       # want what's inside the capture group
-      parsed.content.gsub(COMPONENT_PLACEHOLDER_REGEX) do
+      # NB: we need to parse a second time as a component may contain a $value$
+      substitute_values(substitute_components_and_values(parsed.content))
+    end
+
+    # rubocop:disable Style/PerlBackrefs
+    def substitute_components_and_values(content)
+      content.gsub(COMPONENT_PLACEHOLDER_REGEX) do
         safe_join([cta_component($1), content_component($1), image($1), value($1)].compact).strip
       end
+    end
+
+    def substitute_values(content)
+      content.gsub(COMPONENT_PLACEHOLDER_REGEX) { safe_join([value($1)].compact).strip }
     end
     # rubocop:enable Style/PerlBackrefs
 

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -51,7 +51,6 @@ module TemplateHandlers
       autolink_html render_markdown
     end
 
-
     def markdown
       # use $1 rather than a block argument here because gsub assigns the
       # entire placeholder to the arg (including dollar symbols) but we only


### PR DESCRIPTION
### Trello card

Relates to [Config file of bursaries and scholarships](https://trello.com/c/2WHavuTv/6009-populate-our-centralised-config-file-of-bursary-scholarship-salary-and-other-currency-figures-with-currency-values-from-across-t)

### Context
A small bug-fix to ensure that components are re-parsed for values after they are rendered

### Changes proposed in this pull request

### Guidance to review

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
