### PR TITLE
Fixes issue with wrapping on section containers

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -68,7 +68,6 @@ body {
 section.container {
   display: flex;
   flex-grow: 0;
-  flex-wrap: wrap;
   flex-direction: column;
   margin: 1em 0;
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/Jd9HvLCS/6811-phase-5-repurpose-navigation-component-for-life-as-a-teacher-section?filter=member:spencerldixon

### Context

When collapsing the page between tablet and mobile breakpoints, the content overlaps the footer.

### Changes proposed in this pull request

- Removes `flex-wrap` from section container class

### Guidance to review

Also found on the following pages, please check that these still work as expected:

- `life-as-a-teacher/_how-to-become-a-teacher-cta.html.erb`
- `life-as-a-teacher/change-careers/_what-teachers-have-to-say.html.erb`
- `life-as-a-teacher/pay-and-benefits/_what-teachers-have-to-say.html.erb`
- `life-as-a-teacher/teaching-as-a-career/_what-teachers-have-to-say.html.erb`