### PR TITLE
Allow inset text component to take optional heading_tag parameter

### DIFF
--- a/app/components/content/inset_text_component.html.erb
+++ b/app/components/content/inset_text_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.section(class: classes) do %>
   <% if header.present? || title.present? %>
-    <%= tag.h2 role: "text" do %>
+    <%= content_tag(@heading_tag, role: "text") do %>
       <%= tag.span(header, class: "header") if header.present? %>
       <%= tag.span(title, class: "title") if title.present? %>
     <% end %>

--- a/app/components/content/inset_text_component.html.erb
+++ b/app/components/content/inset_text_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.section(class: classes) do %>
   <% if header.present? || title.present? %>
-    <%= content_tag(@heading_tag, role: "text") do %>
+    <%= content_tag(heading_tag, role: "text") do %>
       <%= tag.span(header, class: "header") if header.present? %>
       <%= tag.span(title, class: "title") if title.present? %>
     <% end %>

--- a/app/components/content/inset_text_component.rb
+++ b/app/components/content/inset_text_component.rb
@@ -1,16 +1,17 @@
 module Content
   class InsetTextComponent < ViewComponent::Base
-    attr_reader :header, :title, :text, :color
+    attr_reader :header, :title, :text, :color, :heading_tag
 
     include ContentHelper
 
-    def initialize(text:, title: nil, header: nil, color: "yellow")
+    def initialize(text:, title: nil, header: nil, color: "yellow", heading_tag: "h2")
       super
 
       @text = substitute_values(text)
       @title = substitute_values(title)
       @header = substitute_values(header.present? && title.present? ? "#{header}:" : header)
       @color = color
+      @heading_tag = heading_tag
     end
 
     def classes

--- a/app/components/content/talk_to_us_component.html.erb
+++ b/app/components/content/talk_to_us_component.html.erb
@@ -28,7 +28,8 @@
           <%= render Content::InsetTextComponent.new(
             header: "Non-UK citizens:",
             text: "You can call us on <a href=\"tel:+448003892500\">+44 800 389 2500</a>, or use the free live chat service. Calls will be charged at your country's standard rate.",
-            color: "purple-white"
+            color: "purple-white",
+            heading_tag: "h3"
           ) %>
       </div>
     </div>

--- a/app/components/funding_widget_component.html.erb
+++ b/app/components/funding_widget_component.html.erb
@@ -33,7 +33,8 @@
               <%= render Content::InsetTextComponent.new(
                 header: "Non-UK citizens:",
                 text: "You're unlikely to get help funding your training unless you have permission to <a href=\"https://www.gov.uk/browse/visas-immigration/settle-in-the-uk\">live permanently in the UK</a>. Find out about <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">funding for non-UK citizens</a>.",
-                color: "purple-white"
+                color: "purple-white",
+                heading_tag: "h4"
               ) %>
             </div>
           </div>
@@ -51,7 +52,8 @@
                       <p>Other funding like tuition fee loans and maintenance loans are normally only available for UK citizens or non-UK citizens with permission to <a href=\"https://www.gov.uk/browse/visas-immigration/settle-in-the-uk\">live permanently in the UK</a>.</p>
                       <br>
                       <p>Find out about <a href=\"/non-uk-teachers/fees-and-funding-for-non-uk-trainees\">funding for non-UK citizens</a>.</p>",
-                color: "purple-white"
+                color: "purple-white",
+                heading_tag: "h4"
               ) %>
             </div>
           </div>

--- a/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/_article.html.erb
@@ -6,7 +6,8 @@
     <%= render Content::InsetTextComponent.new(
       header: "Non-UK citizens:",
       text: "<p>If you're not from the UK, find out about <a href=\"/non-uk-teachers/train-to-teach-in-england-as-an-international-student\">training to teach in England as a non-UK citizen</a>.</p>",
-      color: "purple"
+      color: "purple",
+      heading_tag: "h3"
     ) %>
     <h3>If you have a degree</h3>
     <p>If you already have a degree, you can do a postgraduate teacher training course to gain QTS.</p>

--- a/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers/_article.html.erb
@@ -4,7 +4,8 @@
     <%= render Content::InsetTextComponent.new(
       header: "Non-UK citizens:",
       text: "<p>If you're not from the UK, find out about <a href=\"/non-uk-teachers/train-to-teach-in-england-as-an-international-student\">training to teach in England as a non-UK citizen</a>.</p>",
-      color: "purple"
+      color: "purple",
+      heading_tag: "h2"
     ) %>
     <h2 class="heading--box-blue">Get advice and guidance from an expert</h2>
     <h3>Teacher training advisers</h3>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -24,7 +24,8 @@
 <%= render Content::InsetTextComponent.new(
   header: "Non-UK citizens:",
   text: "If you qualified as a teacher outside the UK, you need English qualified teacher status (QTS) to get an adviser. <a href=\"/non-uk-teachers/teach-in-england-if-you-trained-overseas\">Find out about teaching in England if you qualified outside the UK</a>.",
-  color: "purple"
+  color: "purple",
+  heading_tag: "h2"
 ) %>
 
 <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>

