### PR TITLE
Improve breadcrumbs across layouts

### DIFF
--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,10 +1,10 @@
 class HeaderComponent < ViewComponent::Base
   attr_reader :breadcrumbs, :front_matter
 
-  def initialize(breadcrumbs: false, front_matter: {})
+  def initialize(front_matter = {})
     super
 
-    @breadcrumbs = breadcrumbs
+    @breadcrumbs = front_matter["breadcrumbs"] != false
     @front_matter = front_matter
   end
 end

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -4,7 +4,7 @@ class HeaderComponent < ViewComponent::Base
   def initialize(front_matter = {})
     super
 
-    @breadcrumbs = front_matter["breadcrumbs"] != false
+    @breadcrumbs = front_matter.with_indifferent_access["breadcrumbs"] != false
     @front_matter = front_matter
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,8 @@ private
       return render status: :invalid_server_error, body: nil
     end
 
+    breadcrumb status_code_symbol.to_s.humanize, request.path
+
     respond_to do |format|
       format.html do
         render \

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -34,7 +34,7 @@ class ErrorsController < ApplicationController
     end
   end
 
-  private
+private
 
   def set_breadcrumbs
     breadcrumb params[:action].humanize, request.path

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,6 @@
 class ErrorsController < ApplicationController
   layout "application"
+  before_action :set_breadcrumbs
 
   def not_found
     respond_to do |format|
@@ -31,5 +32,11 @@ class ErrorsController < ApplicationController
       format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
       format.all { render status: :unprocessable_entity, body: nil }
     end
+  end
+
+  private
+
+  def set_breadcrumbs
+    breadcrumb params[:action].humanize, request.path
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -43,11 +43,13 @@ class PagesController < ApplicationController
                         GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
                       end
 
-    render template: "pages/privacy_policy"
+    breadcrumb @page_title, request.path
   end
 
   def cookies
-    render template: "pages/cookies", layout: "disclaimer"
+    breadcrumb "Cookies Policy", request.path
+
+    render layout: "disclaimer"
   end
 
   def show

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,6 @@
 class SearchesController < ApplicationController
   before_action :set_page_title, :noindex
+  before_action :set_breadcrumbs
 
   def show
     @search = Search.new(search_params)
@@ -14,6 +15,10 @@ private
 
   def set_page_title
     @page_title = "Search Get Into Teaching"
+  end
+
+  def set_breadcrumbs
+    breadcrumb @page_title, request.path
   end
 
   def search_params

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -23,7 +23,7 @@ class TeachingEventsController < ApplicationController
     @front_matter = {
       title: "Find an event near you or online",
       description: "Find out more about getting into teaching at a free event where you can get all your questions answered by teachers, advisers and training providers.",
-      breadcrumbs: false
+      breadcrumbs: false,
     }.with_indifferent_access
 
     setup_results

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -23,6 +23,7 @@ class TeachingEventsController < ApplicationController
     @front_matter = {
       title: "Find an event near you or online",
       description: "Find out more about getting into teaching at a free event where you can get all your questions answered by teachers, advisers and training providers.",
+      breadcrumbs: false
     }.with_indifferent_access
 
     setup_results

--- a/app/controllers/teaching_events_controller.rb
+++ b/app/controllers/teaching_events_controller.rb
@@ -64,6 +64,8 @@ class TeachingEventsController < ApplicationController
       description: "Find out what happens at a Get Into Teaching event and book your place, whether you’re ready to start your career in teaching or just curious.",
     }.with_indifferent_access
 
+    breadcrumb @front_matter[:title], request.path
+
     render layout: "minimal"
   end
 

--- a/app/views/content/help-and-support.md
+++ b/app/views/content/help-and-support.md
@@ -8,7 +8,6 @@ description: |-
 navigation: 40
 layout: "layouts/minimal"
 talk_to_us: false
-breadcrumbs: false
 content:
   - content/help-and-support/header
   - content/help-and-support/talk-to-us

--- a/app/views/content/help-and-support.md
+++ b/app/views/content/help-and-support.md
@@ -8,6 +8,7 @@ description: |-
 navigation: 40
 layout: "layouts/minimal"
 talk_to_us: false
