### PR TITLE
Update postcode content on the mailing list 

### DIFF
--- a/app/views/event_steps/_personalised_updates.html.erb
+++ b/app/views/event_steps/_personalised_updates.html.erb
@@ -29,8 +29,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <p>We run in-person events in the UK that we can tell you about if you give us your UK postcode.</p>
-    <p>If you do not live in the UK, you do not need to give us your postcode.</p>
-    <p>Instead, you can just select 'Complete sign up' to finish signing up for your event.</p>
+    <p>We run in-person events in the UK. We can tell you about these if you give us your UK postcode.</p>
+    <p>If you do not live in the UK, you do not need to give us your postcode. Instead, you can just select 'Complete sign up' to finish signing up for your event.</p>
   </div>
 </details>

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -16,8 +16,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <p>We run in-person events in the UK that we can tell you about if you give us your UK postcode.</p>
-    <p>If you do not live in the UK, you do not need to give us your postcode.</p>
-    <p>Instead, you can just select 'Complete sign up' to receive tailored guidance about teacher training.</p>
+    <p>We run in-person events in the UK. We can tell you about these if you give us your UK postcode.</p>
+    <p>If you do not live in the UK, you do not need to give us your postcode. Instead, you can just select 'Complete sign up' to receive tailored guidance about teacher training.</p>
   </div>
 </details>

--- a/app/views/mailing_list/steps/_postcode.html.erb
+++ b/app/views/mailing_list/steps/_postcode.html.erb
@@ -6,7 +6,7 @@
     size: "xl",
     text: t('helpers.label.mailing_list_steps_postcode.address_postcode', **Value.data),
   } do %>
-  <p>If you give us your postcode, we'll let you know about events happening near you.</p>
+  <p>We'll only use this to send you information about events happening near you.</p>
 <% end %>
 
 <details class="govuk-details">
@@ -18,6 +18,6 @@
   <div class="govuk-details__text">
     <p>We run in-person events in the UK that we can tell you about if you give us your UK postcode.</p>
     <p>If you do not live in the UK, you do not need to give us your postcode.</p>
-    <p>Instead, you can just select 'Complete sign up' to receive tailored guidance around teacher training.</p>
+    <p>Instead, you can just select 'Complete sign up' to receive tailored guidance about teacher training.</p>
   </div>
 </details>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -785,7 +785,7 @@ en:
       events_steps_contact_details:
         address_telephone: What is your telephone number? (optional)
       events_steps_personalised_updates:
-        address_postcode: What is your UK postcode? (optional)
+        address_postcode: What's your UK postcode? (optional)
         degree_status_id: Do you have a degree?
         consideration_journey_stage_id: How close are you to applying for teacher training?
         preferred_teaching_subject_id: What do you want to teach?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -826,10 +826,10 @@ en:
           resent: We've sent you another email
       events_steps_personalised_updates:
         address_postcode: |-
-          If you give us your postcode, we'll let you know about events happening near you.
+          We'll only use this to send you information about events happening near you.
       mailing_list_signup:
         address_postcode: |-
-          If you give us your postcode, we'll let you know about events happening near you.
+          We'll only use this to send you information about events happening near you.
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "Type to enter your degree subject or select from the suggestions."
         degree_subject_nojs: "Type to enter your degree subject."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,7 +811,7 @@ en:
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Which subject do you want to teach?
       mailing_list_steps_postcode:
-        address_postcode: Your UK postcode (optional)
+        address_postcode: What's your UK postcode? (optional)
 
       search:
         search: Search for ...

--- a/docs/sign-up-journeys.md
+++ b/docs/sign-up-journeys.md
@@ -18,7 +18,7 @@ graph TD;
   
   teacher_training --> subject[Which subject do you want to teach?]
 
-  subject --> postcode["Your UK postcode (optional)"]
+  subject --> postcode["What's your UK postcode? (optional)"]
   
   postcode --> show_welcome_guide{Show welcome guide?}
   

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature "Event wizard", type: :feature do
     end
     click_on "Complete sign up"
 
-    expect(page).not_to have_text("What is your UK postcode? (optional)")
+    expect(page).not_to have_text("What's your UK postcode? (optional)")
     fill_in_personalised_updates
 
     expect_sign_up_with_attributes(
@@ -304,8 +304,8 @@ RSpec.feature "Event wizard", type: :feature do
   )
     select_value_or_default "Do you have a degree?", degree_status
     select_value_or_default "How close are you to applying for teacher training?", consideration_journey_stage
-    if page.has_text?("What is your UK postcode? (optional)")
-      fill_in "What is your UK postcode? (optional)", with: postcode
+    if page.has_text?("What's your UK postcode? (optional)")
+      fill_in "What's your UK postcode? (optional)", with: postcode
     end
     select_value_or_default "What do you want to teach?", preferred_teaching_subject
   end

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
@@ -77,7 +77,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
@@ -116,7 +116,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
@@ -155,7 +155,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
@@ -345,7 +345,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: ""
     click_on "Complete sign up"
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_title("You've signed up | Get Into Teaching")
@@ -78,7 +78,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "Test, you're signed up"
@@ -117,7 +117,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "Test, you're signed up"
@@ -156,7 +156,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text "Test, you're signed up"
@@ -346,7 +346,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: ""
+    fill_in "What's your UK postcode? (optional)", with: ""
     click_on "Complete sign up"
 
     expect(page).to have_text "you're signed up"

--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Integration tests", :integration, :js, type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text("you're signed up")
@@ -89,7 +89,7 @@ RSpec.feature "Integration tests", :integration, :js, type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "We'll only use this to send you information about events happening near you"
-    fill_in "Your UK postcode (optional)", with: "TE57 1NG"
+    fill_in "What's your UK postcode? (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
     expect(page).to have_text("you're signed up")

--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Integration tests", :integration, :js, type: :feature do
     select "Chemistry"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 
@@ -88,7 +88,7 @@ RSpec.feature "Integration tests", :integration, :js, type: :feature do
     select "Maths"
     click_on "Next step"
 
-    expect(page).to have_text "If you give us your postcode"
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
     fill_in "Your UK postcode (optional)", with: "TE57 1NG"
     click_on "Complete sign up"
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/ML8z1D9w/7053

### Context
We ran user research on the mailing list sign up, and changed some of the content on the postcode step.

### Changes proposed in this pull request
Update the content below the question on the postcode page.

### Guidance to review

