### PR TITLE
Moves green arrow cta to a component

### DIFF
--- a/app/components/calls_to_action/arrow_link_component.html.erb
+++ b/app/components/calls_to_action/arrow_link_component.html.erb
@@ -1,0 +1,4 @@
+<a class="cta-circle-link-wrapper" href="<%= @link_target %>">
+  <span class="cta-circle-button"><i class="fa-solid fa-arrow-right"></i></span>
+  <span class="cta-link-text"><%= @link_text %></span>
+</a>

--- a/app/components/calls_to_action/arrow_link_component.rb
+++ b/app/components/calls_to_action/arrow_link_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CallsToAction::ArrowLinkComponent < ViewComponent::Base
+  attr_reader :link_target, :link_text
+
+  def initialize(link_target:, link_text:)
+    super
+
+    @link_target = link_target
+    @link_text = link_text
+  end
+end

--- a/app/components/content/results_box_component.html.erb
+++ b/app/components/content/results_box_component.html.erb
@@ -27,7 +27,7 @@
     </div>
     <div class="results-box__text results-box__full-width-text"><%= text %></div>
     <div class="results-box__cta">
-      <%= render "content/shared/links_and_buttons/cta_circle_button_link", href: @link_target, cta_link_text: @link_text %>
+      <%= render CallsToAction::ArrowLinkComponent.new(link_target: @link_target, link_text: @link_text) %>
     </div>
   </section>
 </div>

--- a/app/views/content/shared/links_and_buttons/_cta_circle_button_link.html.erb
+++ b/app/views/content/shared/links_and_buttons/_cta_circle_button_link.html.erb
@@ -1,4 +1,0 @@
-<a class="cta-circle-link-wrapper" href="<%= href %>">
-  <span class="cta-circle-button"><i class="fa-solid fa-arrow-right"></i></span>
-  <span class="cta-link-text"><%= cta_link_text %></span>
-</a>

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -48,17 +48,11 @@ expander:
     header: "Ukraine citizens:"
     title: moving to the UK
     text: Check what you need to do before you travel and after you arrive <a href="https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine">if you're moving to the UK from Ukraine</a>.
-
 quote:
   olivia:
     text: "You'll learn a lot about yourself during your teacher training year, and it's the most rewarding journey to be on."
     name: "Olivia, drama teacher"
     classes: quote--indent
-
-cta_arrow_link:
-  arrowtime:
-    link_target: "https://google.com"
-    link_text: "Hello world"
 ---
 
 You need a bachelor's degree in any subject to teach in primary, secondary and special schools in England.

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -48,11 +48,17 @@ expander:
     header: "Ukraine citizens:"
     title: moving to the UK
     text: Check what you need to do before you travel and after you arrive <a href="https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine">if you're moving to the UK from Ukraine</a>.
+
 quote:
   olivia:
     text: "You'll learn a lot about yourself during your teacher training year, and it's the most rewarding journey to be on."
     name: "Olivia, drama teacher"
     classes: quote--indent
+
+cta_arrow_link:
+  arrowtime:
+    link_target: "https://google.com"
+    link_text: "Hello world"
 ---
 
 You need a bachelor's degree in any subject to teach in primary, secondary and special schools in England.
@@ -64,6 +70,8 @@ If you have a bachelor's degree, you can do postgraduate teacher training to get
 Teacher training courses usually take 9 months full-time, or 18 to 24 months part-time.
 
 $international-content$
+
+$arrowtime$
 
 ## Teacher training course providers
 

--- a/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
+++ b/app/views/content/train-to-be-a-teacher/if-you-have-a-degree.md
@@ -65,8 +65,6 @@ Teacher training courses usually take 9 months full-time, or 18 to 24 months par
 
 $international-content$
 
-$arrowtime$
-
 ## Teacher training course providers
 
 Your postgraduate teacher training course might be provided by: 

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -239,8 +239,8 @@ body a.govuk-back-link {
   }
 }
 
-// CTA link with green arrow circle button
-// Partial for rendering here: app/views/shared/_cta_circle_link.html.erb
+// CTA link with green arrow circle button CallsToAction::ArrowLinkComponent
+
 .cta-circle-link-wrapper {
   display: flex;
   align-items: top;

--- a/lib/template_handlers/markdown.rb
+++ b/lib/template_handlers/markdown.rb
@@ -10,7 +10,7 @@ module TemplateHandlers
 
     DEFAULTS = {}.freeze
     GLOBAL_FRONT_MATTER = Rails.root.join("config/frontmatter.yml").freeze
-    COMPONENT_TYPES = %w[quote quote_list inset_text youtube_video steps expander cta_adviser cta_routes cta_mailinglist].freeze
+    COMPONENT_TYPES = %w[quote quote_list inset_text youtube_video steps expander cta_adviser cta_routes cta_mailinglist cta_arrow_link].freeze
 
     class << self
       def call(template, source = nil)

--- a/spec/components/calls_to_action/arrow_link_component_spec.rb
+++ b/spec/components/calls_to_action/arrow_link_component_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe CallsToAction::ArrowLinkComponent, type: :component do
       expect(page).to have_css(".cta-link-text", text: link_text)
     end
 
-    specify "the link text is present" do
-      expect(page).to have_css(".cta-link-text", text: link_text)
-    end
-
     specify "the link is present" do
       expect(page).to have_link(link_text, href: link_target)
     end

--- a/spec/components/calls_to_action/arrow_link_component_spec.rb
+++ b/spec/components/calls_to_action/arrow_link_component_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CallsToAction::ArrowLinkComponent, type: :component do
+  let(:link_text) { "Click here" }
+  let(:link_target) { "/some-dir/some-page" }
+
+  describe "rendering the component" do
+    let(:kwargs) { { link_text: link_text, link_target: link_target } }
+
+    let(:component) { described_class.new(**kwargs) }
+
+    before { render_inline(component) { content } }
+
+    specify "renders the green arrow icon" do
+      expect(page).to have_css(".cta-circle-button")
+      expect(page).to have_css("i.fa-arrow-right")
+    end
+
+    specify "the link text is present" do
+      expect(page).to have_css(".cta-link-text", text: link_text)
+    end
+
+    specify "the link text is present" do
+      expect(page).to have_css(".cta-link-text", text: link_text)
+    end
+
+    specify "the link is present" do
+      expect(page).to have_link(link_text, href: link_target)
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

https://trello.com/c/hE6i8kVs/7490-change-green-arrow-cta-partial-into-a-component?filter=member:spencerldixon

### Context

We recently built a green arrow CTA partial for use on the routes completion page (see https://trello.com/c/4KTcG2Y0 )

We want to use this on other pages across the site but the existing partial can only be used in html files and not markdown files

### Changes proposed in this pull request

- Move partial to a component
- Add component to list of approved components to be used in markdown files
- Refactor routes wizard to use new component
- Remove partial
- Add specs for new component

### Guidance to review

