### PR TITLE
small fix for Safari

### DIFF
--- a/app/webpacker/styles/header/navigation.scss
+++ b/app/webpacker/styles/header/navigation.scss
@@ -358,6 +358,10 @@ body > header {
               color: $black;
               background: #DEDEDE;
 
+              .menu-title {
+                text-decoration-thickness: max(3px, .1875rem, .12em); // fix required for Safari
+              }
+
               .nav-icon {
                 &__contracted, &__expanded {
                   background-image: url("../images/navigation/arrow-right-black.svg");


### PR DESCRIPTION
### Trello card
[Safari underlines on dropdown menu](https://trello.com/c/y03FrRdz/6205-bug-underlining-of-dropdown-menu-in-safari-should-be-bolder)

### Context

### Changes proposed in this pull request

### Guidance to review

### Pre-election period restrictions

* [x] This change is permitted within the constraints of the [pre-election period guidelines](https://www.gov.uk/government/publications/election-guidance-for-civil-servants/general-election-guidance-2024-guidance-for-civil-servants-html#publishing-content-online-)
