### PR TITLE
Hover state dropdown menu

### DIFF
--- a/app/components/header/navigation_component.html.erb
+++ b/app/components/header/navigation_component.html.erb
@@ -2,7 +2,7 @@
 <%= tag.nav id: "primary-navigation", class: "hidden-mobile", data: { "navigation-target": "nav", action: "click->navigation#handleNavMenuClick" }, "aria-label": "Primary navigation", role: "navigation" do %>
   <%= tag.ol class: "primary", data: { "navigation-target": "primary" } do %>
     <% all_resources.each do |resource| %>
-      <%= nav_link(resource, :mobile) %>
+      <%= nav_link(resource, :mobile, underline_on_hover: false) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/header/navigation_component.rb
+++ b/app/components/header/navigation_component.rb
@@ -24,7 +24,7 @@ module Header
       mode == :mobile ? :desktop : :mobile
     end
 
-    def nav_link(resource, mode)
+    def nav_link(resource, mode, underline_on_hover: true)
       title = resource.title
       path = resource.path
       li_id = "#{path.parameterize}-#{mode}"
@@ -34,7 +34,7 @@ module Header
       child_menu_ids = [child_menu_id, corresponding_child_menu_id].join(" ")
       li_css = ("active" if uri_is_root?(path) || first_uri_segment_matches_link?(path)).to_s
       show_dropdown = resource.children?
-      link_css = "menu-link link link--black link--no-underline"
+      link_css = "menu-link link link--black link--no-underline #{underline_on_hover ? 'link--underline-on-hover' : ''}"
       aria_attributes = show_dropdown ? { expanded: false, controls: child_menu_ids } : {}
       tag.li id: li_id, class: li_css, data: { "corresponding-id": corresponding_li_id, "child-menu-id": child_menu_id, "corresponding-child-menu-id": corresponding_child_menu_id, "direct-link": !show_dropdown, "toggle-secondary-navigation": show_dropdown } do
         safe_join([
@@ -82,7 +82,7 @@ module Header
       corresponding_child_menu_id = page_list_id(resource, subcategory, corresponding_mode(mode))
       child_menu_ids = [child_menu_id, corresponding_child_menu_id].join(" ")
       li_css = ("active" if subcategory == front_matter["subcategory"]).to_s
-      link_css = "menu-link link link--black link--no-underline btn-as-link"
+      link_css = "menu-link link link--black link--no-underline link--underline-on-hover btn-as-link"
       aria_attributes = { expanded: false, controls: child_menu_ids }
       tag.li id: li_id, class: li_css, data: { "corresponding-id": corresponding_li_id, "child-menu-id": child_menu_id, "corresponding-child-menu-id": corresponding_child_menu_id, "direct-link": false } do
         safe_join(

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -34,10 +34,10 @@
   text-underline-offset: .08em;
   box-shadow: none;
 
-  &:hover { 
+  &:hover {
     text-decoration-thickness: max(3px, .1875rem);
   }
-  
+
   &:focus {
     color: $white;
     background-color: $black;
@@ -98,7 +98,7 @@ ol.primary > li {
     border-color: $black;
   }
 
-  &:hover { 
+  &:hover {
     text-decoration-thickness: max(3px, .1875rem, .12em)};
 
   &:focus {
@@ -137,6 +137,13 @@ ol.primary > li {
 
 .link--no-underline {
   text-decoration: none;
+}
+
+.link--underline-on-hover {
+  &:hover {
+    text-decoration: underline;
+    text-decoration-thickness: max(3px, .1875rem, .12em)};
+  }
 }
 
 a {

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -142,7 +142,7 @@ ol.primary > li {
 .link--underline-on-hover {
   &:hover {
     text-decoration: underline;
-    text-decoration-thickness: max(3px, .1875rem, .12em)};
+    text-decoration-thickness: max(3px, .1875rem, .12em);
   }
 }
 


### PR DESCRIPTION
### Trello card
[Ensure hover state on dropdown menu](https://trello.com/c/2XlbCf6a/6019-ensure-hover-state-of-dropdown-category-page-menu-is-accessible)

### Context
To improve accessibility, add underlines to hover states on the dropdown menu

NB: this includes the PR https://github.com/DFE-Digital/get-into-teaching-app/pull/4033

### Changes proposed in this pull request

### Guidance to review
Test carefully at multiple screen widths (mobile version for widths under 1000px)

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
