### PR TITLE
Page title callback completion page

### DIFF
--- a/app/controllers/callbacks/steps_controller.rb
+++ b/app/controllers/callbacks/steps_controller.rb
@@ -65,7 +65,7 @@ module Callbacks
     end
 
     def set_completed_page_title
-      @page_title = "Callback confirmed"
+      @page_title = "Book a callback, callback confirmed"
     end
   end
 end

--- a/spec/features/book_callback_spec.rb
+++ b/spec/features/book_callback_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Book a callback", type: :feature do
     )
   end
 
-  let(:callback_page_title) { "Callback confirmed | Get Into Teaching" }
+  let(:callback_page_title) { "Book a callback, callback confirmed | Get Into Teaching" }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::CallbackBookingQuotasApi).to \


### PR DESCRIPTION
### Trello card

https://trello.com/c/HKURp2Lf/7573-gds-accessibility-audit-25-insufficiently-descriptive-page-title-on-callback-completion-page

### Context

WCAG 2.4.2 Page titled: [Understanding Success Criterion 2.4.2: Page Titled | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/page-titled)

Pages must have titles that describe the topic or purpose of the page. This helps users avoid having to read or search through content to see if it is relevant. Good titles are descriptive, meaningful and unique. In most browsers the title will usually be displayed in the top title bar or as the tab name.

Throughout the Callback journey the page title describes which journey the user is moving through, along with the step. For example, “Book a callback, talking points step”. However, for the last page, once the journey is complete, the page title is “Callback confirmed” which is not fully descriptive for users.

### Changes proposed in this pull request

- tweaked title in `StepsController` to `Book a callback, callback confirmed`.
- adapted test to reflect this change.

### Guidance to review

