### PR TITLE
Change date formats on check answers page in adviser funnel

### DIFF
--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -4,7 +4,7 @@ module AnswerHelper
   def format_answer(answer)
     case answer
     when Date
-      answer = answer.to_formatted_s(:govuk_date)
+      answer = answer.to_formatted_s(:govuk_zero_pad)
     when Time
       answer = answer.in_time_zone.to_formatted_s(:govuk_time)
     end

--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AnswerHelper, type: :helper do
 
     it "correctly formats a date" do
       answer = Date.new(2011, 1, 24)
-      expect(helper.format_answer(answer)).to eq("<span>24 01 2011</span>")
+      expect(helper.format_answer(answer)).to eq("<span>24 January 2011</span>")
     end
 
     it "correctly formats a time" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/Z6odPjEh/6961-change-date-formats-on-check-answers-page-in-adviser-funnel-on-git

### Context

Whilst reviewing the adviser funnel as part of the move to GIT, a few minor improvements were noticed. One of these concerns the date format used on the check answers page ([/teacher-training-adviser/sign_up/review_answers](https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/review_answers)) for date of birth and for the callback bookings. The date format should be e.g. 1 January 1990.

### Changes proposed in this pull request

Minor tweak to `AnswerHelper` to format dates with `:govuk_zero_pad`

### Guidance to review

- check visuals meet GDS best practice on check answers page. 
- ensure this change only relates to the display on the review answers page; the format of the value passed to CRM should not be changed.