### PR TITLE
Replace broken link on veterans page

### DIFF
--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -54,7 +54,7 @@ All teacher training candidates are also eligible for [tuition fee and maintenan
 
 ## Get support
 
-[The Career Transition Partnership website](https://www.ctp.org.uk/) supports leavers of the armed forces as they transition from the military into civilian life.
+[The Career Transition Partnership website](https://www.modctp.co.uk/) supports leavers of the armed forces as they transition from the military into civilian life.
 
 The [MOD's Enhanced Learning Credits Scheme (ELC) website](https://www.enhancedlearningcredits.com/) promotes lifelong learning amongst members of the armed forces by providing financial support to pay for approved qualifications. You can contact them to find out about eligibility.
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/dkGQTRW3

### Context
The Career Transition Partnership website has moved so we need to change the link on the support for veterans' page.

