### PR TITLE
Page titles on the mailing list funnel

### DIFF
--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -65,7 +65,8 @@ module MailingList
     end
 
     def set_completed_page_title
-      @page_title = "Free personalised teacher training guidance, sign up completed"
+      @page_title = "Free personalised teacher training guidance"
+      @page_title += ", sign up completed"
     end
   end
 end

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -57,7 +57,7 @@ module MailingList
     end
 
     def set_step_page_title
-      @page_title = "Get tailored guidance in your inbox"
+      @page_title = "Free personalised teacher training guidance"
 
       if @current_step&.title
         @page_title += ", #{@current_step.title.downcase} step"
@@ -65,7 +65,7 @@ module MailingList
     end
 
     def set_completed_page_title
-      @page_title = "You've signed up"
+      @page_title = "Free personalised teacher training guidance, sign up completed"
     end
   end
 end

--- a/app/models/mailing_list/steps/teacher_training.rb
+++ b/app/models/mailing_list/steps/teacher_training.rb
@@ -13,6 +13,10 @@ module MailingList
       def consideration_journey_stage_ids
         consideration_journey_stages.map { |option| option.id.to_i }
       end
+
+      def title
+        "interest"
+      end
     end
   end
 end

--- a/app/views/mailing_list/steps/_teacher_training.html.erb
+++ b/app/views/mailing_list/steps/_teacher_training.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "interest" %>
 <%= f.govuk_collection_radio_buttons :consideration_journey_stage_id,
   f.object.consideration_journey_stages,
   :id,


### PR DESCRIPTION
### Trello card

https://trello.com/c/bH2AkE6v/7555-gds-accessibility-audit-25-insufficiently-descriptive-page-title-on-mailing-list-completion-page

### Context

WCAG 2.4.2 Page titled: https://www.w3.org/WAI/WCAG22/Understanding/page-titled

Pages must have titles that describe the topic or purpose of the page. This helps users avoid having to read or search through content to see if it is relevant. Good titles are descriptive, meaningful and unique. In most browsers the title will usually be displayed in the top title bar or as the tab name.

### Changes proposed in this pull request
- Changed common page title in the `steps_controller` which applies to ALL pages in the funnel; this is to reflect the new heading on the mailing list start page:
FROM `Get tailored guidance in your inbox` TO `Free personalised teacher training guidance`. 
- Changed `teacher training step` to `interest step` by creating a `title` method in `app/models/mailing_list/steps/teacher_training.rb` (this overrides default wizard behaviour which takes page title from class name. This page now has a title of `Free personalised teacher training guidance, interest step`.
- Changed page title of completion page to `Free personalised teacher training guidance, sign up completed`. 

### Guidance to review

