### PR TITLE
Details expander component

### DIFF
--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -11,11 +11,11 @@
 
     <div class="expander-details__summary__show">
       <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
-      <a>Show</a>
+      <%= tag.a "Show", class: "link--underline", id: show_link_id %>
     </div>
     <div class="expander-details__summary__hide">
       <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>
-       <a>Hide</a>
+      <%= tag.a "Hide", class: "link--underline", id: hide_link_id %>
     </div>
   </summary>
 

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -11,11 +11,11 @@
 
     <div class="expander-details__summary__show">
       <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
-      Show
+      <a>Show</a>
     </div>
     <div class="expander-details__summary__hide">
       <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>
-      Hide
+       <a>Hide</a>
     </div>
   </summary>
 

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -1,0 +1,32 @@
+<%= tag.details(class: expander_class, open: expanded) do %>
+  <summary class="expander-details__summary">
+    <% if header.present? %>
+      <span class="expander-details__summary__header">
+        <%= header %>
+      </span>
+    <% end %>
+    <span class="expander-details__summary__title">
+      <%= title %>
+    </span>
+
+    <div class="expander-details__summary__show">
+      <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
+      Show
+    </div>
+    <div class="expander-details__summary__hide">
+      <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>
+      Hide
+    </div>
+  </summary>
+
+  <div class="expander-details__text">
+    <p>
+      <%= text %>
+    </p>
+    <% if show_link? %>
+      <p>
+        <%= link_to link_title, link_url %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -9,11 +9,11 @@
       <%= title %>
     </span>
 
-    <div class="expander-details__summary__show">
+    <div class="expander-details__summary__show" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
       <%= tag.a "Show", class: "link--underline", id: show_link_id %>
     </div>
-    <div class="expander-details__summary__hide">
+    <div class="expander-details__summary__hide" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>
       <%= tag.a "Hide", class: "link--underline", id: hide_link_id %>
     </div>
@@ -25,7 +25,7 @@
     </p>
     <% if show_link? %>
       <p>
-        <%= link_to link_title, link_url %>
+        <%= link_to link_title, link_url %>.
       </p>
     <% end %>
   </div>

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -1,21 +1,23 @@
 <%= tag.details(class: expander_class, open: expanded) do %>
   <summary class="expander-details__summary">
-    <% if header.present? %>
-      <span class="expander-details__summary__header">
-        <%= header %>
+    <%= tag.div role: "text" do %>
+      <% if header.present? %>
+        <span class="expander-details__summary__header">
+          <%= header %>
+        </span>
+      <% end %>
+      <span class="expander-details__summary__title">
+        <%= title %>
       </span>
     <% end %>
-    <span class="expander-details__summary__title">
-      <%= title %>
-    </span>
 
     <div class="expander-details__summary__show" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
-      <%= tag.a "Show", class: "link--underline", id: show_link_id %>
+      <%= tag.a "Show", class: "link--underline", id: show_link_id, aria: { hidden: "true" }  %>
     </div>
     <div class="expander-details__summary__hide" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>
-      <%= tag.a "Hide", class: "link--underline", id: hide_link_id %>
+      <%= tag.a "Hide", class: "link--underline", id: hide_link_id, aria: { hidden: "true" } %>
     </div>
   </summary>
 

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -13,7 +13,7 @@
 
     <div class="expander-details__summary__show" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__open" aria-hidden="true"></span>
-      <%= tag.a "Show", class: "link--underline", id: show_link_id, aria: { hidden: "true" }  %>
+      <%= tag.a "Show", class: "link--underline", id: show_link_id, aria: { hidden: "true" } %>
     </div>
     <div class="expander-details__summary__hide" aria-hidden="true">
       <span class="expander-details__summary__icon expander-details__summary__icon__close" aria-hidden="true"></span>

--- a/app/components/content/expander_component.rb
+++ b/app/components/content/expander_component.rb
@@ -18,7 +18,7 @@ module Content
       @header = header
       @title = title
       @text = text
-      @link_title = link_title
+      @link_title = link_title&.strip&.chomp(".")
       @link_url = link_url
       @background = background
       @expanded = expanded

