### PR TITLE
Fix link checker

### DIFF
--- a/spec/support/page_testing_support.rb
+++ b/spec/support/page_testing_support.rb
@@ -59,7 +59,7 @@ class LinkChecker
   end
 
   def links
-    document.css("a").pluck("href")
+    document.css("a").pluck("href").map { |link| link.gsub("\\", "") }
   end
 
   def faraday(link)


### PR DESCRIPTION
### Trello card

https://trello.com/c/QLoh13fG/7507-fix-external-link-checker-to-recognise-urls-in-expanders-correctly?filter=member:spencerldixon

### Context

The issue is that the external link checker is not recognising the URLs in the expander on this page because of the \ character

### Changes proposed in this pull request

- Remove backslashes from links in the link checker

### Guidance to review

