### PR TITLE
Non-uk-link-WCAG-changes

### DIFF
--- a/app/views/content/non-uk-teachers/non-uk-qualifications.md
+++ b/app/views/content/non-uk-teachers/non-uk-qualifications.md
@@ -67,7 +67,7 @@ Before you apply for teacher training in England, you must check that you have [
 
 ## How to check your qualifications
 
-The simplest way to check your qualifications meet the required standard in England is to get a [statement of comparability](https://enic.org.uk/Qualifications/SOC/Default.aspx) from the UK European Network of Information Centres (UK ENIC).
+The simplest way to check your qualifications meet the required standard in England is to get a [statement of comparability from the UK European Network of Information Centres (UK ENIC)](https://enic.org.uk/Qualifications/SOC/Default.aspx).
 
 This is a certificate that proves your school and university qualifications are the same standard as UK GCSEs and a UK bachelor's degree.
 
@@ -110,9 +110,9 @@ If you have not passed an English language test like this, or do not have qualif
 
 ## If you do not have a bachelor's degree
 
-If you do not have a degree, you can apply to study a 3 to 4 year [undergraduate course in England](https://www.ucas.com/postgraduate/teacher-training/applying-teacher-training/find-teacher-training-programmes) which combines a teaching degree with [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). When you complete your studies, you’ll be able to apply for jobs as a teacher in England.
+If you do not have a degree, you can apply for an [undergraduate course in England on the UCAS website](https://www.ucas.com/postgraduate/teacher-training/applying-teacher-training/find-teacher-training-programmes). These ungergraduate courses are 3 to 4 years and combine a teaching degree with [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). When you complete your studies, you’ll be able to apply for jobs as a teacher in England.
 
-The [UK Council for International Student Affairs](https://www.ukcisa.org.uk/) has lots of helpful information about studying at an English university.
+The [UK Council for International Student Affairs website](https://www.ukcisa.org.uk/) has lots of helpful information about studying at an English university.
 
 ## How to apply
 

--- a/app/views/content/non-uk-teachers/non-uk-qualifications.md
+++ b/app/views/content/non-uk-teachers/non-uk-qualifications.md
@@ -110,7 +110,7 @@ If you have not passed an English language test like this, or do not have qualif
 
 ## If you do not have a bachelor's degree
 
-If you do not have a degree, you can apply for an [undergraduate course in England on the UCAS website](https://www.ucas.com/postgraduate/teacher-training/applying-teacher-training/find-teacher-training-programmes). These ungergraduate courses are 3 to 4 years and combine a teaching degree with [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). When you complete your studies, you’ll be able to apply for jobs as a teacher in England.
+If you do not have a degree, you can apply for an [undergraduate course in England on the UCAS website](https://www.ucas.com/postgraduate/teacher-training/applying-teacher-training/find-teacher-training-programmes). These undergraduate courses are 3 to 4 years and combine a teaching degree with [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts). When you complete your studies, you’ll be able to apply for jobs as a teacher in England.
 
 The [UK Council for International Student Affairs website](https://www.ukcisa.org.uk/) has lots of helpful information about studying at an English university.
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -51,7 +51,7 @@ If you do not want to come to England to train, you should consider [internation
 
 If you are already a qualified teacher, you do not need to retrain to teach in England. However, you will need:
 
-* to apply for English 'qualified teacher status', or be able to demonstrate strong non-UK qualifications and experience 
+* to apply for English qualified teacher status, or be able to demonstrate strong non-UK qualifications and experience 
 * a high standard of written and spoken English
 * to pass criminal and professional safeguarding checks (these will be organised by your employer)
 * [a visa or immigration status allowing you to work in the UK](/non-uk-teachers/visas-for-non-uk-teachers)

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -37,11 +37,11 @@ Teach in England and you’ll benefit from working in a world-class education sy
 
 You’ll earn a [competitive salary](/life-as-a-teacher/pay-and-benefits/teacher-pay), get supported in your professional development and have varied job opportunities.
 
-You could also consider teaching in other areas of the UK, including:
+To find out about teaching in other areas of the UK, visit the:
 
-* [Wales at the Educator Wales website](https://www.ewc.wales/site/index.php/en/registration/index.php?option=com_content&view=article&id=12&Itemid=170&lang=en)
-* [Scotland at the Teach in Scotland website](https://teachinscotland.scot/)
-* [Northern Ireland at the Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
+* [Educator Wales website](https://www.ewc.wales/site/index.php/en/registration/index.php?option=com_content&view=article&id=12&Itemid=170&lang=en)
+* [Teach in Scotland website](https://teachinscotland.scot/)
+* [Northern Ireland Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
 
 Not qualified as a teacher yet? Find out [how to train to teach in England as a non-UK citizen](/non-uk-teachers/train-to-teach-in-england-as-an-international-student). 
 
@@ -199,6 +199,6 @@ The following suggestions and resources may be useful:
 
 The Department for Education (DfE) does not employ teachers directly. Do not send us your CV, as we will not be able to help you find a teaching job. 
 
-Please do not email to ask when a country or subject will be added to [Apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). We'll publish updates about eligiblity for the service at [A fairer approach to awarding QTS to overseas teachers](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).
+Do not email to ask when a country or subject will be added. We'll publish [updates about eligibility for the service on the GOV.UK website](https://apply-for-qts-in-england.education.gov.uk/eligibility/start).
 
 If you have general questions about the information on this page, you can email us at teach.inengland@education.gov.uk.

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -66,14 +66,14 @@ Qualified teacher status (QTS) is the professional status teachers in England ga
 
 However, if you’re a qualified teacher from outside the UK, you can [work as a teacher in England for up to 4 years without QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk).
 
-After that, you will need QTS to teach in many schools in England, although it is not a legal requirement in some types of school (for example, [academy schools, free schools and private schools](https://www.gov.uk/types-of-school)). 
+After that, you will need QTS to teach in many schools in England, although it is not a legal requirement in some types of school, such as academy schools, free schools and private schools. Find out more about [the different types of schools in England](https://www.gov.uk/types-of-school). 
  
 
 ### Applying for QTS
 
 Depending on where you qualified, the subject you teach and your qualifications, you may be able to use a new professional recognition service to apply for English qualified teacher status.  
 
-You will not have to pay a fee or undergo further training when you apply for QTS. However, you will have to meet strict requirements. These requirements are mandatory and must be met in full exactly as set out in [‘Awarding qualified teacher status to overseas teachers’](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).  
+You will not have to pay a fee or undergo further training when you apply for QTS. However, you will have to meet strict requirements. These requirements are mandatory and must be met in full exactly as set out on [the GOV.UK website](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).  
 
 It's important to note that getting QTS does not lead to a teaching job or visa – you'll need to apply for these separately. 
 
@@ -124,7 +124,7 @@ Submit your application to a school that can sponsor visas, and if you are offer
 
 ### Your professional qualifications 
 
-If you haven't got QTS, schools you apply to will want to see alternative evidence of your teaching and academic qualifications. You can [get a statement of comparability from the UK information centre for international qualifications and skills](https://www.enic.org.uk/Qualifications/SOC/Default.aspx) showing how your qualifications compare to English ones.  
+If you haven't got QTS, schools you apply to will want to see alternative evidence of your teaching and academic qualifications. You can [get a statement of comparability from the UK information centre for international qualifications and skills](https://www.enic.org.uk/Qualifications/SOC/Default.aspx) (UK ENIC) showing how your qualifications compare to English ones.  
 
 ### Tips on applying
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -51,7 +51,7 @@ If you do not want to come to England to train, you should consider [internation
 
 If you are already a qualified teacher, you do not need to retrain to teach in England. However, you will need:
 
-* to apply for English qualified teacher status, or be able to demonstrate strong non-UK qualifications and experience 
+* to apply for English qualified teacher status (QTS), or be able to demonstrate strong non-UK qualifications and experience 
 * a high standard of written and spoken English
 * to pass criminal and professional safeguarding checks (these will be organised by your employer)
 * [a visa or immigration status allowing you to work in the UK](/non-uk-teachers/visas-for-non-uk-teachers)

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -199,6 +199,6 @@ The following suggestions and resources may be useful:
 
 The Department for Education (DfE) does not employ teachers directly. Do not send us your CV, as we will not be able to help you find a teaching job. 
 
-Do not email to ask when a country or subject will be added. We'll publish [updates about eligibility for the service on the GOV.UK website](https://apply-for-qts-in-england.education.gov.uk/eligibility/start).
+Do not email to ask when a country or subject will be added to [Apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). We'll publish [updates about eligibility for the service on the GOV.UK website](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).
 
 If you have general questions about the information on this page, you can email us at teach.inengland@education.gov.uk.

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -37,9 +37,15 @@ Teach in England and you’ll benefit from working in a world-class education sy
 
 You’ll earn a [competitive salary](/life-as-a-teacher/pay-and-benefits/teacher-pay), get supported in your professional development and have varied job opportunities.
 
-You could also consider teaching in [Wales](https://www.ewc.wales/site/index.php/en/registration/index.php?option=com_content&view=article&id=12&Itemid=170&lang=en), [Scotland](https://teachinscotland.scot/) or [Northern Ireland](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland).
+You could also consider teaching in other areas of the UK, including:
 
-Not qualified as a teacher yet? Find out [how to train to teach in England as a non-UK citizen](/non-uk-teachers/train-to-teach-in-england-as-an-international-student). If you don't want to come to England to train, you should consider [international qualified teacher status (iQTS)](/non-uk-teachers/international-qualified-teacher-status), which leads to the automatic award of English qualified teacher status. 
+* [Wales at the Educator Wales website](https://www.ewc.wales/site/index.php/en/registration/index.php?option=com_content&view=article&id=12&Itemid=170&lang=en)
+* [Scotland at the Teach in Scotland website](https://teachinscotland.scot/)
+* [Northern Ireland at the Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
+
+Not qualified as a teacher yet? Find out [how to train to teach in England as a non-UK citizen](/non-uk-teachers/train-to-teach-in-england-as-an-international-student). 
+
+If you do not want to come to England to train, you should consider [international qualified teacher status (iQTS)](/non-uk-teachers/international-qualified-teacher-status), which leads to the automatic award of English qualified teacher status. 
 
 ## What you'll need to teach in England
 
@@ -140,7 +146,7 @@ If you’re shortlisted, you’ll be invited for interview and asked to demonstr
 
 ### Prepare for your interview
 
-You may be asked about your knowledge of English education in interviews for teaching jobs. To prepare, you can [read other teachers’ stories](/blog) and research the [English national curriculum](https://www.gov.uk/national-curriculum) and [teachers’ standards](https://www.gov.uk/government/publications/teachers-standards).
+You may be asked about your knowledge of English education in interviews for teaching jobs. To prepare, you can research the [English national curriculum](https://www.gov.uk/national-curriculum) and [teachers’ standards](https://www.gov.uk/government/publications/teachers-standards).
 
 ### Safeguarding checks
 
@@ -184,7 +190,7 @@ The following suggestions and resources may be useful:
 * open an account with a digital bank based in the UK – you can do this before you arrive in the UK, and you will not need a UK address to do so
 * [find somewhere to live](https://www.gov.uk/government/publications/how-to-rent)
 * [get a national insurance (NI) number](https://www.gov.uk/national-insurance/your-national-insurance-number)
-* [register with a doctor](https://www.nhs.uk/nhs-services/gps/how-to-register-with-a-gp-surgery/)
+* [register with a doctor through the NHS](https://www.nhs.uk/nhs-services/gps/how-to-register-with-a-gp-surgery/)
 * [find childcare](https://www.gov.uk/get-childcare)
 * [learn about tax](https://www.gov.uk/income-tax)
 * learn about [indefinite leave to remain](https://www.gov.uk/indefinite-leave-to-remain)
@@ -193,6 +199,6 @@ The following suggestions and resources may be useful:
 
 The Department for Education (DfE) does not employ teachers directly. Do not send us your CV, as we will not be able to help you find a teaching job. 
 
-Please do not email to ask when a country or subject will be added to [Apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). We'll publish updates about eligiblity for the service at ['A fairer approach to awarding QTS to overseas teachers'](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).
+Please do not email to ask when a country or subject will be added to [Apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). We'll publish updates about eligiblity for the service at [A fairer approach to awarding QTS to overseas teachers](https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers).
 
 If you have general questions about the information on this page, you can email us at teach.inengland@education.gov.uk.

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -91,11 +91,11 @@ QTS will allow you to apply for teaching jobs in all schools in England.
 
 ## Other ways to train
 
-You can apply to train to teach in other areas of the UK, including:
+To find out about teaching in other areas of the UK, visit the:
 
-* [Wales at the Educator Wales website](https://educators.wales/home)
-* [Scotland at the Teach in Scotland website](https://teachinscotland.scot/)
-* [Northern Ireland at the Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
+* [Educator Wales website](https://educators.wales/home)
+* [Teach in Scotland website](https://teachinscotland.scot/)
+* [Northern Ireland Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
 
 If you don’t want to come to England to study you can apply to train for international qualified teacher status (iQTS). This meets the same high standards as [English qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts) and, if successfully completed, leads to the automatic award of QTS.
 
@@ -128,7 +128,7 @@ If you are not training to teach in these subjects, any support you get will dep
 
 ## Find and apply for teacher training courses
 
-Your teacher training course must lead to [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). 
+Your teacher training course must lead to [qualified teacher status (QTS)](/train-to-be-a-teacher/what-is-qts). 
 
 Some courses combine QTS with a [postgraduate certificate in education (PGCE) or postgraduate diploma in education (PGDE)](/train-to-be-a-teacher/what-is-a-pgce). These are optional: you do not need a PGCE or PGDE to teach in England.
 
@@ -195,7 +195,7 @@ Due to rules about immigration, not all providers can accept international appli
 
 You can apply to any English teacher training provider if you have settled or pre-settled status under either:
 
-* <a href="https://www.gov.uk/settled-status-eu-citizens-families">EU Settlement Scheme</a>
+* <a href="https://www.gov.uk/settled-status-eu-citizens-families">the EU Settlement Scheme</a>
 * <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain</a>
 
 ### Postgraduate teaching apprenticeships
@@ -226,7 +226,7 @@ To train to teach in England, you will need a visa or immigration status allowin
 
 ## Plan your move to the UK
 
-[Visit the UK Council for International Student Affairs](https://www.ukcisa.org.uk/) (UKCISA) for advice about immigration, finding a place to live and opening a bank account. For support over the phone, [visit the UKCISA Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
+[Visit the UK Council for International Student Affairs](https://www.ukcisa.org.uk/) (UKCISA) for advice about immigration, finding a place to live and opening a bank account. For support over the phone, [visit the UKCISA Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us).
 
 Your teacher training provider may also be able to help you plan your move to the UK  – contact them directly to ask.
 

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -124,7 +124,9 @@ If you are not training to teach in these subjects, any support you get will dep
 
 ## Find and apply for teacher training courses
 
-Your teacher training course must lead to [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). Some courses combine QTS with a [postgraduate certificate in education (PGCE) or postgraduate diploma in education (PGDE)](/train-to-be-a-teacher/what-is-a-pgce). These are optional: you do not need a PGCE or PGDE to teach in England.
+Your teacher training course must lead to [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts). 
+
+Some courses combine QTS with a [postgraduate certificate in education (PGCE) or postgraduate diploma in education (PGDE)](/train-to-be-a-teacher/what-is-a-pgce). These are optional: you do not need a PGCE or PGDE to teach in England.
 
 You can train in a school or in a university setting, and study full-time (over a year) or part-time (over 2 or more years). Teacher training courses can also be 'fee-paying' or 'salaried'.
 
@@ -153,7 +155,7 @@ The subject you apply to teach must usually be the same as, or closely related t
 
 ### Finding the right course for you
 
-You can [search for postgraduate teacher training courses](https://find-teacher-training-courses.service.gov.uk/) that lead to [qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts).
+You can [search for postgraduate teacher training courses](https://find-teacher-training-courses.service.gov.uk/) that lead to qualified teacher status (QTS).
 
 To find the right training for you, you can filter courses by:
 
@@ -187,7 +189,10 @@ Due to rules about immigration, not all providers can accept international appli
 
 ### Already living in the UK?
 
-If you have settled or pre-settled status under the <a href="https://www.gov.uk/settled-status-eu-citizens-families">EU Settlement Scheme</a>, or <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain</a>, you can apply to any English teacher training provider.
+You can apply to any English teacher training provider if you have settled or pre-settled status under either:
+
+* <a href="https://www.gov.uk/settled-status-eu-citizens-families">EU Settlement Scheme</a>
+* <a href="https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk">indefinite leave to remain</a>
 
 ### Postgraduate teaching apprenticeships
 

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -91,7 +91,11 @@ QTS will allow you to apply for teaching jobs in all schools in England.
 
 ## Other ways to train
 
-You can also apply to [train to teach in Wales](https://educators.wales/home), [train to teach in Scotland](https://teachinscotland.scot/) or [train to teach in Northern Ireland](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland).
+You can apply to train to teach in other areas of the UK, including:
+
+* [Wales at the Educator Wales website](https://educators.wales/home)
+* [Scotland at the Teach in Scotland website](https://teachinscotland.scot/)
+* [Northern Ireland at the Department for Education website](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland)
 
 If you don’t want to come to England to study you can apply to train for international qualified teacher status (iQTS). This meets the same high standards as [English qualified teacher status (QTS)](https://www.gov.uk/guidance/qualified-teacher-status-qts) and, if successfully completed, leads to the automatic award of QTS.
 
@@ -167,7 +171,7 @@ To find the right training for you, you can filter courses by:
 
 ### Writing your personal statement
 
-It's important that you give yourself time to write the best possible [personal statement](/how-to-apply-for-teacher-training/teacher-training-personal-statement). Providers read your personal statement carefully as part of their assessment of your application.
+It's important that you give yourself time to [write the best possible personal statement](/how-to-apply-for-teacher-training/teacher-training-personal-statement). Providers read your personal statement carefully as part of their assessment of your application.
 
 Your personal statement can be up to 1000 words. 90% of successful candidates write 500 words or more.
 
@@ -222,7 +226,7 @@ To train to teach in England, you will need a visa or immigration status allowin
 
 ## Plan your move to the UK
 
-Visit the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/) for advice about immigration, finding a place to live and opening a bank account. Their [Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
+[Visit the UK Council for International Student Affairs](https://www.ukcisa.org.uk/) (UKCISA) for advice about immigration, finding a place to live and opening a bank account. For support over the phone, [visit the UKCISA Student Advice Line](https://www.ukcisa.org.uk/About-UKCISA/Contact-us) also offers support over the phone.
 
 Your teacher training provider may also be able to help you plan your move to the UK  – contact them directly to ask.
 
@@ -250,10 +254,10 @@ Learn more about:
 - [curriculum and qualifications](https://www.gov.uk/national-curriculum)
 - [behaviour and discipline in schools](https://www.gov.uk/government/publications/behaviour-and-discipline-in-schools)
 - [Office for Standards in Education, Children’s Services and Skills (Ofsted)](https://www.gov.uk/government/organisations/ofsted)
-- [The Education Endowment Foundation](https://educationendowmentfoundation.org.uk/guidance-for-teachers) – a charity gathering international evidence on teaching 5 to 16 year olds
-- [Times Educational Supplement (TES)](https://www.tes.com/) – information and resources for teachers
+- [The Education Endowment Foundation website](https://educationendowmentfoundation.org.uk/guidance-for-teachers) – a charity gathering international evidence on teaching 5 to 16 year olds
+- [Times Educational Supplement (TES) website](https://www.tes.com/) – information and resources for teachers
 - [join the Aspiring Teachers Forum on Facebook](https://www.facebook.com/groups/1357146377672255/)
-- [read interviews with real teachers](/blog)
+
 
 ## Non-UK citizens who trained to teach in England share their experiences
 

--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -37,7 +37,10 @@ keywords:
 ---
 The [Department for Education (DfE)](https://www.gov.uk/government/organisations/department-for-education) supports and encourages Ukrainian trainees and teachers seeking teacher training places and jobs. 
 
-We can help if you’re interested in teaching children aged 5 to 18. If you'd like to teach other age groups, try [teaching in a university](https://nationalcareers.service.gov.uk/job-profiles/higher-education-lecturer) or [teaching in further education](https://www.teach-in-further-education.campaign.gov.uk/). 
+We can help if you’re interested in teaching children aged 5 to 18. If you'd like to teach other age groups, visit:
+
+* the National Careers Service for information on [teaching in a university](https://nationalcareers.service.gov.uk/job-profiles/higher-education-lecturer)
+* the Teach In Further Education for information on [teaching in further education](https://www.teach-in-further-education.campaign.gov.uk/)
 
 ## General information for Ukrainian teachers and trainees coming to the UK
 

--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -39,8 +39,8 @@ The [Department for Education (DfE)](https://www.gov.uk/government/organisations
 
 We can help if you’re interested in teaching children aged 5 to 18. If you'd like to teach other age groups, visit:
 
-* the National Careers Service for information on [teaching in a university](https://nationalcareers.service.gov.uk/job-profiles/higher-education-lecturer)
-* the Teach In Further Education for information on [teaching in further education](https://www.teach-in-further-education.campaign.gov.uk/)
+* the [National Careers Service website](https://nationalcareers.service.gov.uk/job-profiles/higher-education-lecturer) for information on teaching in a university
+* the [Teach in further education website](https://www.teach-in-further-education.campaign.gov.uk/) for information on teaching people over 16 who are not studying for a degree
 
 ## General information for Ukrainian teachers and trainees coming to the UK
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/Xdh77TwB/6809-content-non-uk-changes-to-meet-wcag-22-258-target-size-minimum

### Context - NON-UK

When two or more lines of content containing links are close together in a paragraph, it doesn’t meet the new WCAG 2.2 standard. Content needs to be reworked to use less links or more spaced out in the paragraph.

### Changes proposed in this pull request

### Guidance to review