+breadcrumbs: false
 content:
   - content/help-and-support/header
   - content/help-and-support/talk-to-us

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -11,6 +11,7 @@
   hero_bg_color: yellow
   title_bg_color: white
   mailing_list: true
+  breadcrumbs: false
   content:
     - content/home/purple-box
     - content/home/calls-to-action

--- a/app/views/content/landing/campus-advisers.md
+++ b/app/views/content/landing/campus-advisers.md
@@ -9,4 +9,5 @@ layout: "layouts/minimal"
 colour: pink-yellow
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/campus-mailing-list.md
+++ b/app/views/content/landing/campus-mailing-list.md
@@ -9,4 +9,5 @@ colour: pink-yellow
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/careers.md
+++ b/app/views/content/landing/careers.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/food-for-thought.md
+++ b/app/views/content/landing/food-for-thought.md
@@ -9,4 +9,5 @@ image: "static/images/content/hero-images/cake.png"
 layout: "layouts/minimal"
 colour: pink-yellow
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/grow.md
+++ b/app/views/content/landing/grow.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/how-much-do-teachers-get-paid.md
+++ b/app/views/content/landing/how-much-do-teachers-get-paid.md
@@ -12,4 +12,5 @@ colour: "pink-blue"
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/how-to-become-a-teacher.md
+++ b/app/views/content/landing/how-to-become-a-teacher.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue  
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/how-to-fund-your-teacher-training.md
+++ b/app/views/content/landing/how-to-fund-your-teacher-training.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/mailing-list-1.md
+++ b/app/views/content/landing/mailing-list-1.md
@@ -8,4 +8,5 @@ image: "static/images/content/hero-images/0027.jpg"
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/mailing-list-2.md
+++ b/app/views/content/landing/mailing-list-2.md
@@ -8,4 +8,5 @@ colour: pink-blue
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/mailing-list-3.md
+++ b/app/views/content/landing/mailing-list-3.md
@@ -8,4 +8,5 @@ image: "static/images/content/hero-images/0027.jpg"
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/mailing-list.md
+++ b/app/views/content/landing/mailing-list.md
@@ -8,4 +8,5 @@ image: "static/images/content/hero-images/0027.jpg"
 layout: "layouts/minimal"
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/return-to-teaching-advisers.md
+++ b/app/views/content/landing/return-to-teaching-advisers.md
@@ -9,4 +9,5 @@ layout: "layouts/minimal"
 colour: green-yellow
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/still-time-to-apply.md
+++ b/app/views/content/landing/still-time-to-apply.md
@@ -10,4 +10,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: false
+breadcrumbs: false
 ---

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree.md
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/train-to-teach.md
+++ b/app/views/content/landing/train-to-teach.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/landing/what-teaching-taught-me.md
+++ b/app/views/content/landing/what-teaching-taught-me.md
@@ -12,4 +12,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/content/trainees/start-your-teacher-training.md
+++ b/app/views/content/trainees/start-your-teacher-training.md
@@ -9,4 +9,5 @@ layout: "layouts/minimal"
 colour: pink-blue
 talk_to_us: false
 noindex: true
+breadcrumbs: false
 ---

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/blog/index.html.erb
+++ b/app/views/layouts/blog/index.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <section class="container blog main-section">

--- a/app/views/layouts/blog/post.html.erb
+++ b/app/views/layouts/blog/post.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <section class="container blog main-section">

--- a/app/views/layouts/category.html.erb
+++ b/app/views/layouts/category.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag(class: "category") do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= body_tag do %>
       <%= render "sections/govuk_javascript" %>
-      <%= render HeaderComponent.new(breadcrumbs: true, front_matter: @front_matter) %>
+      <%= render HeaderComponent.new(@front_matter) %>
 
       <%= main_tag do %>
         <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/disclaimer.html.erb
+++ b/app/views/layouts/disclaimer.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <section class="container main-section">

