### PR TITLE
Privacy notice link opening in new tab changes

### DIFF
--- a/app/components/content/adviser_component.html.erb
+++ b/app/components/content/adviser_component.html.erb
@@ -19,7 +19,7 @@
         <%= f.hidden_field :sub_channel_id, value: f.object&.sub_channel_id.presence || params[:sub_channel] %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
-        <p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
+        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 

--- a/app/components/content/adviser_component.html.erb
+++ b/app/components/content/adviser_component.html.erb
@@ -19,7 +19,7 @@
         <%= f.hidden_field :sub_channel_id, value: f.object&.sub_channel_id.presence || params[:sub_channel] %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
-        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
+        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 

--- a/app/components/content/mailing_list_component.html.erb
+++ b/app/components/content/mailing_list_component.html.erb
@@ -19,7 +19,7 @@
         <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id.presence %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
-        <p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
+        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 

--- a/app/components/content/mailing_list_component.html.erb
+++ b/app/components/content/mailing_list_component.html.erb
@@ -19,7 +19,7 @@
         <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id.presence %>
         <%= f.hidden_field :accepted_policy_id, value: privacy_policy.id %>
 
-        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
+        <p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>.</p>
 
         <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>
 

--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -14,7 +14,7 @@
 
         <p>
           <small>
-            Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>. This explains how we use your personal data. It's important you read it before signing up to receive emails.
+            Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>. This explains how we use your personal data. It's important you read it before signing up to receive emails.
           </small>
         </p>
       </div>

--- a/app/components/home/mailing_list_component.html.erb
+++ b/app/components/home/mailing_list_component.html.erb
@@ -14,7 +14,7 @@
 
         <p>
           <small>
-            Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>. This explains how we use your personal data. It's important you read it before signing up to receive emails.
+            Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: privacy_policy.id), { class: "link--black", target: :blank }) %>. This explains how we use your personal data. It's important you read it before signing up to receive emails.
           </small>
         </p>
       </div>

--- a/app/views/callbacks/steps/_personal_details.html.erb
+++ b/app/views/callbacks/steps/_personal_details.html.erb
@@ -11,6 +11,6 @@
 <%= f.govuk_email_field :email, autocomplete: "email", width: 'two-thirds' %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before booking a callback.</p>

--- a/app/views/callbacks/steps/_personal_details.html.erb
+++ b/app/views/callbacks/steps/_personal_details.html.erb
@@ -11,6 +11,6 @@
 <%= f.govuk_email_field :email, autocomplete: "email", width: 'two-thirds' %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before booking a callback.</p>

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -7,6 +7,6 @@
 <%= f.hidden_field :channel_id, value: params[:channel] || f.object&.channel_id %>
 <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up for an event.</p>

--- a/app/views/event_steps/_personal_details.html.erb
+++ b/app/views/event_steps/_personal_details.html.erb
@@ -7,6 +7,6 @@
 <%= f.hidden_field :channel_id, value: params[:channel] || f.object&.channel_id %>
 <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object&.sub_channel_id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up for an event.</p>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -22,6 +22,6 @@ Find out how to get:
 <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object.sub_channel_id %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>

--- a/app/views/mailing_list/steps/_name.html.erb
+++ b/app/views/mailing_list/steps/_name.html.erb
@@ -22,6 +22,6 @@ Find out how to get:
 <%= f.hidden_field :sub_channel_id, value: params[:sub_channel] || f.object.sub_channel_id %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to("privacy notice", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
+<p>Your details are protected under the terms of our <%= link_to("privacy notice (opens in a new tab)", privacy_policy_path(id: f.object.latest_privacy_policy.id), { target: :blank }) %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to receive emails.</p>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -34,6 +34,6 @@
 <%= f.hidden_field :sub_channel_id, value: f.object.sub_channel_id.presence || params[:sub_channel] %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to "privacy notice (opens in a new tab)", privacy_policy_path(id: session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id), target: :blank %>.</p>
+<p>Your details are protected under the terms of our <%= link_to "privacy notice (opens in new tab)", privacy_policy_path(id: session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id), target: :blank %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to get support from an adviser.</p>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -34,6 +34,6 @@
 <%= f.hidden_field :sub_channel_id, value: f.object.sub_channel_id.presence || params[:sub_channel] %>
 <%= f.hidden_field :accepted_policy_id, value: f.object.latest_privacy_policy.id %>
 
-<p>Your details are protected under the terms of our <%= link_to "privacy notice", privacy_policy_path(id: session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id), target: :blank %>.</p>
+<p>Your details are protected under the terms of our <%= link_to "privacy notice (opens in a new tab)", privacy_policy_path(id: session[:privacy_policy_id].presence || GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy.id), target: :blank %>.</p>
 
 <p>Our privacy notice explains how we use your personal data. It's important you read this before signing up to get support from an adviser.</p>

--- a/spec/components/content/adviser_component_spec.rb
+++ b/spec/components/content/adviser_component_spec.rb
@@ -15,7 +15,7 @@ describe Content::AdviserComponent, type: :component do
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--#{color}") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
   it { is_expected.not_to have_css(".action-container--no-margin") }
 
   context "when color is trasparent" do

--- a/spec/components/content/adviser_component_spec.rb
+++ b/spec/components/content/adviser_component_spec.rb
@@ -15,7 +15,7 @@ describe Content::AdviserComponent, type: :component do
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--#{color}") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in new tab)", href: "/privacy-policy?id=123") }
   it { is_expected.not_to have_css(".action-container--no-margin") }
 
   context "when color is trasparent" do

--- a/spec/components/content/mailing_list_component_spec.rb
+++ b/spec/components/content/mailing_list_component_spec.rb
@@ -15,7 +15,7 @@ describe Content::MailingListComponent, type: :component do
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--#{color}") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
   it { is_expected.not_to have_css(".action-container--no-margin") }
 
   context "when color is trasparent" do

--- a/spec/components/content/mailing_list_component_spec.rb
+++ b/spec/components/content/mailing_list_component_spec.rb
@@ -15,7 +15,7 @@ describe Content::MailingListComponent, type: :component do
   it { is_expected.to have_css("p", text: "intro") }
   it { is_expected.to have_css(".action-container--#{color}") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in new tab)", href: "/privacy-policy?id=123") }
   it { is_expected.not_to have_css(".action-container--no-margin") }
 
   context "when color is trasparent" do

--- a/spec/components/home/mailing_list_component_spec.rb
+++ b/spec/components/home/mailing_list_component_spec.rb
@@ -11,5 +11,5 @@ describe Home::MailingListComponent, type: :component do
   it { is_expected.to have_css(".home-mailing-list") }
   it { is_expected.to have_css("h2") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in new tab)", href: "/privacy-policy?id=123") }
 end

--- a/spec/components/home/mailing_list_component_spec.rb
+++ b/spec/components/home/mailing_list_component_spec.rb
@@ -11,5 +11,5 @@ describe Home::MailingListComponent, type: :component do
   it { is_expected.to have_css(".home-mailing-list") }
   it { is_expected.to have_css("h2") }
   it { is_expected.to have_css("form") }
-  it { is_expected.to have_link("privacy notice", href: "/privacy-policy?id=123") }
+  it { is_expected.to have_link("privacy notice (opens in a new tab)", href: "/privacy-policy?id=123") }
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/z1slwQj4
### Context
On the ‘Get Into Teaching’ page, there is a link that opens in a new tab, but which neither visually nor programmatically forewarns users that this will be the case.

### Changes proposed in this pull request
Added `(opens in a new tab)` to all privacy notice links - this is the only internal link that opens in a new tab across the site



