### PR TITLE
Updated aria label for chat button to match link text

### DIFF
--- a/app/components/chat_component.html.erb
+++ b/app/components/chat_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div data: { controller: "chat", available: Chat.available?, "chat-target": "container" }, class: "chat" do %>
   <div data-chat-target="online" class="hidden">
     <p>
-      <a class="button new-tab" href="/chat#root" target="chat" data-action="chat#start" data-chat-target="chat" aria-label="Chat online">Open chat in new tab</a>
+      <a class="button new-tab" href="/chat#root" target="chat" data-action="chat#start" data-chat-target="chat" aria-label="Open chat in new tab">Open chat in new tab</a>
     </p>
   </div>
   <div data-chat-target="offline" class="hidden">


### PR DESCRIPTION
### Trello card

https://trello.com/c/4FhYDfev/7100-update-or-remove-aria-label-for-chat-button-in-footer

### Context

One of our new accessibility tools, ARC Toolkit, has flagged that the aria label for the chat button in the footer is now different to the visible text. This means that people using assistive technologies may have problems accessing the link.

### Changes proposed in this pull request

Updated aria label for chat button to match link text i.e. "Open chat in new tab". 

### Guidance to review

