### PR TITLE
Adding an extra H2 to the advisers page - accessibility

### DIFF
--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -27,7 +27,7 @@
   color: "purple"
 ) %>
 
-<h2>Tell us about yourself</h2>
+<h2 class="heading-m">Tell us about yourself</h2>
 
 <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
 <%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -27,6 +27,8 @@
   color: "purple"
 ) %>
 
+<h2>Tell us about yourself</h2>
+
 <%= f.govuk_text_field :first_name, width: 'two-thirds', autocomplete: "given-name" %>
 <%= f.govuk_text_field :last_name, width: 'two-thirds', autocomplete: "family-name" %>
 <%= f.govuk_email_field :email, width: 'two-thirds', autocomplete: "email" %>


### PR DESCRIPTION

### Trello card
https://trello.com/c/gA2npYUZ/7636-add-additional-h2-header-to-adviser-form-start-page

### Context

### Changes proposed in this pull request

As part of the accessibility audit, we need to add an additional H2 to the advisers sign-up page so the form doesn't come under the non-UK H2.
### Guidance to review