--- a/app/views/layouts/events.html.erb
+++ b/app/views/layouts/events.html.erb
@@ -6,7 +6,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/feedback.html.erb
+++ b/app/views/layouts/feedback.html.erb
@@ -12,7 +12,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag(class: "main-section") do %>
       <section class="feature registration container">

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -5,7 +5,7 @@
     <%= render "sections/govuk_javascript" %>
     <%= render(partial: "sections/content_errors") %>
 
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag(class: @front_matter["main_class"]) do %>
       <% @front_matter["content"]&.each do |partial| %>

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <section class="main-section">
       <section class="feature registration container">

--- a/app/views/layouts/registration.html.erb
+++ b/app/views/layouts/registration.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(@front_matter) %>
+    <%= render HeaderComponent.new(breadcrumbs: false) %>
 
     <section class="main-section">
       <section class="feature registration container">

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(@front_matter) %>
+    <%= render HeaderComponent.new(breadcrumbs: false) %>
     <%= yield(:back_link) %>
 
     <%= main_tag(class: "main-section registration-with-image-above") do %>

--- a/app/views/layouts/registration_with_image_above.html.erb
+++ b/app/views/layouts/registration_with_image_above.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
     <%= yield(:back_link) %>
 
     <%= main_tag(class: "main-section registration-with-image-above") do %>

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(@front_matter) %>
+    <%= render HeaderComponent.new(breadcrumbs: false) %>
 
     <div class="main-section registration-with-side-images">
       <section class="signup-container">

--- a/app/views/layouts/registration_with_side_images.html.erb
+++ b/app/views/layouts/registration_with_side_images.html.erb
@@ -7,7 +7,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <div class="main-section registration-with-side-images">
       <section class="signup-container">

--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -3,7 +3,7 @@
     <%= render "sections/head" %>
     <%= body_tag do %>
       <%= render "sections/govuk_javascript" %>
-      <%= render HeaderComponent.new(breadcrumbs: true) %>
+      <%= render HeaderComponent.new(@front_matter) %>
 
       <%= main_tag do %>
         <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/teaching_event.html.erb
+++ b/app/views/layouts/teaching_event.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new(breadcrumbs: true) %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/teaching_events.html.erb
+++ b/app/views/layouts/teaching_events.html.erb
@@ -3,7 +3,7 @@
   <%= render "sections/head" %>
   <%= body_tag do %>
     <%= render "sections/govuk_javascript" %>
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag do %>
       <%= render Content::HeroComponent.new(@front_matter) %>

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -5,7 +5,7 @@
     <%= render "sections/govuk_javascript" %>
     <%= render(partial: "sections/content_errors") %>
 
-    <%= render HeaderComponent.new %>
+    <%= render HeaderComponent.new(@front_matter) %>
 
     <%= main_tag(class: "main-section welcome-guide") do %>
       <%= yield %>

--- a/docs/content.md
+++ b/docs/content.md
@@ -118,7 +118,7 @@ Knowing which frontmatter values are available for a page is not always obvious,
 
 ### Breadcrumbs
 
-Breadcrumbs are included by default on most layouts. You can chose to optionally disable breadcrumbs by setting the following in the front matter:
+Breadcrumbs are included by default on most layouts with the exception of registration layouts. You can chose to optionally disable breadcrumbs by setting the following in the front matter:
 
 ```yaml
 ---

--- a/docs/content.md
+++ b/docs/content.md
@@ -9,7 +9,7 @@ This documentation aims to be a reference for content editors that want to make 
 3. [Content Editing Tips/Info](#content-editing-tips-info)
 	* [Headings](#headings)
 	* [Frontmatter](#frontmatter)
-    * [Breadcrumbs](#breadcrumbs)
+	* [Breadcrumbs](#breadcrumbs)
 	* [Links](#links)
 	* [SEO](#seo)
 	* [Prevent Indexing](#prevent-indexing)

--- a/docs/content.md
+++ b/docs/content.md
@@ -9,6 +9,7 @@ This documentation aims to be a reference for content editors that want to make 
 3. [Content Editing Tips/Info](#content-editing-tips-info)
 	* [Headings](#headings)
 	* [Frontmatter](#frontmatter)
+    * [Breadcrumbs](#breadcrumbs)
 	* [Links](#links)
 	* [SEO](#seo)
 	* [Prevent Indexing](#prevent-indexing)
@@ -114,6 +115,16 @@ nested:
 ```
 
 Knowing which frontmatter values are available for a page is not always obvious, but the best method is to look at a similar page and copy the frontmatter from there (or look at the page examples in this document).
