### PR TITLE
Fix overflow issue with text on events page

### DIFF
--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -68,7 +68,6 @@ body {
 section.container {
   display: flex;
   flex-grow: 0;
-  flex-wrap: wrap;
   flex-direction: column;
   margin: 1em 0;
 

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -68,8 +68,10 @@ body {
 section.container {
   display: flex;
   flex-grow: 0;
+  flex-wrap: wrap;
   flex-direction: column;
   margin: 1em 0;
+  word-break: break-word;
 
   > main.within-section,
   > .back-link {

--- a/app/webpacker/styles/layout.scss
+++ b/app/webpacker/styles/layout.scss
@@ -71,7 +71,7 @@ section.container {
   flex-wrap: wrap;
   flex-direction: column;
   margin: 1em 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 
   > main.within-section,
   > .back-link {


### PR DESCRIPTION
### Trello card

https://trello.com/b/lRXllOHK/git-website-sprint-board

### Context

On the Find an event near you or online page, some content is cut off the screen at 400% zoom. This includes some of the bullet points under “Events” and the text under “Do you have a teaching event?”. Moving the page view to see these items results in header items being cut off instead.

### Changes proposed in this pull request

- Removes flex wrap from section container

### Guidance to review

Seems to fix the issue but I'm not sure if this affects anything else. Please test thoroughly!
