### PR TITLE
Bump kramdown from 2.4.0 to 2.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,8 +352,8 @@ GEM
     kaminari-core (1.2.2)
     knapsack (4.0.0)
       rake
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
@@ -495,8 +495,7 @@ GEM
     request_store_rails (2.0.0)
       concurrent-ruby (~> 1.0)
     retriable (3.1.2)
-    rexml (3.3.3)
-      strscan
+    rexml (3.4.0)
     rinku (2.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -606,7 +605,6 @@ GEM
       spring (>= 4)
     stoplight (3.0.2)
       redlock (~> 1.0)
-    strscan (3.1.2)
     text (1.3.1)
     thor (1.3.2)
     timeliness (0.4.5)

--- a/spec/requests/accessible_footnotes_spec.rb
+++ b/spec/requests/accessible_footnotes_spec.rb
@@ -8,8 +8,8 @@ describe "Accessible footnotes", type: :request do
   subject { response.body }
 
   it "makes footnotes accessible" do
-    is_expected.to include(%(<a href="#fn:1" class="footnote" rel="footnote"><span class="visually-hidden">Footnote </span>1</a>))
-    is_expected.to include(%(<a href="#fn:2" class="footnote" rel="footnote"><span class="visually-hidden">Footnote </span>2</a>))
+    is_expected.to include(%(<a href="#fn:1" class="footnote" rel="footnote" role="doc-noteref"><span class="visually-hidden">Footnote </span>1</a>))
+    is_expected.to include(%(<a href="#fn:2" class="footnote" rel="footnote" role="doc-noteref"><span class="visually-hidden">Footnote </span>2</a>))
 
     is_expected.to include(%(<a href="#fnref:1" class="reversefootnote" role="doc-backlink"><span class="visually-hidden">Location of footnote 1</span>↩</a>))
     is_expected.to include(%(<a href="#fnref:2" class="reversefootnote" role="doc-backlink"><span class="visually-hidden">Location of footnote 2</span>↩</a>))


### PR DESCRIPTION
### Trello card

https://trello.com/c/KLUZlrRP/7288-bump-kramdown-from-240-to-251

### Context

As part of the monthly dependency updates the bump of Kramdown was breaking the `accessible_footnotes `spec test and needed further investigation.

The original dependabot PR can be found [here](https://github.com/DFE-Digital/get-into-teaching-app/pull/4457).

### Changes proposed in this pull request

Adapted `accessible_footnotes` test: it looks like Kramdown now requires the test to include `role="doc-noteref"`. This attribute is now added to footnote references in the generated HTML to improve accessibility, making it clearer for assistive technologies. The update ensures the test reflects the new output and validates accessibility.

### Guidance to review

