### PR TITLE
Ensure buttons styles as links are transparent in safari

### DIFF
--- a/app/webpacker/styles/header/navigation.scss
+++ b/app/webpacker/styles/header/navigation.scss
@@ -18,8 +18,11 @@ body > header {
     border-style: none;
     font: inherit;
     text-align: start;
-    -moz-appearance: none;
     line-height: 1.375;
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background-color: rgba(0,0,0,0);
   }
 
   .menu-link {


### PR DESCRIPTION
### Trello card
[Fix incorrect colour of dropdown buttons in Safari](https://trello.com/c/wcApjXcl/6175-bug-dropdown-menu-in-safari-desktop-has-incorrect-background-colour)

### Context
Safari sets a default colour on buttons, overriding the specified background colour

### Changes proposed in this pull request
Ensure dropdown menu buttons on Safari have a transparent background

### Guidance to review
Test in Safari

### Pre-election period restrictions

* [ ] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
