### PR TITLE
Removing teach first from non-UK wizard results

### DIFF
--- a/config/routes_into_teaching.yml
+++ b/config/routes_into_teaching.yml
@@ -57,7 +57,7 @@ routes:
       - question: unqualified_teacher
         answers: ["*"]
       - question: location
-        answers: ["yes"]
+        answers: ["Yes"]
 
   - title: Undergraduate initial teacher training
     course_length: 3 to 4 years

--- a/config/routes_into_teaching.yml
+++ b/config/routes_into_teaching.yml
@@ -57,7 +57,7 @@ routes:
       - question: unqualified_teacher
         answers: ["*"]
       - question: location
-        answers: ["*"]
+        answers: ["yes"]
 
   - title: Undergraduate initial teacher training
     course_length: 3 to 4 years


### PR DESCRIPTION
### Trello card
https://trello.com/c/Tm6iVGxK/7405-update-routes-wizard-to-not-display-teach-first-for-users-located-outside-uk
### Context

### Changes proposed in this pull request

### Guidance to review

