### PR TITLE
Routes wizard back button

### DIFF
--- a/app/components/content/results_box_component.html.erb
+++ b/app/components/content/results_box_component.html.erb
@@ -13,17 +13,17 @@
         <div class="results-box__label">Course fee</div>
         <div class="results-box__value"><%= fee %></div>
       </div>
-      <hr>
+      <hr aria-hidden="true">
       <div class="results-box__info-row">
         <div class="results-box__label">Course length </div>
         <div class="results-box__value"><%= course_length %></div>
       </div>
-      <hr>
+      <hr aria-hidden="true">
       <div class="results-box__info-row">
         <div class="results-box__label">Funding </div>
         <div class="results-box__value"><%= funding %></div>
       </div>
-      <hr>
+      <hr aria-hidden="true">
     </div>
     <div class="results-box__text results-box__full-width-text"><%= text %></div>
     <div class="results-box__cta">

--- a/app/views/routes_into_teaching/steps/_undergraduate_degree.html.erb
+++ b/app/views/routes_into_teaching/steps/_undergraduate_degree.html.erb
@@ -1,5 +1,9 @@
 <% @page_title = "Do you have an undergraduate degree?" %>
 
+<% content_for(:back_link) do %>
+  <%= render BackComponent.new(path: routes_into_teaching_steps_path) %>
+<% end %>
+
 <%= f.govuk_collection_radio_buttons :undergraduate_degree, @wizard.find_current_step.options, :answer, :text,
   legend: { tag: "h1", text: @page_title },
   hint: { text: "You'll find routes into teaching based on your circumstances" }

--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -38,14 +38,6 @@
         <li><%= location_summary %></li>
       </ul>
 
-      <% if non_uk? %>
-        <%= render Content::ExpanderComponent.new(
-          title: "visa sponsorship",
-          text: "<p>If you do not have the right to study or work in the UK, you will need a visa. Your visa will need to be sponsored by a course provider.</p>
-          <p><a href=\"/non-uk-teachers/visas-for-non-uk-trainees\">Learn more about applying for your visa to train to teach in England</a>.</p>",
-        ) %>
-      <% end %>
-
       <p>You can <%= link_to "change your answers", routes_into_teaching_steps_path %> if you need to.</p>
     </div>
   </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/e2pnl2Bs

### Context

We need to test the routes wizard before it is deployed to production

### Changes proposed in this pull request

- Adds a back button to the first question of the wizard
- Removes the Non-UK expander component

### Guidance to review

