### PR TITLE
Routes wizard fallback

### DIFF
--- a/app/helpers/routes_into_teaching_helper.rb
+++ b/app/helpers/routes_into_teaching_helper.rb
@@ -1,6 +1,6 @@
 module RoutesIntoTeachingHelper
   def answers
-    session[:routes_into_teaching]
+    session[:routes_into_teaching] || {}
   end
 
   def undergraduate_degree_summary

--- a/app/helpers/routes_into_teaching_helper.rb
+++ b/app/helpers/routes_into_teaching_helper.rb
@@ -8,21 +8,21 @@ module RoutesIntoTeachingHelper
       "Yes" => "have a bachelor's degree",
       "Not yet" => "are studying for a bachelor's degree",
       "No" => "do not have a bachelor's degree",
-    }[answers["undergraduate_degree"]] || "No answer given for degree"
+    }[answers["undergraduate_degree"]] || "no answer given for degree"
   end
 
   def unqualified_teacher_summary
     {
       "Yes" => "have previously worked in a school",
       "No" => "have not previously worked in a school",
-    }[answers["unqualified_teacher"]] || "No answer given for unqualified teacher"
+    }[answers["unqualified_teacher"]] || "no answer given for unqualified teacher"
   end
 
   def location_summary
     {
       "Yes" => "live in England",
       "No" => "do not live in England",
-    }[answers["location"]] || "No answer given for location"
+    }[answers["location"]] || "no answer given for location"
   end
 
   def non_uk?

--- a/app/helpers/routes_into_teaching_helper.rb
+++ b/app/helpers/routes_into_teaching_helper.rb
@@ -8,21 +8,21 @@ module RoutesIntoTeachingHelper
       "Yes" => "have a bachelor's degree",
       "Not yet" => "are studying for a bachelor's degree",
       "No" => "do not have a bachelor's degree",
-    }[answers["undergraduate_degree"]]
+    }[answers["undergraduate_degree"]] || "No answer given for degree"
   end
 
   def unqualified_teacher_summary
     {
       "Yes" => "have previously worked in a school",
       "No" => "have not previously worked in a school",
-    }[answers["unqualified_teacher"]]
+    }[answers["unqualified_teacher"]] || "No answer given for unqualified teacher"
   end
 
   def location_summary
     {
       "Yes" => "live in England",
       "No" => "do not live in England",
-    }[answers["location"]]
+    }[answers["location"]] || "No answer given for location"
   end
 
   def non_uk?

--- a/app/models/routes_into_teaching/routes.rb
+++ b/app/models/routes_into_teaching/routes.rb
@@ -5,6 +5,8 @@ module RoutesIntoTeaching
     end
 
     def self.recommended(answers_hash = {})
+      return all if answers_hash.nil?
+
       all.select do |teaching_route|
         next false if teaching_route["matches"].blank?
 

--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -28,20 +28,18 @@
 %>
 
 <section class="container">
-    <div class="row inset">
-      <div class="col col-845">
-        <% if session[:routes_into_teaching] %>
-          <h2>You told us that you:</h2>
-          <ul>
-            <li><%= undergraduate_degree_summary %></li>
-            <li><%= unqualified_teacher_summary %></li>
-            <li><%= location_summary %></li>
-          </ul>
-        <% end %>
+  <div class="row inset">
+    <div class="col col-845">
+      <h2>You told us that you:</h2>
+      <ul>
+        <li><%= undergraduate_degree_summary %></li>
+        <li><%= unqualified_teacher_summary %></li>
+        <li><%= location_summary %></li>
+      </ul>
 
-        <p>You can <%= link_to "change your answers", routes_into_teaching_steps_path %> if you need to.</p>
-      </div>
+      <p>You can <%= link_to "change your answers", routes_into_teaching_steps_path %> if you need to.</p>
     </div>
+  </div>
 
   <div class="row inset">
     <div class="col col-845">

--- a/app/views/routes_into_teaching/steps/completed.html.erb
+++ b/app/views/routes_into_teaching/steps/completed.html.erb
@@ -7,7 +7,7 @@
   class: "hidden",
   data: {
     id: "undergraduate_degree",
-    key: session[:routes_into_teaching]["undergraduate_degree"],
+    key: session.dig(:routes_into_teaching, "undergraduate_degree"),
   }
 %>
 
@@ -15,7 +15,7 @@
   class: "hidden",
   data: {
     id: "unqualified_teacher",
-    key: session[:routes_into_teaching]["unqualified_teacher"],
+    key: session.dig(:routes_into_teaching, "unqualified_teacher"),
   }
 %>
 
@@ -23,24 +23,25 @@
   class: "hidden",
   data: {
     id: "location",
-    key: session[:routes_into_teaching]["location"],
+    key: session.dig(:routes_into_teaching, "location"),
   }
 %>
 
 <section class="container">
-  <div class="row inset">
-    <div class="col col-845">
-      <h2>You told us that you:</h2>
+    <div class="row inset">
+      <div class="col col-845">
+        <% if session[:routes_into_teaching] %>
+          <h2>You told us that you:</h2>
+          <ul>
+            <li><%= undergraduate_degree_summary %></li>
+            <li><%= unqualified_teacher_summary %></li>
+            <li><%= location_summary %></li>
+          </ul>
+        <% end %>
 
-      <ul>
-        <li><%= undergraduate_degree_summary %></li>
-        <li><%= unqualified_teacher_summary %></li>
-        <li><%= location_summary %></li>
-      </ul>
-
-      <p>You can <%= link_to "change your answers", routes_into_teaching_steps_path %> if you need to.</p>
+        <p>You can <%= link_to "change your answers", routes_into_teaching_steps_path %> if you need to.</p>
+      </div>
     </div>
-  </div>
 
   <div class="row inset">
     <div class="col col-845">


### PR DESCRIPTION
### Trello card

https://trello.com/c/p887min8

### Context

If a user lands on /routes-into-teaching/completed directly (ie without going through the 3 questions first), they currently get a 500 error

This is unlikely to happen often as this page is noindexed but it would be good if we could handle this more gracefully

### Changes proposed in this pull request

- Adds conditionals to protect from nil values
- Returns all routes if no answers available
- Removes the "You told us that you..." section if no answers selected

### Guidance to review

