### PR TITLE
Remove chat_enabled feature flag

### DIFF
--- a/app/components/chat_component.html.erb
+++ b/app/components/chat_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div data: { controller: "chat", enabled: Chat.enabled?, available: Chat.available?, "chat-target": "container" }, class: "chat" do %>
+<%= tag.div data: { controller: "chat", available: Chat.available?, "chat-target": "container" }, class: "chat" do %>
   <div data-chat-target="online" class="hidden">
     <p>
       <a class="button" href="/chat#root" target="chat" data-action="chat#start" data-chat-target="chat" aria-label="Chat online">Chat online <span class="visually-hidden">(opens in new window)</span> <span></span></a>

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,10 +1,6 @@
 class Chat
   delegate :to_json, to: :to_h
 
-  def self.enabled?
-    ActiveModel::Type::Boolean.new.cast(ENV.fetch("CHAT_ENABLED", false))
-  end
-
   def self.available?
     new.available
   end

--- a/spec/features/chat_spec.rb
+++ b/spec/features/chat_spec.rb
@@ -5,128 +5,58 @@ RSpec.feature "Chat", type: :feature do
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with("CHAT_ENABLED", false).and_return(new_chat_enabled)
     allow(ENV).to receive(:fetch).with("CHAT_AVAILABILITY_API", nil).and_return("http://api.example/")
     stub_request(:get, "http://api.example/")
       .to_return(status: 200, body: "{\"skillid\": 123456, \"available\": false, \"status_age\": 123 }")
   end
 
-  context "when new-chat is enabled" do
-    let(:new_chat_enabled) { "1" }
-
-    context "when javascript is enabled", :js do
-      context "when agents are available" do
-        before do
-          stub_request(:get, "http://api.example/")
-            .to_return(status: 200, body: "{\"skillid\": 123456,	\"available\": true, \"status_age\": 123 }")
-        end
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit root_path
-          dismiss_cookies
-
-          within(".talk-to-us") do
-            click_link("Chat online")
-          end
-
-          popup_window_handle = (page.driver.browser.window_handles - [page.driver.current_window_handle]).first
-          page.driver.switch_to_window(popup_window_handle)
-          expect(page.driver.current_url).to end_with("/chat")
-          expect(page).to have_css("#root", visible: false)
-          page.driver.close_window(popup_window_handle)
-        end
+  context "when javascript is enabled", :js do
+    context "when agents are available" do
+      before do
+        stub_request(:get, "http://api.example/")
+          .to_return(status: 200, body: "{\"skillid\": 123456,	\"available\": true, \"status_age\": 123 }")
       end
 
-      context "when agents are not available" do
-        before do
-          stub_request(:get, "http://api.example/")
-            .to_return(status: 200, body: "{\"skillid\": 123456,	\"available\": false, \"status_age\": 123 }")
-        end
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit root_path
-          dismiss_cookies
-
-          within(".talk-to-us") do
-            expect(page).to have_text("Chat is closed")
-          end
-        end
-      end
-    end
-
-    context "when javascript is not enabled", js: false do
       scenario "viewing the chat section of the talk to us component" do
         visit root_path
         dismiss_cookies
 
         within(".talk-to-us") do
-          expect(page).to have_text("Chat not available")
+          click_link("Chat online")
+        end
+
+        popup_window_handle = (page.driver.browser.window_handles - [page.driver.current_window_handle]).first
+        page.driver.switch_to_window(popup_window_handle)
+        expect(page.driver.current_url).to end_with("/chat")
+        expect(page).to have_css("#root", visible: false)
+        page.driver.close_window(popup_window_handle)
+      end
+    end
+
+    context "when agents are not available" do
+      before do
+        stub_request(:get, "http://api.example/")
+          .to_return(status: 200, body: "{\"skillid\": 123456,	\"available\": false, \"status_age\": 123 }")
+      end
+
+      scenario "viewing the chat section of the talk to us component" do
+        visit root_path
+        dismiss_cookies
+
+        within(".talk-to-us") do
+          expect(page).to have_text("Chat is closed")
         end
       end
     end
   end
 
