### PR TITLE
Update application dates for 2025 cycle

### DIFF
--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -21,11 +21,11 @@ expander:
     text: You should check the deadline for non-UK applications with training providers. They may close earlier than for other applicants. 
 ---
 
-You can apply for postgraduate teacher training courses starting in $recruitmentcycle_coursestart$ $recruitmentcycle_alltimesanddates$. 
+You can apply for postgraduate teacher training courses starting in $recruitmentcycle_coursestart$ $recruitmentcycle_openanddeadline$. 
 
 ## Find and apply for teacher training courses
 
-From $recruitmentcycle_openingdateonly$, you can <a href="https://www.gov.uk/apply-for-teacher-training">apply for a teacher training course</a>.
+From $recruitmentcycle_openingdate$, you can <a href="https://www.gov.uk/apply-for-teacher-training">apply for a teacher training course</a>.
  
 You can apply to up to 4 courses at a time.  
 
@@ -53,15 +53,15 @@ $q-jacub-pask$
 
 ## Deadlines for applications and training provider decisions 
 
-### $recruitmentcycle_deadlinedateonly$
+### $recruitmentcycle_deadlinedate$
 
-This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in $recruitmentcycle_coursestart$. You must submit your application before $recruitmentcycle_deadlinetimeonly$.
+This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in $recruitmentcycle_coursestart$. You must submit your application before $recruitmentcycle_deadlinetime$.
 
-### $recruitmentcycle_providerresponsedeadline$
+### $recruitmentcycle_providerdeadline$
 
 This is the last day for training providers to make a decision on all applications for courses starting in $recruitmentcycle_coursestart$. 
 
-If a decision has not been made by the end of September, your applications will automatically be rejected so that you can start applying for next year’s courses in October. 
+If a decision has not been made by $recruitmentcycle_providerdeadline$, your applications will automatically be rejected so that you can start applying for next year’s courses in $recruitmentcycle_openingmonth$. 
 
 ## Interview timeline 
 

--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -21,11 +21,11 @@ expander:
     text: You should check the deadline for non-UK applications with training providers. They may close earlier than for other applicants. 
 ---
 
-You can apply for postgraduate teacher training courses starting in September 2024 from 10 October 2023 to 17 September 2024. 
+You can apply for postgraduate teacher training courses starting in $recruitmentcycle_coursestart$ $recruitmentcycle_alltimesanddates$. 
 
 ## Find and apply for teacher training courses
 
-From 10 October 2023, you can <a href="https://www.gov.uk/apply-for-teacher-training">apply for a teacher training course</a>.
+From $recruitmentcycle_openingdateonly$, you can <a href="https://www.gov.uk/apply-for-teacher-training">apply for a teacher training course</a>.
  
 You can apply to up to 4 courses at a time.  
 
@@ -53,13 +53,13 @@ $q-jacub-pask$
 
 ## Deadlines for applications and training provider decisions 
 
-### 17 September 2024 
+### $recruitmentcycle_openingdateonly$ 
 
-This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in September 2024.
+This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in $recruitmentcycle_coursestart$.
 
-### 25 September 2024 
+### $recruitmentcycle_deadlinedateonly$ 
 
-This is the last day for training providers to make a decision on all applications for courses starting in September 2024. 
+This is the last day for training providers to make a decision on all applications for courses starting in $recruitmentcycle_coursestart$. 
 
 If a decision has not been made by the end of September, your applications will automatically be rejected so that you can start applying for next year’s courses in October. 
 

--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -53,11 +53,11 @@ $q-jacub-pask$
 
 ## Deadlines for applications and training provider decisions 
 
-### $recruitmentcycle_openingdateonly$ 
+### $recruitmentcycle_deadlinedateonly$
 
-This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in $recruitmentcycle_coursestart$.
+This is the last day you’ll be able to apply for a postgraduate teacher training courses starting in $recruitmentcycle_coursestart$. You must submit your application before $recruitmentcycle_deadlinetimeonly$.
 
-### $recruitmentcycle_deadlinedateonly$ 
+### $recruitmentcycle_providerresponsedeadline$
 
 This is the last day for training providers to make a decision on all applications for courses starting in $recruitmentcycle_coursestart$. 
 

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,0 +1,2 @@
+recruitmentcycle:
+  dates: from 9am on 10 October 2024 to 6pm on 16 September 2025

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -4,5 +4,5 @@ recruitmentcycle:
   openingdateonly: 10 October 2024
   deadlinedateonly: 16 September 2025
   deadlinetimeonly: 6pm
-  providerresponsedeadline: 16 September 2025
+  providerresponsedeadline: 24 September 2025
   

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,2 +1,7 @@
 recruitmentcycle:
-  dates: from 9am on 10 October 2024 to 6pm on 16 September 2025
+  coursestart: September 2025
+  alltimesanddates: from 9am on 10 October 2024 to 6pm on 16 September 2025
+  openingdateonly: 10 October 2024
+  deadlinedateonly: 16 September 2025
+  deadlinetimeonly: 6pm
+  

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -4,4 +4,5 @@ recruitmentcycle:
   openingdateonly: 10 October 2024
   deadlinedateonly: 16 September 2025
   deadlinetimeonly: 6pm
+  providerresponsedeadline: 16 September 2025
   

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,8 +1,8 @@
 recruitmentcycle:
   coursestart: September 2025
-  alltimesanddates: from 9am on 10 October 2024 to 6pm on 16 September 2025
-  openingdateonly: 10 October 2024
-  deadlinedateonly: 16 September 2025
-  deadlinetimeonly: 6pm
-  providerresponsedeadline: 24 September 2025
+  openanddeadline: from 9am on 8 October 2024 to 6pm on 16 September 2025
+  openingdate: 8 October 2024
+  deadlinedate: 16 September 2025
+  deadlinetime: 6pm
+  providerdeadline: 24 September 2025
   

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -2,6 +2,7 @@ recruitmentcycle:
   coursestart: September 2025
   openanddeadline: from 9am on 8 October 2024 to 6pm on 16 September 2025
   openingdate: 8 October 2024
+  openingmonth: October
   deadlinedate: 16 September 2025
   deadlinetime: 6pm
   providerdeadline: 24 September 2025


### PR DESCRIPTION
### Trello card
https://trello.com/c/CLAqDuqk/6579-update-when-to-apply-page-for-the-new-cycle-and-add-variables-for-cycle-dates 

### Context
The 2024 recruitment cycle closes on 17th September. 

### Changes proposed in this pull request
Update the application dates on GIT to reflect the next recruitment cycle. 

We will also add these new dates as values in a config file, for ease in the future when they need updating. 

### Guidance to review

