### PR TITLE
Tweak ordering on Assessment only page and Internships page to ignore case

### DIFF
--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -15,7 +15,7 @@ module GroupedCards
     end
 
     def items(group)
-      @data.dig(group, "providers")
+      @data.dig(group, "providers").sort_by { |provider| provider["header"].to_s.downcase }
     end
 
     def description(group)

--- a/app/components/grouped_cards/listing_component.rb
+++ b/app/components/grouped_cards/listing_component.rb
@@ -15,7 +15,7 @@ module GroupedCards
     end
 
     def items(group)
-      @data.dig(group, "providers").sort_by { |provider| provider["header"].to_s.downcase }
+      @data.dig(group, "providers")
     end
 
     def description(group)

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -4,6 +4,7 @@ heading: "Assessment only route to QTS for unqualified teachers"
 subcategory: Other routes into teaching
 description: |-
   Find out about the assessment only route to qualified teacher status (QTS) for unqualified teachers who have worked in a classroom.
+date: "2021-06-08"
 image: false
 backlink: /
 promo_content:
@@ -395,6 +396,13 @@ provider_groups:
       telephone: "01227 925555"
       international_phone: "+441227925555"
       
+    - header: "i2i Teaching Partnership SCITT"
+      link: "https://www.i2ipartnership.co.uk/"
+      name: "Krissy Taylor"
+      email: "ktaylor@i2ipartnership.co.uk"
+      telephone: "01252 900550"
+      international_phone: "+441252900550"
+      
     - header: "Inspiring Futures Partnership Trust"
       link: "https://cheppingviewscitt.com/Entry-Criteria/"
       name: "Nicky Stephenson"
@@ -457,13 +465,6 @@ provider_groups:
       email: "h.grout@reading.ac.uk"
       telephone: "0118 378 7237"
       international_phone: "+441183787237"
-      
-    - header: "i2i Teaching Partnership SCITT"
-      link: "https://www.i2ipartnership.co.uk/"
-      name: "Krissy Taylor"
-      email: "ktaylor@i2ipartnership.co.uk"
-      telephone: "01252 900550"
-      international_phone: "+441252900550"
       
   South West:
     providers:

--- a/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
+++ b/app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md
@@ -4,7 +4,6 @@ heading: "Assessment only route to QTS for unqualified teachers"
 subcategory: Other routes into teaching
 description: |-
   Find out about the assessment only route to qualified teacher status (QTS) for unqualified teachers who have worked in a classroom.
-date: "2021-06-08"
 image: false
 backlink: /
 promo_content:

--- a/app/views/content/train-to-be-a-teacher/teaching-internships.md
+++ b/app/views/content/train-to-be-a-teacher/teaching-internships.md
@@ -4,7 +4,6 @@ heading: "Get teaching experience with an internship"
 subcategory: Postgraduate teacher training
 description: |-
   Find paid teaching internships to gain new skills and see what classroom life is like. Explore chemistry, computing, languages, maths and physics internships.
-date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships

--- a/app/views/content/train-to-be-a-teacher/teaching-internships.md
+++ b/app/views/content/train-to-be-a-teacher/teaching-internships.md
@@ -4,6 +4,7 @@ heading: "Get teaching experience with an internship"
 subcategory: Postgraduate teacher training
 description: |-
   Find paid teaching internships to gain new skills and see what classroom life is like. Explore chemistry, computing, languages, maths and physics internships.
+date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships
@@ -365,6 +366,13 @@ provider_groups:
         areas: "West Berkshire"
         name: "Claire Hickling"
         email: "c.hickling@niot.org.uk"
+      - header: "i2i Teaching Partnership"
+        link: "https://www.i2ipartnership.co.uk/1243/undergraduate-teaching-internship-programme"
+        applications: "Open January"
+        subjects: "chemistry, computing, maths, physics, languages"
+        areas: "Hampshire, Surrey"
+        name: "Liz Wylie"
+        email: "lwylie@i2ipartnership.co.uk"
       - header: "Ringwood School"
         link: "https://www.ringwood.hants.sch.uk/teacher-training/paid-internships/"
         applications: "Open April"
