### PR TITLE
Update button text for event search on Help and support page

### DIFF
--- a/app/views/content/help-and-support/_events.html.erb
+++ b/app/views/content/help-and-support/_events.html.erb
@@ -11,7 +11,7 @@
             <%= f.hidden_field :online, multiple: true, value: false %>
             <%= f.label :postcode, "Enter postcode" %>
             <%= f.text_field :postcode, class: "govuk-input", autocomplete: "postal-code" %>
-            <%= tag.button("Search", class: "button", type: :submit, id: "event-search") %>
+            <%= tag.button("Search for an event", class: "button", type: :submit, id: "event-search") %>
           <% end %>
           <p class="govuk-!-padding-top-5">
             Or <%= link_to("find an online event", events_path(add_online_events(params))) %>.


### PR DESCRIPTION
### Trello card
https://trello.com/c/bZQR1y63

### Context
The events search button on the Help and support page has the same label as the search function in the extra navigation bar at the top of the page, which is confusing for screen reader users.