### PR TITLE
Replaces header tag in landing hero component with div

### DIFF
--- a/app/components/content/landing_hero_component.html.erb
+++ b/app/components/content/landing_hero_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.header(class: "#{classes.join(' ')} #{title_paragraph ? 'deeper' : 'landing-hero'}") do %>
+<%= tag.div(class: "#{classes.join(' ')} #{title_paragraph ? 'deeper' : 'landing-hero'}") do %>
 
   <%= header_image %>
 

--- a/spec/components/content/landing_hero_component_spec.rb
+++ b/spec/components/content/landing_hero_component_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Content::LandingHeroComponent, type: "component" do
   end
 
   it { is_expected.to have_css(".landing-hero") }
-  it { is_expected.to have_css("header") }
   it { is_expected.to have_css("h1", text: "My page") }
   it { is_expected.to have_css(%(img)) }
 
@@ -31,6 +30,6 @@ RSpec.describe Content::LandingHeroComponent, type: "component" do
   context "when the colour is overridden" do
     let(:colour) { "purple" }
 
-    it { is_expected.to have_css("header.purple") }
+    it { is_expected.to have_css(".purple") }
   end
 end


### PR DESCRIPTION
### Trello card

http://trello.com/c/rYjt2grx/7505-remove-duplicate-header-landmark-on-category-sub-category-and-inspiration-pages?filter=member:spencerldixon

### Context

Pages should only have one headerelement which is used by keyboard users and screen readers when navigating the page

ARC Toolkit has flagged that pages using a particular header have two headerelements (see screenshot)

This can be seen in the code (see screenshot)

This header component is used at different levels eg

/life-as-a-teacher

/life-as-a-teacher/explore-subjects

/life-as-a-teacher/explore-subjects/art-and-design

### Changes proposed in this pull request

- Replaces the header tag in the `LandingHeroComponent` with a div given that the `header` tag is being used for the main navigation bar

### Guidance to review

