### PR TITLE
Adviser funnel missing autocomplete attributes

### DIFF
--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "What is your telephone number?" %>
 
 <%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
-  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
+  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value, autocomplete: "tel-national" %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -9,7 +9,7 @@
 
   <p>Or, you can call us on 0800 389 2500.<p>
 
-  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
+  <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value, autocomplete: "tel-national" %>
 
   <%= f.govuk_collection_select :time_zone,
     f.object.filtered_time_zones,

--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "What is your postcode?" %>
 
-<%= f.govuk_text_field :address_postcode, width: 20, label: { text: @page_title, size: "m", tag: "h1" } do %>
+<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", width: 20, label: { text: @page_title, size: "m", tag: "h1" } do %>
   <p>We try and match you with an adviser providing support in your region.</p>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -6,7 +6,7 @@
   <p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>
   <p>You must have the details of the qualifications you gained outside the UK when we contact you.</p>
 
-  <%= f.govuk_phone_field :address_telephone, width: 20 %>
+  <%= f.govuk_phone_field :address_telephone, autocomplete: "tel", width: 20 %>
 
   <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
 

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = "What is your telephone number?" %>
 
 <%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
-  <%= f.govuk_phone_field :address_telephone, width: 20 %>
+  <%= f.govuk_phone_field :address_telephone, autocomplete: "tel", width: 20 %>
 <% end %>


### PR DESCRIPTION
### Trello card

https://trello.com/c/7xRzl5nu/7551-gds-accessibility-audit-16-adviser-funnel-missing-autocomplete-attributes-level-aa

### Context

Within the Adviser journey, there are two places where personal information is required and the fields do not have corresponding autocomplete attributes. This is the case for: • the postcode field on the ‘What is your postcode?’ page • the telephone number field on the ‘What is your telephone number?’ page. 

[WCAG 1.3.5 Identify input purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose).

Where technologically possible, the code must identify the data it expects if the input is one of the types listed in [WCAG 2.2 Section 7 - Input Purposes for User Interface Components](https://www.w3.org/TR/WCAG22/#input-purposes). This can be done by adding an autocomplete attribute with an appropriate value.

### Changes proposed in this pull request

- added `autocomplete: "postal-code"` to postcode steps within the adviser funnel.
- added `autocomplete: "tel"` to UK phone number steps within the adviser funnel.
- added `autocomplete: "tel-national"` to overseas phone number steps within the adviser funnel (_telephone number without the country code component, with a country-internal prefix applied if applicable_). In this step, the country code is given to the user after selecting their country in the previous step.
- checked the mailing list, events and callback funnels for missing autocompletes (no missing attributes spotted).

### Guidance to review

