### PR TITLE
Update events holding message for Summer 2025 events

### DIFF
--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -69,7 +69,7 @@
         </section>
       <% else %>
         <section class="col col-720 col-space-m">
-          <p>This summer we'll be holding events Birmingham, Leicester, Middlesborough, Manchester, Portsmouth, Ipswich, Leeds, London and Exeter, and also online.</p>
+          <p>This summer we'll be holding events in Middlesbrough, Leeds, Manchester, Leicester, Birmingham, Ipswich, London, Portsmouth, and Exeter, and also online.</p>
           <p>We'll update this page in April with more details about each event and how to register.</p>
         </section>
 

--- a/app/views/teaching_events/about_git_events.html.erb
+++ b/app/views/teaching_events/about_git_events.html.erb
@@ -69,8 +69,8 @@
         </section>
       <% else %>
         <section class="col col-720 col-space-m">
-          <p>From January to March 2025, we'll be holding events in Newcastle, Sheffield, Manchester, Nottingham, Birmingham, London, Norwich, Bristol and Brighton, and also online.</p>
-          <p>We'll update this page in January with more details about each event and how to register.</p>
+          <p>This summer we'll be holding events Birmingham, Leicester, Middlesborough, Manchester, Portsmouth, Ipswich, Leeds, London and Exeter, and also online.</p>
+          <p>We'll update this page in April with more details about each event and how to register.</p>
         </section>
 
         <section class="col col-720">

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -101,7 +101,7 @@ describe "teaching events", type: :request do
       context "when there are no GiT events" do
         let(:events) { [] }
 
-        it { is_expected.to include("From January to March 2025, we'll be holding events in Newcastle, Sheffield, Manchester, Nottingham, Birmingham, London, Norwich, Bristol and Brighton, and also online.") }
+        it { is_expected.to include("This summer we'll be holding events Birmingham, Leicester, Middlesborough, Manchester, Portsmouth, Ipswich, Leeds, London and Exeter, and also online") }
       end
     end
 

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -101,7 +101,7 @@ describe "teaching events", type: :request do
       context "when there are no GiT events" do
         let(:events) { [] }
 
-        it { is_expected.to include("This summer we'll be holding events Birmingham, Leicester, Middlesborough, Manchester, Portsmouth, Ipswich, Leeds, London and Exeter, and also online") }
+        it { is_expected.to include("This summer we'll be holding events in Middlesbrough, Leeds, Manchester, Leicester, Birmingham, Ipswich, London, Portsmouth, and Exeter, and also online.") }
       end
     end
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/Syf6pIQ5/7659-update-holding-message-on-about-git-events-page-for-summer-events

### Context
We have a default message that is displayed on the About GIT events page when there are no events listed

### Changes proposed in this pull request
We need to update this messaging to reflect the summer events 

### Guidance to review

