### PR TITLE
Page titles in adviser funnel

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -96,7 +96,7 @@ module TeacherTrainingAdviser
     end
 
     def set_completed_page_title
-      @page_title = "You've signed up"
+      @page_title = "Get a free adviser, sign up completed"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -15,5 +15,9 @@ module TeacherTrainingAdviser::Steps
     def skipped?
       other_step(:what_degree_class).skipped?
     end
+
+    def title
+      "english and maths gcses"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -16,5 +16,9 @@ module TeacherTrainingAdviser::Steps
 
       !returning_teacher || teacher_id_prefilled
     end
+
+    def title
+      "have teacher reference number"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_callback.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_callback.rb
@@ -22,5 +22,9 @@ module TeacherTrainingAdviser::Steps
 
       callback_not_offered || overseas_country_skipped || have_a_degree_skipped || !equivalent_degree
     end
+
+    def title
+      "callback time"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -34,6 +34,10 @@ module TeacherTrainingAdviser::Steps
       end
     end
 
+    def title
+      "country"
+    end
+
   private
 
     def country_name

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -29,5 +29,9 @@ module TeacherTrainingAdviser::Steps
 
       overseas_country_skippped || equivalent_degree
     end
+
+    def title
+      "international telephone"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -44,5 +44,9 @@ module TeacherTrainingAdviser::Steps
 
       overseas_country_skipped || !equivalent_degree
     end
+
+    def title
+      "contact details and timezone"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -15,5 +15,9 @@ module TeacherTrainingAdviser::Steps
 
       has_teacher_id_skipped || !has_id
     end
+
+    def title
+      "teacher reference number"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -17,5 +17,9 @@ module TeacherTrainingAdviser::Steps
       (retake_gcse_maths_english_skipped || retaking_gcse_maths_english) &&
         (retake_gcse_science_skipped || retaking_gcse_science)
     end
+
+    def title
+      "gcses required"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -21,5 +21,9 @@ module TeacherTrainingAdviser::Steps
 
       gcse_maths_english_skipped || has_gcse_maths_english
     end
+
+    def title
+      "retake english and maths gcses"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -21,5 +21,9 @@ module TeacherTrainingAdviser::Steps
     def returning_teacher?
       other_step(:returning_teacher).returning_to_teaching
     end
+
+    def title
+      "stage interested in teaching"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -37,5 +37,9 @@ module TeacherTrainingAdviser::Steps
     def self.options
       generate_api_options(GetIntoTeachingApiClient::PickListItemsApi, :get_qualification_degree_status, nil, DEGREE_STATUS.values)
     end
+
+    def title
+      "degree stage"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_trained.rb
+++ b/app/models/teacher_training_adviser/steps/stage_trained.rb
@@ -31,5 +31,9 @@ module TeacherTrainingAdviser::Steps
     def stage_taught_primary?
       stage_taught_id == OPTIONS[:primary]
     end
+
+    def title
+      "stage trained to teach"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -45,6 +45,10 @@ module TeacherTrainingAdviser::Steps
       itt_years.find { |item| item.value == inferred_year.to_s }&.id
     end
 
+    def title
+      "teacher training year"
+    end
+
   private
 
     def itt_years

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -21,5 +21,9 @@ module TeacherTrainingAdviser::Steps
 
       have_a_degree_skipped || phase_is_not_secondary
     end
+
+    def title
+      "subject interested in teaching"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -18,5 +18,9 @@ module TeacherTrainingAdviser::Steps
         answers["preferred_teaching_subject_id"] = Crm::TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id)
       end
     end
+
+    def title
+      "subject you want to teach"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/subject_trained.rb
+++ b/app/models/teacher_training_adviser/steps/subject_trained.rb
@@ -25,5 +25,9 @@ module TeacherTrainingAdviser::Steps
         answers["subject_taught_id"] = Crm::TeachingSubject.lookup_by_uuid(subject_taught_id)
       end
     end
+
+    def title
+      "subject trained to teach"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -14,6 +14,10 @@ module TeacherTrainingAdviser::Steps
       other_step(:uk_or_overseas).uk_or_overseas != UkOrOverseas::OPTIONS[:uk]
     end
 
+    def title
+      "postcode"
+    end
+
   private
 
     def sanitize_input

--- a/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
+++ b/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
@@ -15,5 +15,9 @@ module TeacherTrainingAdviser::Steps
         "uk_or_overseas" => uk_or_overseas,
       }
     end
+
+    def title
+      "location"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -33,5 +33,9 @@ module TeacherTrainingAdviser::Steps
         answers["uk_degree_grade_id"] = self.class.options.key(uk_degree_grade_id)
       end
     end
+
+    def title
+      "degree class"
+    end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -26,5 +26,9 @@ module TeacherTrainingAdviser::Steps
 
       have_a_degree_skipped || not_studying_or_have_a_degree
     end
+
+    def title
+      "degree subject"
+    end
   end
 end

--- a/app/views/teacher_training_adviser/not_available.html.erb
+++ b/app/views/teacher_training_adviser/not_available.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Sorry, the adviser service is currently unavailable" %>
-
 <div class="govuk-width-container">
   <h1>Sorry, the adviser service is currently unavailable</h1>
   <p>To sign up whilst this service is unavailable, you can call us on

--- a/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
+++ b/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "You have already signed up for an adviser" %>
-
 <div class="govuk-form-group">
   <h1>You've already signed up</h1>
 

--- a/app/views/teacher_training_adviser/steps/_authenticate.html.erb
+++ b/app/views/teacher_training_adviser/steps/_authenticate.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "You've already registered with us" %>
-
 <%= f.govuk_fieldset legend: { text: "You're already registered with us", tag: "h1" } do %>
   <%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_teacher_training_adviser_steps_path %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
+++ b/app/views/teacher_training_adviser/steps/_date_of_birth.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Enter your date of birth" %>
-
 <%= f.govuk_date_field(:date_of_birth, date_of_birth: true, legend: { tag: "h1" }) do %>
   <p class="govuk-body">
     We ask for your date of birth to check you're over 18. We also use it to

--- a/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_maths_english.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Do you have grade 4 (C) or above in English and maths GCSEs, or equivalent?" %>
-
 <%= f.govuk_collection_radio_buttons :has_gcse_maths_and_english_id, f.object.class::OPTIONS, :last, nil, inline: true, legend: { tag: "h1" } %>
 
 <details class="govuk-details">

--- a/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_gcse_science.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Do you have grade 4 (C) or above in GCSE science, or equivalent?" %>
-
 <%= f.govuk_collection_radio_buttons :has_gcse_science_id, f.object.class::OPTIONS, :last, nil, inline: true, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_have_a_degree.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Do you have a degree?" %>
-
 <%= f.govuk_collection_radio_buttons :degree_options, f.object.class::DEGREE_OPTIONS, :last, nil, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_no_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_no_degree.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "We're sorry, but you need a degree to sign up for an adviser" %>
-
 <div class="govuk-form-group">
   <h1>We're sorry, but you need a degree to sign up for an adviser</h1>
 

--- a/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
+++ b/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Sorry, you are not eligible for this service" %>
-
 <div class="govuk-form-group">
   <h1>Sorry, you are not eligible for this service</h1>
 

--- a/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Choose a time" %>
-
 <%= f.govuk_fieldset legend: { text: "Choose a time", tag: "h1" } do %>
 <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_country.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Which country do you live in?" %>
-
 <%= f.govuk_collection_select :country_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "What is your telephone number?" %>
-
 <%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
   <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "You told us you have an equivalent degree and live overseas" %>
-
 <%= f.govuk_fieldset legend: { text: "You told us you have an equivalent degree and live overseas", tag: "h1" } do %>
 
 <% if f.object.class.callback_booking_quotas.any? %>

