### PR TITLE
Improve accessibility of alt text for DfE logo in site footer

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -92,7 +92,7 @@
       </div>
       <div class="site-footer-bottom__logo-container">
         <%= link_to "https://www.gov.uk/government/organisations/department-for-education" do %>
-          <%= image_pack_tag 'static/images/dfelogo-black.svg', alt: "Department for Education logo", size: "124x73" %>
+          <%= image_pack_tag 'static/images/dfelogo-black.svg', alt: "Go to the Department for Education homepage, Department for Education logo", size: "124x73" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/cAhVmNO9

### Context
The alt text on the Department for Education logo in our site footer needs to describe where the user is taken if selected, not just that it is a logo
