### PR TITLE
Update find links

### DIFF
--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -6,11 +6,10 @@ description: |-
 cta_adviser:
   adviser:
     text: "An adviser with years of teaching experience can answer all your questions about salaried teacher training. Chat by phone, text or email, as little or as often as you need."
-calls_to_action:
-  find:
-    name: find
-    arguments:
-      title: "Find a salaried teacher training course"
+cta_arrow_link:
+  find-courses:
+    link_target: "https://find-teacher-training-courses.service.gov.uk/results?funding%5B%5D=salary&funding%5B%5D=apprenticeship&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+    link_text: "Find a salaried teacher training course"
 navigation: 20.20
 navigation_description: Find out about School Direct salaried courses, postgraduate teaching apprenticeships and training delivered by Teach First.
 keywords:
@@ -105,11 +104,11 @@ Find out more about [what to expect during your teacher training](/train-to-be-a
 
 ## How do I find a salaried teacher training course? 
 
-To apply for salaried teacher training, you can [find postgraduate teacher training](https://find-teacher-training-courses.service.gov.uk/) and use the filter to only show courses that come with a salary. 
-
 It’s usually wise to apply for fee-paying courses as well to increase your chances of getting a place on a course.
 
 Some salaried teacher training providers will want you to have already arranged a school to work in while you train. Check with providers before you apply.
+
+$find-courses$
 
 ### Teach First 
 
@@ -117,5 +116,4 @@ Teach First delivers a 2 year employment-based route to teaching for high perfor
 
 To apply and find out more, you should [visit the Teach First website](https://www.teachfirst.org.uk/).
 
-$find$
 $adviser$

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -8,7 +8,7 @@ cta_adviser:
     text: "An adviser with years of teaching experience can answer all your questions about salaried teacher training. Chat by phone, text or email, as little or as often as you need."
 cta_arrow_link:
   find-courses:
-    link_target: "https://find-teacher-training-courses.service.gov.uk/results?funding%5B%5D=salary&funding%5B%5D=apprenticeship&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+    link_target: "https://find-teacher-training-courses.service.gov.uk/results?funding%5B%5D=salary&funding%5B%5D=apprenticeship&applications_open=true&order=course_name_ascending"
     link_text: "Find a salaried teacher training course"
 navigation: 20.20
 navigation_description: Find out about School Direct salaried courses, postgraduate teaching apprenticeships and training delivered by Teach First.

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
@@ -94,6 +94,9 @@
     <h3>Progression as a primary school teacher<h3>
       <p>As a primary school teacher, there's plenty of opportunity for progression and opportunities to lead beyond the classroom. That could mean becoming a lead in a subject, leading a key stage or even becoming a part of the senior management team.</p>
      <%= render 'content/shared/quotes/quote_primary_phil' %>
+    <h3>Find primary teacher training courses<h3>
+      <p>Explore the different primary courses available.</p>
+      <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=00&subjects%5B%5D=01&subjects%5B%5D=02&subjects%5B%5D=03&subjects%5B%5D=04&subjects%5B%5D=06&subjects%5B%5D=07&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending", link_text: "Find your primary teacher training course") %>
     </section>
 
   <section class="col col-720">

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
@@ -95,7 +95,7 @@
       <p>As a primary school teacher, there's plenty of opportunity for progression and opportunities to lead beyond the classroom. That could mean becoming a lead in a subject, leading a key stage or even becoming a part of the senior management team.</p>
      <%= render 'content/shared/quotes/quote_primary_phil' %>
     <h3>Find primary teacher training courses</h3>
-      <p>Explore the different primary courses available.</p>
+      <p>Explore the different primary courses available. As a trainee primary teacher you’ll learn to teach all subjects across the national curriculum. Some courses also enable you to develop your knowledge of a particular subject or teaching pupils with special educational needs and disabilities (SEND).</p>
       <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/primary", link_text: "Find your primary teacher training course") %>
     </section>
 

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary/_article.html.erb
@@ -91,12 +91,12 @@
     <!-- Funding and Support -->
     <%= render 'content/shared/teaching/funding_support' %>
     <%= render 'content/shared/qualifications-training/get_school_experience' %>
-    <h3>Progression as a primary school teacher<h3>
+    <h3>Progression as a primary school teacher</h3>
       <p>As a primary school teacher, there's plenty of opportunity for progression and opportunities to lead beyond the classroom. That could mean becoming a lead in a subject, leading a key stage or even becoming a part of the senior management team.</p>
      <%= render 'content/shared/quotes/quote_primary_phil' %>
-    <h3>Find primary teacher training courses<h3>
+    <h3>Find primary teacher training courses</h3>
       <p>Explore the different primary courses available.</p>
-      <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=00&subjects%5B%5D=01&subjects%5B%5D=02&subjects%5B%5D=03&subjects%5B%5D=04&subjects%5B%5D=06&subjects%5B%5D=07&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending", link_text: "Find your primary teacher training course") %>
+      <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/primary", link_text: "Find your primary teacher training course") %>
     </section>
 
   <section class="col col-720">

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary/_article.html.erb
@@ -83,7 +83,7 @@
    <h3>Apply for a paid internship</h3>
    <p>If you're currently doing an undergraduate or master's degree and are interested in chemistry, computing, languages, maths or physics, you could apply for a <a href="/train-to-be-a-teacher/teaching-internships">paid teaching internship</a>.</p>
    <p>The 3-week programme could help you to understand what it's really like in the classroom and get a feel for school life.</p></div>
-   <h3>Find secondary teacher training courses<h3>
+   <h3>Find secondary teacher training courses</h3>
     <p>Explore the different secondary courses available.</p>
     <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/secondary", link_text: "Find your secondary teacher training course") %>
   </section>

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary/_article.html.erb
@@ -83,6 +83,9 @@
    <h3>Apply for a paid internship</h3>
    <p>If you're currently doing an undergraduate or master's degree and are interested in chemistry, computing, languages, maths or physics, you could apply for a <a href="/train-to-be-a-teacher/teaching-internships">paid teaching internship</a>.</p>
    <p>The 3-week programme could help you to understand what it's really like in the classroom and get a feel for school life.</p></div>
+   <h3>Find secondary teacher training courses<h3>
+    <p>Explore the different secondary courses available.</p>
+    <%= render CallsToAction::ArrowLinkComponent.new(link_target: "https://find-teacher-training-courses.service.gov.uk/secondary", link_text: "Find your secondary teacher training course") %>
   </section>
   <section class="col col-720">
     <%= render 'content/shared/teaching/ect_support' %>

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
@@ -9,7 +9,7 @@ cta_adviser:
     text: Talk to an adviser with years of teaching experience about opportunities to teach pupils with SEND. Chat by phone, text or email, as little or as often as you need.
 cta_arrow_link:
   find:
-    link_target: "https://find-teacher-training-courses.service.gov.uk/results?send_courses=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+    link_target: "https://find-teacher-training-courses.service.gov.uk/results?send_courses=true&applications_open=true&order=course_name_ascending"
     link_text: "Find a teacher training course with a SEND specialism"
 keywords:
   - SEND

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
@@ -9,8 +9,8 @@ cta_adviser:
     text: Talk to an adviser with years of teaching experience about opportunities to teach pupils with SEND. Chat by phone, text or email, as little or as often as you need.
 cta_arrow_link:
   find:
-    link_target: "https://find-teacher-training-courses.service.gov.uk/"
-    link_text: "Find a teacher training course"
+    link_target: "https://find-teacher-training-courses.service.gov.uk/results?send_courses=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+    link_text: "Find a teacher training course with a SEND specialism"
 keywords:
   - SEND
   - disabled
@@ -91,8 +91,7 @@ An MQSI will give you the skills needed to recognise any barriers to learning th
 
 ## Training for teaching pupils with SEND
 
+You'll learn about teaching pupils with SEND in any initial teacher training course. However, if you're particularly interested in this area, some training providers offer courses with a SEND specialism.
+
 $find$
-
-Filter by ‘courses with a SEND specialism’ if you have a particular interest in this area. 
-
 $adviser$

--- a/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
@@ -21,9 +21,9 @@
      <p>You'll also be invited to a community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p><a href="https://find-teacher-training-courses.service.gov.uk/results?engineers_teach_physics=true&study_type%5B%5D=full_time&study_type%5B%5D=part_time&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&degree_required=two_two&applications_open=false&applications_open=true&l=2&subjects%5B%5D=F3">Find Engineers teach physics teacher training courses</a>.
-     </p>
-    <p>You can also <a href="https://find-teacher-training-courses.service.gov.uk/">search for physics teacher training courses</a> that are not part of the Engineers teach physics training programme.</p>
+    <p><a href="https://find-teacher-training-courses.service.gov.uk/results?engineers_teach_physics=true&subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">Find Engineers teach physics teacher training courses</a>.</p>
+    
+    <p>You can also <a href="https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">explore physics teacher training courses</a> that are not part of the Engineers teach physics training programme.</p>
     <%= render 'content/shared/quotes/quote_engineers_teach_physics_chris' %>
   </section>
 

--- a/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
@@ -21,9 +21,9 @@
      <p>You'll also be invited to a community day and have the opportunity to network with existing physics teachers.
      </p>
 
-    <p><a href="https://find-teacher-training-courses.service.gov.uk/results?engineers_teach_physics=true&subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">Find Engineers teach physics teacher training courses</a>.</p>
+    <p><a href="https://find-teacher-training-courses.service.gov.uk/results?engineers_teach_physics=true&subjects%5B%5D=F3&applications_open=true&order=course_name_ascending">Find Engineers teach physics teacher training courses</a>.</p>
 
-    <p>You can also <a href="https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">explore physics teacher training courses</a> that are not part of the Engineers teach physics training programme.</p>
+    <p>You can also <a href="https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=F3&applications_open=true&order=course_name_ascending">explore physics teacher training courses</a> that are not part of the Engineers teach physics training programme.</p>
     <%= render 'content/shared/quotes/quote_engineers_teach_physics_chris' %>
   </section>
 

--- a/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics/_article.html.erb
@@ -22,7 +22,7 @@
      </p>
 
     <p><a href="https://find-teacher-training-courses.service.gov.uk/results?engineers_teach_physics=true&subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">Find Engineers teach physics teacher training courses</a>.</p>
-    
+
     <p>You can also <a href="https://find-teacher-training-courses.service.gov.uk/results?subjects%5B%5D=F3&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">explore physics teacher training courses</a> that are not part of the Engineers teach physics training programme.</p>
     <%= render 'content/shared/quotes/quote_engineers_teach_physics_chris' %>
   </section>

--- a/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
@@ -28,7 +28,6 @@ expander:
       <p>If you <a href="/non-uk-teachers/fees-and-funding-for-non-uk-trainees">have refugee status you'll usually be eligible for financial support to help you train</a>.
       <p>If you're in <a href="https://www.gov.uk/claim-asylum"> the process of seeking asylum</a>, check your immigration bail conditions to see if you have permission to study on a teacher training course in England. Even if you have permission, you're unlikely to be eligible for financial support.</p>
       <p>If you're granted asylum in the UK, you may be eligible for financial support to train to teach.</p>
-
 cta_arrow_link:
    immigration:
      link_target: "https://www.gov.uk/check-uk-visa"
@@ -36,7 +35,9 @@ cta_arrow_link:
    train-in-uk:
       link_target: "/non-uk-teachers/train-to-teach-in-england-as-an-international-student"
       link_text: "Find out more about training to teach in England as a non-UK citizen"
-      
+   find:
+      link_target: "https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+      link_text: "Search for postgraduate teacher training courses that offer visa sponsorship"    
 keywords:
   - International
   - Teaching
@@ -134,8 +135,9 @@ You may be able to train part-time, but your part-time salary must be at least $
 
 
 ## What you need to do to apply for your visa 
-You can apply for your visa once you have a confirmed offer of a training place. 
-[Search for postgraduate teacher training courses](https://find-teacher-training-courses.service.gov.uk/) that offer visa sponsorship. 
+You can apply for your visa once you have a confirmed offer of a training place.
+
+$find$
 
 Email your chosen provider to check if they can sponsor you. Once you have confirmation, you can then [apply for your teacher training course](/how-to-apply-for-teacher-training). 
 

--- a/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/visas-for-non-uk-trainees.md
@@ -36,7 +36,7 @@ cta_arrow_link:
       link_target: "/non-uk-teachers/train-to-teach-in-england-as-an-international-student"
       link_text: "Find out more about training to teach in England as a non-UK citizen"
    find:
-      link_target: "https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending"
+      link_target: "https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&order=course_name_ascending"
       link_text: "Search for postgraduate teacher training courses that offer visa sponsorship"    
 keywords:
   - International

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -42,7 +42,7 @@ expander:
       <p>
       You’ll need the right to work or study in the UK to do your teacher training in England.</p>
       <p>
-      If you do not have the right to work in the UK, you should only apply to courses that have visa sponsorship available. You can filter by ‘visa sponsorship’ to <a href="https://find-teacher-training-courses.service.gov.uk/">find courses where visas can be sponsored</a>.
+      If you do not have the right to work in the UK, you should only apply to courses that have visa sponsorship available. You can <a href="https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">find courses where visas can be sponsored</a>.
       </p>
       <p>
       If your application is successful, the training provider may be able to help you with applying for your visa. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out how to apply for your visa to train to teach in England</a>.

--- a/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
+++ b/app/views/content/train-to-be-a-teacher/how-to-choose-your-teacher-training-course.md
@@ -42,7 +42,7 @@ expander:
       <p>
       You’ll need the right to work or study in the UK to do your teacher training in England.</p>
       <p>
-      If you do not have the right to work in the UK, you should only apply to courses that have visa sponsorship available. You can <a href="https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&subject_name=&subject_code=&location=&radius=10&provider_name=&provider_code=&order=course_name_ascending">find courses where visas can be sponsored</a>.
+      If you do not have the right to work in the UK, you should only apply to courses that have visa sponsorship available. You can <a href="https://find-teacher-training-courses.service.gov.uk/results?can_sponsor_visa=true&applications_open=true&order=course_name_ascending">find courses where visas can be sponsored</a>.
       </p>
       <p>
       If your application is successful, the training provider may be able to help you with applying for your visa. <a href="/non-uk-teachers/visas-for-non-uk-trainees">Find out how to apply for your visa to train to teach in England</a>.

--- a/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
+++ b/app/views/content/train-to-be-a-teacher/teacher-degree-apprenticeships.md
@@ -11,7 +11,7 @@ calls_to_action:
       title: "Find a teacher degree apprenticeship"
 cta_arrow_link:
   tda:
-    link_target: "https://find-teacher-training-courses.service.gov.uk/results?age_group=secondary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&university_degree_status=false&visa_status=false"
+    link_target: "https://find-teacher-training-courses.service.gov.uk/results?applications_open=true&minimum_degree_required=no_degree_required"
     link_text: "View the teacher degree apprenticeship courses currently available"
 navigation: 20.45
 navigation_title: If you want to do a teaching apprenticeship


### PR DESCRIPTION
### Trello card
https://trello.com/c/dWtOke2G/7606-replace-links-to-find-following-the-find-restructure

### Context
Find have restructured their site meaning it is much easier to deeplink to a subset of courses from GIT - users can then use the new location and other filters on the search results page to refine the results further

### Changes proposed in this pull request
We need to review our links to Find and replace some with deeplinks

### Guidance to review

