### PR TITLE
Update events link text

### DIFF
--- a/app/components/header/extra_navigation_component.html.erb
+++ b/app/components/header/extra_navigation_component.html.erb
@@ -7,7 +7,7 @@
     </li>
     <li class="extra-navigation__link extra-navigation__calendar">
       <%= link_to("/events", class: "link--black") do %>
-        Find an event<span class="icon icon-calendar hide-on-narrow" aria-hidden="true"></span><span class="icon icon-calendar-white hide-on-narrow" aria-hidden="true"></span>
+        Upcoming events<span class="icon icon-calendar hide-on-narrow" aria-hidden="true"></span><span class="icon icon-calendar-white hide-on-narrow" aria-hidden="true"></span>
       <% end %>
     </li>
     <%= tag.li(class: %w[extra-navigation__link extra-navigation__search]) do %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/rmVdVuUI/7142

### Context
We ran a split test before Christmas on the h1 on the event link text in the extra nav bar. The variant link performed better.

### Changes proposed in this pull request
We want to implement the variant link text.

### Guidance to review