@@ -400,13 +408,6 @@ provider_groups:
         areas: "Slough, Surrey"
         name: "Natasha Bisset"
         email: "n.bisset@xaviercet.org.uk"
-      - header: "i2i Teaching Partnership"
-        link: "https://www.i2ipartnership.co.uk/1243/undergraduate-teaching-internship-programme"
-        applications: "Open January"
-        subjects: "chemistry, computing, maths, physics, languages"
-        areas: "Hampshire, Surrey"
-        name: "Liz Wylie"
-        email: "lwylie@i2ipartnership.co.uk"
   South West:
     providers:
       - header: "Excalibur Academies Trust"

--- a/lib/tasks/generate_assessment_only_providers.rake
+++ b/lib/tasks/generate_assessment_only_providers.rake
@@ -19,7 +19,7 @@ namespace :assessment_only_providers do
       end
     end
 
-    provider_groups = provider_groups.transform_values { |v| v["providers"].sort_by { |a| a["header"] } }.sort_by { |x, _y| [case x when "Non-UK"then 2; when "National" then 0; else 1 end, x] }
+    provider_groups = provider_groups.transform_values { |v| v["providers"].sort_by { |a| a["header"].to_s.downcase } }.sort_by { |x, _y| [case x when "Non-UK"then 2; when "National" then 0; else 1 end, x] }
 
     File.open("app/views/content/train-to-be-a-teacher/assessment-only-route-to-qts.md", "w") do |f|
       f.write ERB.new(File.read("lib/tasks/support/assessment-only-route-to-qts.md.erb"), trim_mode: "<>").result(binding)

--- a/lib/tasks/generate_teaching_internship_providers.rake
+++ b/lib/tasks/generate_teaching_internship_providers.rake
@@ -14,7 +14,7 @@ namespace :teaching_internship_providers do
       h[ip.region.to_s]["providers"] << ip.to_h
     end
 
-    providers.transform_values! { |v| v["providers"].sort_by { |a| a["header"] } }
+    providers.transform_values! { |v| v["providers"].sort_by { |a| a["header"].to_s.downcase } }
     provider_groups = providers.sort
 
     File.open("app/views/content/train-to-be-a-teacher/teaching-internships.md", "w") do |f|

--- a/lib/tasks/support/assessment-only-route-to-qts.md.erb
+++ b/lib/tasks/support/assessment-only-route-to-qts.md.erb
@@ -4,7 +4,6 @@ heading: "Assessment only route to QTS for unqualified teachers"
 subcategory: Other routes into teaching
 description: |-
   Find out about the assessment only route to qualified teacher status (QTS) for unqualified teachers who have worked in a classroom.
-date: "2021-06-08"
 image: false
 backlink: /
 promo_content:

--- a/lib/tasks/support/teaching-internship-providers.md.erb
+++ b/lib/tasks/support/teaching-internship-providers.md.erb
@@ -4,7 +4,6 @@ heading: "Get teaching experience with an internship"
 subcategory: Postgraduate teacher training
 description: |-
   Find paid teaching internships to gain new skills and see what classroom life is like. Explore chemistry, computing, languages, maths and physics internships.
-date: "2021-04-14"
 image: false
 promo_content:
   - content/train-to-be-a-teacher/promos/eta-promo-internships


### PR DESCRIPTION
### Trello card

https://trello.com/c/vQCGgTHI/7005-tweak-ordering-on-assessment-only-page-and-internships-page-to-ignore-case

### Context

We have recently made a change to allow the upload of Assessment only provider listings, to make future maintenance easier. The upload process lists providers alphabetically within each regional section. However, it currently orders by providers starting with an uppercase letter first, and then lowercase letters later. 

### Changes proposed in this pull request

Adapted the rake tasks to convert provider value to a string and make it lowercase; this ensures case-insensitive sorting on the the Assessment only page and the Internships page.

### Guidance to review

