### PR TITLE
Highlight state for details component within forms

### DIFF
--- a/app/webpacker/styles/govuk-reset.scss
+++ b/app/webpacker/styles/govuk-reset.scss
@@ -23,3 +23,9 @@ h2.govuk-error-summary__title {
 .govuk-label {
   @include font;
 }
+
+.govuk-details .govuk-details__summary {
+  &:focus {
+    @extend .link; 
+  }
+}


### PR DESCRIPTION
### Trello card

https://trello.com/c/LJrOjB6l/6879-dac-audit-2023-different-highlight-state-for-details-component-within-forms

### Context

Different highlights were found across the ['Are you qualified to teach'](https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/returning_teacher) page; when tabbing through the page, the highlight of the details component ‘What is QTS?’ was inconsistent/a different colour.

### Changes proposed in this pull request

- updated `govuk-reset.scss` file to apply custom focus style to `govuk-details` component (specifically `.govuk-details_summary`); the component summary now takes its focus styling from `.link` in `links-and-buttons.scss`.

### Guidance to review

- check this is the best approach from a code perspective.
- check that the highlight state is behaving as expected.