### PR TITLE
Remove title from inset component

### DIFF
--- a/app/components/content/inset_text_component.html.erb
+++ b/app/components/content/inset_text_component.html.erb
@@ -1,8 +1,7 @@
 <%= tag.section(class: classes) do %>
-  <% if header.present? || title.present? %>
+  <% if header.present? %>
     <%= content_tag(heading_tag, role: "text") do %>
-      <%= tag.span(header, class: "header") if header.present? %>
-      <%= tag.span(title, class: "title") if title.present? %>
+      <%= tag.span(header, class: "header") %>
     <% end %>
   <% end %>
   <%= tag.p(helpers.safe_html_format(text)) %>

--- a/app/components/content/inset_text_component.rb
+++ b/app/components/content/inset_text_component.rb
@@ -1,15 +1,14 @@
 module Content
   class InsetTextComponent < ViewComponent::Base
-    attr_reader :header, :title, :text, :color, :heading_tag
+    attr_reader :header, :text, :color, :heading_tag
 
     include ContentHelper
 
-    def initialize(text:, title: nil, header: nil, color: "yellow", heading_tag: "h2")
+    def initialize(text:, header: nil, color: "yellow", heading_tag: "h2")
       super
 
       @text = substitute_values(text)
-      @title = substitute_values(title)
-      @header = substitute_values(header.present? && title.present? ? "#{header}:" : header)
+      @header = substitute_values(header)
       @color = color
       @heading_tag = heading_tag
     end

--- a/spec/components/content/inset_text_component_spec.rb
+++ b/spec/components/content/inset_text_component_spec.rb
@@ -16,8 +16,6 @@ describe Content::InsetTextComponent, type: :component do
   it { is_expected.to have_css(".inset-text h2 span.header", text: "#{header}:") }
 
   context "when there is a header" do
-    let(:title) { nil }
-
     it { is_expected.to have_css(".inset-text h2 span.header", text: header) }
   end
 

--- a/spec/components/content/inset_text_component_spec.rb
+++ b/spec/components/content/inset_text_component_spec.rb
@@ -2,10 +2,9 @@ require "rails_helper"
 
 describe Content::InsetTextComponent, type: :component do
   let(:header) { "Header" }
-  let(:title) { "Title" }
   let(:text) { "Text" }
   let(:color) { "yellow" }
-  let(:component) { described_class.new(text: text, header: header, title: title, color: color) }
+  let(:component) { described_class.new(text: text, header: header, color: color) }
 
   subject do
     render_inline(component)
@@ -15,27 +14,11 @@ describe Content::InsetTextComponent, type: :component do
   it { is_expected.to have_css("section.inset-text.yellow") }
   it { is_expected.to have_css(".inset-text p", text: text) }
   it { is_expected.to have_css(".inset-text h2 span.header", text: "#{header}:") }
-  it { is_expected.to have_css(".inset-text h2 span.title", text: title) }
 
-  context "when there is no title nor header" do
-    let(:title) { nil }
-    let(:header) { nil }
-
-    it { is_expected.not_to have_css(".inset-text h2") }
-  end
-
-  context "when there is only a title but no header" do
-    let(:header) { nil }
-
-    it { is_expected.not_to have_css(".inset-text h2 span.header") }
-    it { is_expected.to have_css(".inset-text h2 span.title", text: title) }
-  end
-
-  context "when there is only a header but no title" do
+  context "when there is a header" do
     let(:title) { nil }
 
     it { is_expected.to have_css(".inset-text h2 span.header", text: header) }
-    it { is_expected.not_to have_css(".inset-text h2 span.title") }
   end
 
   context "when the text contains HTML" do
@@ -64,10 +47,10 @@ describe Content::InsetTextComponent, type: :component do
 
   context "when the heading_tag is overridden" do
     let(:custom_heading_tag) { "h4" }
-    let(:component) { described_class.new(text: text, header: header, title: title, color: color, heading_tag: custom_heading_tag) }
+    let(:component) { described_class.new(text: text, header: header, color: color, heading_tag: custom_heading_tag) }
 
     specify "the custom heading tag is used" do
-      expect(subject).to have_css(".inset-text #{custom_heading_tag}[role=\"text\"]", text: title)
+      expect(subject).to have_css(".inset-text #{custom_heading_tag}[role=\"text\"]", text: header)
     end
   end
 end

--- a/spec/components/previews/content/inset_text_component_preview.rb
+++ b/spec/components/previews/content/inset_text_component_preview.rb
@@ -4,11 +4,6 @@ class Content::InsetTextComponentPreview < ViewComponent::Preview
     render(component)
   end
 
-  def with_title
-    component = Content::InsetTextComponent.new(**text.merge(title))
-    render(component)
-  end
-
 private
 
   def text
@@ -17,12 +12,6 @@ private
       "Praesent a nisl semper, efficitur velit ac, tincidunt arcu.</p>"\
       "<p>Morbi non nisl eu arcu molestie lacinia <a href=\"#\">quis quis</a> libero.</p>"\
       "<p><a href=\"#\">Link</a></p>",
-    }
-  end
-
-  def title
-    {
-      title: "Optional title",
     }
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/uQgMe3ks/7638-remove-title-from-inset-component

### Context

Whilst updating the inset component as part of https://trello.com/c/MDXOSArb, we found that the title was superfluous

### Changes proposed in this pull request

- Remove title from inset component and tests

### Guidance to review

