### PR TITLE
Routes wizard early years and further education section

### DIFF
--- a/app/helpers/routes_into_teaching_helper.rb
+++ b/app/helpers/routes_into_teaching_helper.rb
@@ -28,4 +28,8 @@ module RoutesIntoTeachingHelper
   def non_uk?
     answers["location"] == "No"
   end
+
+  def no_degree?
+    answers["undergraduate_degree"] == "No"
+  end
 end

--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -51,6 +51,15 @@
     </div>
   </div>
 
+  <% if no_degree? %>
+    <div class="row inset">
+      <div class="col col-845">
+        <h2 class="heading--box-blue">Other routes into teaching</h2>
+        <p>You do not need a degree and QTS to <%= link_to "teach in further education", "/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers" %> or to <%= link_to "teach in early years", "/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers" %>. So if you want to become a teacher but are not able to get a degree, you can explore these options.
+      </div>
+    </div>
+  <% end %>
+
   <div class="row inset">
     <div class="col col-845">
       <h2 class="heading--box-blue">Next steps</h2>


### PR DESCRIPTION
### Trello card

https://trello.com/c/qlszIoje/7280-add-early-years-and-further-education-to-routes-wizard-results?filter=member:spencerldixon

### Context

We want to add in a section to the results page referencing early years and further education for some of the answer combinations (but not all)

To begin with, we want to show this content only if the user has selected No for the degree question

### Changes proposed in this pull request

- Adds helper for `no_degree` option selected
- Adds section for early years and further education

### Guidance to review

