### PR TITLE
Improve regex for financial variables check

### DIFF
--- a/app/views/content/home/_salaries-banner.html.erb
+++ b/app/views/content/home/_salaries-banner.html.erb
@@ -1,6 +1,6 @@
 <div id="salary-banner" class="banner">
   <%= render CallsToAction::SimpleComponent.new(icon: "icon-money") do %>
-    <h2 class="call-to-action__heading">Earn a minimum of &pound;30k a year</h2>
+    <h2 class="call-to-action__heading">Earn a minimum of <%= v :salaries_starting_minshortened %> a year</h2>
     <p>All qualified teachers get a <strong>minimum starting salary of <%= v :salaries_starting_minshortened %></strong> (or higher in London), so it pays to do what you love.</p>
     <p>And with lots of opportunities to progress, you could <strong>earn over <%= v :salaries_fiveyears_maxshortened %> within 5 years</strong>.</p>
     <p><%= link_to("Find out more about teacher pay", page_path("life-as-a-teacher/pay-and-benefits/teacher-pay")) %>.</p>

--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -111,5 +111,5 @@ class LinkChecker
 end
 
 class MonetaryChecker
-  MONEY_REGEXP = /([$£€]\d+(,\d{3})*([.,]\d{1,2}p?)?k?)/m
+  MONEY_REGEXP = /(([$£€]|&dollar;|&pound;|&euro;|&#36;|&#163;|&#8364;)\d+(,\d{3})*([.,]\d{1,2}p?)?k?)/m
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/7WVoxjci/6486-extend-test-checking-for-financial-values-to-cover-other-formats?filter=member:spencerldixon

### Context

We recently replaced all hardcoded financial values on the site with variables controlled in a set of config files, to make future updates easier. We have a test that checks for £ used outside these config files, however, the test does not cover other formats.

### Changes proposed in this pull request

- Adds html entities and codes for $, £, and € in `MonetaryChecker::MONEY_REGEX`

### Guidance to review

