### PR TITLE
Label on verification code field in funnels

### DIFF
--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -5,6 +5,7 @@
 
 <%= f.govuk_text_field :timed_one_time_password,
 autocomplete: "off",
+aria: { labelledby: "git-wizard-steps-authenticate-timed-one-time-password-hint" },
 label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', **Value.data), class: "govuk-hint" },
 hint: { text: safe_html_format(hint_text) } %>
 

--- a/app/views/wizard/steps/_authenticate.html.erb
+++ b/app/views/wizard/steps/_authenticate.html.erb
@@ -1,3 +1,5 @@
+<p>To verify your details, we've sent a code to your email address.</p>
+
 <%
   hint_text = t("helpers.hint.wizard_steps_authenticate.timed_one_time_password.text", **Value.data)
   hint_text += "<br><b>#{t('helpers.hint.wizard_steps_authenticate.timed_one_time_password.resent')}</b>" if params[:verification_resent]
@@ -5,9 +7,7 @@
 
 <%= f.govuk_text_field :timed_one_time_password,
 autocomplete: "off",
-aria: { labelledby: "git-wizard-steps-authenticate-timed-one-time-password-hint" },
-label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', **Value.data), class: "govuk-hint" },
-hint: { text: safe_html_format(hint_text) } %>
+label: { text: t('helpers.label.wizard_steps_authenticate.timed_one_time_password', **Value.data), class: "govuk-hint" } %>
 
 <% content_for(:form_help) do %>
   <p>The code expires in 15 minutes.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,7 +694,7 @@ en:
 
     label:
       wizard_steps_authenticate:
-        timed_one_time_password: "To verify your details, we've sent a code to your email address."
+        timed_one_time_password: "Enter your verification code"
 
       teacher_training_adviser_steps_identity:
         first_name: "First name"
@@ -826,7 +826,7 @@ en:
            We'll use this to send you a reminder and let you know about any last-minute cancellations.
       wizard_steps_authenticate:
         timed_one_time_password:
-          text: "Enter your code here:"
+          text: "Verification code"
           resent: We've sent you another email
       events_steps_personalised_updates:
         address_postcode: |-


### PR DESCRIPTION
### Trello card

https://trello.com/c/6L0PfRl4/7608-gds-accessibility-audit-32-label-on-verification-code-field-in-funnels-is-not-meaningful-level-aa

### Context

Within the Personalised email guidance journey, on the ‘You’ve already registered with us’ page, the main programmatic label of the input field is “To verify your details, we’ve sent a code to your email address”. This is not fully meaningful for users as the main instruction would be the text “Enter your code here” which is coded as the description.

This also exists for our other funnels so looking at these at the same time:
- callback
- mailing list
- events
- adviser

### Changes proposed in this pull request

- removed hint text from wizard authenticate step
- changed wording of label to 'Enter your verification code"

### Guidance to review

- URLs to access the relevant page in the different funnels:
_/callbacks/book/authenticate
/teacher-training-adviser/sign_up/authenticate
/mailinglist/signup/authenticate#main-content
_/events/250331-get-into-teaching-london-event/apply/authenticate_
- check on screen reader(s).
- check wording is ok and meets criteria. 

Mailing list and Adviser funnel:
![Screenshot 2025-03-19 at 13 35 02](https://github.com/user-attachments/assets/c73bab91-eb2d-454a-8d2f-d97482ca4b0a)

Callback funnel:
![Screenshot 2025-03-19 at 13 59 13](https://github.com/user-attachments/assets/67d1f10e-ff15-4543-8ab9-d8e69fd1b4b0)

Events funnel:
![Screenshot 2025-03-19 at 14 04 03](https://github.com/user-attachments/assets/802c4fc6-62f7-4374-b2bd-ec0fb2ec82df)