### PR TITLE
update chat email address

### DIFF
--- a/app/components/chat_component.html.erb
+++ b/app/components/chat_component.html.erb
@@ -13,7 +13,7 @@
     <p>
       <strong>Chat not available</strong>
       <br>
-      Email: <%= mail_to("getintoteaching.getintoteaching@education.gov.uk", class: "link--dark") %>
+      Email: <%= mail_to("getinto.teaching@service.education.gov.uk", class: "link--dark") %>
     </p>
   </div>
 </div>

--- a/spec/components/chat_component_spec.rb
+++ b/spec/components/chat_component_spec.rb
@@ -12,5 +12,5 @@ describe ChatComponent, type: "component" do
   it { is_expected.to have_css("[data-chat-target=online] a[data-action='chat#start']") }
   it { is_expected.to have_css("[data-chat-target=offline].hidden") }
   it { is_expected.to have_css("[data-chat-target=unavailable]:not(.hidden)") }
-  it { is_expected.to have_css("[data-chat-target=unavailable] a[href='mailto:getintoteaching.getintoteaching@education.gov.uk']") }
+  it { is_expected.to have_css("[data-chat-target=unavailable] a[href='mailto:getinto.teaching@service.education.gov.uk']") }
 end

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Chat", type: :feature do
 
         within(".talk-to-us") do
           expect(page).to have_text("Chat not available")
-          expect(page).to have_link("getintoteaching.getintoteaching@education.gov.uk")
+          expect(page).to have_link("getinto.teaching@service.education.gov.uk")
         end
       end
     end
@@ -58,7 +58,7 @@ RSpec.feature "Chat", type: :feature do
 
         within(".talk-to-us") do
           expect(page).to have_text("Chat not available")
-          expect(page).to have_link("getintoteaching.getintoteaching@education.gov.uk")
+          expect(page).to have_link("getinto.teaching@service.education.gov.uk")
         end
       end
     end


### PR DESCRIPTION
### Trello card
[Update chat email address](https://trello.com/c/EJaR81Lm)

### Context
The email address for chatting with advisers is changing

### Changes proposed in this pull request

### Guidance to review

