### PR TITLE
Phone number styled as interactive on help and support page

### DIFF
--- a/app/components/content/talk_to_us_component.html.erb
+++ b/app/components/content/talk_to_us_component.html.erb
@@ -12,7 +12,7 @@
         <div>
           <h3 class="heading-l">Call our support team</h3>
           <p>Our phone line gives you a quick and easy way to get one-off support.</p>
-          <p><a href="tel:08003892500" class="telephone link--black">0800 389 2500</a></p>
+          <p><a href="tel:08003892500" class="telephone link">0800 389 2500</a></p>
         </div>
       </div>
       <div>

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -101,7 +101,7 @@
 
     .telephone {
       font-weight: bold;
-      text-decoration: none;
+      text-decoration: underline;
       font-size: 1.3em;
     }
   }

--- a/app/webpacker/styles/sections/talk-to-us.scss
+++ b/app/webpacker/styles/sections/talk-to-us.scss
@@ -101,8 +101,7 @@
 
     .telephone {
       font-weight: bold;
-      text-decoration: underline;
-      font-size: 1.3em;
+      font-size: 1.75em;
     }
   }
 }


### PR DESCRIPTION
### Trello card

https://trello.com/c/8JIryjs3/7550-gds-accessibility-audit-8-phone-number-not-styled-as-interactive-on-help-and-support-page-level-a

### Context

On the Help and support getting into teaching page, there is a telephone number link beneath “Call us” in the “Talk to us” section. The telephone number is visually styled similar to a heading or important text and does not look interactive. The visual styling does not match the programmatic information.

### Changes proposed in this pull request

- visually styled the phone number as interactive (similar to the phone number in the footer)
- adapted `class` in HTML and added an `underline` styling

###  Guidance to review
![Screenshot 2025-02-27 at 11 34 04](https://github.com/user-attachments/assets/193cbc17-12cd-4f33-b4d0-8de257e43a25)
