### PR TITLE
Added return false for when no answers present for highlight check

### DIFF
--- a/app/models/routes_into_teaching/route.rb
+++ b/app/models/routes_into_teaching/route.rb
@@ -26,6 +26,7 @@ module RoutesIntoTeaching
 
     def highlighted?
       return false unless @route_finder && @highlight
+      return false if @route_finder.answers.nil?
 
       highlight["matches"].all? do |rule|
         question_id = rule["question"]


### PR DESCRIPTION
### Trello card

https://trello.com/c/S05TkSxI/7504-fix-error-accessing-the-route-into-teaching-completed-page-with-no-or-partial-answers

### Context

The new Routes into teaching wizard is causing multiple sentry errors

This is triggered by having no or partial answers being passed to the highlighted logic

### Changes proposed in this pull request

- Adds check to return false if there are no answers for the routes finder

### Guidance to review

