### PR TITLE
Target size list styles

### DIFF
--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -16,10 +16,30 @@ dt,
 }
 
 li {
-  margin-bottom: .5em;
+  margin-bottom: 0.5em; 
 
   &:last-child {
-    margin-bottom: 0;
+    margin-bottom: 0; // Remove margin from the last <li> in a list
+  }
+
+  // Apply margin if this <li> has a link and is followed by another <li> with a link
+  &:has(a) {
+    // Ensure this <li> applies margin to the next <li> that has a link
+    &:not(:last-child) {
+      & + li:has(a) {
+        margin-top: 1.5em; // Adds 1.5em margin above the next <li> with a link
+      }
+    }
+  }
+}
+
+p {
+  &:has(a) {
+    &:not(:last-child) {
+      & +p:has(a) {
+        margin-top: 1.5em;
+      }
+    }
   }
 }
 

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -19,21 +19,33 @@ li {
   margin-bottom: 0.5em; 
 
   &:last-child {
-    margin-bottom: 0; // Remove margin from the last <li> in a list
+    margin-bottom: 0;
   }
 
-  // Apply margin if this <li> has a link and is followed by another <li> with a link
+  a {
+    display: inline-block;
+    min-width: 24px;
+    min-height: 24px;
+  }
+
   &:has(a) {
-    // Ensure this <li> applies margin to the next <li> that has a link
     &:not(:last-child) {
       & + li:has(a) {
-        margin-top: 1.5em; // Adds 1.5em margin above the next <li> with a link
+        margin-top: 1.5em;
       }
     }
   }
 }
 
 p {
+
+  a {
+    display: inline-block;
+    min-width: 24px;
+    min-height: 24px;
+  }
+
+
   &:has(a) {
     &:not(:last-child) {
       & +p:has(a) {

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -38,7 +38,6 @@ li {
 }
 
 p {
-
   a {
     display: inline-block;
     min-width: 24px;

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -22,37 +22,37 @@ li {
     margin-bottom: 0;
   }
 
-  a {
-    display: inline-block;
-    min-width: 24px;
-    min-height: 24px;
+  a { // Selects the anchor tag within the li element 
+    display: inline-block; // Makes the anchor tag a block element
+    min-width: 24px; // Sets the minimum width of the anchor tag
+    min-height: 24px; // Sets the minimum height of the anchor tag
   }
 
-  &:has(a) {
-    &:not(:last-child) {
-      & + li:has(a) {
-        margin-top: 1.5em;
-      }
-    }
-  }
+  // &:has(a) { // Selects the li element that contains an anchor tag
+  //   &:not(:last-child) { // Selects the li element that contains an anchor tag and is not the last child
+  //     & + li:has(a) { 
+  //       margin-top: 1.5em; // Adds margin to the top of the next li element that contains an anchor tag
+  //     }
+  //   }
+  // }
 }
 
-p {
-  a {
-    display: inline-block;
-    min-width: 24px;
-    min-height: 24px;
-  }
+// p {
+//   a {
+//     display: inline-block;
+//     min-width: 24px;
+//     min-height: 24px;
+//   }
 
 
-  &:has(a) {
-    &:not(:last-child) {
-      & +p:has(a) {
-        margin-top: 1.5em;
-      }
-    }
-  }
-}
+//   &:has(a) {
+//     &:not(:last-child) {
+//       & +p:has(a) {
+//         margin-top: 1.5em;
+//       }
+//     }
+//   }
+// }
 
 .strong {
   font-weight: bold;

--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -22,37 +22,12 @@ li {
     margin-bottom: 0;
   }
 
-  a { // Selects the anchor tag within the li element 
-    display: inline-block; // Makes the anchor tag a block element
-    min-width: 24px; // Sets the minimum width of the anchor tag
-    min-height: 24px; // Sets the minimum height of the anchor tag
+  a {
+    display: inline-block; 
+    min-width: 24px; 
+    min-height: 24px; 
   }
-
-  // &:has(a) { // Selects the li element that contains an anchor tag
-  //   &:not(:last-child) { // Selects the li element that contains an anchor tag and is not the last child
-  //     & + li:has(a) { 
-  //       margin-top: 1.5em; // Adds margin to the top of the next li element that contains an anchor tag
-  //     }
-  //   }
-  // }
 }
-
-// p {
-//   a {
-//     display: inline-block;
-//     min-width: 24px;
-//     min-height: 24px;
-//   }
-
-
-//   &:has(a) {
-//     &:not(:last-child) {
-//       & +p:has(a) {
-//         margin-top: 1.5em;
-//       }
-//     }
-//   }
-// }
 
 .strong {
   font-weight: bold;


### PR DESCRIPTION
### Trello card

https://trello.com/c/Y4B3WJrk/6602-update-list-styles-wcag-22-258-target-size-minimum

### Context

We need to be WCAG 2.2 AA compliant by October 2024. We have checked our tap target sizes meet the new WCAG 2.2 standard and need to make changes to the list style to have more space.

### Changes proposed in this pull request

Following further review of WCAG guidance, changes are not necessarily needed. However, styling has been applied to anchor tags within `<li>` elements to ensure min width/height of 24px. 

### Guidance to review

It would be great to have a tech and design review to see whether the code is appropriate/it is the best approach, and has the desired effect where needed.

- Styling changes made within `text.scss`
- Example page for links within `<li>` tags: http://localhost:3000 (homepage feature at the bottom with images / links underneath and 'Related Content section on most pages). 

