### PR TITLE
Teacher degree apprenticeship page changes

### DIFF
--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -28,13 +28,13 @@ The teaching apprenticeship is a 4-year, full-time course that lets you train as
 
 The salary you’ll earn as a trainee will reflect the level of responsibility that’s suitable for each stage of your teaching apprenticeship course. You do not have to pay tuition fees but you will not be eligible for student finance.
 
-The teacher training providers confirmed so far will offer TDAs in maths, with other subjects likely to be offered too.
+The teacher training providers confirmed so far will offer TDAs in secondary maths, with other subjects likely to be offered too.
 
 The providers offering teacher degree apprenticeships are:
 
 * Nottingham Trent University
-* Staffordshire University, in partnership with the Stoke-on-Trent and Staffordshire Teacher Education Collective (SSTEC)
-* University College London (UCL)
+* Staffordshire University, in partnership with the Stoke-on-Trent and Staffordshire Teacher Education Collective
+* University College London
 * University of Brighton
 * University of Huddersfield
 * University of Nottingham
@@ -42,7 +42,7 @@ The providers offering teacher degree apprenticeships are:
 * Xavier Teach Southeast, in partnership with the University of Sussex
 
 ## Who’s eligible to apply for a teacher degree apprenticeship?
-Teacher degree apprenticeships will be available to people who are leaving school and those already working who are interested in becoming a teacher, including teaching assistants.
+Teacher degree apprenticeship will be open to anyone who would like to gain a degree and become a qualified teacher. This includes, but is not limited to, teaching assistants, school leavers or people looking to change careers.
 
 To be eligible to apply for a teacher degree apprenticeship you’ll need the following qualifications:
 

--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -42,7 +42,7 @@ The providers offering teacher degree apprenticeships are:
 * Xavier Teach Southeast, in partnership with the University of Sussex
 
 ## Who’s eligible to apply for a teacher degree apprenticeship?
-Teacher degree apprenticeship will be open to anyone who would like to gain a degree and become a qualified teacher. This includes, but is not limited to, teaching assistants, school leavers or people looking to change careers.
+Teacher degree apprenticeships will be open to anyone who would like to gain a degree and become a qualified teacher. This includes, but is not limited to, teaching assistants, school leavers or people looking to change careers.
 
 To be eligible to apply for a teacher degree apprenticeship you’ll need the following qualifications:
 

--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -28,7 +28,7 @@ The teaching apprenticeship is a 4-year, full-time course that lets you train as
 
 The salary you’ll earn as a trainee will reflect the level of responsibility that’s suitable for each stage of your teaching apprenticeship course. You do not have to pay tuition fees but you will not be eligible for student finance.
 
-The [teacher training providers confirmed so far](https://www.gov.uk/government/publications/secondary-maths-teacher-degree-apprenticeship-funding-pilot-providers?) will offer TDAs in maths, with other subjects likely to be offered too.
+The teacher training providers confirmed so far will offer TDAs in maths, with other subjects likely to be offered too.
 
 The providers offering teacher degree apprenticeships are:
 

--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -55,4 +55,4 @@ You also need to be:
 * age 16 years or over 
 
 ## How to apply for a teacher degree apprenticeship 
-Applications for new teaching apprenticeships are expected to open from autumn 2024 for both primary and secondary, with the first cohort of training due to start in autumn 2025.
+Applications for new teaching apprenticeships are expected to open from autumn 2024 for both primary and secondary, with the first trainees due to start their apprenticeships in autumn 2025.

--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -21,19 +21,30 @@ If you do not already have an undergraduate degree, you may be eligible to do a 
 
 $teacher-degree-apprenticeships$
 
-##  How do teacher degree apprenticeships (TDAs) work?
-This new teacher training programme means you’ll work in a school and earn a salary while getting a bachelor’s degree and [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts).
+##  How do teacher degree apprenticeships work?
+The teacher degree apprenticeship is a new teacher training programme where you’ll work in a school and earn a salary while getting a bachelor’s degree and [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts).
  
 The teaching apprenticeship is a 4-year, full-time course that lets you train as either a primary or secondary teacher with an accredited teacher training provider. Trainee teachers will spend an average of 40% of their time (two days a week) studying for their degree with a university.
 
-The salary you’ll earn as a trainee will reflect the level of responsibility that’s suitable for each stage of your course. You do not have to pay tuition fees but you will not be eligible for student finance.
+The salary you’ll earn as a trainee will reflect the level of responsibility that’s suitable for each stage of your teaching apprenticeship course. You do not have to pay tuition fees but you will not be eligible for student finance.
 
 The [teacher training providers confirmed so far](https://www.gov.uk/government/publications/secondary-maths-teacher-degree-apprenticeship-funding-pilot-providers?) will offer TDAs in maths, with other subjects likely to be offered too.
 
-## Who’s eligible to apply for a teacher degree apprenticeship (TDA)?
-Teaching degree apprenticeships will be available to both people who are leaving school and those already working who are interested in becoming a teacher, including teaching assistants.
+The providers offering teacher degree apprenticeships are:
 
-To be eligible to apply for a teacher apprenticeship degree you’ll need the following qualifications:
+* Nottingham Trent University
+* Staffordshire University, in partnership with the Stoke-on-Trent and Staffordshire Teacher Education Collective (SSTEC)
+* University College London (UCL)
+* University of Brighton
+* University of Huddersfield
+* University of Nottingham
+* University of Wolverhampton
+* Xavier Teach Southeast, in partnership with the University of Sussex
+
+## Who’s eligible to apply for a teacher degree apprenticeship?
+Teacher degree apprenticeships will be available to people who are leaving school and those already working who are interested in becoming a teacher, including teaching assistants.
+
+To be eligible to apply for a teacher degree apprenticeship you’ll need the following qualifications:
 
 * GCSEs at grade 4 (C) or above in English and maths (and science if you want to teach primary)
 * A levels - the number of A levels and grades required will be set by individual universities
@@ -43,5 +54,5 @@ You also need to be:
 * a resident of England for the last 3 years or more
 * age 16 years or over 
 
-## How to apply for a teacher degree apprenticeship (TDA)
-Applications for the new TDAs are expected to open in autumn 2024 for both primary and secondary, with training due to start in autumn 2025.
+## How to apply for a teacher degree apprenticeship 
+Applications for new teaching apprenticeships are expected to open from autumn 2024 for both primary and secondary, with the first cohort of training due to start in autumn 2025.


### PR DESCRIPTION
### Trello card
https://trello.com/c/W5jo88Mb/6321-update-teacher-degree-apprenticeship-page-with-provider-list-and-other-changes?filter=member:sarahstewart179

### Context
Updating the TDA page so the providers are on the page and users don't need to click through to two more pages. Also made some small tweaks from policy and added a couple more teaching apprenticeships' for SEO purposes.
### Changes proposed in this pull request

### Guidance to review

Relates to this page https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships