### PR TITLE
Update H1 on adviser start page

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -88,7 +88,7 @@ module TeacherTrainingAdviser
     end
 
     def set_step_page_title
-      @page_title = "Get an adviser"
+      @page_title = "Get a free adviser"
 
       if @current_step&.title
         @page_title += ", #{@current_step.title.downcase} step"

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -2,7 +2,7 @@
 <% content_for(:right_image) { "images/content/tta-sign-up/right.jpg" } %>
 <% content_for(:mobile_image) { "images/content/tta-sign-up/mobile.jpg" } %>
 
-<h1>Get an adviser</h1>
+<h1>Get a free adviser</h1>
 
 <p>
   If you're thinking about teaching in England, an adviser can provide free, one-to-one support by phone,

--- a/spec/features/teacher_training_adviser/sign_up_spec.rb
+++ b/spec/features/teacher_training_adviser/sign_up_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       visit teacher_training_adviser_step_path(:identity, channel: 123_456, sub_channel: sub_channel_id)
       click_on "Next step"
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       # Simulate en error to ensure channel id is not lost
       click_on "Next step"
       expect(page).to have_text("You need to enter your first name")
@@ -133,7 +133,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       visit "/teacher-training-advisers?channel=123456&sub_channel=#{sub_channel_id}"
       click_on "Next step"
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       # Simulate en error to ensure channel id is not lost
       click_on "Next step"
       expect(page).to have_text("You need to enter your first name")
@@ -209,7 +209,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       visit teacher_training_adviser_step_path(:identity, channel: 123_456)
       click_on "Next step"
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -275,7 +275,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "that is a returning teacher" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -349,7 +349,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "with an equivalent degree (overseas)" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -418,7 +418,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "with an equivalent degree (UK)" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -485,7 +485,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       scenario "with an equivalent degree" do
         visit teacher_training_adviser_steps_path
 
-        expect(page).to have_css "h1", text: "Get an adviser"
+        expect(page).to have_css "h1", text: "Get a free adviser"
         fill_in_identity_step
         click_on "Next step"
 
@@ -547,7 +547,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       scenario "with an equivalent degree (UK)" do
         visit teacher_training_adviser_steps_path
 
-        expect(page).to have_css "h1", text: "Get an adviser"
+        expect(page).to have_css "h1", text: "Get a free adviser"
         fill_in_identity_step
         click_on "Next step"
 
@@ -610,7 +610,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "studying for a degree (not final year)" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -674,7 +674,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "studying for a degree (final year)" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -754,7 +754,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "candidate changes an answer" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -831,7 +831,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "candidate is a returning primary teacher" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -895,7 +895,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "without a degree" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -914,7 +914,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "without science GCSEs, primary" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -961,7 +961,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "without english/maths GCSEs, primary" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -1000,7 +1000,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "without GCSEs, secondary" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -1066,7 +1066,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "matchback" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 
@@ -1149,7 +1149,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
     scenario "skipping pre-filled optional steps" do
       visit teacher_training_adviser_steps_path
 
-      expect(page).to have_css "h1", text: "Get an adviser"
+      expect(page).to have_css "h1", text: "Get a free adviser"
       fill_in_identity_step
       click_on "Next step"
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/V5NL1yZ3/7143

### Context
We ran a split test before Christmas on the h1 on the adviser funnel start page. 

### Changes proposed in this pull request
We want to implement the variant h1 and change the heading on the adviser funnel start page

### Guidance to review

