### PR TITLE
Implement additional international fee variables

### DIFF
--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -81,8 +81,8 @@ Teacher training fees for non-UK candidates vary between training providers.
 
 Fees cost:
 
-* an average of £14,765
-* a maximum of about £36,000
+* an average of $fees_pgitt_internationalaverage$
+* a maximum of about $fees_pgitt_internationalmaxfulltime$
 
 Most non-UK candidates will not be eligible for financial support to help with fees.
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/yYsObVrs

### Context
We are centralising our financial values into one place for easier maintenance. This PR implements the international fee variables on the Fees and funding page

### Guidance to review
* Check right variables have been used
* Check that values match currently those in production (note that the average fee has been increased to £15k - this is deliberate and was implemented as part of https://github.com/DFE-Digital/get-into-teaching-app/pull/4088)

