### PR TITLE
Remove manual dates from content pages

### DIFF
--- a/app/views/content/a-day-in-the-life-of-a-teacher.md
+++ b/app/views/content/a-day-in-the-life-of-a-teacher.md
@@ -2,7 +2,6 @@
   title: "A day in the life of a teacher"
   description: |-
     Find out about a day in the life of a teacher in a secondary school, including an example of teacher working hours and their day to day routine.
-  date: "2021-03-08"
   image: "static/images/content/hero-images/0011.jpg"
   backlink: "../"
   keywords:

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -4,7 +4,6 @@
   description: |-
     Explore how to get into teaching with official Department for Education guidance on training courses, finding funding, and what teaching is really like.
   fullwidth: true
-  date: "2023-04-19"
   title_paragraph: "Nobody knows teaching like we do. Whether you're just thinking about it or ready to apply, we offer <strong>free advice and support</strong> to decide if <strong>teaching in a primary or secondary school</strong> in England is right for you. Discover a career with <strong>lots of opportunities to grow</strong>."
   image: "static/images/content/hero-images/chemistry-crop.jpg"
   hero_content_width: even

--- a/app/views/content/how-to-apply-for-teacher-training/if-your-application-is-unsuccessful.md
+++ b/app/views/content/how-to-apply-for-teacher-training/if-your-application-is-unsuccessful.md
@@ -10,7 +10,6 @@ related_content:
 navigation: 30.30
 navigation_title: If your application is unsuccessful
 navigation_description: Find out what to do if your teacher training application is unsuccessful.
-date: "2023-03-30"
 keywords:
   - adviser
   - advisor

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-application.md
@@ -5,7 +5,6 @@ description: |-
 related_content:
     How to choose your teacher training course : "/train-to-be-a-teacher/how-to-choose-your-teacher-training-course"
     Get school experience : "/train-to-be-a-teacher/get-school-experience"
-date: "2021-06-24"
 keywords:
   - adviser
   - advisor

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-interview.md
@@ -9,7 +9,6 @@ related_content:
 navigation: 30.20
 navigation_title: Teacher training interviews
 navigation_description: Find out how to prepare for your teacher training interviews.
-date: "2023-06-09"
 keywords:
   - adviser
   - advisor

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-references.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-references.md
@@ -9,7 +9,6 @@ related_content:
 navigation: 30.15
 navigation_title: Teacher training references
 navigation_description: Find out which teacher training references you need to provide and what they should include.
-date: "2023-07-03"
 keywords:
   - teacher training references
   - adviser

--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -7,7 +7,6 @@ related_content:
 navigation: 30.16
 navigation_title: When to apply for teacher training
 navigation_description:  Find out when you can apply for postgraduate teacher training courses.
-date: "2023-03-30"
 keywords:
   - teacher training applications
 quote:

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers.md
@@ -15,7 +15,6 @@ keywords:
  - nursery
  - preschool
  - year one
-date: "2021-03-29"
 description: |-
   Find out how to become an early years teacher. Discover the qualifications you need, the different early years teacher training routes and the cost.
 inset_text:

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers.md
@@ -4,7 +4,6 @@ article_classes: ['longform']
 image: "static/images/content/hero-images/0031.jpg"
 description: |-
   Find out how to teach in further education in England. Explore which qualifications you need and how to find further education teacher training.
-date: "2023-02-23"
 keywords:
   - Further
   - Further education

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
@@ -3,7 +3,6 @@ title: "Teach pupils with special educational needs and disabilities (SEND)"
 heading: "Teach pupils with special educational needs and disabilities (SEND)"
 description: |-
   Find out how you can teach pupils with special educational needs and disabilities (SEND) and how to become a special educational needs coordinator (SENCO).
-date: "2021-05-07"
 image: "static/images/content/hero-images/0032.jpg"
 promo_content:
     - content/train-to-be-a-teacher/promos/adviser-promo-send

