### PR TITLE
Close button on search

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -1,18 +1,18 @@
 <%= tag.div(class: classes, data: { controller: "searchbox", "searchbox-search-input-id-value" => search_input_id }, role: "navigation") do %>
   <ul class="extra-navigation__list extra-navigation__flex">
-      <li class="extra-navigation__link extra-navigation__mail">
-        <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
+    <li class="extra-navigation__link extra-navigation__mail">
+      <%= link_to("/mailinglist/signup/name", class: "link--black") do %>
         Sign up for emails<span class="icon icon-mail hide-on-narrow" aria-hidden="true"></span><span class="icon icon-mail-white hide-on-narrow" aria-hidden="true"></span>
-        <% end %>
-      </li>
-      <li class="extra-navigation__link extra-navigation__calendar">
-        <%= link_to("/events", class: "link--black") do %>
+      <% end %>
+    </li>
+    <li class="extra-navigation__link extra-navigation__calendar">
+      <%= link_to("/events", class: "link--black") do %>
         Find an event<span class="icon icon-calendar hide-on-narrow" aria-hidden="true"></span><span class="icon icon-calendar-white hide-on-narrow" aria-hidden="true"></span>
-        <% end %>
-      </li>
+      <% end %>
+    </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden hidden], data: { "searchbox-target": "label" }) %>
-      <%= link_to(search_path, id: "search-toggle", role: "button", aria: { label: "Search", expanded: "false", controls: "search-bar" }, data: { action: "searchbox#toggle" }) do %>
+      <%= link_to(search_path, id: "search-toggle", role: "button", aria: { label: "Search", expanded: "false", controls: "search-bar" }, data: { action: "searchbox#toggle", "searchbox-target": "toggleButton" }) do %>
         <span class="icon icon-search"></span>
         <span class="icon icon-close"></span>
       <% end %>

--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -12,7 +12,7 @@
     </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>
       <%= tag.label("Search", for: search_input_id, class: %w[searchbox__label visually-hidden hidden], data: { "searchbox-target": "label" }) %>
