### PR TITLE
Amends image block component to support an optional title color

### DIFF
--- a/app/components/content/image_block_component.html.erb
+++ b/app/components/content/image_block_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(class: "image-block") do %>
   <%= image %>
-  <%= tag.h2(class: "heading--overlap heading--highlight-yellow heading--margin-top-0 heading-xl") do %>
+  <%= tag.h2(class: "heading--overlap heading--highlight-#{title_color} heading--margin-top-0 heading-xl") do %>
     <%= tag.span(title) %>
   <% end %>
   <%= content %>

--- a/app/components/content/image_block_component.rb
+++ b/app/components/content/image_block_component.rb
@@ -1,14 +1,15 @@
 module Content
   class ImageBlockComponent < ViewComponent::Base
-    attr_reader :title, :image_path
+    attr_reader :title, :image_path, :title_color
 
     include ContentHelper
 
-    def initialize(title:, image_path:)
+    def initialize(title:, image_path:, title_color: "yellow")
       super
 
       @title = substitute_values(title)
       @image_path = image_path
+      @title_color = title_color
     end
 
     def image


### PR DESCRIPTION
### Trello card

https://trello.com/c/Jd9HvLCS/6811-phase-5-repurpose-navigation-component-for-life-as-a-teacher-section

### Context

GIT users need to feel inspired to teach and reassured that teaching is a viable career for them

Repurpose the navigation component used on the homepage to be used throughout the pages within the Life as a teacher section

### Changes proposed in this pull request

- Amends the `ImageBlockComponent` to support an optional `title_color` param. A list of colours can be found in `app/webpacker/styles/headings.scss:148-168` (use the color as a string from `heading--highlight-COLOR`).

### Guidance to review

