### PR TITLE
Replace rack-page_caching with actionpack-page_caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,8 @@ gem "view_component", "~> 3.10.0"
 
 gem "google-api-client", ">= 0.53.0", require: false
 
+gem "actionpack-page_caching"
 gem "net-smtp", ">= 0.3.3", require: false
-gem "rack-page_caching", github: "pkorenev/rack-page_caching", ref: "9ca404f"
 
 # Fix CVE errors
 gem "delegate", ">= 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,14 +56,6 @@ GIT
       rspec (~> 3.0)
 
 GIT
-  remote: https://github.com/pkorenev/rack-page_caching.git
-  revision: 9ca404f7f7e4773030e75799da7ab02e27cbe9a3
-  ref: 9ca404f
-  specs:
-    rack-page_caching (0.0.3)
-      rack
-
-GIT
   remote: https://github.com/waiting-for-dev/front_matter_parser.git
   revision: 01187017cb5b20ff1cf92809969ecd385d613aaa
   specs:
@@ -107,6 +99,8 @@ GEM
     actionpack-cloudfront (1.2.0)
       actionpack (>= 4.2)
       railties (>= 4.2)
+    actionpack-page_caching (1.2.4)
+      actionpack (>= 4.0.0)
     actiontext (7.0.2.4)
       actionpack (= 7.0.2.4)
       activerecord (= 7.0.2.4)
@@ -586,6 +580,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-cloudfront (>= 1.2.0)
+  actionpack-page_caching
   addressable (~> 2.8.4)
   amazing_print
   better_html (>= 1.0.16)
@@ -636,7 +631,6 @@ DEPENDENCIES
   rack-attack
   rack-cors
   rack-host-redirect
-  rack-page_caching!
   rails (~> 7.0.2.3)
   rails_semantic_logger (>= 4.12.0)
   redis

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module GetIntoTeachingWebsite
     config.view_component.default_preview_layout = "component_preview"
 
     config.skylight.environments.append("preprod", "dev", "test", "staging", "rolling")
+    config.action_controller.page_cache_directory = Rails.root.join("public/cached_pages")
   end
 end
 

--- a/config/initializers/middleware.rb
+++ b/config/initializers/middleware.rb
@@ -5,10 +5,10 @@ require "middleware/page_cache_exclusion"
 Rails.application.config.middleware.use(Middleware::PageCacheExclusion)
 
 # Page caching middleware
-Rails.application.config.middleware.use Rack::PageCaching,
-                                        page_cache_directory: Rails.root.join("public/cached_pages"),
-                                        gzip: :best_compression,
-                                        include_hostname: false
+# Rails.application.config.middleware.use Rack::PageCaching,
+#                                         page_cache_directory: Rails.root.join("public/cached_pages"),
+#                                         gzip: :best_compression,
+#                                         include_hostname: false
 
 # Transform HTML responses (image optimisations, links)
 Rails.application.config.middleware.use(Middleware::HtmlResponseTransformer)

--- a/config/initializers/middleware.rb
+++ b/config/initializers/middleware.rb
@@ -4,12 +4,6 @@ require "middleware/page_cache_exclusion"
 # Prevent certain pages from being cached
 Rails.application.config.middleware.use(Middleware::PageCacheExclusion)
 
-# Page caching middleware
-# Rails.application.config.middleware.use Rack::PageCaching,
-#                                         page_cache_directory: Rails.root.join("public/cached_pages"),
-#                                         gzip: :best_compression,
-#                                         include_hostname: false
-
 # Transform HTML responses (image optimisations, links)
 Rails.application.config.middleware.use(Middleware::HtmlResponseTransformer)
 

--- a/lib/middleware/page_cache_exclusion.rb
+++ b/lib/middleware/page_cache_exclusion.rb
@@ -26,6 +26,7 @@ module Middleware
 
       cache_file = cache_file_for(path)
       return if cache_file.blank?
+
       @cache.expire(cache_file)
     end
 
@@ -33,6 +34,7 @@ module Middleware
       raise "No cache present" if @cache.blank?
 
       return if path.blank?
+
       @cache.send(:cache_file, path, extension)
     end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/wpcleikM/6326-update-replace-rack-pagecaching-library

### Context

The `rack-page_caching` gem that we use hasn't been touched in 10 years and is the source of multiple `no implicit conversion of nil into String` errors being reported on production

### Changes proposed in this pull request

- Remove the `rack-page_caching` gem
- Replace with `actionpack-page_caching` gem
- Refactor the middleware that filters out dynamic pages from being cached
- Adjust tests to handle new gem

### Guidance to review

