### PR TITLE
Fix overlap on title of inspiration component

### DIFF
--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -152,6 +152,7 @@
       h2,
       h3 {
         @extend .heading-m, .heading--margin-0;
+        line-height: 2rem;
       }
     }
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/L6SCrYsP/6676-fix-heading-styling-on-inspiration-navigation-cards?filter=member:spencerldixon

### Context

We need to fix the heading styling so it doesn’t overlap when wrapping

### Changes proposed in this pull request

- Adds a little extra line height to prevent title from overlapping.

### Guidance to review

