### PR TITLE
Bumped govuk frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete",
     "file-loader": "^6.2.0",
     "flatpickr": "^4.6.13",
-    "govuk-frontend": "5.6.0",
+    "govuk-frontend": "^5.7.1",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.5",
     "lazysizes": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,10 +4165,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.6.0.tgz#8c0975f0d825ec7192bcfe64e3e97ef3dfa7dea1"
-  integrity sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==
+govuk-frontend@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.7.1.tgz#d4c561ebf8c0b76130f31df8c2e4d70d340cd63f"
+  integrity sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
### Trello card

https://trello.com/c/c8yqXNXI/6910-bump-govuk-frontend-to-v571-on-git-website

### Context

We need to bump up the version of Frontend to 5.7.1 due to GDS update. 

### Changes proposed in this pull request

Bumped GOVUK frontend.

### Guidance to review

- check visuals.
- check deprecation warnings in the console.

