### PR TITLE
Changes to external link text

### DIFF
--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -31,7 +31,7 @@ For example, that means you should be able to:
 
 We’ve also made the website text as simple as possible to understand.
 
-[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+The [AbilityNet website](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
 
 ## Feedback and contact information
 
@@ -49,7 +49,7 @@ We’re always looking to improve the accessibility of this website. If you find
 
 The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
 
-If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service](https://www.equalityadvisoryservice.com/).
+If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service via their website](https://www.equalityadvisoryservice.com/).
 
 ## Technical information about this website’s accessibility
 

--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -53,11 +53,11 @@ All teacher training candidates are also eligible for [tuition fee and maintenan
 
 ## Get support
 
-[The Career Transition Partnership](https://www.ctp.org.uk/) supports leavers of the armed forces as they transition from the military into civilian life.
+[The Career Transition Partnership website](https://www.ctp.org.uk/) supports leavers of the armed forces as they transition from the military into civilian life.
 
-The [MOD's Enhanced Learning Credits Scheme (ELC)](https://www.enhancedlearningcredits.com/) promotes lifelong learning amongst members of the armed forces by providing financial support to pay for approved qualifications. You can contact them to find out about eligibility.
+The [MOD's Enhanced Learning Credits Scheme (ELC) website](https://www.enhancedlearningcredits.com/) promotes lifelong learning amongst members of the armed forces by providing financial support to pay for approved qualifications. You can contact them to find out about eligibility.
 
-If you're unsure about who to contact for support, [Veteran's Gateway](https://www.veteransgateway.org.uk/about/) can help put you in touch with the organisations you may need for advice and support.
+If you're unsure about who to contact for support, [Veteran's Gateway website](https://www.veteransgateway.org.uk/about/) can help put you in touch with the organisations you may need for advice and support.
 
 ### Get an adviser
 

--- a/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
+++ b/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
@@ -83,16 +83,16 @@ You do not have to pay a bursary or scholarship back. You can get a bursary or s
 
 You’ll need to contact your country’s student finance body to find out about your eligibility for funding if you live in Wales, Scotland, or Northern Ireland.
 
-Find out about:
+Find out about student finance across the UK:
 
-* [student finance in Wales](https://www.studentfinancewales.co.uk/)
-* [student finance in Scotland](https://www.saas.gov.uk/)
-* [student finance in Northern Ireland](https://www.studentfinanceni.co.uk/)
+* [Student Finance Wales website](https://www.studentfinancewales.co.uk/)
+* [Student Awards Agency Scotland website](https://www.saas.gov.uk/)
+* [student Finance Northern Ireland website](https://www.studentfinanceni.co.uk/)
 
 Or, you'll need to contact the education authority if you live in Jersey, Guernsey, or the Isle of Man.
 
-Find out about:
+Find out about student finance in the Channel Islands and the Isle of Man:
 
-* [funding in Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx)
-* [funding in Guernsey](https://www.gov.gg/article/152744/Policies)
-* [funding in the Isle of Man](https://www.gov.im/student-grants)
+* [student finance guidance from the Government of Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx)
+* [student finance guidance from the Sates of Guernsey](https://www.gov.gg/article/152744/Policies)
+* [student awards guidance from the Isle of Man government website](https://www.gov.im/student-grants)

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
@@ -45,4 +45,4 @@ You need [specific qualifications to teach a class of pupils with hearing impair
 
 A special educational needs coordinator (SENCO) assesses, plans and monitors the progress of disabled pupils and pupils with special educational needs.
 
-Once you’re a qualified teacher you'll need to complete the [National Award in Special Educational Needs Coordination (NASENCo)](https://nasen.org.uk/page/nasenco) when you take up your SENCO post.
+Once you’re a qualified teacher you'll need to complete further training when you take up your post. [Visit the National Award in Special Educational Needs Coordination website for more on SENCO training](https://nasen.org.uk/page/nasenco).

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -151,7 +151,7 @@ Talk to your training provider about the home fee rate, [bursaries and scholarsh
 
 [Student Finance England](https://www.gov.uk/contact-student-finance-england) has a dedicated service for EU students and for EEA citizens working in the UK.
 
-The [UK Council for International Student Affairs](https://www.ukcisa.org.uk/About-UKCISA) offers advice to international students about what financial support may be available.
+The [UK Council for International Student Affairs website](https://www.ukcisa.org.uk/About-UKCISA) offers advice to international students about what financial support may be available.
 
 ## Contact us
 

--- a/app/views/content/non-uk-teachers/non-uk-qualifications.md
+++ b/app/views/content/non-uk-teachers/non-uk-qualifications.md
@@ -100,11 +100,11 @@ You'll also need to:
 
 ## English language, maths and science proficiency
 
-If you’ve reached a certain proficiency in an English language test, some providers will accept this as evidence you meet the standard of a grade 4 GCSE in English – for example:
+If you’ve reached a certain proficiency in an English language test, some providers will accept this as evidence you meet the standard of a grade 4 GCSE in English. You can find out more by visiting the following websites:
 
-* [International English Language Testing System (IELTS)](https://www.ielts.org/)
-* [Test of English as a Foreign Language (TOEFL)](https://www.ets.org/toefl)
-* [C2 Proficiency, formerly known as Cambridge English: Proficiency (CPE)](https://www.cambridgeenglish.org/exams-and-tests/proficiency/)
+* [International English Language Testing System (IELTS) website](https://www.ielts.org/)
+* [Test of English as a Foreign Language (TOEFL) website](https://www.ets.org/toefl)
+* [C2 Proficiency, formerly known as Cambridge English: Proficiency (CPE) website](https://www.cambridgeenglish.org/exams-and-tests/proficiency/)
 
 If you have not passed an English language test like this, or do not have qualifications in maths or science which are the same standard as grade 4 GCSE, some teacher training providers will let you sit tests in these subjects. It’s best to contact them to ask about their policy before you apply.
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -57,9 +57,10 @@ $international-content$
 
 Your postgraduate teacher training course might be provided by: 
 
-* a university (sometimes referred to as university-led training) 
-* a school or group of schools (sometimes referred to as school-led training, or an apprenticeship) 
-* [Teach First](https://www.teachfirst.org.uk/) (a charitable organisation)
+* a university, sometimes referred to as university-led training 
+* a school or group of schools, sometimes referred to as school-led training 
+
+Your teacher training course may also be provided by a company or charity. For example, [Teach First is a charitable organisation that provides teacher training](https://www.teachfirst.org.uk/).
 
 Some providers are ‘accredited’ – this means they've been approved by the Department for Education (DfE) to run teacher training courses.
 


### PR DESCRIPTION
### Trello card

### Context

Our DAC audit last year flagged that we don’t tell users when links are opening in a new tab (see attached tickets).

We’ve developed some standards for how links work on our site:

internal and external links will only open in a new tab if the user would lose information such as filling out a form eg. Privacy policy

we will tell users when they are clicking on an external non-gov.uk site by providing more descriptive content to the user

### Changes proposed in this pull request

### Guidance to review

