### PR TITLE
SEO updates to busaries page

### DIFF
--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -46,6 +46,8 @@ A bursary is paid over a minimum of 10 months by your teacher training provider 
 
 You will not need to pay tax or National Insurance on bursary payments. 
 
+You do not have to pay a bursary back.
+
 ### How to get a bursary
 
 You do not need to apply for a bursary. When you apply for teacher training, your provider will check if you're eligible for a bursary. If you are, your provider will confirm this in writing before you start your course. 
@@ -69,6 +71,8 @@ Scholarships offer more than just financial benefits. For example, they can prov
 A scholarship is paid over a minimum of 10 months by your teacher training provider across the duration of your course. They will confirm when you will get the payments. 
 
 You will not need to pay tax or National Insurance on scholarship payments. 
+
+You do not have to pay a scholarship back.
 
 ### How to apply for a scholarship
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -76,13 +76,13 @@ You do not have to pay a scholarship back.
 
 ### How to apply for a scholarship
 
-You need to apply directly to the scholarship provider. Each provider sets their own application deadline and will confirm if you meet their eligibility requirements. You can out find about how to apply, deadlines and more details about each scholarship on the scholarship providers' websites:
+You need to apply directly to the scholarship provider. Each provider sets their own application deadline and will confirm if you meet their eligibility requirements. You can out find about how to apply, deadlines and more details about each scholarship on the scholarship providers'website:
 
