### PR TITLE
Change age validation on training adviser date of birth from 70 to 99

### DIFF
--- a/app/models/teacher_training_adviser/steps/date_of_birth.rb
+++ b/app/models/teacher_training_adviser/steps/date_of_birth.rb
@@ -6,7 +6,7 @@ module TeacherTrainingAdviser::Steps
     include ::ActiveRecord::AttributeAssignment
 
     MIN_AGE = 18
-    MAX_AGE = 70
+    MAX_AGE = 99
 
     attribute :date_of_birth, :date
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,7 +510,7 @@ en:
             date_of_birth:
               blank: "You need to enter your date of birth"
               on_or_before: "You must be 18 years or older to use this service"
-              on_or_after: "You must be less than 70 years old"
+              on_or_after: "You must be less than 99 years old"
               invalid: "You did not enter a valid date of birth"
 
         funding_widget:


### PR DESCRIPTION
### Trello card

https://trello.com/c/AC9XeUlq/7414-change-the-over-70-age-validation-in-the-adviser-funnel?filter=member:spencerldixon

### Context

As a web service
I want to change the validation for 70 years age limit on the DOB page
So that I am legally compliant with the age discrimination laws.

Acceptance Criteria

Validation to check that a person is 18+ remains
Validation to check that a person is under 70 is changed to under 99
Change is implemented for all user types including returners

### Changes proposed in this pull request

- Bump age validation from 70 to 99
- Change validation error message from 70 to 99

### Guidance to review

