### PR TITLE
update docker setup-buildx-action version

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -56,6 +56,8 @@ jobs:
           target: base
           build-args: |
             SHA=${{ steps.sha.outputs.short }}
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Build release image locally
         uses: docker/build-push-action@v6
@@ -66,6 +68,8 @@ jobs:
           load: true
           build-args: |
             SHA=${{ steps.sha.outputs.short }}
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
-        with:
-          version: v0.9.1  # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: sha
@@ -79,6 +77,8 @@ jobs:
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - uses: Azure/login@v2
         if: failure() && github.ref == 'refs/heads/master'
@@ -121,8 +121,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
-        with:
-          version: v0.9.1 # More recent buildx versions generate an OCI manifest which is incompatible with Cloud Foundry
 
       - name: Get Short SHA
         id: sha
@@ -169,6 +167,8 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             SHA=${{ steps.sha.outputs.short }}
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Push release-build image
         uses: docker/build-push-action@v6
@@ -187,6 +187,8 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             SHA=${{ steps.sha.outputs.short }}
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - uses: Azure/login@v2
         if: failure() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
### Trello card

https://trello.com/c/54CpSWSs/2078-git-snyk-alerts

### Context

While fixing snyk base image vulnerabilities, noticed docker/setup-buildx-action was pinned to version 0.9.1
Removed this, and also added DOCKER_BUILD_RECORD_UPLOAD:false to build-push-action.

### Changes proposed in this pull request

Updates to build and build-no-cache workflows

### Guidance to review

Check build runs and review app deploys ok
