### PR TITLE
Change details for Wessex Schools Training Partnership on Assessment only page

### DIFF
--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -369,6 +369,10 @@ provider_groups:
     - header: Bath Spa University
       name: Fiona Hunt
       email: assessmentonly@bathspa.ac.uk
+    - header: Bournemouth Bay Teacher Training Partnership
+      name: James Mosley
+      telephone: 01202 662038
+      email: j.mosley@poolehigh.poole.sch.uk
     - header: Cornwall School Centred Initial Teacher Training (Cornwall SCITT)
       link: https://www.cornwallscitt.org/
       name: Lex Blake
@@ -394,10 +398,6 @@ provider_groups:
       name: Carrie McMillan
       telephone: 01392 686165
       email: swtt@westexe.devon.sch.uk
-    - header: Wessex Schools Training Partnership
-      name: Claire Porter
-      telephone: 01202 662038
-      email: WSTP@poolehigh.poole.sch.uk
   West Midlands:
     providers:
     - header: Birmingham City University


### PR DESCRIPTION
### Trello card
https://trello.com/c/m8wV5vQb

### Context
Request received via GIT support team to change the name and contact details for the Wessex Schools Training Partnership on the Assessment only page

