### PR TITLE
Run migrations prior to booting app and worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ COPY --from=release-build /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
-CMD ["rails db:migrate && rails server"]
+CMD ["rails server"]
 
 ARG SHA
 RUN echo "sha-${SHA}" > /etc/get-into-teaching-app-sha

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -33,7 +33,6 @@ module "application_configuration" {
 
 # Run database migrations
 # https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database
-# https://github.com/ilyakatz/data-migrate
 # Terraform waits for this to complete before starting web_application and worker_application
 resource "kubernetes_job" "migrations" {
   metadata {

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -31,8 +31,88 @@ module "application_configuration" {
   }
 }
 
+# Run database migrations
+# https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database
+# https://github.com/ilyakatz/data-migrate
+# Terraform waits for this to complete before starting web_application and worker_application
+resource "kubernetes_job" "migrations" {
+  metadata {
+    name      = "${var.service_name}-${var.environment}-migrations"
+    namespace = var.namespace
+  }
+
+  spec {
+    template {
+      metadata {
+        labels = { app = "${var.service_name}-${var.environment}-migrations" }
+        annotations = {
+          "logit.io/send"        = "true"
+          "fluentbit.io/exclude" = "true"
+        }
+      }
+
+      spec {
+        container {
+          name    = "migrate"
+          image   = var.docker_image
+          command = ["bundle"]
+          args    = ["exec", "rails", "db:prepare"]
+
+          env_from {
+            config_map_ref {
+              name = module.application_configuration.kubernetes_config_map_name
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = module.application_configuration.kubernetes_secret_name
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = module.cluster_data.configuration_map.cpu_min
+              memory = "1Gi"
+            }
+            limits = {
+              cpu    = 1
+              memory = "1Gi"
+            }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+
+            capabilities {
+              drop = ["ALL"]
+              add  = ["NET_BIND_SERVICE"]
+            }
+          }
+        }
+
+        restart_policy = "Never"
+      }
+    }
+
+    backoff_limit = 1
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "11m"
+    update = "11m"
+  }
+}
+
 module "web_application" {
   source = "./vendor/modules/aks//aks/application"
+  depends_on = [kubernetes_job.migrations]
 
   is_web = true
 
@@ -56,6 +136,8 @@ module "web_application" {
 
 module "worker_application" {
   source                     = "./vendor/modules/aks//aks/application"
+  depends_on = [kubernetes_job.migrations]
+
   name                       = "worker"
   is_web                     = false
   namespace                  = var.namespace

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -36,14 +36,14 @@ module "application_configuration" {
 # Terraform waits for this to complete before starting web_application and worker_application
 resource "kubernetes_job" "migrations" {
   metadata {
-    name      = "${var.service_name}-${var.environment}-migrations"
+    name      = "${var.service_name}-${local.environment}-migrations"
     namespace = var.namespace
   }
 
   spec {
     template {
       metadata {
-        labels = { app = "${var.service_name}-${var.environment}-migrations" }
+        labels = { app = "${var.service_name}-${local.environment}-migrations" }
         annotations = {
           "logit.io/send"        = "true"
           "fluentbit.io/exclude" = "true"


### PR DESCRIPTION
### Trello card
[Improve pod stability](https://trello.com/c/l3CnCqqD/6852-improve-pod-stability-during-deployment-process)

### Context
On deployment to production, pods can crash if migrations are run on multiple pods at the same time

### Changes proposed in this pull request
This PR is based on https://github.com/DFE-Digital/itt-mentor-services/pull/893/ . It ensures migrations run as a kubernetes job prior to booting the rails app/worker

### Guidance to review


