### PR TITLE
Update links to Teaching Vacancies site

### DIFF
--- a/app/views/content/steps-to-become-a-teacher/_step_7_apply_for_a_teaching_role.erb
+++ b/app/views/content/steps-to-become-a-teacher/_step_7_apply_for_a_teaching_role.erb
@@ -8,4 +8,4 @@
     <p>You can also explore our advice about <a href=\"/non-uk-teachers\"> teaching in England as a non-UK citizen</a>.</p>",
   ) %>
 
-<p><a href="https://teaching-vacancies.campaign.gov.uk/application-advice/">Get help applying for teaching jobs</a>.</p>
+<p><a href="https://teaching-vacancies.service.gov.uk/jobseeker-guides/get-help-applying-for-your-teaching-role">Get help applying for teaching jobs</a>.</p>

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -537,7 +537,7 @@ keywords:
 
 If you’ve worked as an unqualified teacher, you may be able to get [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts) through an assessment only programme.
 
-If you already have QTS, find out how you can [return to teaching](https://teaching-vacancies.campaign.gov.uk/return-to-teaching/).
+If you already have QTS, find out how you can [return to teaching](https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/).
 
 ## What is the assessment only route to QTS?
 

--- a/app/views/mailing_list/steps/_already_qualified.html.erb
+++ b/app/views/mailing_list/steps/_already_qualified.html.erb
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-  If you completed your teacher training in England, <%= link_to("find out how you can return to teaching", "https://teaching-vacancies.campaign.gov.uk/return-to-teaching/") %>.
+  If you completed your teacher training in England, <%= link_to("find out how you can return to teaching", "https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/") %>.
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,9 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/returning-to-teaching", to: redirect("https://teaching-vacancies.campaign.gov.uk/return-to-teaching/")
+  get "/returning-to-teaching", to: redirect("https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/")
 
-  "https://teaching-vacancies.campaign.gov.uk/return-to-england-after-teaching-overseas/".tap do |teaching_vacancies|
+  "https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-england-after-teaching-overseas".tap do |teaching_vacancies|
     get "/non-uk-teachers/return-to-england-after-teaching-overseas",                         to: redirect(teaching_vacancies)
     get "/international-returners",                                                           to: redirect(teaching_vacancies)
     get "/explore-my-options/return-to-teaching/return-to-teaching-in-england-from-overseas", to: redirect(teaching_vacancies)

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "Redirects", content: true, type: :request do
   before(:all) { @result = {} }
 
-  let(:teaching_vacancies_url) { "https://teaching-vacancies.campaign.gov.uk/return-to-teaching/" }
+  let(:teaching_vacancies_url) { "https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/" }
   let(:query_string) { "#{expected_query_string}&page=5" }
   let(:expected_query_string) { "abc=def&ghi=jkl" }
   let(:valid_results) { [200, 301, 302] }


### PR DESCRIPTION
### Trello card
https://trello.com/c/SD9cPOhT

### Context
Teaching Vacancies have moved their content that was previously on their separate campaign site into their main site. This PR updates the links from GIT.

### Guidance to review
* Check that new links work as expected
* Note that the external redirects file and a spec test have been updated - these need a tech review

