### PR TITLE
Update talk to us links

### DIFF
--- a/app/views/errors/bad_request.erb
+++ b/app/views/errors/bad_request.erb
@@ -14,6 +14,6 @@
   </header>
 
   <article class="text-content">
-    <p><a href="#talk-to-us">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
+    <p><a href="/help-and-support">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
   </article>
 </section>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -14,6 +14,6 @@
   </header>
 
   <article class="text-content">
-    <p><a href="#talk-to-us">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
+    <p><a href="/help-and-support">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
   </article>
 </section>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -16,6 +16,6 @@
   <article class="text-content">
     <p>Try again later.</p>
 
-    <p><a href="#talk-to-us">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
+    <p><a href="/help-and-support">Contact us</a> if you need to speak to someone about Get Into Teaching</p>
   </article>
 </section>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -19,7 +19,7 @@
 
     <p>
       You can <a href="/">browse from the homepage</a>
-      or <a href="#talk-to-us">contact us</a>
+      or <a href="/help-and-support">contact us</a>
       if you need to speak to someone about Get Into Teaching.
     </p>
   </article>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -16,6 +16,6 @@
   <article class="text-content">
     <p>You have tried to access a page too often in a short space of time.</p>
     <p>You can go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
-    <p>You can <a href="/">browse the homepage</a> or <a href="#talk-to-us">talk to us</a> if you have a question about teaching or teacher training.</p>
+    <p>You can <a href="/">browse the homepage</a> or <a href="/help-and-support">talk to us</a> if you have a question about teaching or teacher training.</p>
   </article>
 </section>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -16,6 +16,6 @@
   <article class="text-content">
     <p>You may not have permissions to perform that action.</p>
 
-    <p><a href="#talk-to-us">Contact us</a> if you need to speak to someone about Get Into Teaching.</p>
+    <p><a href="/help-and-support">Contact us</a> if you need to speak to someone about Get Into Teaching.</p>
   </article>
 </section>


### PR DESCRIPTION
### Trello card
https://trello.com/c/ciU5tQ9a/7621-fix-talk-to-us-links-on-error-pages
### Context
This ticket updates old talk to us links 
### Changes proposed in this pull request
We removed this Talk to us component last year 
### Guidance to review

