### PR TITLE
Remove National Tutoring Programme from RTTA funnel completion page

### DIFF
--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -20,12 +20,13 @@
 
   <h2 class="govuk-heading-m">Get support returning to teaching</h2>
 
-  <p>Read our helpful guidance about <%= link_to "returning to teaching", "/returning-to-teaching" %>, including:</p>
+  <p>Read our helpful guidance about <%= link_to "returning to teaching", "https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/" %>, including:</p>
 
   <ul>
-    <li>joining the National Tutoring Programme</li>
     <li>catching up on changes in teaching</li>
     <li>using the early career framework resources</li>
+    <li>finding a teaching role at the right school</li>
+    <li>applying for a teaching job</li>
   </ul>
 
   <p>You can also <%= link_to("find teaching jobs in England", "https://teaching-vacancies.service.gov.uk/") %>.</p>


### PR DESCRIPTION
### Trello card
https://trello.com/c/NbJbgVnk

### Context
The National Tutoring Programme has now ended so we need to remove the reference to it on the adviser completion page. The link to returners content also needs updating.

### Guidance to review
To test this, need to go through the RTTA branch of the adviser funnel (qualified to teach)
* Check that link works
* Check that new bullets make sense


