### PR TITLE
Fix codespaces not working since introduction of redis dependency

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // This can be used to network with other containers or the host.
-  "forwardPorts": [2222],
+  "forwardPorts": [2222, 3000, 6379],
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": ".devcontainer/boot.sh"
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build:
@@ -8,6 +6,13 @@ services:
     volumes:
       - ../..:/workspaces:cached
     command: sleep infinity
+    depends_on:
+      - redis
+      - postgres
+    environment:
+      REDIS_URL: redis://redis:6379
+    ports:
+      - 3000:3000
   postgres:
     image: postgres:15-alpine
     restart: unless-stopped
@@ -18,10 +23,12 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
   redis:
-    image: redis:7-alpine
+    image: redis:6.0.14-alpine
     restart: unless-stopped
     volumes:
       - redis-data:/data
+    ports:
+      - 6379:6379
 
 volumes:
   postgres-data:

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
-rails: bundle exec rails s --port=3000
+rails: bundle exec rails s -p 3000 -b 0.0.0.0
 webpacker: ./bin/shakapacker-dev-server
-redis: redis-server
 worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
### Trello card

https://trello.com/c/AJTpvoFL/6362-create-a-devcontainer-environment-for-git-in-vscode?filter=member:spencerldixon

### Context

Introducing sidekiq has broken codespaces for developers using them as there is now a redis dependency.

### Changes proposed in this pull request

- Update devcontainer config to include redis 6.0.14 (same as production)
- Modernise docker compose file

### Guidance to review

