### PR TITLE
Bumped GOVUK frontend to 5.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete",
     "file-loader": "^6.2.0",
     "flatpickr": "^4.6.13",
-    "govuk-frontend": "^5.7.1",
+    "govuk-frontend": "^5.8.0",
     "is-touch-device": "^1.0.1",
     "js-cookie": "^3.0.5",
     "lazysizes": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4230,10 +4230,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.7.1.tgz#d4c561ebf8c0b76130f31df8c2e4d70d340cd63f"
-  integrity sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==
+govuk-frontend@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.8.0.tgz#da1b03cb4f2ba1f6036be0dac3c5327c3405174c"
+  integrity sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
### Trello card

https://trello.com/c/NHgfitYM/7263-bump-frontend-to-580-for-git-website

### Context

GDS has recently released a new version of Frontend - 5.8.0, and we need to bump to the latest version.

### Changes proposed in this pull request

Bump of GOV.UK frontend. Ran tests and did a careful check of visuals; all looks ok.

### Guidance to review