--- a/app/components/content/expander_component.rb
+++ b/app/components/content/expander_component.rb
@@ -1,0 +1,41 @@
+module Content
+  class ExpanderComponent < ViewComponent::Base
+    attr_reader :header, :title, :text, :link_title, :link_url,
+                :background, :expanded, :classes
+
+    def initialize(
+      title:, text:, header: "Non-UK citizens:",
+      link_title: nil,
+      link_url: nil,
+      background: "grey",
+      expanded: false,
+      classes: nil
+    )
+      super
+
+      @header = header
+      @title = title
+      @text = text
+      @link_title = link_title
+      @link_url = link_url
+      @background = background
+      @expanded = expanded
+      @classes = classes
+
+      fail(ArgumentError, "title must be present") if title.blank?
+      fail(ArgumentError, "text must be present") if text.blank?
+      fail(ArgumentError, "background must be grey") unless %w[grey].any?(background)
+    end
+
+    def show_link?
+      link_url.present? && link_title.present?
+    end
+
+    def expander_class
+      %w[expander-details].tap do |c|
+        c << "expander-details__background-#{background}" if background
+        c << classes if classes.present?
+      end
+    end
+  end
+end

--- a/app/components/content/expander_component.rb
+++ b/app/components/content/expander_component.rb
@@ -3,11 +3,13 @@ module Content
     attr_reader :header, :title, :text, :link_title, :link_url,
                 :background, :expanded, :classes
 
+    include ActiveSupport::Inflector
+
     def initialize(
       title:, text:, header: "Non-UK citizens:",
       link_title: nil,
       link_url: nil,
-      background: "grey",
+      background: "purple",
       expanded: false,
       classes: nil
     )
@@ -24,11 +26,19 @@ module Content
 
       fail(ArgumentError, "title must be present") if title.blank?
       fail(ArgumentError, "text must be present") if text.blank?
-      fail(ArgumentError, "background must be grey") unless %w[grey].any?(background)
+      fail(ArgumentError, "background must be purple") unless %w[purple].any?(background)
     end
 
     def show_link?
       link_url.present? && link_title.present?
+    end
+
+    def show_link_id
+      parameterize("show #{header} #{title}")
+    end
+
+    def hide_link_id
+      parameterize("hide #{header} #{title}")
     end
 
     def expander_class

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -48,7 +48,8 @@ Make sure you check which qualification you’ll get through your training cours
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 
 <div class="inset">
