### PR TITLE
Update holding message on About GIT events page

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -69,8 +69,8 @@
         </section>
       <% else %>
         <section class="col col-720 col-space-m">
-          <p>Our spring events are coming soon to Newcastle, Norwich, Sheffield, Manchester, Nottingham, Birmingham, London, Bristol, and Brighton.</p>
-          <p>We'll update this page with more details in January.</p>
+          <p>From January to March 2025, we'll be holding events in Newcastle, Sheffield, Manchester, Nottingham, Birmingham, London, Norwich, Bristol and Brighton, and also online.</p>
+          <p>We'll update this page in January with more details about each event and how to register.</p>
         </section>
 
         <section class="col col-720">

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -101,7 +101,7 @@ describe "teaching events", type: :request do
       context "when there are no GiT events" do
         let(:events) { [] }
 
-        it { is_expected.to include("Our spring events are coming soon to Newcastle, Norwich, Sheffield, Manchester, Nottingham, Birmingham, London, Bristol, and Brighton.") }
+        it { is_expected.to include("From January to March 2025, we'll be holding events in Newcastle, Sheffield, Manchester, Nottingham, Birmingham, London, Norwich, Bristol and Brighton, and also online.") }
       end
     end
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/KQ2fbEEx

### Context
We now have more details about the Spring term events so are updating the holding message on the About GIT events page
