### PR TITLE
Update link styles 

### DIFF
--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -64,7 +64,7 @@
       h3 {
         text-decoration: underline;
       }
-
+      
       &:focus h2 {
         color: $white;
       }
@@ -79,7 +79,7 @@
 
       h2,
       h3 {
-        text-decoration: none;
+        text-decoration-thickness: max(4px, .25rem);
       }
     }
 

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -34,7 +34,9 @@
   text-underline-offset: .08em;
   box-shadow: none;
 
-  &:hover,
+  &:hover { 
+    text-decoration-thickness: max(3px, .1875rem)};
+
   &:focus {
     text-decoration: none;
   }
@@ -97,6 +99,9 @@ ol.primary > li {
   &::after {
     border-color: $black;
   }
+
+  &:hover { 
+    text-decoration-thickness: max(3px, .1875rem, .12em)};
 
   &:focus {
     color: $white;

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -37,15 +37,13 @@
   &:hover { 
     text-decoration-thickness: max(3px, .1875rem);
   }
-  &:focus {
-    text-decoration: none;
-  }
-
+  
   &:focus {
     color: $white;
     background-color: $black;
     box-shadow: 0 4px $pink;
     outline: 4px solid transparent;
+    text-decoration: none;
 
     &::after {
       border-color: $white;

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -35,8 +35,8 @@
   box-shadow: none;
 
   &:hover { 
-    text-decoration-thickness: max(3px, .1875rem)};
-
+    text-decoration-thickness: max(3px, .1875rem);
+  }
   &:focus {
     text-decoration: none;
   }


### PR DESCRIPTION
### Trello card
https://trello.com/c/0p7NvVfj/6017-review-link-hover-styles

### Context
The links on the Git website have an underline and on hover they disappear. This causes an issue for links that don’t need an underline eg. links in navigation items. It could also be confusing for someone using a screen magnifier who is hovering and might not realise a link is there.

[Gov.uk](http://gov.uk/) and services we point our users to, use a different style, where links are underlined and on hover the underline is bolder. For links without underline, the underline appears on hover.

### Changes proposed in this pull request
updating links styles to include an thicker underline on hover

### Guidance to review

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
