### PR TITLE
Move statement of comparability cost variable to nonuk values file

### DIFF
--- a/app/views/content/non-uk-teachers/non-uk-qualifications.md
+++ b/app/views/content/non-uk-teachers/non-uk-qualifications.md
@@ -73,7 +73,7 @@ This is a certificate that proves your school and university qualifications are 
 
 When you apply for teacher training, you'll be asked to submit details of your statement of comparability. Applications which include this are 28% more likely to be successful.
 
-A statement of comparability costs $finance_statementofcomparabilitycost$. It takes 15 working days to complete your order from the date ENIC receives your qualification documents and payment.
+A statement of comparability costs $nonuk_statementofcomparabilitycost$. It takes 15 working days to complete your order from the date ENIC receives your qualification documents and payment.
 
 ## Get help checking your qualifications
 

--- a/config/values/finance.yml
+++ b/config/values/finance.yml
@@ -16,4 +16,3 @@ finance:
     min: £50
     max: £1,963
     income: £18,835.98
-  statementofcomparabilitycost: £49.50 + VAT

--- a/config/values/nonuk.yml
+++ b/config/values/nonuk.yml
@@ -4,3 +4,4 @@ nonuk:
     value: £10,000
     instalment: £5,000
     salarythresholdfortaxonpayments: £50,270
+  statementofcomparabilitycost: £49.50 + VAT


### PR DESCRIPTION
### Trello card
https://trello.com/c/uHjExE2O

### Context
We are centralising our financial values into one place for easier maintenance. This PR moves the statement of comparability cost variable from the finance values file to the non-uk values file, for easier future maintenance

### Guidance to review
Check that all pages with the variable have been updated with the new variable name
