### PR TITLE
Patch to link error messages to dfe-autocomplete

### DIFF
--- a/app/webpacker/controllers/patch_autocomplete_controller.js
+++ b/app/webpacker/controllers/patch_autocomplete_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    fieldId: String,
+    errorId: String
+  }
+
+  connect() {
+    const autocomplete = document.getElementById(this.fieldIdValue);
+
+    if (autocomplete) {
+      const currentDescribedBy = autocomplete.getAttribute('aria-describedby') || '';
+
+      autocomplete.setAttribute('aria-describedby', `${this.errorIdValue} ${currentDescribedBy}`.trim());
+    }
+  }
+}


### PR DESCRIPTION
### Trello card

https://trello.com/c/UwLBT0gD/7594-gds-accessibility-audit-11-adviser-funnel-error-message-not-working-correctly-for-screen-reader-users-level-a

### Context

In the Adviser journey, on the ‘What subject is your degree?’ page, an error message appears when trying to advance to the next page without entering a subject. The error message of “You need to choose a degree subject” is not programmatically associated with the field and is not announced by the screen reader when tabbing onto the field itself.

(See trello card for more info)

### Changes proposed in this pull request

The `dfe-autocomplete` gem relies on `accessible-autocomplete`. This issue seems to stem from there, and there is a PR to fix it here: https://github.com/alphagov/accessible-autocomplete/pull/769

Ideally, this PR would be merged and we could pull it into `dfe-autocomplete` but since we need to fix this quickly, I've added a stimulus controller which patches this and connected the error message to the field.

- Adds `patch_autocomplete_controller.js` to add an extra `aria-describedby` attribute to link the error message to the field.

### Guidance to review

