### PR TITLE
Fix incorrect aria role on expander component

### DIFF
--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.details(id: details_id, class: expander_class, open: expanded) do %>
-  <summary class="expander-details__summary">
-    <%= tag.div role: "text" do %>
+  <summary class="expander-details__summary" role="button">
+    <%= tag.div do %>
       <% if header.present? %>
         <span class="expander-details__summary__header">
           <%= header %>

--- a/app/components/content/expander_component.html.erb
+++ b/app/components/content/expander_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.details(id: details_id, class: expander_class, open: expanded) do %>
-  <summary class="expander-details__summary" role="button">
+  <summary class="expander-details__summary">
     <%= tag.div do %>
       <% if header.present? %>
         <span class="expander-details__summary__header">


### PR DESCRIPTION
### Trello card

https://trello.com/c/5GlgfNlS/7522-fix-incorrect-aria-role-on-expander-component

### Context

ARC Toolkit has flagged that we are using an incorrect aria role of role=text on our expander component. 

### Changes proposed in this pull request

- Removed role of `text` as not a valid aria role. 
- Removed `role="button"` which was originally added to the `<summary>` element inside `<details>`. `<summary>` already has built-in interactive behaviour, therefore role of button is not needed. `<summary>` is already focusable and supports Enter and Space for toggling. Screen readers already announce it as an expandable/collapsible element and not including a `role` avoids unnecessary ARIA overrides and potential conflicts.


- [WCAG definition of roles](https://www.w3.org/TR/wai-aria/#button)
- [Description](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) of `<summary>` element
- Examples of accordion components:
[Design System](https://design-system.service.gov.uk/components/accordion/)
[NHS Expander](https://service-manual.nhs.uk/design-system/components/expander)

### Guidance to review

- Retest with ARC toolkit
- Screen reader test
- Review as to whether a `role` is needed
