### PR TITLE
Delete visa minimum savings variables

### DIFF
--- a/config/values/nonuk.yml
+++ b/config/values/nonuk.yml
@@ -1,7 +1,5 @@
 ## implemented above this line
 nonuk:
-  highpotentialindividualvisaminimumsavings: £1,270
-  indiayoungprofessionalsschememinimumsavings: £2,530
   internationalrelocationpayment:
     value: £10,000
     instalment: £5,000


### PR DESCRIPTION
### Trello card
https://trello.com/c/dQdKBnmR

### Context
We are centralising our financial values into one place for easier maintenance. This PR removes previously created variables related to minimum savings for different visa types, as our visa guidance has recently been simplified to remove this information.

### Guidance to review
Check that these variables aren't in use anywhere.