-  context "when old-chat is enabled" do
-    let(:new_chat_enabled) { "0" }
+  context "when javascript is not enabled", js: false do
+    scenario "viewing the chat section of the talk to us component" do
+      visit root_path
+      dismiss_cookies
 
-    around do |example|
-      travel_to(date.in_time_zone("London")) { example.run }
-    end
-
-    context "when Javascript is enabled", :js do
-      context "when chat is online" do
-        let(:date) { Time.zone.local(2021, 1, 1, 9) }
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit_on_date root_path
-          dismiss_cookies
-
-          within(".talk-to-us") do
-            click_link("Chat online")
-            expect(page).to have_link("Starting chat...")
-          end
-        end
-      end
-
-      context "when chat is offline" do
-        let(:date) { Time.zone.local(2021, 1, 1, 5) }
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit_on_date root_path
-          dismiss_cookies
-
-          within(".talk-to-us") do
-            expect(page).to have_text("Chat is closed")
-          end
-        end
-      end
-    end
-
-    context "when Javascript is disabled" do
-      context "when chat is online" do
-        let(:date) { Time.zone.local(2021, 1, 1, 9) }
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit_on_date root_path
-
-          within(".talk-to-us") do
-            expect(page).to have_text("Chat not available")
-            expect(page).to have_link("getinto.teaching@service.education.gov.uk")
-          end
-        end
-      end
-
-      context "when chat is offline" do
-        let(:date) { Time.zone.local(2021, 1, 1, 7) }
-
-        scenario "viewing the chat section of the talk to us component" do
-          visit_on_date root_path
-
-          within(".talk-to-us") do
-            expect(page).to have_text("Chat not available")
-            expect(page).to have_link("getinto.teaching@service.education.gov.uk")
-          end
-        end
+      within(".talk-to-us") do
+        expect(page).to have_text("Chat not available")
       end
     end
   end

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -2,7 +2,6 @@ import { Application } from '@hotwired/stimulus';
 import ChatController from 'chat_controller.js';
 
 describe('ChatController', () => {
-
   beforeAll(() => registerController());
   afterEach(() => jest.useRealTimers());
 

--- a/spec/javascript/controllers/chat_controller_spec.js
+++ b/spec/javascript/controllers/chat_controller_spec.js
@@ -8,9 +8,9 @@ describe('ChatController', () => {
   let chatShowSpy;
   let chatOpenSpy;
 
-  const setBody = (chatEnabled = 'true', chatAvailable = 'true') => {
+  const setBody = (chatAvailable = 'true') => {
     document.body.innerHTML = `
-      <div data-controller="chat" data-enabled="${chatEnabled}" data-available="${chatAvailable}" data-chat-target="container" class="chat">
+      <div data-controller="chat" data-available="${chatAvailable}" data-chat-target="container" class="chat">
         <div data-chat-target="online" class="hidden">
           <p>
             <a class="button" href="javascript:void(0)" data-action="chat#start" data-chat-target="chat">Chat online</a>
@@ -47,7 +47,6 @@ describe('ChatController', () => {
     return document.querySelector('a').textContent;
   }
 
-
   describe('when the new chat is enabled', () => {
 
     const mockFetch = (result) => {
@@ -61,7 +60,7 @@ describe('ChatController', () => {
     describe('when the chat is online', () => {
       beforeEach(() => {
         mockFetch({ "skillid": 123456, "available": true, "status_age": 123 } );
-        setBody('true', 'true');
+        setBody('true');
       });
 
       it('hides the unavailable message', () => {
@@ -78,7 +77,7 @@ describe('ChatController', () => {
     describe('when the chat is offline', () => {
       beforeEach(() => {
         mockFetch({ "skillid": 123456, "available": false, "status_age": 123 } );
-        setBody('true', 'false');
+        setBody('false');
       });
 
       it('hides the unavailable message', () => {
@@ -93,94 +92,4 @@ describe('ChatController', () => {
     });
   });
 
-  describe('when the new chat is not enabled', () => {
-
-    describe('when the chat is online', () => {
-      beforeEach(() => {
-        chatShowSpy = jest.fn(() => true);
-        chatOpenSpy = jest.fn();
-
-        jest.spyOn(global, 'window', 'get').mockImplementation(() => ({ zE: chatOpenSpy, zEACLoaded: chatShowSpy }));
-
-        setBody('false');
-        setCurrentTime('2021-01-01 10:00');
-      });
-
-      it('hides the unavailable message', () => {
-        const button = document.querySelector('[data-chat-target="unavailable"]')
-        expect(button.classList.contains('hidden')).toBe(true)
-      })
-
-      it('displays the chat online button', () => {
-        const button = document.querySelector('[data-chat-target="online"]')
-        expect(button.classList.contains('hidden')).toBe(false)
-      })
-
-      describe('when clicking the chat button', () => {
-        it('appends the Zendesk snippet, shows a loading message and then opens the chat window', () => {
-          const button = document.querySelector('a');
-          button.click();
-          expect(document.querySelector('#ze-snippet')).not.toBeNull();
-          expect(getButtonText()).toEqual("Starting chat...");
-          jest.runOnlyPendingTimers(); // Timer for script loading,
-          jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
-          jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-          expect(chatOpenSpy).toHaveBeenCalled();
-          expect(getButtonText()).toEqual("Chat online");
-        });
-      });
-
-      describe('when clicking the chat button twice', () => {
-        it('only appends the Zendesk snippet once and does not show the loading message for the second click', () => {
-          const button = document.querySelector('a');
-          button.click();
-          expect(button.textContent).toEqual("Starting chat...");
-          jest.runOnlyPendingTimers(); // Timer for script loading,
-          jest.runOnlyPendingTimers(); // Timer to wait for the widget to load.
-          jest.runOnlyPendingTimers(); // Timer to wait for chat window to open.
-          expect(chatOpenSpy).toHaveBeenCalled();
-          expect(button.textContent).toEqual("Chat online");
-          button.click();
-          expect(button.textContent).toEqual("Chat online");
-          expect(document.querySelectorAll('#ze-snippet').length).toEqual(1);
-        });
-      });
-    })
-
-    describe("when the chat is offline (too early)", () => {
-      beforeEach(() => {
-        setBody('false');
-        setCurrentTime('2021-01-01 08:29');
-      });
-
-      it('displays the chat offline message', () => {
-        const button = document.querySelector('[data-chat-target="offline"]')
-        expect(button.classList.contains('hidden')).toBe(false)
-      })
-    })
-
-    describe("when the chat is offline (too late)", () => {
-      beforeEach(() => {
-        setBody('false');
-        setCurrentTime('2021-01-01 17:31');
-      });
-
-      it('displays the chat offline message', () => {
-        const button = document.querySelector('[data-chat-target="offline"]')
-        expect(button.classList.contains('hidden')).toBe(false)
-      })
-    })
-
-    describe("when the chat is offline (weekend)", () => {
-      beforeEach(() => {
-        setBody('false');
-        setCurrentTime('2021-12-18 11:00');
-      });
-
-      it('displays the chat offline message', () => {
-        const button = document.querySelector('[data-chat-target="offline"]')
-        expect(button.classList.contains('hidden')).toBe(false)
-      })
-    })
-  });
 });

--- a/spec/models/chat_spec.rb
+++ b/spec/models/chat_spec.rb
@@ -1,28 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Chat, type: :model do
-  describe "self.enabled?" do
-    subject { described_class.enabled? }
-
-    context "when CHAT_ENABLED=0" do
-      before { allow(ENV).to receive(:fetch).with("CHAT_ENABLED", false).and_return("0") }
-
-      it { is_expected.to be false }
-    end
-
-    context "when CHAT_ENABLED=1" do
-      before { allow(ENV).to receive(:fetch).with("CHAT_ENABLED", false).and_return("1") }
-
-      it { is_expected.to be true }
-    end
-
-    context "when CHAT_ENABLED is not set" do
-      before { allow(ENV).to receive(:fetch).with("CHAT_ENABLED", false).and_return("") }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
   describe "#to_h" do
     subject { described_class.new.to_h }
 


### PR DESCRIPTION
### Trello card
[Delete feature flag for webchat widget](https://trello.com/c/xD046qkD/6817-delete-feature-flag-code-for-webchat-widget)

### Context
Now that the new chat is live, the feature flag is no longer required

### Changes proposed in this pull request
Remove feature flag

### Guidance to review

