### PR TITLE
Page title on event completion page

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -72,7 +72,7 @@ private
   end
 
   def set_completed_page_title
-    @page_title = "Sign up complete"
+    @page_title = "#{@event.name}, sign up completed"
   end
 
   def set_is_walk_in

--- a/spec/features/event_wizard_spec.rb
+++ b/spec/features/event_wizard_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Event wizard", type: :feature do
   let(:event_name) { "Event Name" }
   let(:event) { build(:event_api, readable_id: event_readable_id, name: event_name) }
   let(:individual_event_page_title) { "Sign up for #{event.name}, personal details step | Get Into Teaching" }
-  let(:sign_up_complete_page_title) { "Sign up complete | Get Into Teaching" }
+  let(:sign_up_complete_page_title) { "#{event.name}, sign up completed | Get Into Teaching" }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \


### PR DESCRIPTION
### Trello card

https://trello.com/c/cWu29PWr/7572-gds-accessibility-audit-25-insufficiently-descriptive-page-title-on-event-completion-page

### Context

WCAG 2.4.2 Page titled: [Understanding Success Criterion 2.4.2: Page Titled | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/page-titled)

Pages must have titles that describe the topic or purpose of the page. This helps users avoid having to read or search through content to see if it is relevant. Good titles are descriptive, meaningful and unique. In most browsers the title will usually be displayed in the top title bar or as the tab name.

### Changes proposed in this pull request

- added the common part of the page title to the event completion page and tweaked the step title to read e.g. `Sign up for Get Into Teaching event: East of England, sign up completed.`

### Guidance to review

