### PR TITLE
Update content on consideration step in mailing list funnel

### DIFF
--- a/app/views/mailing_list/steps/_teacher_training.html.erb
+++ b/app/views/mailing_list/steps/_teacher_training.html.erb
@@ -5,6 +5,6 @@
   legend: { tag: "h1", text: t('helpers.label.mailing_list_steps_teacher_training.consideration_journey_stage_id', **Value.data) } do
 %>
 <p>
-  You'll get the most relevant guidance to support you depending on your circumstances.
+  You'll find out how to become a teacher based on your circumstances.
 </p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -807,7 +807,7 @@ en:
       mailing_list_steps_degree_status:
         degree_status_id: Do you have a degree?
       mailing_list_steps_teacher_training:
-        consideration_journey_stage_id: How close are you to applying for teacher training?
+        consideration_journey_stage_id: How interested are you in applying for teacher training?
       mailing_list_steps_subject:
         preferred_teaching_subject_id: Select the subject you're most interested in teaching
       mailing_list_steps_postcode:

--- a/spec/integration/mailing_list_spec.rb
+++ b/spec/integration/mailing_list_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Integration tests", :integration, :js, type: :feature do
     click_label "Yes, I already have a degree"
     click_on "Next step"
 
-    expect(page).to have_text("How close are you to applying for teacher training?")
+    expect(page).to have_text("How interested are you in applying for teacher training?")
     click_label "I’m not sure and finding out more"
     click_on "Next step"
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/dSX1PpU1/7412-update-content-on-consideration-step-in-mailing-list-funnel

### Context
We want to update the consideration step to make it easier for users to complete and more useful in terms of segmenting them.

### Changes proposed in this pull request
We need to updated the content on the consideration step in the mailing list funnel.

### Guidance to review

