### PR TITLE
Allow promo components to take an optional heading tag

### DIFF
--- a/app/components/calls_to_action/adviser_component.html.erb
+++ b/app/components/calls_to_action/adviser_component.html.erb
@@ -8,9 +8,12 @@
   </div>
 
   <div class="adviser__right">
-    <h2 class="heading-l">
-      <%= tag.span title if title.present? %>
-    </h2>
+    <% if title.present? %>
+      <%= content_tag heading_tag, class: "heading-l" do %>
+        <%= title %>
+      <% end %>
+    <% end %>
+
     <%= tag.p text, class: 'adviser__text' if text.present? %>
     <p></p>
     <%= link_to link_text, link_target, class: "button", role: "button", data: { "promo-type": "adviser" } if link_text.present? && link_target.present? %>

--- a/app/components/calls_to_action/adviser_component.rb
+++ b/app/components/calls_to_action/adviser_component.rb
@@ -1,5 +1,5 @@
 class CallsToAction::AdviserComponent < ViewComponent::Base
-  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border
+  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border, :heading_tag
 
   def initialize(
     title: "Get free one-to-one support",
@@ -8,7 +8,8 @@ class CallsToAction::AdviserComponent < ViewComponent::Base
     link_text: "Find out more about advisers",
     link_target: "/teacher-training-advisers",
     classes: [],
-    border: true
+    border: true,
+    heading_tag: "h2"
   )
     super
 
@@ -19,5 +20,6 @@ class CallsToAction::AdviserComponent < ViewComponent::Base
     @link_target = link_target
     @classes = ["adviser", *classes].compact.join(" ")
     @border = border
+    @heading_tag = heading_tag
   end
 end

--- a/app/components/calls_to_action/apply_component.html.erb
+++ b/app/components/calls_to_action/apply_component.html.erb
@@ -3,7 +3,9 @@
 
   <div class="call-to-action__content">
     <% if title.present? %>
-      <%= tag.span(title, class: "call-to-action__heading") %>
+      <%= content_tag heading_tag, class: "call-to-action__heading" do %>
+        <%= title %>
+      <% end %>
     <% end %>
 
     <% if text.present? || content.present? %>

--- a/app/components/calls_to_action/apply_component.rb
+++ b/app/components/calls_to_action/apply_component.rb
@@ -1,8 +1,8 @@
 module CallsToAction
   class ApplyComponent < ViewComponent::Base
-    attr_accessor :icon, :title, :text, :link
+    attr_accessor :icon, :title, :text, :link, :heading_tag
 
-    def initialize(icon: "icon-school-black", link_text: "Apply for a course", link_target: "https://www.gov.uk/apply-for-teacher-training", title: "Start your application", text: "Create an account and start your application for a teacher training course.", hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false)
+    def initialize(icon: "icon-school-black", link_text: "Apply for a course", link_target: "https://www.gov.uk/apply-for-teacher-training", title: "Start your application", text: "Create an account and start your application for a teacher training course.", hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false, heading_tag: "h2")
       super
 
       @icon_filename = icon
@@ -10,6 +10,7 @@ module CallsToAction
       @text          = text
       @link_text     = link_text
       @link_target   = link_target
+      @heading_tag   = heading_tag
 
       @hide_on_mobile  = hide_on_mobile
       @hide_on_tablet  = hide_on_tablet

--- a/app/components/calls_to_action/find_component.html.erb
+++ b/app/components/calls_to_action/find_component.html.erb
@@ -3,7 +3,9 @@
 
   <div class="call-to-action__content">
     <% if title.present? %>
-      <%= tag.span(title, class: "call-to-action__heading") %>
+      <%= content_tag heading_tag, class: "call-to-action__heading" do %>
+        <%= title %>
+      <% end %>
     <% end %>
 
     <% if text.present? || content.present? %>

--- a/app/components/calls_to_action/find_component.rb
+++ b/app/components/calls_to_action/find_component.rb
@@ -1,8 +1,8 @@
 module CallsToAction
   class FindComponent < ViewComponent::Base