+
+### Breadcrumbs
+
+Breadcrumbs are included by default on most layouts. You can chose to optionally disable breadcrumbs by setting the following in the front matter:
+
+```yaml
+---
+breadcrumbs: false
+---
+```
 
 ### Links
 

--- a/spec/components/events/event_box_component_spec.rb
+++ b/spec/components/events/event_box_component_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe Events::EventBoxComponent, type: "component" do
-  include_context "with stubbed types api"
   subject! { render_inline(described_class.new(event)) }
 
   let(:event) { build(:event_api) }

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Breadcrumbs", type: :feature do
-  include_context "with stubbed types api"
-
   subject { page }
 
   let(:event) { build(:event_api) }

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -11,7 +11,6 @@ class StoredPage
 end
 
 RSpec.feature "content pages check", :content, type: :feature do
-  include_context "with stubbed types api"
   include Values
 
   let(:other_paths) { %w[/ /feedback /blog /blog/post_invalid_tag /search /teacher-training-adviser/sign_up/identity /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference] }

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Event wizard", type: :feature do
-  include_context "with stubbed types api"
-
   let(:git_api_endpoint) { ENV["GIT_API_ENDPOINT"] }
   let(:event_readable_id) { "123" }
   let(:event_name) { "Event Name" }

--- a/spec/features/teaching_events/listing_and_searching_spec.rb
+++ b/spec/features/teaching_events/listing_and_searching_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Searching for teaching events", type: :feature do
-  include_context "with stubbed types api"
-
   let(:event_count) { 5 }
   let(:events) { build_list(:event_api, event_count) }
 

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Searching for teaching events", type: :feature do
-  include_context "with stubbed types api"
-
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to receive(:get_teaching_event).and_return(event)
   end

--- a/spec/models/events/steps/personalised_updates_spec.rb
+++ b/spec/models/events/steps/personalised_updates_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe Events::Steps::PersonalisedUpdates do
   include_context "with wizard step"
-  include_context "with stubbed types api"
 
   it_behaves_like "a with wizard step"
 

--- a/spec/requests/event_steps_controller_spec.rb
+++ b/spec/requests/event_steps_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe EventStepsController, type: :request do
-  include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed event add attendee api"
 

--- a/spec/requests/mailing_list/steps_controller_spec.rb
+++ b/spec/requests/mailing_list/steps_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe MailingList::StepsController, type: :request do
-  include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
   include_context "with stubbed mailing list add member api"
   include_context "with stubbed callback quotas api"

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "Rate limiting", type: :request do
-  include_context "with stubbed types api"
   include_context "with stubbed candidate create access token api"
 
   let(:ip) { "1.2.3.4" }

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -1,6 +1,3 @@
-shared_context "with stubbed types api" do
-end
-
 shared_context "with stubbed candidate create access token api" do
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \

--- a/spec/support/views/content/home-page.md
+++ b/spec/support/views/content/home-page.md
@@ -7,6 +7,7 @@
   hide_page_helpful_question: true
   subtitle: "Get information and support to help you become a teacher"
   image: "static/images/content/hero-images/0032.jpg"
+  breadcrumbs: false
   content:
     - content/home/test_content
 ---


### PR DESCRIPTION
### Trello card

https://trello.com/c/KzENJ1NN/6378-add-breadcrumb-to-subject-pages-and-explore-teaching-adviser-page?filter=member:spencerldixon

### Context

Pages using the subject-style layout don’t have a breadcrumb currently which is not good for accessibility

### Changes proposed in this pull request

- Render breadcrumbs by default in the header component unless `breadcrumbs: false` is set in the front matter
- Amends layouts to include a header component with front matter included
- Overrides breadcrumbs on a few pages that we don't want them on
- Removes an unused shared context from tests

### Guidance to review