-  <p>If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out more about how to apply for a visa to train to teach in England</a>.</p>
+<p>If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out more about how to apply for a visa to train to teach in England</a>.</p>
+
 </div>
 
 [Find a postgraduate teacher training course](https://www.find-postgraduate-teacher-training.service.gov.uk/). 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -34,13 +34,6 @@ promo_content:
 navigation: 30.05
 navigation_title: Teacher training application
 navigation_description: Find out what you need to include in your teacher training application and when to apply.
-expander:
-  check-your-qualifications:
-    title: Check your qualifications
-    text: If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas.
-    link_title: Find out more about how to apply for a visa to train to teach in England
-    link_url: /non-uk-teachers/visas-for-non-uk-trainees
-    expanded: false
 
 ---
 
@@ -54,17 +47,9 @@ Make sure you check which qualification you’ll get through your training cours
 
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 
-$check-your-qualifications$
-
----
-
 <div class="inset">
-<p>(TODO: REMOVE THIS INSET)</p>
-<p>If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out more about how to apply for a visa to train to teach in England</a>.</p>
-
+  <p>If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out more about how to apply for a visa to train to teach in England</a>.</p>
 </div>
-
----
 
 [Find a postgraduate teacher training course](https://www.find-postgraduate-teacher-training.service.gov.uk/). 
 

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -34,6 +34,13 @@ promo_content:
 navigation: 30.05
 navigation_title: Teacher training application
 navigation_description: Find out what you need to include in your teacher training application and when to apply.
+expander:
+  check-your-qualifications:
+    title: Check your qualifications
+    text: If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas.
+    link_title: Find out more about how to apply for a visa to train to teach in England
+    link_url: /non-uk-teachers/visas-for-non-uk-trainees
+    expanded: false
 
 ---
 
@@ -47,10 +54,17 @@ Make sure you check which qualification you’ll get through your training cours
 
 While you do not need a PGCE to teach in England, you do need QTS to teach in many primary and secondary schools.
 
+$check-your-qualifications$
+
+---
+
 <div class="inset">
+<p>(TODO: REMOVE THIS INSET)</p>
 <p>If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out more about how to apply for a visa to train to teach in England</a>.</p>
 
 </div>
+
+---
 
 [Find a postgraduate teacher training course](https://www.find-postgraduate-teacher-training.service.gov.uk/). 
 

--- a/app/webpacker/images/navigation/arrow-down-purple.svg
+++ b/app/webpacker/images/navigation/arrow-down-purple.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="13" viewBox="0 0 21 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="2.58324" height="14.6383" transform="matrix(0.717291 0.696774 -0.717291 0.696773 19.1465 0.840332)" fill="#AD52A4"/>
+<rect width="2.58324" height="14.6383" transform="matrix(-0.717291 0.696773 -0.717291 -0.696774 12.3516 11.0396)" fill="#AD52A4"/>
+</svg>

--- a/app/webpacker/images/navigation/arrow-up-purple.svg
+++ b/app/webpacker/images/navigation/arrow-up-purple.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="13" viewBox="0 0 21 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="2.58324" height="14.6383" transform="matrix(-0.717291 -0.696774 0.717291 -0.696773 1.85352 12.8394)" fill="#AD52A4"/>
+<rect width="2.58324" height="14.6383" transform="matrix(0.717291 -0.696773 0.717291 0.696774 8.64844 2.64014)" fill="#AD52A4"/>
+</svg>

--- a/app/webpacker/styles/components/expander.scss
+++ b/app/webpacker/styles/components/expander.scss
@@ -1,0 +1,54 @@
+.expander-details {
+  padding: 0.4em 1.5em;
+
+  &__background-grey {
+    background: $grey;
+  }
+
+  &__summary {
+    list-style: none;
+
+    &__header {
+      font-weight: bold;
+    }
+
+    &__show {
+      display: block;
+    }
+
+    &__hide {
+      display: none;
+    }
+
+    &__icon {
+      display: inline-block;
+      padding-right: 0;
+      width: 21px;
+      height: 21px;
+      margin-top: 0;
+      background-repeat: no-repeat;
+
+      &__open {
+        background-image: url("../images/navigation/arrow-down-pink.svg");
+      }
+
+      &__close {
+        background-image: url("../images/navigation/arrow-up-pink.svg");
+      }
+    }
+  }
+
+  &__text {
+    padding-top: 1em;
+  }
+}
+
+.expander-details[open] {
+  .expander-details__summary__hide {
+    display: block;
+  }
+
+  .expander-details__summary__show {
+    display: none;
+  }
+}

--- a/app/webpacker/styles/components/expander.scss
+++ b/app/webpacker/styles/components/expander.scss
@@ -8,6 +8,10 @@
     background: rgba($purple, .1);
   }
 
+  &__summary::-webkit-details-marker{
+    display:none
+  }
+
   &__summary {
     list-style: none;
 

--- a/app/webpacker/styles/components/expander.scss
+++ b/app/webpacker/styles/components/expander.scss
@@ -4,7 +4,7 @@
   margin-top: 2em;
   margin-bottom: 2em;
 
-  &__background-grey {
+  &__background-purple {
     background: rgba($purple, .1);
   }
 
@@ -45,7 +45,7 @@
   &__text {
     padding-top: 1em;
   }
-  
+
   .expander-details__summary__show {
 	margin-top: 0.25em;
 	cursor:pointer;
@@ -54,12 +54,12 @@
 
 .expander-details[open] {
   .expander-details__summary__hide {
-    display: block;	
+    display: block;
 	  cursor:pointer;
-	  margin-top: 0.25em;	
+	  margin-top: 0.25em;
   }
 
   .expander-details__summary__show {
-    display: none;	
+    display: none;
   }
 }

--- a/app/webpacker/styles/components/expander.scss
+++ b/app/webpacker/styles/components/expander.scss
@@ -1,8 +1,11 @@
 .expander-details {
-  padding: 0.4em 1.5em;
+  padding: 0.75em 1em;
+  border-left:6px solid $purple;
+  margin-top: 2em;
+  margin-bottom: 2em;
 
   &__background-grey {
-    background: $grey;
+    background: rgba($purple, .1);
   }
 
   &__summary {
@@ -24,16 +27,17 @@
       display: inline-block;
       padding-right: 0;
       width: 21px;
-      height: 21px;
+      height: 13px;
       margin-top: 0;
+	    margin-right: 0.15em;
       background-repeat: no-repeat;
 
       &__open {
-        background-image: url("../images/navigation/arrow-down-pink.svg");
+        background-image: url("../images/navigation/arrow-down-purple.svg");
       }
 
       &__close {
-        background-image: url("../images/navigation/arrow-up-pink.svg");
+        background-image: url("../images/navigation/arrow-up-purple.svg");
       }
     }
   }
@@ -41,14 +45,21 @@
   &__text {
     padding-top: 1em;
   }
+  
+  .expander-details__summary__show {
+	margin-top: 0.25em;
+	cursor:pointer;
+  }
 }
 
 .expander-details[open] {
   .expander-details__summary__hide {
-    display: block;
+    display: block;	
+	  cursor:pointer;
+	  margin-top: 0.25em;	
   }
 
   .expander-details__summary__show {
-    display: none;
+    display: none;	
   }
 }

--- a/app/webpacker/styles/git.scss
+++ b/app/webpacker/styles/git.scss
@@ -43,6 +43,7 @@
 @import "./components/chat";
 @import "./components/checklist-collage";
 @import "./components/event-box";
+@import "./components/expander";
 @import "./components/fact-list";
 @import "./components/content-cta";
 @import "./components/content-alert";

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -135,6 +135,10 @@ ol.primary > li {
   }
 }
 
+.link--underline {
+  text-decoration: underline;
+}
+
 .link--no-underline {
   text-decoration: none;
 }

--- a/docs/content.md
+++ b/docs/content.md
@@ -253,6 +253,35 @@ inset_text:
 $important-content$
 ```
 
+### Details expander
+
+You can use the details expander component to highlight content for a non-UK audience, which is rendered as an expandable inset box. Specify the component in the frontmatter and then include it anywhere in the page. Only the title and text parameters are required:
+
+```yaml
+---
+expander:
+  check-your-qualifications:
+    title: Check your qualifications
+    text: If you're a non-UK citizen and need a visa to come to the UK to train to teach, you need to make sure the course you’re applying for sponsors visas.
+    link_title: Find out more about how to apply for a visa to train to teach in England
+    link_url: /non-uk-teachers/visas-for-non-uk-trainees
+
+  another-example:
+    title: Another example
+    text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper, purus eget lobortis maximus, diam leo consequat tellus, in interdum odio nisl sed nibh.
+    header: Non-UK citizens
+    background: purple
+    expanded: true
+---
+
+# My page
+
+$check-your-qualifications$
+
+$another-example$
+
+```
+
 ### YouTube video
 
 To add a YouTube video to your content you need to know the video ID. You can find this out by visiting the video on [youtube.com](https://www.youtube.com/) and looking in the address bar of your browser (it is in the format `watch?v=<video_id>`).

--- a/docs/content.md
+++ b/docs/content.md
@@ -270,7 +270,6 @@ expander:
     title: Another example
     text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper, purus eget lobortis maximus, diam leo consequat tellus, in interdum odio nisl sed nibh.
     header: Non-UK citizens
-    background: purple
     expanded: true
 ---
 

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -7,7 +7,7 @@ module TemplateHandlers
     DEFAULTS = {}.freeze
     GLOBAL_FRONT_MATTER = Rails.root.join("config/frontmatter.yml").freeze
     COMPONENT_PLACEHOLDER_REGEX = /\$([A-z0-9-]+)\$/
-    COMPONENT_TYPES = %w[quote quote_list inset_text youtube_video steps].freeze
+    COMPONENT_TYPES = %w[quote quote_list inset_text youtube_video steps expander].freeze
 
     class << self
       def call(template, source = nil)

--- a/spec/components/content/expander_component_spec.rb
+++ b/spec/components/content/expander_component_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+describe Content::ExpanderComponent, type: :component do
+  subject do
+    render_inline(component)
+    page
+  end
+
+  let(:component) do
+    described_class.new(
+      header: header,
+      title: title,
+      text: text,
+      link_title: link_title,
+      link_url: link_url,
+      background: background,
+      expanded: expanded,
+      classes: classes,
+    )
+  end
+  let(:header) { "header goes here" }
+  let(:title) { "title goes here" }
+  let(:text) { "text goes here" }
+  let(:link_title) { "link title goes here" }
+  let(:link_url) { "/somewhere/over/the/rainbow" }
+  let(:background) { "grey" }
+  let(:expanded) { false }
+  let(:classes) { "extra-class1 extra-class2" }
+
+  describe "expander classes" do
+    it { is_expected.to have_css(".expander-details") }
+    it { is_expected.to have_css(".expander-details__background-grey") }
+    it { is_expected.to have_css(".extra-class1") }
+    it { is_expected.to have_css(".extra-class2") }
+  end
+
+  describe "expander header" do
+    it { is_expected.to have_css("span.expander-details__summary__header", text: header) }
+  end
+
+  describe "expander title" do
+    it { is_expected.to have_css("span.expander-details__summary__title", text: title) }
+  end
+
+  context "when the expander is closed" do
+    it { is_expected.not_to have_link(link_title, href: link_url) }
+    it { is_expected.not_to have_css("div.expander-details__text p", text: text) }
+  end
+
+  context "when the expander is opened" do
+    let(:expanded) { true }
+
+    it { is_expected.to have_link(link_title, href: link_url) }
+    it { is_expected.to have_css("div.expander-details__text p", text: text) }
+  end
+
+  describe "argument checks" do
+    it do
+      expect { described_class.new(title: title, text: nil) }.to \
+        raise_error(ArgumentError, "text must be present")
+    end
+
+    it do
+      expect { described_class.new(title: title, text: "  ") }.to \
+        raise_error(ArgumentError, "text must be present")
+    end
+
+    it do
+      expect { described_class.new(text: text, title: nil) }.to \
+        raise_error(ArgumentError, "title must be present")
+    end
+
+    it do
+      expect { described_class.new(text: text, title: "  ") }.to \
+        raise_error(ArgumentError, "title must be present")
+    end
+
+    it do
+      expect { described_class.new(text: text, title: title, background: "green") }.to \
+        raise_error(ArgumentError, "background must be grey")
+    end
+  end
+end

--- a/spec/components/content/expander_component_spec.rb
+++ b/spec/components/content/expander_component_spec.rb
@@ -23,13 +23,13 @@ describe Content::ExpanderComponent, type: :component do
   let(:text) { "text goes here" }
   let(:link_title) { "link title goes here" }
   let(:link_url) { "/somewhere/over/the/rainbow" }
-  let(:background) { "grey" }
+  let(:background) { "purple" }
   let(:expanded) { false }
   let(:classes) { "extra-class1 extra-class2" }
 
   describe "expander classes" do
     it { is_expected.to have_css(".expander-details") }
-    it { is_expected.to have_css(".expander-details__background-grey") }
+    it { is_expected.to have_css(".expander-details__background-purple") }
     it { is_expected.to have_css(".extra-class1") }
     it { is_expected.to have_css(".extra-class2") }
   end
@@ -77,7 +77,7 @@ describe Content::ExpanderComponent, type: :component do
 
     it do
       expect { described_class.new(text: text, title: title, background: "green") }.to \
-        raise_error(ArgumentError, "background must be grey")
+        raise_error(ArgumentError, "background must be purple")
     end
   end
 end

--- a/spec/components/content/expander_component_spec.rb
+++ b/spec/components/content/expander_component_spec.rb
@@ -54,6 +54,14 @@ describe Content::ExpanderComponent, type: :component do
     it { is_expected.to have_css("div.expander-details__text p", text: text) }
   end
 
+  describe "link title" do
+    let(:link_title) { " link title with a full stop. " }
+    let(:expanded) { true }
+
+    it { is_expected.to have_link("link title with a full stop", href: link_url) }
+    it { is_expected.not_to have_link("link title with a full stop.", href: link_url) }
+  end
+
   describe "argument checks" do
     it do
       expect { described_class.new(title: title, text: nil) }.to \


### PR DESCRIPTION
### Trello card
[Build Non-UK expander component](https://trello.com/c/Cjr2eEiy/6151-build-the-non-uk-expander-component)

### Context
Highlights content for non-uk audiences

### Changes proposed in this pull request
Infrastructure for new details component.

NB: Styles need to be defined and implemented/

### Guidance to review

### Pre-election period restrictions

To be deployed after the PEP.

* [ ] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