--- a/app/views/teacher_training_adviser/steps/_paid_teaching_experience_in_uk.html.erb
+++ b/app/views/teacher_training_adviser/steps/_paid_teaching_experience_in_uk.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Do you have paid teaching experience in the UK?" %>
-
 <%= f.govuk_radio_buttons_fieldset(:has_paid_experience_in_uk, inline: true, legend: { tag: "h1", text: "Do you have paid teaching experience in the UK of at least one term?" }) do %>
   <%= f.govuk_radio_button :has_paid_experience_in_uk, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :has_paid_experience_in_uk, false, label: { text: 'No' }, link_errors: true %>

--- a/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
+++ b/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Get the right GCSEs or equivalent qualifications" %>
-
 <h1>We're sorry, but you need the right GCSEs to sign up for an adviser</h1>
 <div class="govuk-form-group">
     <p>To train to be a teacher, teacher training providers ask you to show your ability through GCSEs. You'll need the following GCSEs (or an equivalent):</p>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_maths_english.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Are you planning to retake either English or maths (or both) GCSEs, or equivalent?" %>
-
 <%= f.govuk_collection_radio_buttons :planning_to_retake_gcse_maths_and_english_id, f.object.class::OPTIONS, :last, nil, inline: true, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
+++ b/app/views/teacher_training_adviser/steps/_retake_gcse_science.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Are you planning to retake your science GCSE?" %>
-
 <%= f.govuk_collection_radio_buttons :planning_to_retake_gcse_science_id, f.object.class::OPTIONS, :last, nil, inline: true, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
+++ b/app/views/teacher_training_adviser/steps/_returning_teacher.html.erb
@@ -1,4 +1,3 @@
-<% @page_title = "Are you qualified to teach?" %>
 <%= f.govuk_collection_radio_buttons :type_id, f.object.class::OPTIONS, :last, nil, inline: true, legend: { tag: "h1" } %>
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Check your answers before you continue" %>
-
 <h1>Check your answers before you continue</h1>
 
 <h2 class="govuk-heading-m">Personal details</h2>

--- a/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_interested_teaching.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Which stage are you interested in teaching?" %>
-
 <%= f.govuk_collection_radio_buttons :preferred_education_phase_id, f.object.class::OPTIONS, :last, nil, inline: true, hint: { hidden: f.object.returning_teacher? }, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_of_degree.html.erb
@@ -1,4 +1,2 @@
-<% @page_title = "In which year are you studying?" %>
-
 <% options = f.object.class.options %>
 <%= f.govuk_collection_radio_buttons :degree_status_id, options, :last, :first, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_stage_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_taught.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Which stage did you previously teach?" %>
-
 <%= f.govuk_collection_radio_buttons :stage_taught_id, f.object.class::OPTIONS, :last, nil, inline: true, hint: { hidden: f.object.returning_teacher? }, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_stage_trained.html.erb
+++ b/app/views/teacher_training_adviser/steps/_stage_trained.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Which stage did you train to teach?" %>
-
 <%= f.govuk_collection_radio_buttons :stage_taught_id, f.object.class::OPTIONS, :last, nil, inline: true, hint: { hidden: f.object.returning_teacher? }, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
+++ b/app/views/teacher_training_adviser/steps/_start_teacher_training.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "When do you want to start your teacher training?" %>
-
 <%= f.govuk_collection_select :initial_teacher_training_year_id,
   f.object.years,
   :id,

--- a/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_interested_teaching.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "What would you like to teach?" %>
-
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_like_to_teach.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Which subject would you like to teach if you return to teaching?" %>
-
 <%= f.govuk_collection_select :preferred_teaching_subject_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_taught.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Which main subject did you previously teach?" %>
-
 <%= f.govuk_collection_select :subject_taught_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_subject_trained.html.erb
+++ b/app/views/teacher_training_adviser/steps/_subject_trained.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Which subject did you train to teach?" %>
-
 <%= f.govuk_collection_select :subject_taught_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_train_to_teach_in_uk.html.erb
