### PR TITLE
Show icon funding widget mobile

### DIFF
--- a/app/components/calls_to_action/simple_component.html.erb
+++ b/app/components/calls_to_action/simple_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: %w[call-to-action call-to-action--simple] << responsive_classes) do %>
+<%= tag.div(class: %w[call-to-action] << responsive_classes) do %>
   <%= icon %>
 
   <div class="call-to-action__content">

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -9,7 +9,6 @@
   }
 
   @include mq($until: tablet) {
-    
   &--simple {
       picture {
         display: none;

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -9,7 +9,6 @@
   }
 
   @include mq($until: tablet) {
-    // flex-direction: column;
     
   &--simple {
       picture {

--- a/app/webpacker/styles/call-to-action.scss
+++ b/app/webpacker/styles/call-to-action.scss
@@ -9,7 +9,7 @@
   }
 
   @include mq($until: tablet) {
-    flex-direction: column;
+    // flex-direction: column;
     
   &--simple {
       picture {


### PR DESCRIPTION
### Trello card

https://trello.com/c/yc3LHedm/6628-show-icon-on-funding-widget-on-mobile

### Context

Currently the money icon contained within the funding widget on the bursaries and scholarship page disappears when the screen shrinks to mobile size - the icon needs to stay on screen and not disappear, so that the component still stands out to users.

### Changes proposed in this pull request

SimpleComponent (rendered within the funding widget) styling adapted to have desired effect.

### Guidance to review

- Please check the [scholarships and bursaries](https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries) page to make sure the funding widget/icon behaves as expected on different screen sizes.

![Screenshot 2024-09-27 at 15 36 23](https://github.com/user-attachments/assets/ddd756be-06c6-479b-a970-9f35a532922d)
![Screenshot 2024-09-27 at 15 33 37](https://github.com/user-attachments/assets/184f3e1e-b899-48ee-8285-c6aa5d90b66b)

- The SimpleComponent in question is also utilised on the [homepage](https://getintoteaching.education.gov.uk/) (salaries banner) but the changes don't appear to have affected the banner due to some overriding CSS; an extra pair of eyes to check this would be appreciated (the money icon should still disappear on smaller screen sizes here). 

![Screenshot 2024-09-27 at 15 31 13](https://github.com/user-attachments/assets/4f2a1558-f708-4509-a61a-187c338244af)
![Screenshot 2024-09-27 at 15 35 21](https://github.com/user-attachments/assets/5f012c88-5bbc-405b-a3fe-f7d1783cdf34)

