### PR TITLE
Welcome guide numbered sections

### DIFF
--- a/app/views/content/welcome/landing/_bringing-your-lessons-to-life.html.erb
+++ b/app/views/content/welcome/landing/_bringing-your-lessons-to-life.html.erb
@@ -1,10 +1,11 @@
 
 <section class="landing bringing-your-lessons-to-life numbered">
   <div class="section-number">
-    <span>03</span>
+    <span aria-hidden="true">03</span>
+    <span class="visually-hidden">Section 3</span>
   </div>
 
-  <div class="arrow-container mobile">
+  <div class="arrow-container mobile" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 200,
@@ -20,7 +21,7 @@
     %>
   </div>
 
-  <div class="arrow-container desktop">
+  <div class="arrow-container desktop" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 320,

--- a/app/views/content/welcome/landing/_bringing-your-lessons-to-life.html.erb
+++ b/app/views/content/welcome/landing/_bringing-your-lessons-to-life.html.erb
@@ -1,9 +1,5 @@
 
 <section class="landing bringing-your-lessons-to-life numbered">
-  <div class="section-number">
-    <span aria-hidden="true">03</span>
-    <span class="visually-hidden">Section 3</span>
-  </div>
 
   <div class="arrow-container mobile" aria-hidden="true">
     <%=

--- a/app/views/content/welcome/landing/_did-you-know.html.erb
+++ b/app/views/content/welcome/landing/_did-you-know.html.erb
@@ -1,6 +1,6 @@
 <div class="landing did-you-know">
   <div class="triangle green">
-    <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none">
+    <svg height="100%" width="100%" viewbox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
       <polygon points="0,100 100,0 100,100" />
     </svg>
   </div>

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -10,8 +10,8 @@
     </p>
   </div>
 
-  <div class="stages">
-    <div class="stage">
+  <ol class="stages">
+    <li class="stage">
       <div class="card">
         <div class="number">1</div>
         <%= image_pack_tag("static/images/content/welcome-guide/school.svg", **image_alt_attribs_for_text("")) %>
@@ -26,11 +26,11 @@
           </a>
         </div>
       </div>
-    </div>
+    </li>
 
-    <div class="stage">
+    <li class="stage">
       <div class="card">
