### PR TITLE
Remove frontdoor caching for webchat

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -7,9 +7,7 @@
           "apex"
         ],
         "cached_paths": [
-          "/packs/*",
-          "/chat/*",
-          "/chat"
+          "/packs/*"
         ],
         "environment_short": "pd",
         "origin_hostname": "get-into-teaching-app-production.teacherservices.cloud",


### PR DESCRIPTION
### Trello card
[Investigate broken webchat](https://trello.com/c/tRj9pTp7/7639-investigate-why-webchat-is-unavailable)

### Context
Frontdoor caching on the webchat was breaking things because it could not differentiate between json and html

### Changes proposed in this pull request
Remove caching on the webchat

### Guidance to review

