### PR TITLE
Replace footer tag in quotes with a div tag

### DIFF
--- a/app/components/content/quote_component.html.erb
+++ b/app/components/content/quote_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.blockquote(class: quote_class) do %>
   <p><%= text_sans_last_word %> <span><%= text_last_word %></span></p>
   <% if show_footer? %>
-    <%= tag.footer(class: "footer") do %>
+    <%= tag.div(class: "footer") do %>
       <div class="author">
         <div>
           <% if name.present? %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/7bDrM3jr/7501-fix-erroneous-footer-landmark-in-quotes?filter=member:spencerldixon

### Context

ARC Toolkit has flagged that our quotes have an erroneous footer landmark, which means we have multiple areas on a page flagged as footers

See screenshot as an example (/life-as-a-teacher/why-teach/why-become-a-teacher)

This is confusing for screen reader users

### Changes proposed in this pull request

- Replaces the `footer` tag with a `div` tag

### Guidance to review

