### PR TITLE
Fix misalignment of links in bulletpoints when content wraps

### DIFF
--- a/app/webpacker/styles/text.scss
+++ b/app/webpacker/styles/text.scss
@@ -16,16 +16,15 @@ dt,
 }
 
 li {
-  margin-bottom: 0.5em; 
+  margin-bottom: 0.5em;
 
   &:last-child {
     margin-bottom: 0;
   }
 
   a {
-    display: inline-block; 
-    min-width: 24px; 
-    min-height: 24px; 
+    min-width: 24px;
+    min-height: 24px;
   }
 }
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/dk5nSfRd/7419-fix-misalignment-of-bullet-points-when-links-wrap-over-two-lines

### Context

When we have long links in bullet points that go over two lines, the bullet point drops to align with the second line rather than the first (see screenshot)

An example of this can be seen on the iQTS page - although the link text has been shortened so the issue no longer occurs on desktop, it does still occur on mobile (see screenshot)

In addition, if the link is long and in the middle of a sentence, sometimes the link is displayed as starting on a new line (ask Sarah S for an example)

### Changes proposed in this pull request

- Removes `inline-block` style for links within bulletpoints

### Guidance to review

