### PR TITLE
Time format check answers

### DIFF
--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -8,14 +8,16 @@ module AnswerHelper
     when Time
       formatted_time = answer.in_time_zone.to_formatted_s(:govuk_time_with_period)
 
-      # Convert "12:00pm" to "midday" as per GDS guidance
-      answer = if formatted_time == "12:00pm"
+      # Convert "12:00pm" to "midday" and "12:00am" to "midnight" as per GDS guidance
+      answer = case formatted_time
+               when "12:00pm"
                  "midday"
+               when "12:00am"
+                 "midnight"
                else
                  formatted_time
                end
     end
-
     safe_format(answer.to_s, wrapper_tag: "span")
   end
 

--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -6,7 +6,14 @@ module AnswerHelper
     when Date
       answer = answer.to_formatted_s(:govuk_date)
     when Time
-      answer = answer.in_time_zone.to_formatted_s(:govuk_time)
+      formatted_time = answer.in_time_zone.to_formatted_s(:govuk_time_with_period)
+
+      # Convert "12:00pm" to "midday" as per GDS guidance
+      answer = if formatted_time == "12:00pm"
+                 "midday"
+               else
+                 formatted_time
+               end
     end
 
     safe_format(answer.to_s, wrapper_tag: "span")

--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -13,7 +13,17 @@ RSpec.describe AnswerHelper, type: :helper do
 
     it "correctly formats a time" do
       answer = Time.utc(2011, 1, 24, 10, 30)
-      expect(helper.format_answer(answer)).to eq("<span>10:30</span>")
+      expect(helper.format_answer(answer)).to eq("<span>10:30am</span>")
+    end
+
+    it "correctly formats a time of midday" do
+      answer = Time.utc(2011, 1, 24, 12, 0)
+      expect(helper.format_answer(answer)).to eq("<span>midday</span>")
+    end
+
+    it "correctly formats a time of midnight" do
+      answer = Time.utc(2011, 1, 24, 0, 0)
+      expect(helper.format_answer(answer)).to eq("<span>midnight</span>")
     end
 
     it "calls safe_format" do
@@ -26,7 +36,7 @@ RSpec.describe AnswerHelper, type: :helper do
 
       it "correctly formats a time" do
         answer = Time.utc(2011, 1, 24, 10, 30)
-        expect(helper.format_answer(answer)).to eq("<span>00:30</span>")
+        expect(helper.format_answer(answer)).to eq("<span>12:30am</span>")
       end
     end
   end


### PR DESCRIPTION
### Trello card

https://trello.com/c/vSQni4QV/6962-change-time-formats-on-check-answers-page-in-adviser-funnel-on-git

### Context

Whilst reviewing the adviser funnel as part of the move to GIT, a few minor improvements were noticed. One of these concerns the time format used on the check answers page ([/teacher-training-adviser/sign_up/review_answers](https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/review_answers)) for callback bookings. The time format should be e.g. 5:30pm.

### Changes proposed in this pull request

- Minor tweak to `AnswerHelper` to format times with `:govuk_time_with_period`.
- When time is 12:00pm or 00:00am, `AnswerHelper` converts to _midday_ and _midnight_ as per [GDS guidance](https://www.gov.uk/guidance/style-guide/a-to-z#time).
- Updated `AnswerHelper` test. 

### Guidance to review

- Please double guidance, especially in relation to _midday_ and _midnight_ formatting (see above). This can be removed if not needed. 
- Cannot be merged until check is done with CRM to ensure time values passed are not affected. 