-        <div class="number">2</div>
+        <div class="number" aria-hidden="true">2</div>
         <%= image_pack_tag("static/images/content/welcome-guide/person-paper.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Check your qualifications.</h3>
@@ -43,9 +43,9 @@
           </a>
         </div>
       </div>
-    </div>
+    </li>
 
-    <div class="stage">
+    <li class="stage">
       <div class="card">
         <div class="number">3</div>
         <%= image_pack_tag("static/images/content/welcome-guide/money-icon.svg", **image_alt_attribs_for_text("")) %>
@@ -60,9 +60,9 @@
           </a>
         </div>
       </div>
-    </div>
+    </li>
 
-    <div class="stage">
+    <li class="stage">
       <div class="card">
         <div class="number">4</div>
         <%= image_pack_tag("static/images/content/welcome-guide/click-person.svg", **image_alt_attribs_for_text("")) %>
@@ -77,9 +77,9 @@
           </a>
         </div>
       </div>
-    </div>
+    </li>
 
-    <div class="stage">
+    <li class="stage">
       <div class="card">
         <div class="number">5</div>
         <%= image_pack_tag("static/images/content/welcome-guide/paper-and-pencil.svg", **image_alt_attribs_for_text("")) %>
@@ -94,8 +94,8 @@
           </a>
         </div>
       </div>
-    </div>
-  </div>
+    </li>
+  </ol>
 
   <div class="good-luck">
     <p>

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -100,7 +100,7 @@
         <span class="yellow">Good luck!</span> You've got this.
       <% end %>
     </p>
-    <div class="arrow-container">
+    <div class="arrow-container" aria-hidden="true">
       <%=
         render ArrowComponent.new(
           width: 200,

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -13,7 +13,6 @@
   <ol class="stages">
     <li class="stage">
       <div class="card">
-        <div class="number">1</div>
         <%= image_pack_tag("static/images/content/welcome-guide/school.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Get experience.</h3>
@@ -30,7 +29,6 @@
 
     <li class="stage">
       <div class="card">
-        <div class="number">2</div>
         <%= image_pack_tag("static/images/content/welcome-guide/person-paper.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Check your qualifications.</h3>
@@ -47,7 +45,6 @@
 
     <li class="stage">
       <div class="card">
-        <div class="number">3</div>
         <%= image_pack_tag("static/images/content/welcome-guide/money-icon.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Think about funding.</h3>
@@ -64,7 +61,6 @@
 
     <li class="stage">
       <div class="card">
-        <div class="number">4</div>
         <%= image_pack_tag("static/images/content/welcome-guide/click-person.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Choose your training provider.</h3>
@@ -81,7 +77,6 @@
 
     <li class="stage">
       <div class="card">
-        <div class="number">5</div>
         <%= image_pack_tag("static/images/content/welcome-guide/paper-and-pencil.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Apply for your course.</h3>

--- a/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
+++ b/app/views/content/welcome/landing/_exciting-times-ahead.html.erb
@@ -30,7 +30,7 @@
 
     <li class="stage">
       <div class="card">
-        <div class="number" aria-hidden="true">2</div>
+        <div class="number">2</div>
         <%= image_pack_tag("static/images/content/welcome-guide/person-paper.svg", **image_alt_attribs_for_text("")) %>
         <div class="stage-info">
           <h3 class="stage-name">Check your qualifications.</h3>

--- a/app/views/content/welcome/landing/_my-journey-into-teaching.html.erb
+++ b/app/views/content/welcome/landing/_my-journey-into-teaching.html.erb
@@ -1,8 +1,4 @@
 <section class="landing my-journey-into-teaching numbered">
-  <div class="section-number">
-    <span aria-hidden="true">02</span>
-    <span class="visually-hidden">Section 2</span>
-  </div>
 
   <div class="arrow-container mobile" aria-hidden="true">
     <%=

--- a/app/views/content/welcome/landing/_my-journey-into-teaching.html.erb
+++ b/app/views/content/welcome/landing/_my-journey-into-teaching.html.erb
@@ -1,9 +1,10 @@
 <section class="landing my-journey-into-teaching numbered">
   <div class="section-number">
-    <span>02</span>
+    <span aria-hidden="true">02</span>
+    <span class="visually-hidden">Section 2</span>
   </div>
 
-  <div class="arrow-container mobile">
+  <div class="arrow-container mobile" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 150,
@@ -19,7 +20,7 @@
     %>
   </div>
 
-  <div class="arrow-container desktop">
+  <div class="arrow-container desktop" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 350,

--- a/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
+++ b/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
@@ -1,9 +1,10 @@
 <section class="landing teaching-is-so-rewarding numbered">
-    <div class="section-number">
-      <span>01</span>
-    </div>
+  <div class="section-number">
+    <span aria-hidden="true">01</span>
+    <span class="visually-hidden">Section 1</span>
+  </div>
 
-    <div class="arrow-container mobile">
+    <div class="arrow-container mobile" aria-hidden="true">
       <%=
         render ArrowComponent.new(
           width: 250,
@@ -19,7 +20,7 @@
       %>
     </div>
 
-    <div class="arrow-container desktop">
+    <div class="arrow-container desktop" aria-hidden="true">
       <%=
         render ArrowComponent.new(
           width: 320,

--- a/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
+++ b/app/views/content/welcome/landing/_teaching-is-so-rewarding.html.erb
@@ -1,8 +1,4 @@
 <section class="landing teaching-is-so-rewarding numbered">
-  <div class="section-number">
-    <span aria-hidden="true">01</span>
-    <span class="visually-hidden">Section 1</span>
-  </div>
 
     <div class="arrow-container mobile" aria-hidden="true">
       <%=

--- a/app/views/content/welcome/landing/_welcome-to-teaching.html.erb
+++ b/app/views/content/welcome/landing/_welcome-to-teaching.html.erb
@@ -28,7 +28,7 @@
     </h1>
   </div>
 
-  <div class="arrow-container mobile">
+  <div class="arrow-container mobile" aria-hidden="true">
     <%=
     render ArrowComponent.new(
         width: 80,
@@ -44,7 +44,7 @@
     %>
   </div>
 
-  <div class="arrow-container top desktop">
+  <div class="arrow-container top desktop" aria-hidden="true">
     <%=
     render ArrowComponent.new(
         width: 300,
@@ -60,7 +60,7 @@
     %>
   </div>
 
-  <div class="arrow-container bottom desktop">
+  <div class="arrow-container bottom desktop" aria-hidden="true">
     <%=
     render ArrowComponent.new(
         width: 300,

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -38,7 +38,6 @@
 
   <%= image_pack_tag("static/images/content/hero-images/english.jpg", **image_alt_attribs("static/images/content/hero-images/english.jpg")) %>
 
-
   <div class="text">
     <h2>
       <span class="blue no-wrap">

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -1,5 +1,10 @@
 <section class="landing youre-not-the-only-one-with-questions numbered">
-  <div class="arrow-container top mobile">
+    <div class="section-number">
+     <span aria-hidden="true">04</span>
+     <span class="visually-hidden">Section 4</span>
+   </div>
+
+  <div class="arrow-container top mobile" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 150,
@@ -15,7 +20,7 @@
     %>
   </div>
 
-  <div class="arrow-container top desktop">
+  <div class="arrow-container top desktop" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 300,
@@ -33,9 +38,6 @@
 
   <%= image_pack_tag("static/images/content/hero-images/english.jpg", **image_alt_attribs("static/images/content/hero-images/english.jpg")) %>
 
-  <div class="section-number">
-    <span>04</span>
-  </div>
 
   <div class="text">
     <h2>
@@ -99,7 +101,7 @@
     </div>
   </div>
 
-  <div class="arrow-container bottom mobile">
+  <div class="arrow-container bottom mobile" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 200,
@@ -115,7 +117,7 @@
     %>
   </div>
 
-  <div class="arrow-container bottom desktop">
+  <div class="arrow-container bottom desktop" aria-hidden="true">
     <%=
       render ArrowComponent.new(
         width: 500,

--- a/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
+++ b/app/views/content/welcome/landing/_youre-not-the-only-one-with-questions.html.erb
@@ -1,8 +1,4 @@
 <section class="landing youre-not-the-only-one-with-questions numbered">
-    <div class="section-number">
-     <span aria-hidden="true">04</span>
-     <span class="visually-hidden">Section 4</span>
-   </div>
 
   <div class="arrow-container top mobile" aria-hidden="true">
     <%=


### PR DESCRIPTION
### Trello card

https://trello.com/c/ntqeaEh5/7614-gds-accessibility-audit-10-welcome-guide-numbered-sections-not-marked-up-correctly-level-a

### Context

On the Welcome to teaching page, there are two numbered sections. In each case, the numbers appear to be important and used to signal either a section or a step. Programmatically these numbers are in `<span>` and `<div>` tags and do not convey the same structural information as the visual presentation.

### Changes proposed in this pull request

- removed the big section numbers on the first half of the guide as not strictly needed (the sections are already marked up as `h2`s so don’t need numbering as well).
- removed the numbers from the 'Exciting times' steps. However, it is structured as an ordered list (`<ol>`) containing li (`<li>`) items; this helps screen readers to announce the information in a clear, more structured way and will read the step heading followed by e.g. 1 of 5. 
- added `aria-hidden="true"` to arrows on page as they don't appear to add any navigational support for screen reader users. 

### Guidance to review

- tested on Mac VoiceOver ✅
- tested on Samsung TalkBack ✅
- check ok to hide arrow images from screen readers or would prefer to add some alternative text to describe image. 

