### PR TITLE
Scrape custom metrics

### DIFF
--- a/lib/prometheus/metrics.rb
+++ b/lib/prometheus/metrics.rb
@@ -1,98 +1,77 @@
 module Prometheus
   module Metrics
-    def self.preset_labels
-      {
-        app: Rails.application.config.x.vcap_app["application_name"],
-        organisation: Rails.application.config.x.vcap_app["organization_name"],
-        space: Rails.application.config.x.vcap_app["space_name"],
-        app_instance: ENV["CF_INSTANCE_INDEX"],
-      }
-    end
-
     prometheus = Prometheus::Client.registry
 
     prometheus.counter(
       :app_requests_total,
       docstring: "A counter of requests",
-      labels: %i[path method status] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[path method status],
     )
 
     prometheus.histogram(
       :app_request_duration_ms,
       docstring: "A histogram of request durations",
-      labels: %i[path method status] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[path method status],
     )
 
     prometheus.histogram(
       :app_request_view_runtime_ms,
       docstring: "A histogram of request view runtimes",
-      labels: %i[path method status] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[path method status],
     )
 
     prometheus.histogram(
       :app_render_view_ms,
       docstring: "A histogram of view rendering times",
-      labels: %i[identifier] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[identifier],
     )
 
     prometheus.histogram(
       :app_render_partial_ms,
       docstring: "A histogram of partial rendering times",
-      labels: %i[identifier] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[identifier],
     )
 
     prometheus.counter(
       :app_csp_violations_total,
       docstring: "A counter of CSP violations",
-      labels: %i[blocked_uri document_uri violated_directive] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[blocked_uri document_uri violated_directive],
     )
 
     prometheus.gauge(
       :app_page_speed_score_performance,
       docstring: "Google page speed scores (performance)",
-      labels: %i[strategy path] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[strategy path],
     )
 
     prometheus.gauge(
       :app_page_speed_score_accessibility,
       docstring: "Google page speed scores (accessibility)",
-      labels: %i[strategy path] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[strategy path],
     )
 
     prometheus.gauge(
       :app_page_speed_score_seo,
       docstring: "Google page speed scores (seo)",
-      labels: %i[strategy path] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[strategy path],
     )
 
     prometheus.counter(
       :app_client_cookie_consent_total,
       docstring: "A counter of cookie consent",
-      labels: %i[non_functional marketing] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[non_functional marketing],
     )
 
     prometheus.counter(
       :app_tta_feedback_visit_total,
       docstring: "A counter of feedback visit responses",
-      labels: %i[topic] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[topic],
     )
 
     prometheus.counter(
       :app_tta_feedback_rating_total,
       docstring: "A counter of feedback rating responses",
-      labels: %i[rating] + preset_labels.keys,
-      preset_labels: preset_labels,
+      labels: %i[rating],
     )
   end
 end

--- a/spec/lib/prometheus/metrics_spec.rb
+++ b/spec/lib/prometheus/metrics_spec.rb
@@ -9,7 +9,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of requests") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_csp_violations_total" do
@@ -18,7 +17,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of CSP violations") }
     it { expect { subject.get(labels: %i[blocked_uri document_uri violated_directive]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_request_duration_ms" do
@@ -27,7 +25,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request durations") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_request_view_runtime_ms" do
@@ -36,7 +33,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of request view runtimes") }
     it { expect { subject.get(labels: %i[path method status]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_render_view_ms" do
@@ -45,7 +41,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of view rendering times") }
     it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_render_partial_ms" do
@@ -54,7 +49,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A histogram of partial rendering times") }
     it { expect { subject.get(labels: %i[identifier]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_performance" do
@@ -63,7 +57,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (performance)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_accessibility" do
@@ -72,7 +65,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (accessibility)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_page_speed_score_seo" do
@@ -81,7 +73,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "Google page speed scores (seo)") }
     it { expect { subject.get(labels: %i[strategy path]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_client_cookie_consent_total" do
@@ -90,7 +81,6 @@ describe Prometheus::Metrics do
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of cookie consent") }
     it { expect { subject.get(labels: %i[non_functional marketing]) }.not_to raise_error }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
   end
 
   describe "app_tta_feedback_visit_total" do
@@ -98,7 +88,6 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of feedback visit responses") }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[topic]) }.not_to raise_error }
   end
 
@@ -107,16 +96,6 @@ describe Prometheus::Metrics do
 
     it { is_expected.not_to be_nil }
     it { is_expected.to have_attributes(docstring: "A counter of feedback rating responses") }
-    it { is_expected.to have_attributes(preset_labels: expected_preset_labels) }
     it { expect { subject.get(labels: %i[rating]) }.not_to raise_error }
-  end
-
-  def expected_preset_labels
-    {
-      app: "app-name",
-      organisation: "org-name",
-      space: "space-name",
-      app_instance: "app-instance",
-    }
   end
 end

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -50,4 +50,6 @@ module "web_application" {
 
   docker_image = var.docker_image
   enable_logit = var.enable_logit
+
+  enable_prometheus_monitoring  = var.enable_prometheus_monitoring
 }

--- a/terraform/aks/config/development.tfvars.json
+++ b/terraform/aks/config/development.tfvars.json
@@ -3,5 +3,6 @@
     "namespace": "git-development",
     "environment": "development",
     "replicas": 2,
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -14,5 +14,6 @@
         "start_minute": 0
       },
     "external_url": "https://getintoteaching.education.gov.uk/healthcheck.json",
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/review.tfvars.json
+++ b/terraform/aks/config/review.tfvars.json
@@ -4,6 +4,5 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl": false,
-    "enable_logit": true,
-    "enable_prometheus_monitoring": true
+    "enable_logit": true
 }

--- a/terraform/aks/config/review.tfvars.json
+++ b/terraform/aks/config/review.tfvars.json
@@ -4,5 +4,6 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl": false,
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/test.tfvars.json
+++ b/terraform/aks/config/test.tfvars.json
@@ -3,5 +3,6 @@
     "namespace": "git-test",
     "environment": "test",
     "internet_hostnames": [ "staging.getintoteaching" ],
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -86,6 +86,10 @@ variable "postgres_enable_high_availability" {
   default = false
 }
 variable "enable_logit" { default = false }
+variable "enable_prometheus_monitoring" {
+  type    = bool
+  default = false
+}
 
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)


### PR DESCRIPTION
### Trello card
https://trello.com/c/Zlih3dRZ/1889-scrape-custom-metrics

### Context
Scrape custom metrics that are exported for gitapp,
which can then be used in dashboards and alerting

### Changes proposed in this pull request
Add enable_prometheus_monitoring to application deployments and set for each env

remove paas labels from custom metrics as these are not relevant after the migration to aks.

remove from review apps before merge

### Guidance to review
make development terraform-plan DOCKER_IMAGE_TAG=x

Review app metrics are visible in prometheus test (most start with 'app').

