### PR TITLE
add id to details tag in expander

### DIFF
--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.details(class: expander_class, open: expanded) do %>
+<%= tag.details(id: details_id, class: expander_class, open: expanded) do %>
   <summary class="expander-details__summary">
     <%= tag.div role: "text" do %>
       <% if header.present? %>

--- a/app/components/content/expander_component.rb
+++ b/app/components/content/expander_component.rb
@@ -42,6 +42,10 @@ module Content
       parameterize("hide #{header} #{title}")
     end
 
+    def details_id
+      parameterize("details #{header} #{title}")
+    end
+
     def expander_class
       %w[expander-details].tap do |c|
         c << "expander-details__background-#{background}" if background

--- a/spec/components/content/expander_component_spec.rb
+++ b/spec/components/content/expander_component_spec.rb
@@ -42,6 +42,18 @@ describe Content::ExpanderComponent, type: :component do
     it { is_expected.to have_css("span.expander-details__summary__title", text: title) }
   end
 
+  describe "show_link_id" do
+    it { is_expected.to have_css("#show-header-goes-here-title-goes-here") }
+  end
+
+  describe "hide_link_id" do
+    it { is_expected.to have_css("#hide-header-goes-here-title-goes-here") }
+  end
+
+  describe "details_id" do
+    it { is_expected.to have_css("#details-header-goes-here-title-goes-here") }
+  end
+
   context "when the expander is closed" do
     it { is_expected.not_to have_link(link_title, href: link_url) }
     it { is_expected.not_to have_css("div.expander-details__text p", text: text) }


### PR DESCRIPTION
### Trello card
[Add unique id to expander control](https://trello.com/c/SShNLLn5/6291-add-unique-id-attribute-to-expander-control-to-assist-with-click-tracking)

### Context
To assist with click tracking on the expander control, add an `id` field to the `<details>` tag

### Changes proposed in this pull request
Adds `id`

### Guidance to review
See `/funding-and-support/scholarships-and-bursaries` for an example
