### PR TITLE
Routes Wizard - No index everything except the index action

### DIFF
--- a/app/controllers/routes_into_teaching/steps_controller.rb
+++ b/app/controllers/routes_into_teaching/steps_controller.rb
@@ -6,7 +6,7 @@ module RoutesIntoTeaching
 
     before_action :set_page_title
     before_action :set_step_page_title, only: %i[show update]
-    before_action :noindex, if: :noindex?
+    before_action :noindex, except: %i[index]
     before_action :set_breadcrumb
 
     layout :resolve_layout
@@ -27,11 +27,6 @@ module RoutesIntoTeaching
     end
 
   private
-
-    def noindex?
-      # Only index the first step.
-      !request.path.include?("/#{first_step_class.key}")
-    end
 
     def first_step_class
       wizard_class.steps.first

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -13,6 +13,7 @@ class SitemapController < ApplicationController
     /events
     /events/about-get-into-teaching-events
     /mailinglist/signup/name
+    /routes-into-teaching
   ].freeze
 
   def show

--- a/lib/page_modification_tracker.rb
+++ b/lib/page_modification_tracker.rb
@@ -6,6 +6,7 @@ class PageModificationTracker
     "/events/about-get-into-teaching-events" => {},
     "/events" => {},
     "/mailinglist/signup/name" => {},
+    "/routes-into-teaching" => {},
   }.freeze
 
   attr_reader :app, :headers


### PR DESCRIPTION
### Trello card

https://trello.com/c/pfYp2AAi/7298-ensure-routes-wizard-start-page-is-added-to-sitemap-and-is-indexable?filter=member:spencerldixon

### Context

We want to make sure the routes wizard start page (/routes-into-teaching) is indexable and appears in the sitemap

The other pages in the route wizard (including the completion page) should not be indexable, as landing in the middle of the wizard would be confusing

### Changes proposed in this pull request

- No index everything in the routes wizard step controller except the index action

### Guidance to review

