### PR TITLE
Routes wizard tracking

### DIFF
--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -7,7 +7,7 @@
   class: "hidden",
   data: {
     id: "undergraduate_degree",
-    key: session[:routes_into_teaching]["undergraduate_degree"]
+    key: session[:routes_into_teaching]["undergraduate_degree"],
   }
 %>
 
@@ -15,7 +15,7 @@
   class: "hidden",
   data: {
     id: "unqualified_teacher",
-    key: session[:routes_into_teaching]["unqualified_teacher"]
+    key: session[:routes_into_teaching]["unqualified_teacher"],
   }
 %>
 
@@ -23,7 +23,7 @@
   class: "hidden",
   data: {
     id: "location",
-    key: session[:routes_into_teaching]["location"]
+    key: session[:routes_into_teaching]["location"],
   }
 %>
 

--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -3,6 +3,30 @@
   colour: "pastel yellow-yellow",
 ) %>
 
+<%= tag.div id: "routes_into_teaching_undergraduate_degree",
+  class: "hidden",
+  data: {
+    id: "undergraduate_degree",
+    key: session[:routes_into_teaching]["undergraduate_degree"]
+  }
+%>
+
+<%= tag.div id: "routes_into_teaching_unqualified_teacher",
+  class: "hidden",
+  data: {
+    id: "unqualified_teacher",
+    key: session[:routes_into_teaching]["unqualified_teacher"]
+  }
+%>
+
+<%= tag.div id: "routes_into_teaching_location",
+  class: "hidden",
+  data: {
+    id: "location",
+    key: session[:routes_into_teaching]["location"]
+  }
+%>
+
 <section class="container">
   <div class="row inset">
     <div class="col col-845">


### PR DESCRIPTION
### Trello card

https://trello.com/c/dGj3fYgS/7295-set-up-tracking-for-answer-combinations-given-within-the-route-wizard?filter=member:spencerldixon

### Context

We want to capture the combination of answers given to each of the 3 questions in the routes wizard (ie when someone clicks on the Complete button)

### Changes proposed in this pull request

- Adds hidden divs with data tags for each answer to the completed page

### Guidance to review

