### PR TITLE
Capture hashed email

### DIFF
--- a/app/controllers/event_steps_controller.rb
+++ b/app/controllers/event_steps_controller.rb
@@ -14,6 +14,12 @@ class EventStepsController < ApplicationController
 
   layout :resolve_layout
 
+  def completed
+    super
+
+    @hashed_email = wizard_store[:hashed_email]
+  end
+
 protected
 
   def not_available_path

--- a/app/controllers/mailing_list/steps_controller.rb
+++ b/app/controllers/mailing_list/steps_controller.rb
@@ -21,6 +21,7 @@ module MailingList
       @first_name = wizard_store[:first_name]
       @degree_status_id = wizard_store[:degree_status_id]
       @degree_status_key = Crm::OptionSet.lookup_by_value(:degree_status, @degree_status_id) if @degree_status_id
+      @hashed_email = wizard_store[:hashed_email]
     end
 
   protected

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -17,6 +17,7 @@ module TeacherTrainingAdviser
       @equivalent = wizard_store[:degree_options] == Steps::HaveADegree::DEGREE_OPTIONS[:equivalent]
       @callback_booked = wizard_store[:callback_offered] && @equivalent
       @first_name = wizard_store[:first_name]
+      @hashed_email = wizard_store[:hashed_email]
     end
 
     def step_params

--- a/app/models/events/wizard.rb
+++ b/app/models/events/wizard.rb
@@ -1,10 +1,12 @@
 require "attribute_filter"
+require "digest"
 
 module Events
   class Wizard < ::GITWizard::Base
     ATTRIBUTES_TO_LEAVE = %w[
       is_walk_in
       sub_channel_id
+      hashed_email
     ].freeze
 
     self.steps = [
@@ -24,6 +26,7 @@ module Events
         break unless result
 
         add_attendee_to_event
+        @store[:hashed_email] = Digest::SHA256.hexdigest(@store[:email]) if @store[:email].present?
 
         @store.prune!(leave: ATTRIBUTES_TO_LEAVE)
       end

--- a/app/models/mailing_list/wizard.rb
+++ b/app/models/mailing_list/wizard.rb
@@ -1,4 +1,5 @@
 require "attribute_filter"
+require "digest"
 
 module MailingList
   class Wizard < ::GITWizard::Base
@@ -9,6 +10,7 @@ module MailingList
       consideration_journey_stage_id
       degree_status_id
       sub_channel_id
+      hashed_email
     ].freeze
 
     self.steps = [
@@ -32,6 +34,7 @@ module MailingList
         break unless result
 
         add_member_to_mailing_list
+        @store[:hashed_email] = Digest::SHA256.hexdigest(@store[:email]) if @store[:email].present?
 
         # we're taking the last name too so if people restart the wizard
         # both are filled rather than just their first name, which looks

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 module TeacherTrainingAdviser
   class Wizard < ::GITWizard::Base
     UK_COUNTRY_ID = "72f5c2e6-74f9-e811-a97a-000d3a2760f2".freeze
@@ -7,6 +9,7 @@ module TeacherTrainingAdviser
       degree_options
       sub_channel_id
       callback_offered
+      hashed_email
     ].freeze
 
     self.steps = [
@@ -61,6 +64,7 @@ module TeacherTrainingAdviser
       return false unless super
 
       sign_up_candidate
+      @store[:hashed_email] = Digest::SHA256.hexdigest(@store[:email]) if @store[:email].present?
 
       @store.prune!(leave: ATTRIBUTES_TO_LEAVE)
     end

--- a/app/views/event_steps/completed.html.erb
+++ b/app/views/event_steps/completed.html.erb
@@ -76,3 +76,4 @@
     <%= link_to "Get an adviser", "/teacher-training-adviser/sign_up/identity", class: "button button--white button--unpadded" %>
   <% end %>
 </div>
+<%= tag.div id: "hashed-email", class: "hidden", data: { id: "hashed-email", value: @hashed_email } %>

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -38,3 +38,4 @@
 </section>
 
 <%= tag.div id: "mailing-list-degree-status", class: "hidden", data: { id: @degree_status_id, key: @degree_status_key } %>
+<%= tag.div id: "hashed-email", class: "hidden", data: { id: "hashed-email", value: @hashed_email } %>

--- a/app/views/teacher_training_adviser/steps/completed.html.erb
+++ b/app/views/teacher_training_adviser/steps/completed.html.erb
@@ -105,3 +105,4 @@
 
   <% end %>
 </section>
+<%= tag.div id: "hashed-email", class: "hidden", data: { id: "hashed-email", value: @hashed_email } %>

--- a/spec/models/events/wizard_spec.rb
+++ b/spec/models/events/wizard_spec.rb
@@ -65,7 +65,11 @@ describe Events::Wizard do
       it { is_expected.to have_received(:valid?) }
 
       it do
-        expect(store[uuid]).to eql({ "is_walk_in" => wizardstore[:is_walk_in] })
+        hashed_email = Digest::SHA256.hexdigest("email@address.com")
+        expect(store[uuid]).to eql({
+          "hashed_email" => hashed_email,
+          "is_walk_in" => wizardstore[:is_walk_in],
+        })
       end
 
       it "logs the request model (filtering sensitive attributes)" do

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "digest"
 
 describe MailingList::Wizard do
   subject { described_class.new wizardstore, "postcode" }
@@ -78,10 +79,12 @@ describe MailingList::Wizard do
     end
 
     it "prunes the store, retaining certain attributes" do
+      hashed_email = Digest::SHA256.hexdigest("email@address.com")
       subject.complete!
       expect(store[uuid]).to eql({
         "first_name" => wizardstore[:first_name],
         "last_name" => wizardstore[:last_name],
+        "hashed_email" => hashed_email,
         "degree_status_id" => wizardstore[:degree_status_id],
         "preferred_teaching_subject_id" => wizardstore[:preferred_teaching_subject_id],
       })

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "digest"
 
 RSpec.describe TeacherTrainingAdviser::Wizard do
   describe ".steps" do
@@ -122,7 +123,12 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
       it { is_expected.to have_received(:can_proceed?) }
 
       it "prunes the store leaving data required to render the completion page" do
-        expect(store).to eql({ "type_id" => 123, "degree_options" => "equivalent", "callback_offered" => true, "first_name" => "Joe" })
+        hashed_email = Digest::SHA256.hexdigest("email@address.com")
+        expect(store).to eql({ "type_id" => 123,
+                               "degree_options" => "equivalent",
+                               "callback_offered" => true,
+                               "first_name" => "Joe",
+                               "hashed_email" => hashed_email })
       end
     end
 


### PR DESCRIPTION
### Trello card
[Enhanced conversions](https://trello.com/c/2fPbWEuX/7587-support-implementation-of-enhanced-conversions-by-capturing-hashed-email-addresses)

### Context
We wish to capture the hashed email address of a user signing up for services, to monitor enhanced conversions

### Changes proposed in this pull request
hash email address and display on the completion screen

### Guidance to review