-    attr_accessor :icon, :title, :text, :link
+    attr_accessor :icon, :title, :text, :link, :heading_tag
 
-    def initialize(icon: "icon-search-black", link_text: "Find your teacher training course", link_target: "https://find-teacher-training-courses.service.gov.uk/", title: "Find your teacher training course", text: "Take a look at the different teacher training courses available.", hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false)
+    def initialize(icon: "icon-search-black", link_text: "Find your teacher training course", link_target: "https://find-teacher-training-courses.service.gov.uk/", title: "Find your teacher training course", text: "Take a look at the different teacher training courses available.", hide_on_mobile: false, hide_on_tablet: false, hide_on_desktop: false, heading_tag: "h2")
       super
 
       @icon_filename = icon
@@ -10,6 +10,7 @@ module CallsToAction
       @text          = text
       @link_text     = link_text
       @link_target   = link_target
+      @heading_tag   = heading_tag
 
       @hide_on_mobile  = hide_on_mobile
       @hide_on_tablet  = hide_on_tablet

--- a/app/components/calls_to_action/mailinglist_component.html.erb
+++ b/app/components/calls_to_action/mailinglist_component.html.erb
@@ -8,9 +8,12 @@
   </div>
 
   <div class="mailinglist__right">
-    <h2 class="heading-l">
-      <%= tag.span title if title.present? %>
-    </h2>
+    <% if title.present? %>
+      <%= content_tag heading_tag, class: "heading-l" do %>
+        <%= title %>
+      <% end %>
+    <% end %>
+
     <%= tag.p text, class: 'mailinglist__text' if text.present? %>
     <p></p>
     <%= link_to link_text, link_target, class: "button", role: "button", data: { "promo-type": "mailinglist" } if link_text.present? && link_target.present? %>

--- a/app/components/calls_to_action/mailinglist_component.rb
+++ b/app/components/calls_to_action/mailinglist_component.rb
@@ -1,5 +1,5 @@
 class CallsToAction::MailinglistComponent < ViewComponent::Base
-  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border
+  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border, :heading_tag
 
   def initialize(
     title: "Find out more about getting into teaching",
@@ -8,7 +8,8 @@ class CallsToAction::MailinglistComponent < ViewComponent::Base
     link_text: "Get tailored advice in your inbox",
     link_target: "/mailinglist/signup/name",
     classes: [],
-    border: true
+    border: true,
+    heading_tag: "h2"
   )
     super
 
@@ -19,5 +20,6 @@ class CallsToAction::MailinglistComponent < ViewComponent::Base
     @link_target = link_target
     @classes = ["mailinglist", *classes].compact.join(" ")
     @border = border
+    @heading_tag = heading_tag
   end
 end

--- a/app/components/calls_to_action/routes_component.html.erb
+++ b/app/components/calls_to_action/routes_component.html.erb
@@ -8,9 +8,12 @@
   </div>
 
   <div class="routes__right">
-    <h2 class="heading-l">
-      <%= tag.span title if title.present? %>
-    </h2>
+    <% if title.present? %>
+      <%= content_tag heading_tag, class: "heading-l" do %>
+        <%= title %>
+      <% end %>
+    <% end %>
+
     <%= tag.p text, class: 'routes__text' if text.present? %>
     <p></p>
     <%= link_to link_text, link_target, class: "button", role: "button", data: { "promo-type": "routes" } if link_text.present? && link_target.present? %>

--- a/app/components/calls_to_action/routes_component.rb
+++ b/app/components/calls_to_action/routes_component.rb
@@ -1,5 +1,5 @@
 class CallsToAction::RoutesComponent < ViewComponent::Base
-  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border
+  attr_reader :title, :text, :image, :link_text, :link_target, :classes, :border, :heading_tag
 
   def initialize(
     title: "Find your route into teaching",
@@ -8,7 +8,8 @@ class CallsToAction::RoutesComponent < ViewComponent::Base
     link_text: "Find your route into teaching",
     link_target: "/find-your-route-into-teaching",
     classes: [],
-    border: true
+    border: true,
+    heading_tag: "h2"
   )
     super
 
