### PR TITLE
Welcome guide - Missing Q&A text alternative

### DIFF
--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -66,7 +66,7 @@
           What's the salary like?
         </h3>
 
-        <figure class="a" role="group">
+        <figure class="a">
           <blockquote>I know some people worry about the pay, especially when they start out. But my career progression has been really fast. Becoming a teacher is worth it.</blockquote>
 
           <figcaption>Jacqui</figcaption>
@@ -78,7 +78,7 @@
           What’s the work balance like?
         </h3>
 
-        <figure class="a" role="group">
+        <figure class="a">
           <blockquote>I sometimes do a couple of hours at the weekend so I'm ready for the week ahead. But I try to keep my weekends free to make sure I have some real downtime.</blockquote>
 
           <figcaption>Sarah</figcaption>
@@ -90,7 +90,7 @@
           Will I have the confidence?
         </h3>
 
-        <figure class="a" role="group">
+        <figure class="a">
           <blockquote>At the start of my training I felt like I didn’t have the authority to be standing up here and asking them to behave a certain way for me&hellip; but it is a confidence thing and now going into my last placement, I feel completely confident with it&hellip; it just comes with time. There’s so much support along the way.</blockquote>
 
           <figcaption>Amy</figcaption>

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -66,7 +66,7 @@
           What's the salary like?
         </p>
 
-        <figure class="a">
+        <figure class="a" role="group">
           <blockquote>I know some people worry about the pay, especially when they start out. But my career progression has been really fast. Becoming a teacher is worth it.</blockquote>
 
           <figcaption>Jacqui</figcaption>
@@ -78,7 +78,7 @@
           What’s the work balance like?
         </p>
 
-        <figure class="a">
+        <figure class="a" role="group">
           <blockquote>I sometimes do a couple of hours at the weekend so I'm ready for the week ahead. But I try to keep my weekends free to make sure I have some real downtime.</blockquote>
 
           <figcaption>Sarah</figcaption>
@@ -90,7 +90,7 @@
           Will I have the confidence?
         </p>
 
-        <figure class="a">
+        <figure class="a" role="group">
           <blockquote>At the start of my training I felt like I didn’t have the authority to be standing up here and asking them to behave a certain way for me&hellip; but it is a confidence thing and now going into my last placement, I feel completely confident with it&hellip; it just comes with time. There’s so much support along the way.</blockquote>
 
           <figcaption>Amy</figcaption>

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -62,9 +62,9 @@
     </div>
     <div class="questions-and-answers">
       <div class="question-and-answer">
-        <p class="q">
+        <h3 class="q">
           What's the salary like?
-        </p>
+        </h3>
 
         <figure class="a" role="group">
           <blockquote>I know some people worry about the pay, especially when they start out. But my career progression has been really fast. Becoming a teacher is worth it.</blockquote>
@@ -74,9 +74,9 @@
       </div>
 
       <div class="question-and-answer">
-        <p class="q">
+        <h3 class="q">
           What’s the work balance like?
-        </p>
+        </h3>
 
         <figure class="a" role="group">
           <blockquote>I sometimes do a couple of hours at the weekend so I'm ready for the week ahead. But I try to keep my weekends free to make sure I have some real downtime.</blockquote>
@@ -86,9 +86,9 @@
       </div>
 
       <div class="question-and-answer">
-        <p class="q">
+        <h3 class="q">
           Will I have the confidence?
-        </p>
+        </h3>
 
         <figure class="a" role="group">
           <blockquote>At the start of my training I felt like I didn’t have the authority to be standing up here and asking them to behave a certain way for me&hellip; but it is a confidence thing and now going into my last placement, I feel completely confident with it&hellip; it just comes with time. There’s so much support along the way.</blockquote>

--- a/app/webpacker/styles/welcome-guide.scss
+++ b/app/webpacker/styles/welcome-guide.scss
@@ -619,14 +619,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
           margin-top: 4em;
         }
 
-        @mixin question-decoration($content) {
-          content: $content;
-          position: absolute;
-          margin-left: -2rem;
-          font-weight: bold;
-          font-size: 1.2rem;
-        }
-
         .intro {
           padding: 2em 4em;
           font-weight: bold;
@@ -652,10 +644,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
 
           .q {
             font-weight: bold;
-
-            &::before {
-              @include question-decoration("Q");
-            }
           }
 
           .a {
@@ -679,10 +667,6 @@ $z-indices: ("bottom": 5, "low": 10, "medium": 15, "high": 20, "top": 25);
                 content: "\2014 "; // emdash
                 margin-right: .3em;
               }
-            }
-
-            &::before {
-              @include question-decoration("A");
             }
           }
         }


### PR DESCRIPTION
### Trello card

https://trello.com/c/oFy4C5hE/7616-gds-accessibility-audit-2-welcome-guide-missing-qa-text-alternative-level-a

### Context

On the Welcome to teaching page, in the “04 You’re not the only one with questions” section, there is a Q&A. When using a screen reader, the ‘Q’ is announced before the question text, but the ‘A’ is announced as “figure”. Screen reader users are not provided the same information as visual users.

### Changes proposed in this pull request

- added `role="group"` to `<figure>` element which wraps the Answer portion of the Q&A, to help screen readers process that content as a group, without announcing unnecessary HTML tags. It should prevent the `"figure"` from being announced (this was the initial issue identified in the audit but I could not replicate so have left this 'fix' in in case it works!).
- removed the 'Q' and 'A' lettering by deleting the pseudo elements in the CSS file
- made each question an h3 - this will differentiate the question from the answer

### Guidance to review

- check with alternative screen reader tools / devices as I could not replicate the 'figure' annoucement on VoiceOver for Mac
- decide if we need to keep role="group" on the `<figure>` tag. 
