### PR TITLE
Allow link text in funding widget

### DIFF
--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -41,7 +41,7 @@
           <div class="call-to-action__text">
             <h3><%= sub_head %></h3>
             <div>
-              <%= funding_results %>
+              <%= helpers.safe_html_format(funding_results) %>
               <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a>.</p>
               <p>You could also get extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> or <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.</p>
               <%= render Content::InsetTextComponent.new(

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -23,7 +23,6 @@
           </div>
         <% end %>
       </div>
-
       <% if form.subject.present? %>
         <% if funding_results.blank? %>
           <div class="call-to-action__text">
@@ -42,7 +41,7 @@
           <div class="call-to-action__text">
             <h3><%= sub_head %></h3>
             <div>
-              <%= helpers.safe_format(funding_results) %>
+              <%= funding_results %>
               <p>You can receive this alongside a <a href="/funding-and-support/tuition-fee-and-maintenance-loans">tuition fee and maintenance loan</a>.</p>
               <p>You could also get extra funding support <a href="/funding-and-support/if-youre-a-parent-or-carer">if you're a parent or carer</a> or <a href="/funding-and-support/if-youre-disabled">if you're disabled</a>.</p>
               <%= render Content::InsetTextComponent.new(

--- a/app/components/funding_widget_component.rb
+++ b/app/components/funding_widget_component.rb
@@ -25,7 +25,7 @@ class FundingWidgetComponent < ViewComponent::Base
   end
 
   def funding_results
-    subject_data.fetch(:funding, "").html_safe
+    subject_data&.fetch(:funding, "")
   end
 
   def next_steps

--- a/app/components/funding_widget_component.rb
+++ b/app/components/funding_widget_component.rb
@@ -25,7 +25,7 @@ class FundingWidgetComponent < ViewComponent::Base
   end
 
   def funding_results
-    subject_data&.fetch(:funding, "")
+    subject_data.fetch(:funding, "").html_safe
   end
 
   def next_steps

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
         name: "Biology"
         group: "Secondary"
         sub_head: "Biology - Secondary"
-        funding: "Bursaries of %{bursaries_postgraduate_biology} are available for trainee biology teachers if you're eligible."
+        funding: "Bursaries of %{bursaries_postgraduate_biology} are available for <a href='/life-as-a-teacher/explore-subjects/biology'>trainee biology teachers</a> if you're eligible."
       business_studies:
         name: "Business studies"
         group: "Secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
         name: "Biology"
         group: "Secondary"
         sub_head: "Biology - Secondary"
-        funding: "Bursaries of %{bursaries_postgraduate_biology} are available for <a href='/life-as-a-teacher/explore-subjects/biology'>trainee biology teachers</a> if you're eligible."
+        funding: "Bursaries of %{bursaries_postgraduate_biology} are available for <a href=\"/life-as-a-teacher/explore-subjects/biology\">trainee biology teachers</a> if you're eligible."
       business_studies:
         name: "Business studies"
         group: "Secondary"


### PR DESCRIPTION
### Trello card

https://trello.com/c/U5rbitfq/6926-allow-link-text-in-funding-widget

### Context

We want to be able to add link text to the subject-specific content in the funding widget on our [bursaries and scholarships](https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries) page.

### Changes proposed in this pull request

Adapted widget code to allow anchor tags by removing `html_safe` from `.erb` file and incorporating into `.rb` file for `funding_results`.

### Guidance to review
- check it's a suitable approach from a code perspective.
- check it has the intended behaviour needed.