-* [the Royal Society of Chemistry](https://www.rsc.org/prizes-funding/funding/find-funding/teacher-training-scholarships/) (chemistry)
-* [BCS The Chartered Institute for IT](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
-* [British Council](https://www.britishcouncil.org/education/he-science/opportunities/ltts) (languages -- French, German and Spanish only)
-* [the Institute of Mathematics and its Applications, and partners](https://teachingmathsscholars.org/home) (maths)
-* [the Institute of Physics](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
+* [Royal Society of Chemistry website](https://www.rsc.org/prizes-funding/funding/find-funding/teacher-training-scholarships/) (chemistry)
+* [BCS The Chartered Institute for IT website](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)
+* [British Council website](https://www.britishcouncil.org/education/he-science/opportunities/ltts) (languages -- French, German and Spanish only)
+* [Institute of Mathematics and its Applications, and partners website](https://teachingmathsscholars.org/home) (maths)
+* [Institute of Physics website](https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref) (physics)
 
 ## Compare bursaries and scholarships
 

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -76,7 +76,7 @@ You do not have to pay a scholarship back.
 
 ### How to apply for a scholarship
 
-You need to apply directly to the scholarship provider. Each provider sets their own application deadline and will confirm if you meet their eligibility requirements. You can out find about how to apply, deadlines and more details about each scholarship on the scholarship providers'website:
+You need to apply directly to the scholarship provider. Each provider sets their own application deadline and will confirm if you meet their eligibility requirements. You can out find about how to apply, deadlines and more details about each scholarship on the scholarship provider's website:
 
 * [Royal Society of Chemistry website](https://www.rsc.org/prizes-funding/funding/find-funding/teacher-training-scholarships/) (chemistry)
 * [BCS The Chartered Institute for IT website](https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/) (computing)

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -6,11 +6,11 @@
 
 <div class="content">
   <section class="col col-720">
-    <p>Bursaries are tax-free payments you receive if you're training to teach certain subjects. If you're eligible for a bursary, you'll get it automatically.</p>
-    <p>Scholarships are awarded by organisations with a passion for their subject area. They combine tax-free payments with extra benefits like subject-specific support, mentoring and networking opportunities. If you're eligible, you can apply directly to the scholarship provider.</p>
+    <p>Postgraduate bursaries are tax-free payments you receive if you're training to teach certain subjects. You do not need to apply for a bursary, you'll automatically get one if you're eligible.</p>
+    <p>Postgraduage scholarships are awarded by organisations with a passion for their subject area. They combine tax-free payments with extra benefits like subject-specific support, mentoring and networking opportunities. If you're eligible, you can apply directly to the scholarship provider.</p>
     <p>You cannot receive both a bursary and a scholarship.</p>
     <p>If you receive either a bursary or a scholarship, you do not need to pay it back.</p>
-    <p>Bursaries and scholarships are not available for:</p>
+    <p>Postgraduate bursaries and scholarships are not available for:</p>
     <ul>
       <li>every subject</li>
       <li>salaried teacher training</li>

--- a/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries/_funding-widget.html.erb
@@ -7,10 +7,10 @@
 <div class="content">
   <section class="col col-720">
     <p>Postgraduate bursaries are tax-free payments you receive if you're training to teach certain subjects. You do not need to apply for a bursary, you'll automatically get one if you're eligible.</p>
-    <p>Postgraduage scholarships are awarded by organisations with a passion for their subject area. They combine tax-free payments with extra benefits like subject-specific support, mentoring and networking opportunities. If you're eligible, you can apply directly to the scholarship provider.</p>
+    <p>Postgraduate scholarships are awarded by organisations with a passion for their subject area. They combine tax-free payments with extra benefits like subject-specific support, mentoring and networking opportunities. If you're eligible, you can apply directly to the scholarship provider.</p>
     <p>You cannot receive both a bursary and a scholarship.</p>
     <p>If you receive either a bursary or a scholarship, you do not need to pay it back.</p>
-    <p>Postgraduate bursaries and scholarships are not available for:</p>
+    <p>Bursaries and scholarships are not available for:</p>
     <ul>
       <li>every subject</li>
       <li>salaried teacher training</li>

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -128,8 +128,9 @@ $salaried-teacher-training$
 Your teacher training course might be provided by: 
 
 * a university, sometimes referred to as university-led training
-* a school or group of schools, sometimes referred to as school-led training, or an apprenticeship 
-* a [charitable organisation such as Teach First](https://www.teachfirst.org.uk/)  
+* a school or group of schools, sometimes referred to as school-led training
+
+Your teacher training course may also be provided by a company or charity. For example, [Teach First is a charitable organisation that provides teacher training](https://www.teachfirst.org.uk).
 
 Once you’ve found a course you’re interested in, you can talk to the training provider before you apply. For example, you might want to find out: 
 

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -99,7 +99,7 @@ Most primary and secondary schools in England need you to have [qualified teache
 
 Most teacher training courses will award QTS, but some will award QTS with a [postgraduate certificate in education (PGCE)](/train-to-be-a-teacher/what-is-a-pgce).
 
-If your teacher training course leads to QTS, you may be eligible for a scholarship or bursary to help you train.
+If your teacher training course leads to QTS, [you may be eligible for a scholarship or bursary](/funding-and-support/scholarships-and-bursaries) to help you train.
 
 ## If the course is fee-funded or salaried
 
@@ -127,9 +127,9 @@ $salaried-teacher-training$
 
 Your teacher training course might be provided by: 
 
-* a university (sometimes referred to as university-led training) 
-* a school or group of schools (sometimes referred to as school-led training, or an apprenticeship) 
-* [Teach First](https://www.teachfirst.org.uk/) (a charitable organisation)  
+* a university, sometimes referred to as university-led training
+* a school or group of schools, sometimes referred to as school-led training, or an apprenticeship 
+* a [charitable organisation such as Teach First](https://www.teachfirst.org.uk/)  
 
 Once you’ve found a course you’re interested in, you can talk to the training provider before you apply. For example, you might want to find out: 
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -64,7 +64,7 @@ $qualified-outside-the-uk$
 If your teacher training course leads to QTS: 
 
 * your course will be regulated by the Department for Education (DfE), ensuring high quality training 
-* you could be eligible for [a scholarship or bursary to help you train](/funding-and-support/scholarships-and-bursaries)
+* you could be [eligible for a scholarship or bursary](/funding-and-support/scholarships-and-bursaries) to help you train.
 
 As a teacher with QTS: 
 

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -100,6 +100,6 @@ You can usually do this if you’ve worked as an unqualified teacher:
 
 ## Get QTS if you qualified as a teacher in Wales, Scotland or Northern Ireland
 
-If you trained to teach in Wales, your QTS will be automatically recognised in England and awarded by the Education Workforce Council (EWC). Visit the [Education Workforce Council website to find out more](https://www.ewc.wales/site/index.php/en/).
+If you trained to teach in Wales, your QTS will automatically be recognised in England. [The Education Workforce Council (EWC) website has more information on awarding QTS in England](https://www.ewc.wales/site/index.php/en/).
 
 If you trained to teach in Scotland or Northern Ireland, you can [apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). If your QTS application is successful, you will gain QTS without any further fees or training.

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -64,7 +64,7 @@ $qualified-outside-the-uk$
 If your teacher training course leads to QTS: 
 
 * your course will be regulated by the Department for Education (DfE), ensuring high quality training 
-* you could be eligible for a scholarship or bursary to help you train
+* you could be eligible for [a scholarship or bursary to help you train](/funding-and-support/scholarships-and-bursaries)
 
 As a teacher with QTS: 
 
@@ -100,6 +100,6 @@ You can usually do this if you’ve worked as an unqualified teacher:
 
 ## Get QTS if you qualified as a teacher in Wales, Scotland or Northern Ireland
 
-If you trained to teach in Wales, your QTS will be automatically recognised in England and awarded by the [Education Workforce Council (EWC)](https://www.ewc.wales/site/index.php/en/).
+If you trained to teach in Wales, your QTS will be automatically recognised in England and awarded by the Education Workforce Council (EWC). Visit the [Education Workforce Council website to find out more](https://www.ewc.wales/site/index.php/en/).
 
 If you trained to teach in Scotland or Northern Ireland, you can [apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). If your QTS application is successful, you will gain QTS without any further fees or training.

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -100,6 +100,6 @@ You can usually do this if you’ve worked as an unqualified teacher:
 
 ## Get QTS if you qualified as a teacher in Wales, Scotland or Northern Ireland
 
-If you trained to teach in Wales, your QTS will automatically be recognised in England. [The Education Workforce Council (EWC) website has more information on awarding QTS in England](https://www.ewc.wales/site/index.php/en/).
+If you trained to teach in Wales, your QTS will automatically be recognised in England. [The Education Workforce Council (EWC) website has more information on being awarded QTS in England](https://www.ewc.wales/site/index.php/en/).
 
 If you trained to teach in Scotland or Northern Ireland, you can [apply for QTS in England](https://apply-for-qts-in-england.education.gov.uk/eligibility/start). If your QTS application is successful, you will gain QTS without any further fees or training.


### PR DESCRIPTION
### Trello card

https://trello.com/c/Gav01Q3k/6882-seo-content-updates-bursary-page

### Context

### Changes proposed in this pull request

We need to include the following keywords in the page in a natural way:

- do you have to pay a bursary back

- how to apply for a bursary

- postgraduate bursaries

 

Add internal links to the bursary page:

What are the benefits of QTS section Qualified teacher status (QTS)

The qualifications awarded by the course section How to choose your teacher training course

### Guidance to review

