### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/ruby:1": {
-      "version": "3.1.4"
+      "version": "3.4.1"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "18.16"


### PR DESCRIPTION
### Trello card
Follow on from 
[Upgrade the Ruby version on Get Into Teaching app from v3.1 to v3.4](https://trello.com/c/VYgJ0v2d/7387-upgrade-the-ruby-version-on-get-into-teaching-app-from-v31-to-v34)

### Context
Update the devcontainer used by codespaces to the correct Ruby version (3.4.1) - this was missed in the [earlier Ruby upgrade](https://github.com/DFE-Digital/get-into-teaching-app/pull/4553).

### Changes proposed in this pull request

### Guidance to review