@@ -19,5 +20,6 @@ class CallsToAction::RoutesComponent < ViewComponent::Base
     @link_target = link_target
     @classes = ["routes", *classes].compact.join(" ")
     @border = border
+    @heading_tag = heading_tag
   end
 end

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -10,8 +10,6 @@ cta_adviser:
 calls_to_action:
   find:
     name: find
-    arguments:
-      heading_tag: "h3"
 cta_arrow_link:
   subjects:
     link_target: "/life-as-a-teacher/explore-subjects"

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -10,6 +10,8 @@ cta_adviser:
 calls_to_action:
   find:
     name: find
+    arguments:
+      heading_tag: "h3"
 cta_arrow_link:
   subjects:
     link_target: "/life-as-a-teacher/explore-subjects"

--- a/spec/components/calls_to_action/adviser_component_spec.rb
+++ b/spec/components/calls_to_action/adviser_component_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe CallsToAction::AdviserComponent, type: :component do
         expect(page).not_to have_css("p.adviser__text")
       end
     end
+
+    context "when the heading_tag is overridden" do
+      let(:custom_heading_tag) { "h4" }
+      let(:component) { described_class.new(
+        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
+      )}
+
+      specify "the custom heading tag is used" do
+        expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)
+      end
+    end
   end
 end

--- a/spec/components/calls_to_action/adviser_component_spec.rb
+++ b/spec/components/calls_to_action/adviser_component_spec.rb
@@ -61,9 +61,11 @@ RSpec.describe CallsToAction::AdviserComponent, type: :component do
 
     context "when the heading_tag is overridden" do
       let(:custom_heading_tag) { "h4" }
-      let(:component) { described_class.new(
-        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
-      )}
+      let(:component) do
+        described_class.new(
+          title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag,
+        )
+      end
 
       specify "the custom heading tag is used" do
         expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)

--- a/spec/components/calls_to_action/apply_component_spec.rb
+++ b/spec/components/calls_to_action/apply_component_spec.rb
@@ -65,5 +65,16 @@ RSpec.describe CallsToAction::ApplyComponent, type: :component do
         expect(page).not_to have_css("p", class: "call-to-action__text")
       end
     end
+
+    context "when the heading_tag is overridden" do
+      let(:custom_heading_tag) { "h4" }
+      let(:component) { described_class.new(
+        icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
+      )}
+
+      specify "the custom heading tag is used" do
+        expect(page).to have_css("#{custom_heading_tag}.call-to-action__heading", text: title)
+      end
+    end
   end
 end

--- a/spec/components/calls_to_action/apply_component_spec.rb
+++ b/spec/components/calls_to_action/apply_component_spec.rb
@@ -68,9 +68,11 @@ RSpec.describe CallsToAction::ApplyComponent, type: :component do
 
     context "when the heading_tag is overridden" do
       let(:custom_heading_tag) { "h4" }
-      let(:component) { described_class.new(
-        icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
-      )}
+      let(:component) do
+        described_class.new(
+          icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag,
+        )
+      end
 
       specify "the custom heading tag is used" do
         expect(page).to have_css("#{custom_heading_tag}.call-to-action__heading", text: title)

--- a/spec/components/calls_to_action/find_component_spec.rb
+++ b/spec/components/calls_to_action/find_component_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe CallsToAction::FindComponent, type: :component do
   let(:link_text) { "Click here" }
   let(:link_target) { "/some-dir/some-page" }
   let(:content) { "some content" }
+  let(:heading_tag) { "h2" }
 
   describe "rendering the component" do
-    let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target } }
+    let(:kwargs) { { icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: "h2" } }
 
     let(:component) { described_class.new(**kwargs) }
 
@@ -63,6 +64,17 @@ RSpec.describe CallsToAction::FindComponent, type: :component do
 
       specify "no paragraph tag should be rendered" do
         expect(page).not_to have_css("p", class: "call-to-action__text")
