### PR TITLE
Salary changes to paid langing pages

### DIFF
--- a/app/components/content/checklist_collage_component.rb
+++ b/app/components/content/checklist_collage_component.rb
@@ -2,10 +2,12 @@ module Content
   class ChecklistCollageComponent < ViewComponent::Base
     attr_reader :checklist, :image_paths, :cta
 
+    include ContentHelper
+
     def initialize(checklist:, image_paths:, cta: nil)
       super
 
-      @checklist = checklist
+      @checklist = checklist.map { |item| substitute_values(item) }
       @image_paths = image_paths
       @cta = cta
     end

--- a/app/views/content/landing/grow/_collage.html.erb
+++ b/app/views/content/landing/grow/_collage.html.erb
@@ -7,7 +7,8 @@
           checklist: [
             "career progression ",
             "personal development",
-            "opportunities to increase your pay"
+            "opportunities to increase your pay",
+            "a minimum starting salary of <%= v :salaries_starting_min %> (or higher in London)",
           ],
           image_paths: [
             "static/images/content/grow/Smiling_Student.jpg",

--- a/app/views/content/landing/grow/_collage.html.erb
+++ b/app/views/content/landing/grow/_collage.html.erb
@@ -8,7 +8,7 @@
             "career progression ",
             "personal development",
             "opportunities to increase your pay",
-            "a minimum starting salary of <%= v :salaries_starting_min %> (or higher in London)",
+            "a minimum starting salary of $salaries_starting_min$ (or higher in London)",
           ],
           image_paths: [
             "static/images/content/grow/Smiling_Student.jpg",

--- a/app/views/content/landing/grow/_collage.html.erb
+++ b/app/views/content/landing/grow/_collage.html.erb
@@ -5,10 +5,10 @@
         <p class="col-720">Teaching is a fulfilling career. Not only can you inspire the pupils you teach, you also get to learn new skills, build your confidence and become your best self. The benefits of being a teacher include:</p>
         <%= render Content::ChecklistCollageComponent.new(
           checklist: [
+            "a starting salary of $salaries_starting_min$ (or higher in London)",
             "career progression ",
             "personal development",
             "opportunities to increase your pay",
-            "a starting salary of $salaries_starting_min$ (or higher in London)",
           ],
           image_paths: [
             "static/images/content/grow/Smiling_Student.jpg",

--- a/app/views/content/landing/grow/_collage.html.erb
+++ b/app/views/content/landing/grow/_collage.html.erb
@@ -8,7 +8,7 @@
             "career progression ",
             "personal development",
             "opportunities to increase your pay",
-            "a minimum starting salary of $salaries_starting_min$ (or higher in London)",
+            "a starting salary of $salaries_starting_min$ (or higher in London)",
           ],
           image_paths: [
             "static/images/content/grow/Smiling_Student.jpg",

--- a/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
@@ -2,7 +2,7 @@
   <div class="col col-full-content">
     <%= render Content::PurpleBoxComponent.new(
       heading: "Find out more about getting into teaching",
-      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love. 
+      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love.
       cta: {
         text: "Get tailored guidance in your inbox",
         path: "/mailinglist/signup/name",

--- a/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
@@ -2,7 +2,7 @@
   <div class="col col-full-content">
     <%= render Content::PurpleBoxComponent.new(
       heading: "Find out more about getting into teaching",
-      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love.
+      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love.",
       cta: {
         text: "Get tailored guidance in your inbox",
         path: "/mailinglist/signup/name",

--- a/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
@@ -2,7 +2,7 @@
   <div class="col col-full-content">
     <%= render Content::PurpleBoxComponent.new(
       heading: "Find out more about getting into teaching",
-      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application.",
+      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of <%= v :salaries_starting_min %> (or higher in London), it pays to do what you love. 
       cta: {
         text: "Get tailored guidance in your inbox",
         path: "/mailinglist/signup/name",

--- a/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_promo.html.erb
@@ -2,7 +2,7 @@
   <div class="col col-full-content">
     <%= render Content::PurpleBoxComponent.new(
       heading: "Find out more about getting into teaching",
-      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of <%= v :salaries_starting_min %> (or higher in London), it pays to do what you love. 
+      text: "Explore how you can get into teaching primary or secondary and find top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love. 
       cta: {
         text: "Get tailored guidance in your inbox",
         path: "/mailinglist/signup/name",

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
@@ -3,7 +3,7 @@
   <% promo.with_right_section(
     heading: "Find out more about getting into teaching"
   ) do %>
-      <p>Find out more about funding your training, as well as top tips on making a successful application. With a competitive starting salary of <%= v :salaries_starting_min %> (or higher in London), it pays to do what you love. </p>
+      <p>Find out more about funding your training, as well as top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love. </p>
 
       <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
   <% end %>

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
@@ -3,7 +3,7 @@
   <% promo.with_right_section(
     heading: "Find out more about getting into teaching"
   ) do %>
-      <p>Find out more about funding your training, as well as top tips on making a successful application.</p>
+      <p>Find out more about funding your training, as well as top tips on making a successful application. With a competitive starting salary of <%= v :salaries_starting_min %> (or higher in London), it pays to do what you love. </p>
 
       <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
   <% end %>

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree/_promo.html.erb
@@ -3,7 +3,7 @@
   <% promo.with_right_section(
     heading: "Find out more about getting into teaching"
   ) do %>
-      <p>Find out more about funding your training, as well as top tips on making a successful application. With a competitive starting salary of $salaries_starting_min$ (or higher in London), it pays to do what you love. </p>
+      <p>Find out more about funding your training, as well as top tips on making a successful application. With a competitive starting salary of <%= v :salaries_starting_min %> (or higher in London), it pays to do what you love. </p>
 
       <%= link_to("Get tailored guidance in your inbox", "/mailinglist/signup/name", class: "button") %>
   <% end %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/1hEfOnoc/6542-update-paid-advertising-landing-pages-to-mention-starting-salary

### Context

The advertising team can’t promote the new £31k starting salary until after the consultation period - and their advertising schedules mean that they can’t start running ads with the new salary amount until the new year

We've added the new £31k to three pages, agreed with the advertising team.

### Changes proposed in this pull request

### Guidance to review

