### PR TITLE
Downgrade sidekiq to version 6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "google-api-client", ">= 0.53.0", require: false
 gem "net-smtp", ">= 0.3.3", require: false
 gem "rack-page_caching", github: "pkorenev/rack-page_caching", ref: "9ca404f"
 
-gem "sidekiq"
+gem "sidekiq", "~> 6.5.0"
 
 # Fix CVE errors
 gem "delegate", ">= 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -526,12 +526,10 @@ GEM
       semantic_range (>= 2.3.0)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.3.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (6.5.5)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.5.0)
     signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -659,7 +657,7 @@ DEPENDENCIES
   sentry-ruby (~> 5.17.3)
   shakapacker (= 8.0.0)
   shoulda-matchers
-  sidekiq
+  sidekiq (~> 6.5.0)
   simplecov
   skylight (~> 6.0.4)
   spring


### PR DESCRIPTION
### Trello card

https://trello.com/c/ByxojH8F/6363-investigate-and-fix-issue-with-git-not-sending-web-events-in-production

### Context

Sidekiq 7 requires Redis 6.2+. Since we're using Redis 6.0 in production, our sidekiq instance falls over.

### Changes proposed in this pull request

- Downgrade Sidekiq to 6.5 to work with Redis 6.0

### Guidance to review