-      <%= link_to(search_path, id: "search-toggle", role: "button", aria: { label: "Search", expanded: "false", controls: "search-bar" }, data: { action: "searchbox#toggle", "searchbox-target": "toggleButton" }) do %>
+      <%= link_to(search_path, id: "search-toggle", role: "button", aria: { label: "Search", expanded: "false", controls: "search-bar" }, data: { action: "searchbox#toggle" }) do %>
         <span class="icon icon-search"></span>
         <span class="icon icon-close"></span>
       <% end %>

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -4,7 +4,7 @@ import Redacter from '../javascript/redacter';
 
 export default class extends Controller {
   static openedClass = 'searchbox--opened';
-  static targets = ['searchbar', 'label', 'toggleButton'];
+  static targets = ['searchbar', 'label'];
   static values = { searchInputId: String };
 
   searchQuery = null;
@@ -83,9 +83,9 @@ export default class extends Controller {
   }
 
   updateAriaLabel(label) {
-    const toggleButton = this.toggleButtonTarget;
-    if (toggleButton) {
-      toggleButton.setAttribute('aria-label', label);
+    const toggle = document.getElementById('search-toggle');
+    if (toggle) {
+      toggle.setAttribute('aria-label', label);
     }
   }
 

--- a/app/webpacker/controllers/searchbox_controller.js
+++ b/app/webpacker/controllers/searchbox_controller.js
@@ -4,7 +4,7 @@ import Redacter from '../javascript/redacter';
 
 export default class extends Controller {
   static openedClass = 'searchbox--opened';
-  static targets = ['searchbar', 'label'];
+  static targets = ['searchbar', 'label', 'toggleButton'];
   static values = { searchInputId: String };
 
   searchQuery = null;
@@ -20,9 +20,11 @@ export default class extends Controller {
     if (this.element.classList.contains('open')) {
       this.element.classList.remove('open');
       this.searchTogglerExpanded(false);
+      this.updateAriaLabel('Search');
     } else {
       this.element.classList.add('open');
       this.searchTogglerExpanded(true);
+      this.updateAriaLabel('Close search');
       this.input.focus();
     }
   }
@@ -77,6 +79,13 @@ export default class extends Controller {
     }
     if (searchInput) {
       searchInput.ariaExpanded = expanded;
+    }
+  }
+
+  updateAriaLabel(label) {
+    const toggleButton = this.toggleButtonTarget;
+    if (toggleButton) {
+      toggleButton.setAttribute('aria-label', label);
     }
   }
 

--- a/spec/javascript/controllers/searchbox_controller_spec.js
+++ b/spec/javascript/controllers/searchbox_controller_spec.js
@@ -6,7 +6,7 @@ describe('SearchboxController', () => {
     <div id="search" data-controller="searchbox" data-searchbox-search-input-id-value="searchbox__input">
       <label for="searchbox__input" data-searchbox-target="label">Search</label>
       <div data-searchbox-target="searchbar"></div>
-      <a data-action="searchbox#toggle">Search</a>
+      <a id="search-toggle" aria-label="Search" data-action="searchbox#toggle">Search</a>
     </div>
   `;
 
@@ -43,6 +43,17 @@ describe('SearchboxController', () => {
     });
   });
 
+  describe('toggles the aria-label', () => {
+    it('sets the aria-label to "Search" or "Close search" depending on the search state', () => {
+      const searchToggle = document.getElementById('search-toggle');
+      expect(searchToggle.getAttribute('aria-label')).toBe('Search');
+      clickSearch();
+      expect(searchToggle.getAttribute('aria-label')).toBe('Close search');
+      clickSearch();
+      expect(searchToggle.getAttribute('aria-label')).toBe('Search');
+    });
+  });
+
   describe('typing in the search box', () => {
     let open;
 
@@ -70,7 +81,7 @@ describe('SearchboxController', () => {
         expect(open).toBeCalledWith(
           'GET',
           '/search.json?search%5Bsearch%5D=search%20term',
-          true
+          true,
         );
         expect(open.mock.calls.length).toBe(1);
         done();
@@ -90,7 +101,7 @@ describe('SearchboxController', () => {
         expect(open).toBeCalledWith(
           'GET',
           '/search.json?search%5Bsearch%5D=last%20term',
-          true
+          true,
         );
         expect(open.mock.calls.length).toBe(1);
         done();
@@ -110,12 +121,12 @@ describe('SearchboxController', () => {
         expect(open).toBeCalledWith(
           'GET',
           '/search.json?search%5Bsearch%5D=first%20term',
-          true
+          true,
         );
         expect(open).toBeCalledWith(
           'GET',
           '/search.json?search%5Bsearch%5D=last%20term',
-          true
+          true,
         );
         expect(open.mock.calls.length).toBe(2);
         done();
@@ -129,7 +140,7 @@ describe('SearchboxController', () => {
 
       setTimeout(() => {
         const noResultsItem = document.querySelector(
-          '.autocomplete__option--no-results'
+          '.autocomplete__option--no-results',
         );
         expect(noResultsItem.innerHTML).toEqual('Searching...');
         done();


### PR DESCRIPTION
### Trello card

https://trello.com/c/CLYeec9P/7014-ensure-close-button-on-search-is-labelled-correctly-for-screen-reader-users

### Context

The accessibility team has flagged an issue with the aria label on the search button: when you select the button it changes visually to a close button, but the accessible name (aria-label) stays as "search". We need to fix how the aria-label works when the search button changes to close.

### Changes proposed in this pull request

Adapted `searchbox_controller.js` to dynamically change the aria-label to `Search` or `Close Search`, depending on whether the search box is open or closed. 

### Guidance to review

Check console to ensure correct aria-labels are present when opening/closing the search.
