### PR TITLE
Adds width to image blocks to prevent collapse with flexbox

### DIFF
--- a/app/webpacker/styles/blocks.scss
+++ b/app/webpacker/styles/blocks.scss
@@ -72,6 +72,8 @@ $space-between-sections: 3.7em;
 }
 
 .image-blocks {
+  width: 100%;
+
   .image-block {
     img {
       width: 100%;


### PR DESCRIPTION
### Trello card

https://trello.com/c/Jd9HvLCS/6811-phase-5-repurpose-navigation-component-for-life-as-a-teacher-section?filter=member:spencerldixon

### Context

When collapsing the page between tablet and mobile breakpoints, the content overlaps the footer.

### Changes proposed in this pull request

- Adds width to `image-blocks` class to ensure that when they collapse they do not overflow
