### PR TITLE
Fix CI destroy permission for review app

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -34,7 +34,7 @@ runs:
 
       - uses: google-github-actions/auth@v2
         with:
-          # project_id: get-into-teaching
+          project_id: get-into-teaching
           workload_identity_provider: projects/574582782335/locations/global/workloadIdentityPools/get-into-teaching-app/providers/get-into-teaching-app
 
       - name: Get Short SHA
@@ -116,7 +116,7 @@ runs:
             APP_LABEL="get-into-teaching-app-${{inputs.environment}}"
             HOST="getintoteaching.education.gov.uk"
           fi
-          
+
           az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --overwrite-existing
           kubelogin convert-kubeconfig -l spn
           POD_NAME=$(kubectl get pods -n ${{ env.NAMESPACE }} -l app=${APP_LABEL} -o jsonpath="{.items[0].metadata.name}")

--- a/.github/workflows/destroy_review.yml
+++ b/.github/workflows/destroy_review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: google-github-actions/auth@v2
         with:
-          # project_id: get-into-teaching
+          project_id: get-into-teaching
           workload_identity_provider: projects/574582782335/locations/global/workloadIdentityPools/get-into-teaching-app/providers/get-into-teaching-app
 
       - name: Setup Environment Variables

--- a/.github/workflows/destroy_review.yml
+++ b/.github/workflows/destroy_review.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - uses: google-github-actions/auth@v2
+        with:
+          # project_id: get-into-teaching
+          workload_identity_provider: projects/574582782335/locations/global/workloadIdentityPools/get-into-teaching-app/providers/get-into-teaching-app
+
       - name: Setup Environment Variables
         id: variables
         run: |


### PR DESCRIPTION


### Trello card
https://trello.com/c/5YFXDRps

### Context
Google authentication must be performed before the destroy workflow can change the gcloud infrastructure.

### Changes proposed in this pull request
Add google authentication step.

### Guidance to review
Verify the google authentication step is included.