--- a/app/views/teaching_events/show/_event-summary.html.erb
+++ b/app/views/teaching_events/show/_event-summary.html.erb
@@ -1,7 +1,7 @@
 <h2>Event information</h2>
 
 <% if @event.message %>
-  <%= render Content::InsetTextComponent.new(text: @event.message) %>
+  <%= render Content::InsetTextComponent.new(text: @event.message, heading_tag: "h3") %>
 <% end %>
 
 <%= tag.div(formatted_event_description(@event.description)) %>

--- a/app/views/teaching_events/show/_other-events.html.erb
+++ b/app/views/teaching_events/show/_other-events.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::InsetTextComponent.new(
-  title: "Find more events",
+  header: "Find more events",
   color: "grey",
   heading_tag: "h2",
   text: <<~HTML

--- a/app/views/teaching_events/show/_other-events.html.erb
+++ b/app/views/teaching_events/show/_other-events.html.erb
@@ -1,6 +1,7 @@
 <%= render Content::InsetTextComponent.new(
   title: "Find more events",
   color: "grey",
+  heading_tag: "h2",
   text: <<~HTML
     <p>There are lots more online and in-person events where you can get your questions answered about teaching.</p>
     <p>#{link_to("Explore all events", events_path)}.</p>

--- a/app/views/teaching_events/show/_other-events.html.erb
+++ b/app/views/teaching_events/show/_other-events.html.erb
@@ -4,6 +4,6 @@
   heading_tag: "h2",
   text: <<~HTML
     <p>There are lots more online and in-person events where you can get your questions answered about teaching.</p>
-    <p>#{link_to("Explore all events", events_path)}.</p>
-    HTML
+    <p>#{link_to('Explore all events', events_path)}.</p>
+  HTML
 ) %>

--- a/app/webpacker/styles/components/inset-text.scss
+++ b/app/webpacker/styles/components/inset-text.scss
@@ -19,7 +19,7 @@ section.inset-text {
     border-left-color: $grey-mid;
   }
 
-  h2 {
+  h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
 
     span.header {
@@ -39,8 +39,7 @@ section.inset-text {
     margin-bottom: 0;
   }
 
-  h2,
-  p {
+  h1, h2, h3, h4, h5, h6, p {
     @include font-size("small");
     margin: 0;
   }

--- a/docs/content.md
+++ b/docs/content.md
@@ -295,6 +295,7 @@ If you need to call out something important in a page and differentiate it from 
 #### Inset component for non-UK content
 
 You do not need to include both a heading and title in the inset text.
+The heading tag will default to a h2, but you can override this by optionally specifying the `heading_tag` parameter.
 
 ```yaml
 ---
@@ -304,6 +305,7 @@ inset_text:
     title: Optional title
     text: Text that can contain <a href="#">links</a>
     color: yellow|grey|purple|purple-white
+    heading_tag: "h3"
 ---
 
 # My page content
@@ -316,7 +318,8 @@ If you need to insert an inset text component in an erb file:
 <%= render Content::InsetTextComponent.new(
   header: "Non-UK citizens:",
   text: "You can call us on <a href=\"tel:+448003892500\">+44 800 389 2500</a>, or use the free live chat service. Calls will be charged at your country's standard rate.",
-  color: "purple-white"
+  color: "purple-white",
+  heading_tag: "h3"
   ) %>
 ```
 

--- a/spec/components/content/inset_text_component_spec.rb
+++ b/spec/components/content/inset_text_component_spec.rb
@@ -61,4 +61,13 @@ describe Content::InsetTextComponent, type: :component do
 
     it { is_expected.to have_css("section.inset-text.purple") }
   end
+
+  context "when the heading_tag is overridden" do
+    let(:custom_heading_tag) { "h4" }
+    let(:component) { described_class.new(text: text, header: header, title: title, color: color, heading_tag: custom_heading_tag) }
+
+    specify "the custom heading tag is used" do
+      expect(subject).to have_css(".inset-text #{custom_heading_tag}[role=\"text\"]", text: title)
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/MDXOSArb/7575-gds-accessibility-audit-7-incorrect-heading-structure-or-visual-appearance-of-non-uk-citizens-component-on-help-and-support-page?filter=member:spencerldixon

### Context

On the Help and support getting into teaching page, the “Talk to us” section has a grey background and visually it appears that everything within this section relates to the level 2 heading of “Talk to us”. However, programmatically, “Non-UK citizens:” within the grey background is also a level 2 heading. The visual information does not match the programmatic structure of the headings.

### Changes proposed in this pull request

- Allow inset text component to take an optional `heading_tag` parameter
- Adjust pages to have appropriate headings depending on structure

### Guidance to review