+      end
+    end
+
+    context "when the heading_tag is overridden" do
+      let(:custom_heading_tag) { "h4" }
+      let(:component) { described_class.new(
+        icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
+      )}
+
+      specify "the custom heading tag is used" do
+        expect(page).to have_css("#{custom_heading_tag}.call-to-action__heading", text: title)
       end
     end
   end

--- a/spec/components/calls_to_action/find_component_spec.rb
+++ b/spec/components/calls_to_action/find_component_spec.rb
@@ -69,9 +69,11 @@ RSpec.describe CallsToAction::FindComponent, type: :component do
 
     context "when the heading_tag is overridden" do
       let(:custom_heading_tag) { "h4" }
-      let(:component) { described_class.new(
-        icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
-      )}
+      let(:component) do
+        described_class.new(
+          icon: icon, title: title, text: text, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag,
+        )
+      end
 
       specify "the custom heading tag is used" do
         expect(page).to have_css("#{custom_heading_tag}.call-to-action__heading", text: title)

--- a/spec/components/calls_to_action/mailinglist_component_spec.rb
+++ b/spec/components/calls_to_action/mailinglist_component_spec.rb
@@ -61,9 +61,11 @@ RSpec.describe CallsToAction::MailinglistComponent, type: :component do
 
     context "when the heading_tag is overridden" do
       let(:custom_heading_tag) { "h4" }
-      let(:component) { described_class.new(
-        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
-      )}
+      let(:component) do
+        described_class.new(
+          title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag,
+        )
+      end
 
       specify "the custom heading tag is used" do
         expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)

--- a/spec/components/calls_to_action/mailinglist_component_spec.rb
+++ b/spec/components/calls_to_action/mailinglist_component_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe CallsToAction::MailinglistComponent, type: :component do
         expect(page).not_to have_css("p.mailinglist__text")
       end
     end
+
+    context "when the heading_tag is overridden" do
+      let(:custom_heading_tag) { "h4" }
+      let(:component) { described_class.new(
+        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
+      )}
+
+      specify "the custom heading tag is used" do
+        expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)
+      end
+    end
   end
 end

--- a/spec/components/calls_to_action/routes_component_spec.rb
+++ b/spec/components/calls_to_action/routes_component_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe CallsToAction::RoutesComponent, type: :component do
         expect(page).not_to have_css("p.routes__text")
       end
     end
+
+    context "when the heading_tag is overridden" do
+      let(:custom_heading_tag) { "h4" }
+      let(:component) { described_class.new(
+        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
+      )}
+
+      specify "the custom heading tag is used" do
+        expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)
+      end
+    end
   end
 end

--- a/spec/components/calls_to_action/routes_component_spec.rb
+++ b/spec/components/calls_to_action/routes_component_spec.rb
@@ -61,9 +61,11 @@ RSpec.describe CallsToAction::RoutesComponent, type: :component do
 
     context "when the heading_tag is overridden" do
       let(:custom_heading_tag) { "h4" }
-      let(:component) { described_class.new(
-        title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag
-      )}
+      let(:component) do
+        described_class.new(
+          title: title, text: text, image: image, link_text: link_text, link_target: link_target, heading_tag: custom_heading_tag,
+        )
+      end
 
       specify "the custom heading tag is used" do
         expect(page).to have_css("#{custom_heading_tag}.heading-l", text: title)


### PR DESCRIPTION
### Trello card

https://trello.com/c/5rHBTe2q/7615-gds-accessibility-audit-9-heading-structure-incorrect-on-find-promo-level-a?filter=member:spencerldixon

### Context

On the Teacher training bursaries page, the “Find your teacher training course” text visually appears similar to other headings on the page and structurally it heads the content underneath. However, programmatically this text is not a heading.

### Changes proposed in this pull request

Allows an optional heading tag to be passed into the following components:

- Find promo
- Apply promo
- Mailing list promo
- Advisor promo
- Routes promo

If no tag is given it will default to a `h2`

### Guidance to review

