### PR TITLE
remove selenium driver from integration tests

### DIFF
--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Integration tests", :integration, :js, type: :feature do
+RSpec.feature "Integration tests", :integration, type: :feature do
   before { config_capybara }
 
   around do |example|

--- a/spec/integration/teacher_training_adviser_spec.rb
+++ b/spec/integration/teacher_training_adviser_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign up", :integration, :js, type: :feature do
+RSpec.describe "Sign up", :integration, type: :feature do
   before do
     config_capybara
 


### PR DESCRIPTION
### Trello card
[Remove JS Selenium driver](https://trello.com/c/X9kToTVR/7092-remove-javascript-selenium-integration-tests)

### Context

### Changes proposed in this pull request
Remove javascript-selenium capybara driver from integration tests

### Guidance to review