--- a/app/views/content/life-as-a-teacher/pay-and-benefits/teacher-pay.md
+++ b/app/views/content/life-as-a-teacher/pay-and-benefits/teacher-pay.md
@@ -3,7 +3,6 @@ title: "Teacher pay"
 heading: "Teacher pay"
 description: |-
   All qualified teachers will have a starting salary of at least $salaries_starting_min$ (or higher in London). Find out about teacher pay ranges and more benefits of teaching.
-date: "2021-06-24"
 backlink: "../../"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo-salaries

--- a/app/views/content/life-as-a-teacher/pay-and-benefits/teachers-pension-scheme.md
+++ b/app/views/content/life-as-a-teacher/pay-and-benefits/teachers-pension-scheme.md
@@ -3,7 +3,6 @@ title: "Teachers' pension scheme"
 heading: "Teachers' pension scheme"
 description: |-
   The teachers' pension scheme is one of the most generous in the country. Learn more about the benefits of the teachers' pension scheme.
-date: "2022-11-29"
 image: false
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo-salaries

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/career-progression.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/career-progression.md
@@ -3,7 +3,6 @@ title: "How to move up the career ladder in teaching"
 heading: "How to move up the career ladder in teaching"
 description: |-
   Teacher training advisers talk about teacher development and how you can progress a career in teaching.
-date: "2024-01-09"
 backlink: "../../"
 promo_content:
     - content/train-to-be-a-teacher/promos/mailing-list-promo-salaries

--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -10,7 +10,6 @@ promo_content:
 navigation: 20.20
 navigation_title: Fees and financial support for non-UK trainee teachers
 navigation_description: Learn more about teacher training fees in England and financial help for physics and languages trainees.
-date: "2021-05-27"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../../"
 keywords:

--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -12,7 +12,6 @@ promo_content:
 navigation: 20.60
 navigation_title: Get an international relocation payment
 navigation_description: Teachers of languages or physics could be eligible for financial help from the UK government worth $nonuk_internationalrelocationpayment_value$.
-date: "2021-05-27"
 image: "static/images/content/hero-images/geography.jpg"
 backlink: "../../"
 inset_text:

--- a/app/views/content/non-uk-teachers/international-qualified-teacher-status.md
+++ b/app/views/content/non-uk-teachers/international-qualified-teacher-status.md
@@ -11,7 +11,6 @@ promo_content:
 navigation: 20.50
 navigation_title: Gain the equivalent of English QTS, from outside the UK
 navigation_description: Train from anywhere in the world to get international qualified teacher status (iQTS), backed by England’s Department for Education.
-date: "2021-08-06"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../"
 keywords:

--- a/app/views/content/non-uk-teachers/non-uk-qualifications.md
+++ b/app/views/content/non-uk-teachers/non-uk-qualifications.md
@@ -10,7 +10,6 @@ related_content:
 navigation: 20.20
 navigation_title: Qualifications you'll need to train to teach in England
 navigation_description: Before you apply, get help checking you have the correct qualifications for English teacher training.
-date: "2021-05-27"
 image: "static/images/content/hero-images/0032.jpg"
 backlink: "../../"
 youtube_video:

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -11,7 +11,6 @@ promo_content:
 navigation: 20.40
 navigation_title: Teach in England as a non-UK qualified teacher
 navigation_description: Find out how you can bring your skills and perspective to an English classroom if you're a qualified teacher from overseas.
-date: "2021-05-27"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../../"
 inset_text:

--- a/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
+++ b/app/views/content/non-uk-teachers/train-to-teach-in-england-as-an-international-student.md
@@ -14,7 +14,6 @@ youtube_video:
 navigation: 20.10
 navigation_title: Train to teach in England as a non-UK citizen
 navigation_description: Find out how to train to teach in England as a non-UK citizen or foreign student and get English qualified teacher status (QTS).
-date: "2021-05-27"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../../"
 keywords:

--- a/app/views/content/non-uk-teachers/ukraine.md
+++ b/app/views/content/non-uk-teachers/ukraine.md
@@ -10,7 +10,6 @@ related_content:
 navigation: 20.70
 navigation_title: Ukrainian teachers and trainees coming to the UK
 navigation_description: Find information and advice for Ukrainian citizens seeking training places and teaching jobs in England.
