### PR TITLE
Improve link on Get school experience page for accessibility

### DIFF
--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -15,7 +15,7 @@ calls_to_action:
         icon: "icon-arrow"
         text: |-
           Use our service to search for and organise a placement in England.
-        link_text: "Get school experience"
+        link_text: "Search for school experience"
         link_target: "https://schoolexperience.education.gov.uk/"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo

--- a/app/views/content/train-to-be-a-teacher/get-school-experience.md
+++ b/app/views/content/train-to-be-a-teacher/get-school-experience.md
@@ -14,7 +14,7 @@ calls_to_action:
       arguments:
         icon: "icon-arrow"
         text: |-
-          Use our service to search for and organise a placement in England.
+          Use our service to search for and organise school experience in England.
         link_text: "Search for school experience"
         link_target: "https://schoolexperience.education.gov.uk/"
 promo_content:


### PR DESCRIPTION
### Trello card
https://trello.com/c/p8Xsb92t

### Context
We are using the same link text (`Get school experience`) in the menu to point to the Get school experience page on GIT and on the Get school experience page itself to point to the GSE service. Using the same link text to point to different destinations is not good practice in terms of accessibility.
