### PR TITLE
Send signal to Clarity when cookie consent is given

### DIFF
--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -45,11 +45,21 @@ export default class Clarity {
 
   listenForConsentChanges() {
     document.addEventListener('cookies:accepted', () => {
+      console.log('cookies:accepted event fired');
+
       if (this.consentValue('non-functional') === 'granted') {
         console.log('User consent granted');
         this.initContainer();
         window.clarity('consent');
         console.log('Clarity consent granted');
+      } else if (this.consentValue('non-functional') === 'denied') {
+        console.log('User consent denied');
+        window.clarity('consent', false); // Inform Clarity that consent is revoked
+        console.log('Clarity consent revoked');
+
+        // Clear non-essential cookies when consent is denied (cookies do not appear to be cleared autmatically when consent is revoked using /cookie_preference page)
+        this.cookiePreferences.clearNonEssentialCookies();
+        console.log('Non-essential cookies cleared');
       }
     });
   }

--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -48,14 +48,10 @@ export default class Clarity {
       console.log('cookies:accepted event fired');
 
       if (this.consentValue('non-functional') === 'granted') {
-        console.log('User consent granted');
         this.initContainer();
         window.clarity('consent');
-        console.log('Clarity consent granted');
       } else if (this.consentValue('non-functional') === 'denied') {
-        console.log('User consent denied');
-        window.clarity('consent', false); // Inform Clarity that consent is revoked
-        console.log('Clarity consent revoked');
+        window.clarity('consent', false);
       }
     });
   }

--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -46,8 +46,10 @@ export default class Clarity {
   listenForConsentChanges() {
     document.addEventListener('cookies:accepted', () => {
       if (this.consentValue('non-functional') === 'granted') {
+        console.log('User consent granted');
         this.initContainer();
         window.clarity('consent');
+        console.log('Clarity consent granted');
       }
     });
   }

--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -45,8 +45,6 @@ export default class Clarity {
 
   listenForConsentChanges() {
     document.addEventListener('cookies:accepted', () => {
-      console.log('cookies:accepted event fired');
-
       if (this.consentValue('non-functional') === 'granted') {
         this.initContainer();
         window.clarity('consent');

--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -56,10 +56,6 @@ export default class Clarity {
         console.log('User consent denied');
         window.clarity('consent', false); // Inform Clarity that consent is revoked
         console.log('Clarity consent revoked');
-
-        // Clear non-essential cookies when consent is denied (cookies do not appear to be cleared autmatically when consent is revoked using /cookie_preference page)
-        this.cookiePreferences.clearNonEssentialCookies();
-        console.log('Non-essential cookies cleared');
       }
     });
   }

--- a/app/webpacker/javascript/clarity.js
+++ b/app/webpacker/javascript/clarity.js
@@ -47,6 +47,7 @@ export default class Clarity {
     document.addEventListener('cookies:accepted', () => {
       if (this.consentValue('non-functional') === 'granted') {
         this.initContainer();
+        window.clarity('consent');
       }
     });
   }


### PR DESCRIPTION
### Trello card

https://trello.com/c/sR8YBd2Z/7246-send-signal-to-clarity-when-cookie-consent-is-given

### Context

We were advised that we may need make changes to the way we drop Clarity cookies:

Clarity relies on cookies to connect page views into sessions, which are critical for many of Clarity’s features. Clarity is transitioning to requiring explicit consent signals for cookies in the EEA, UK and Switzerland.

We are currently not dropping any clarity cookies until a user has consented to accept cookies. However, we need to check if we then set a flag to advise Clarity of the consent status for each individual visitor to our site. Without this consent Clarity's recordings won't be linked together into multi-page sessions. Heat maps and data other than session recordings will continue to be available.

### Changes proposed in this pull request

I could not see a flag set to advise Clarity of the users consent status, so followed the steps provided in Clarity's cookie consent guidance[: ](https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-consent#step-2)[Clarity Cookie Consent](https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-consent).

### Guidance to review
