### PR TITLE
Add non-uk inset text to career changers pages

### DIFF
--- a/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/_article.html.erb
@@ -3,6 +3,11 @@
     <h2 class="heading--box-blue">What you'll need to become a teacher</h2>
     <p>You’ll need a degree and <a href="/train-to-be-a-teacher/what-is-qts">qualified teacher status (QTS)</a> to work in the majority of schools in England. This includes state maintained primary, secondary and special schools.</p>
     <p>There are different ways to get QTS.</p>
+    <%= render Content::InsetTextComponent.new(
+      header: "Non-UK citizens:",
+      text: "<p>If you're not from the UK, find out about <a href=\"/non-uk-teachers/train-to-teach-in-england-as-an-international-student\">training to teach in England as a non-UK citizen</a>.</p>",
+      color: "purple"
+    ) %>
     <h3>If you have a degree</h3>
     <p>If you already have a degree, you can do a postgraduate teacher training course to gain QTS.</p>
     <p>It does not matter when you graduated, and your degree subject does not necessarily need to be in the subject you want to teach. Once you have QTS, you can also teach any other subject, as long as you can show you have enough expertise.</p>

--- a/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers/_article.html.erb
@@ -1,6 +1,11 @@
 <div class="row inset">
   <section class="col col-720 col-space-l-top">
     <p>If you're thinking about changing careers to become a teacher, knowing where to start and understanding what your options are can seem overwhelming. There's lots of dedicated support available to help you navigate the change.</p>
+    <%= render Content::InsetTextComponent.new(
+      header: "Non-UK citizens:",
+      text: "<p>If you're not from the UK, find out about <a href=\"/non-uk-teachers/train-to-teach-in-england-as-an-international-student\">training to teach in England as a non-UK citizen</a>.</p>",
+      color: "purple"
+    ) %>
     <h2 class="heading--box-blue">Get advice and guidance from an expert</h2>
     <h3>Teacher training advisers</h3>
     <p>Our experienced teacher training advisers offer free one-to-one support to thousands of people each year to support them through a career change into teaching. All of our advisers have years of teaching experience, so can also give practical advice and insights on what life in the classroom is like.</p>


### PR DESCRIPTION
### Trello card
https://trello.com/c/FbdUcUta/7198

### Context
Now the career changers section is split into 3 pages, we need to add the non-UK expander back into 2 of these pages.

### Changes proposed in this pull request
The non-UK inset needs adding to the following pages:

Support for career changers | Get Into Teaching GOV.UK

How to change careers to become a teacher | Get Into Teaching GOV.UK

### Guidance to review

