### PR TITLE
Remove duplicate main tag on life as a teacher page

### DIFF
--- a/app/views/content/life-as-a-teacher/_categories.html.erb
+++ b/app/views/content/life-as-a-teacher/_categories.html.erb
@@ -61,7 +61,7 @@
   </section>
 </div>
 
-<%= main_tag(class: "category") do %>
+<%= tag.div(class: "category") do %>
   <% grouped_categories(@page.path).each do |title, pages| %>
     <section class="container category__cards main-section">
       <%= tag.h2(title, id: title.parameterize, class: "heading--box-blue") %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/yLGMPfLS/7502-remove-duplicate-main-tag-used-on-sub-category-pages

### Context

Pages should only have one main element which is used by keyboard users and screen readers to skip to the main content

ARC Toolkit has flagged that our sub-category pages have two main elements (see screenshot)

### Changes proposed in this pull request

- Remove duplicate main tag in favour of a `div` tag

### Guidance to review

