### PR TITLE
Remove current from degree status text

### DIFF
--- a/app/views/mailing_list/steps/_degree_status.html.erb
+++ b/app/views/mailing_list/steps/_degree_status.html.erb
@@ -13,6 +13,6 @@
   legend: { tag: 'h1', text: t("helpers.label.mailing_list_steps_degree_status.degree_status_id", **Value.data) } do
 %>
   <p>
-    You'll find out how to become a teacher based on your current circumstances.
+    You'll find out how to become a teacher based on your circumstances.
   </p>
 <% end %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/0LiVpPLw/7321-update-help-text-content-on-degree-step-in-mailing-list

### Context

We need to update the content on the degree step:

Change help text to remove current

### Changes proposed in this pull request

- Remove `current` from the degree status text

### Guidance to review

