### PR TITLE
update prompt for subject step on mailing list

### DIFF
--- a/app/views/mailing_list/steps/_subject.html.erb
+++ b/app/views/mailing_list/steps/_subject.html.erb
@@ -2,7 +2,7 @@
       f.object.teaching_subjects,
       :id,
       :value,
-      options: { prompt: "Please select" },
+      options: { prompt: "Choose a subject" },
       label: { tag: 'h1', size: "xl", text: t('helpers.label.mailing_list_steps_subject.preferred_teaching_subject_id', **Value.data) } do
 %>
 <p>Select a secondary school subject or select primary.</p>


### PR DESCRIPTION
### Trello card
https://trello.com/c/9Jn9D29s/7245

### Context
The prompt on the subject step of the mailing list form is currently 'Please select'

### Changes proposed in this pull request
Change the prompt to be clearer and more relevant to the step

### Guidance to review

