### PR TITLE
Removed unneeded consideration steps and renamed option value text

### DIFF
--- a/app/helpers/option_set_helper.rb
+++ b/app/helpers/option_set_helper.rb
@@ -3,4 +3,8 @@ module OptionSetHelper
     key = option.value.parameterize(separator: "_")
     I18n.t("helpers.answer.mailing_list_steps_degree_status.degree_status.#{key}", **{ default: option.value }.merge(Value.data))
   end
+
+  def format_option_value(option, translation_key = nil)
+    I18n.t("helpers.answer.#{translation_key}.#{option.id}", **{ default: option.value }.merge(Value.data))
+  end
 end

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -1,7 +1,7 @@
 module MailingList
   module Steps
     class TeacherTraining < ::GITWizard::Step
-      PICKLIST_ALLOW_IDS = [222750000, 222750003]
+      PICKLIST_ALLOW_IDS = [222_750_000, 222_750_003].freeze
 
       attribute :consideration_journey_stage_id, :integer
       validates :consideration_journey_stage_id,

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -1,6 +1,8 @@
 module MailingList
   module Steps
     class TeacherTraining < ::GITWizard::Step
+      PICKLIST_ALLOW_IDS = [222750000, 222750003]
+
       attribute :consideration_journey_stage_id, :integer
       validates :consideration_journey_stage_id,
                 presence: true,
@@ -17,7 +19,9 @@ module MailingList
     private
 
       def query_consideration_journey_stages
-        GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_journey_stages
+        GetIntoTeachingApiClient::PickListItemsApi.new.get_candidate_journey_stages.select do |option|
+          PICKLIST_ALLOW_IDS.include?(option.id)
+        end
       end
     end
   end

--- a/app/views/mailing_list/steps/_teacher_training.html.erb
+++ b/app/views/mailing_list/steps/_teacher_training.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_collection_radio_buttons :consideration_journey_stage_id,
   f.object.consideration_journey_stages,
   :id,
-  :value,
+  ->(option) { format_option_value(option, "mailing_list_steps.teacher_training.consideration_journey_stage") },
   legend: { tag: "h1", text: t('helpers.label.mailing_list_steps_teacher_training.consideration_journey_stage_id', **Value.data) } do
 %>
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,6 +679,10 @@ en:
 
   helpers:
     answer:
+      mailing_list_steps:
+        teacher_training:
+          consideration_journey_stage:
+            222750003: "I think I'll apply"
       mailing_list_steps_degree_status:
         degree_status:
           graduate_or_postgraduate: "Yes, I already have a degree"

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "How interested are you in applying"
-    choose "I'm not sure and finding out more"
+    choose "It's just an idea"
     click_on "Next step"
 
     expect(page).to have_text "Select the subject you're most interested in teaching"
@@ -70,7 +70,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "How interested are you in applying"
-    choose "I'm not sure and finding out more"
+    choose "It's just an idea"
     click_on "Next step"
 
     expect(page).to have_text "Select the subject you're most interested in teaching"
@@ -109,7 +109,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "How interested are you in applying"
-    choose "I'm not sure and finding out more"
+    choose "It's just an idea"
     click_on "Next step"
 
     expect(page).to have_text "Select the subject you're most interested in teaching"
@@ -148,7 +148,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Next step"
 
     expect(page).to have_text "How interested are you in applying"
-    choose "I'm not sure and finding out more"
+    choose "It's just an idea"
     click_on "Next step"
 
     expect(page).to have_text "Select the subject you're most interested in teaching"


### PR DESCRIPTION
### Trello card

https://trello.com/c/GKPSwaTU/7449-remove-unneeded-consideration-step-options-and-reword-the-remaining-ones-in-mailing-list?filter=member:spencerldixon

### Context

We want to remove some of the consideration options and reword the remaining ones to make them easier to understand for users and easier to use by support services

We want to remove the two highlighted options from the front-end

We also want to change the label of the fourth option

FROM I'm very sure and think I'll apply

TO I think I'll apply

### Changes proposed in this pull request

- Allow lists the options we want to filter from the PickList API for controlling presentation options in GIT
- Adds a `format_option_value` helper for replacing text in the translations
- Removes the two options from the front end by filtering out other options from the picklist
- Changes the label of the last option via translations

### Guidance to review

