### PR TITLE
Added manual pages to last mod tracking

### DIFF
--- a/lib/page_modification_tracker.rb
+++ b/lib/page_modification_tracker.rb
@@ -2,6 +2,12 @@ require "action_dispatch/testing/integration"
 require "digest/sha1"
 
 class PageModificationTracker
+  MANUAL_PAGES = {
+    "/events/about-get-into-teaching-events" => {},
+    "/events" => {},
+    "/mailinglist/signup/name" => {},
+  }.freeze
+
   attr_reader :app, :headers
 
   def initialize(host: "localhost:3000", selector: "body")
@@ -41,14 +47,6 @@ class PageModificationTracker
 
 private
 
-  def manual_pages
-    {
-      "/events/about-get-into-teaching-events" => {},
-      "/events" => {},
-      "/mailinglist/signup/name" => {},
-    }
-  end
-
   def published_pages
     events = GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
       start_after: Time.zone.now,
@@ -57,7 +55,7 @@ private
     )
     content_pages = ::Pages::Frontmatter.list.reject { |_path, fm| fm[:draft] }
     event_pages = events.map { |e| Rails.application.routes.url_helpers.event_path(e.readable_id) }.index_with({})
-    content_pages.merge(**event_pages, **manual_pages)
+    content_pages.merge(**event_pages, **MANUAL_PAGES)
   end
 
   def request_path(path, app, headers)

--- a/lib/page_modification_tracker.rb
+++ b/lib/page_modification_tracker.rb
@@ -49,7 +49,13 @@ private
     )
     content_pages = ::Pages::Frontmatter.list.reject { |_path, fm| fm[:draft] }
     event_pages = events.map { |e| Rails.application.routes.url_helpers.event_path(e.readable_id) }.index_with({})
-    content_pages.merge(event_pages)
+    manual_pages = {
+      "/events/about-get-into-teaching-events" => {},
+      "/events" => {},
+      "/mailinglist/signup/name" => {},
+    }
+
+    content_pages.merge(**event_pages, **manual_pages)
   end
 
   def request_path(path, app, headers)

--- a/lib/page_modification_tracker.rb
+++ b/lib/page_modification_tracker.rb
@@ -41,6 +41,14 @@ class PageModificationTracker
 
 private
 
+  def manual_pages
+    {
+      "/events/about-get-into-teaching-events" => {},
+      "/events" => {},
+      "/mailinglist/signup/name" => {},
+    }
+  end
+
   def published_pages
     events = GetIntoTeachingApiClient::TeachingEventsApi.new.search_teaching_events(
       start_after: Time.zone.now,
@@ -49,12 +57,6 @@ private
     )
     content_pages = ::Pages::Frontmatter.list.reject { |_path, fm| fm[:draft] }
     event_pages = events.map { |e| Rails.application.routes.url_helpers.event_path(e.readable_id) }.index_with({})
-    manual_pages = {
-      "/events/about-get-into-teaching-events" => {},
-      "/events" => {},
-      "/mailinglist/signup/name" => {},
-    }
-
     content_pages.merge(**event_pages, **manual_pages)
   end
 

--- a/spec/lib/page_modification_tracker_spec.rb
+++ b/spec/lib/page_modification_tracker_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe PageModificationTracker do
       .to receive(:search_teaching_events)
       .and_return([])
 
+    allow_any_instance_of(described_class)
+      .to receive(:manual_pages)
+      .and_return({})
+
     allow(::Pages::Frontmatter)
       .to receive(:list)
       .and_return({ path => { draft: false } })

--- a/spec/lib/page_modification_tracker_spec.rb
+++ b/spec/lib/page_modification_tracker_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe PageModificationTracker do
       .to receive(:search_teaching_events)
       .and_return([])
 
-    allow_any_instance_of(described_class)
-      .to receive(:manual_pages)
-      .and_return({})
+    stub_const("PageModificationTracker::MANUAL_PAGES", {})
 
     allow(::Pages::Frontmatter)
       .to receive(:list)


### PR DESCRIPTION
### Trello card

https://trello.com/c/e7N621jD/7017-investigate-lastmod-date-for-non-standard-content-pages

### Context

We recently changed how we assign lastmod date to the pages in our sitemap (see attached ticket)

There are a few non-standard content pages that are still using the old default date of 2021-03-01

`/events/about-get-into-teaching-events`
`/events`
`/mailinglist/signup/name`

We want to investigate these and tweak the lastmod process if possible (or change which default date they use)

### Changes proposed in this pull request

- Merge in a set of manual paths with empty frontmatter to the list of pages that lastmod iterates through

### Guidance to review