+++ b/app/views/teacher_training_adviser/steps/_train_to_teach_in_uk.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Did you train to teach in the UK?" %>
-
 <%= f.govuk_radio_buttons_fieldset(:train_to_teach_in_uk, inline: true, legend: { tag: "h1", text: "Did you train to teach in the UK?" }) do %>
   <%= f.govuk_radio_button :train_to_teach_in_uk, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :train_to_teach_in_uk, false, label: { text: 'No' }, link_errors: true %>

--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "What is your postcode?" %>
-
-<%= f.govuk_text_field :address_postcode, width: 20, label: { text: @page_title, size: "m", tag: "h1" } do %>
+<%= f.govuk_text_field :address_postcode, width: 20, label: { text: "What is your postcode?", size: "m", tag: "h1" } do %>
   <p>We try and match you with an adviser providing support in your region.</p>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "You told us you have an equivalent degree and live in the United Kingdom" %>
-
 <%= f.govuk_fieldset legend: { text: "You told us you have an equivalent degree and live in the United Kingdom", tag: "h1" } do %>
 
 <% if f.object.class.callback_booking_quotas.any? %>

--- a/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_or_overseas.html.erb
@@ -1,3 +1,1 @@
-<% @page_title = "Where do you live?" %>
-
 <%= f.govuk_collection_radio_buttons :uk_or_overseas, [["UK"], ["Overseas"]], :first, inline: true, legend: { tag: "h1" } %>

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "What is your telephone number?" %>
-
 <%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
   <%= f.govuk_phone_field :address_telephone, width: 20 %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
@@ -6,8 +6,6 @@ text = if f.object.studying?
        end
 %>
 
-<% @page_title = text %>
-
 <%= f.govuk_collection_select :uk_degree_grade_id,
   f.object.class.options,
   :last,

--- a/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_subject_degree.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "What subject is your degree?" %>
-
 <%= tag.div id: "what-subject-degree-container", data: {controller: 'what-subject-degree'} do %>
 
   <%= tag.div data: {'what-subject-degree-target': 'noJSContainer' } do %>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -1,5 +1,3 @@
-<% @page_title = "Sign up complete" %>
-
 <section class="registration__teacher-training-adviser" data-sub-channel-id="<%= session.dig("sign_up", "sub_channel_id") %>">
 
   <% if @returner %>

--- a/spec/features/teacher_training_adviser/sign_up_spec.rb
+++ b/spec/features/teacher_training_adviser/sign_up_spec.rb
@@ -93,7 +93,10 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       fill_in_date_of_birth_step
       click_on "Next step"
 
+      # check page title remains correct for non completed steps
       expect(page).to have_css "h1", text: "Where do you live?"
+      click_on "Next step"
+      expect(page).to have_title("Get a free adviser, location step | Get Into Teaching GOV.UK")
       choose "UK"
       click_on "Next step"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/JGTkTYCw/7556-gds-accessibility-audit-26-insufficiently-descriptive-page-titles-in-adviser-funnel

### Context

WCAG 2.4.2 Page titled: https://www.w3.org/WAI/WCAG22/Understanding/page-titled

Pages must have titles that describe the topic or purpose of the page. This helps users avoid having to read or search through content to see if it is relevant. Good titles are descriptive, meaningful and unique. In most browsers the title will usually be displayed in the top title bar or as the tab name.

### Changes proposed in this pull request

- removed individual page titles defined for each step in the view files. The pages now take the common page title defined in the `StepsController`, followed by the step name (default behaviour). 
- renamed completed page title: `Get a free adviser, sign up completed`

### Guidance to review

- check page titles for adviser funnel and decide if any step names need adapting.
- step names can be found here: `app/models/teacher_training_adviser/wizard.rb`, e.g. `HaveADegree` step will now create a page title of 'Get a free adviser, have a degree step' unless overridden.

