### PR TITLE
Fix heading overlap

### DIFF
--- a/app/components/content/inspiration_card_component.html.erb
+++ b/app/components/content/inspiration_card_component.html.erb
@@ -9,7 +9,9 @@
         <div class="category__nav-card__wrapper__col1">
           <div class="category__nav-card--content">
             <%= content_tag heading_tag do %>
-              <%= content_tag :span, title %>
+              <%= content_tag :span do %>
+                <%= content_tag :span, title %>
+              <% end %>
             <% end %>
             <%= tag.p(helpers.safe_html_format(description)) %>
           </div>
@@ -22,7 +24,9 @@
     <%= link_to(path, class: "link--pink") do %>
       <div class="category__nav-card--content">
         <%= content_tag heading_tag do %>
-          <%= content_tag :span, title %>
+          <%= content_tag :span do %>
+            <%= content_tag :span, title %>
+          <% end %>
         <% end %>
         <%= tag.p(helpers.safe_html_format(description)) %>
       </div>

--- a/app/webpacker/styles/category.scss
+++ b/app/webpacker/styles/category.scss
@@ -152,7 +152,6 @@
       h2,
       h3 {
         @extend .heading-m, .heading--margin-0;
-        line-height: 2rem;
       }
     }
   }

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -37,6 +37,13 @@
     padding: .5rem;
     background: $backgroundColor;
     box-shadow: 0 0 0 $backgroundColor, -0 0 0 $backgroundColor;
+
+    span {
+      position: relative;
+      background: none;
+      padding: 0;
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/wo4ao4Nj/6765-fix-overlapping-headings-on-inspiration-navigation-cards?filter=member:spencerldixon

### Context

Headings on inspiration navigation cards that wrap onto two lines are overlapping.
We need to fix the styling so that the words aren’t overlapping.

### Changes proposed in this pull request

I find the `highlight-text` mixin isn't working properly and causes multilines of text to overlap.

- Amend the `highlight-text` mixin to apply styles to a second `span` tag that is set to `relative` to create a new stacking context where the text sits on top of the previous span, used as the background.
- Allows existing titles to remain unchanged, but to drop in the new `span` wherever we encounter overlap

### Guidance to review

