### PR TITLE
Ignore migration exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ COPY --from=release-build /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
-CMD ["rails db:migrate && rails server"]
+CMD ["rails db:migrate:ignore_concurrent_migration_exceptions && rails server"]
 
 ARG SHA
 RUN echo "sha-${SHA}" > /etc/get-into-teaching-app-sha


### PR DESCRIPTION
### Trello card
[Improve pod stability during deployment](https://trello.com/c/l3CnCqqD/6852-improve-pod-stability-during-deployment-process)

### Context
pods occasionaly restart during boot because the migrations run on multiple pods - but in fact we don't have any migrations to run

### Changes proposed in this pull request
This ignores migration exceptions when booting pods, reducing restarts and improving stability

### Guidance to review

