### PR TITLE
Bring mobile fonts larger than medium in line with tablet fonts

### DIFF
--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -1,6 +1,6 @@
 html {
-  @include mq($until: mobile) { font-size: 106%; }
-  @include mq($from: mobile, $until: tablet) { font-size: 106%; }
+  @include mq($until: mobile) { font-size: 100%; }
+  @include mq($from: mobile, $until: tablet) { font-size: 100%; }
   @include mq($from: tablet) { font-size: 100%; }
 }
 

--- a/app/webpacker/styles/font-sizes.scss
+++ b/app/webpacker/styles/font-sizes.scss
@@ -18,11 +18,11 @@ $_font-sizes: (
   mobile: (
     "xsmall":   nth($_relative-font-sizes, 1),
     "small":    nth($_relative-font-sizes, 2),
-    "medium":   nth($_relative-font-sizes, 3),
-    "large":    nth($_relative-font-sizes, 4),
-    "xlarge":   nth($_relative-font-sizes, 5),
-    "xxlarge":  nth($_relative-font-sizes, 6),
-    "xxxlarge": nth($_relative-font-sizes, 7),
+    "medium":   nth($_relative-font-sizes, 4),
+    "large":    nth($_relative-font-sizes, 5),
+    "xlarge":   nth($_relative-font-sizes, 6),
+    "xxlarge":  nth($_relative-font-sizes, 7),
+    "xxxlarge": nth($_relative-font-sizes, 8),
   ),
   tablet: (
     "xsmall":   nth($_relative-font-sizes, 2),


### PR DESCRIPTION
### Trello card

https://trello.com/c/8Fvr9Pzl/7407-adjust-h3-styling-so-that-h3s-are-bigger-on-mobile

### Context

Our h3s on desktop appear significantly bigger than those on mobile

This is particularly noticeable in our new routes wizard

### Changes proposed in this pull request

- Reset all font sizes to 100% for consistency (i notice some fonts shrink at tablet size due to mobile and tablet being set to 106% and desktop being set to 100%)
- For mobile sizes, bring every font-size medium and above in line with tablet sizes (xsmall and small remain original sizes)
 
### Guidance to review