-date: "2022-06-24"
 image: "static/images/content/hero-images/english.jpg"
 backlink: "../../"
 keywords:

--- a/app/views/content/non-uk-teachers/visas-for-non-uk-teachers.md
+++ b/app/views/content/non-uk-teachers/visas-for-non-uk-teachers.md
@@ -7,7 +7,6 @@ related_content:
     Teacher pay in England : "/life-as-a-teacher/pay-and-benefits/teacher-pay"
     A day in the life of a teacher in England : "/a-day-in-the-life-of-a-teacher"
 promo_content:
-date: "2021-05-27"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../../"
 keywords:

--- a/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
@@ -11,7 +11,6 @@ promo_content:
 navigation: 20.30
 navigation_title: Apply for your visa to train to teach
 navigation_description: Learn more about applying for a Student or Skilled Worker visa to train to teach in England.
-date: "2021-05-27"
 image: "static/images/content/hero-images/0034.jpg"
 backlink: "../../"
 keywords:

--- a/app/views/content/steps-to-become-a-teacher.md
+++ b/app/views/content/steps-to-become-a-teacher.md
@@ -4,7 +4,6 @@
   layout: "layouts/steps"
   description: |-
     Find out how to become a teacher in England, including the qualifications you need, how to fund your training and where to find school experience.
-  date: "2021-06-24"
   image: "static/images/content/hero-images/0030.jpg"
   backlink: "../"
   navigation: 10

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -4,7 +4,6 @@ heading: "Assessment only route to QTS for unqualified teachers"
 subcategory: Other routes into teaching
 description: |-
   Find out about the assessment only route to qualified teacher status (QTS) for unqualified teachers who have worked in a classroom.
-date: "2021-06-08"
 image: false
 backlink: /
 promo_content:

--- a/app/views/content/train-to-be-a-teacher/teaching-internships.md
+++ b/app/views/content/train-to-be-a-teacher/teaching-internships.md
@@ -4,7 +4,6 @@ heading: "Get teaching experience with an internship"
 subcategory: Postgraduate teacher training
 description: |-
   Find paid teaching internships to gain new skills and see what classroom life is like. Explore chemistry, computing, languages, maths and physics internships.
-date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships

--- a/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-a-pgce.md
@@ -8,7 +8,6 @@ related_content:
     Train to be a teacher if you have or are studying for a degree : "/train-to-be-a-teacher/if-you-have-a-degree"
     How to choose your teacher training course : "/train-to-be-a-teacher/how-to-choose-your-teacher-training-course"
     What will your teacher training year be like? : "/train-to-be-a-teacher/initial-teacher-training"
-date: "2021-11-01"
 backlink: "../../"
 navigation: 20.30
 navigation_title: Postgraduate certificate in education (PGCE)

--- a/app/views/content/train-to-be-a-teacher/what-is-qts.md
+++ b/app/views/content/train-to-be-a-teacher/what-is-qts.md
@@ -4,7 +4,6 @@ heading: "What is qualified teacher status (QTS)?"
 subcategory: Qualifications
 description: |-
   Qualified teacher status (QTS) is what you need to teach in maintained primary, secondary and special schools in England. Find out how to get QTS.
-date: "2021-11-01"
 backlink: "../../"
 related_content:
     What qualifications do you need to be a teacher? : "/train-to-be-a-teacher/qualifications-you-need-to-teach"


### PR DESCRIPTION
### Trello card

https://trello.com/c/JBHFjGrw/6987-remove-manual-dates-from-content-pages?filter=member:spencerldixon

### Context

We are changing the way that our sitemap lastmod value is generated so that we give a better signal to Google when we have fresh content

We want to remove all instances of date in the frontmatter of content pages as these are all very out of date

### Changes proposed in this pull request

- Removes hardcoded `date` in frontmatter to allow Page Modification Tracker to determine last updated at date.

### Guidance to review

