### PR TITLE
Create a sitemap page

### DIFF
--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -88,6 +88,7 @@
         <%= link_to "Privacy notice", privacy_policy_path %>
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>
         <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
+        <%= link_to "Sitemap", sitemap_path %>
         <div class="site-footer-bottom__links-container__license">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0,</a> except where otherwise stated.</div>
       </div>
       <div class="site-footer-bottom__logo-container">

--- a/app/components/footer_component.html.erb
+++ b/app/components/footer_component.html.erb
@@ -88,7 +88,7 @@
         <%= link_to "Privacy notice", privacy_policy_path %>
         <%= link_to("Accessibility", page_path(page: :accessibility)) %>
         <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">Freedom of information</a>
-        <%= link_to "Sitemap", sitemap_path %>
+        <%= link_to "A to Z index", sitemap_path %>
         <div class="site-footer-bottom__links-container__license">All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0,</a> except where otherwise stated.</div>
       </div>
       <div class="site-footer-bottom__logo-container">

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -18,6 +18,7 @@ class SitemapController < ApplicationController
 
   before_action :set_page_title
   before_action :set_breadcrumb
+  before_action :set_metadata
 
   layout "minimal"
 
@@ -87,5 +88,9 @@ private
 
   def set_breadcrumb
     breadcrumb @page_title, request.path
+  end
+
+  def set_metadata
+    @front_matter["description"] = "Explore our comprehensive A to Z index of all the pages on Get Into Teaching"
   end
 end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -11,9 +11,9 @@ class SitemapController < ApplicationController
   # This will keep it consistent with how canonical-rails behaves and ensure search engines are happy.
   OTHER_PATHS = {
     "/events" => { title: "Events" },
-    "/events/about-get-into-teaching-events" => { title: "About Get Into Teaching Events"},
+    "/events/about-get-into-teaching-events" => { title: "About Get Into Teaching Events" },
     "/mailinglist/signup/name" => { title: "Mailing List" },
-    "/routes-into-teaching" => { title: "Routes Into Teaching" }
+    "/routes-into-teaching" => { title: "Routes Into Teaching" },
   }.freeze
 
   before_action :set_page_title
@@ -22,7 +22,7 @@ class SitemapController < ApplicationController
   layout "minimal"
 
   def show
-    @sitemap_data ||= all_sitemap_pages.sort_by { |path, metadata| metadata[:title] }
+    @sitemap_data ||= all_sitemap_pages.sort_by { |_path, metadata| metadata[:title] }
 
     respond_to do |format|
       format.xml { render xml: build.to_xml }
@@ -31,6 +31,7 @@ class SitemapController < ApplicationController
   end
 
 private
+
   def build
     Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -91,6 +91,6 @@ private
   end
 
   def set_metadata
-    @front_matter["description"] = "Explore our comprehensive A to Z index of all the pages on Get Into Teaching"
+    @front_matter["description"] = "Explore our comprehensive A to Z index of all the pages on Get Into Teaching."
   end
 end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -23,6 +23,7 @@ class SitemapController < ApplicationController
 
   def show
     @sitemap_data ||= all_sitemap_pages.sort_by { |_path, metadata| metadata[:title] }
+    @a_z_sitemap_data ||= @sitemap_data.group_by { |_path, metadata| metadata[:title][0] }
 
     respond_to do |format|
       format.xml { render xml: build.to_xml }
@@ -81,7 +82,7 @@ private
   end
 
   def set_page_title
-    @page_title = "Sitemap"
+    @page_title = "A to Z index"
   end
 
   def set_breadcrumb

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -36,8 +36,6 @@ private
     Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
       xml.urlset(xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9") do
         all_sitemap_pages.each do |path, metadata|
-          next if metadata[:noindex]
-
           xml.url do
             xml.loc(request.base_url + page_location(path))
             xml.lastmod(lastmod_date(path, metadata))
@@ -49,7 +47,7 @@ private
   end
 
   def all_sitemap_pages
-    published_pages.merge(OTHER_PATHS)
+    published_pages.merge(OTHER_PATHS).reject { |_path, metadata| metadata[:noindex] }
   end
 
   def lastmod_date(path, metadata = nil)

--- a/app/views/sitemap/show.html.erb
+++ b/app/views/sitemap/show.html.erb
@@ -3,8 +3,6 @@
   colour: "pastel yellow-yellow",
 ) %>
 
-<%= meta_tag(key: 'description', value: "Explore our comprehensive A to Z index of all the pages on Get Into Teaching") %>
-
 <section class="container">
   <div class="row inset">
     <% ('A'..'Z').each do |letter| %>

--- a/app/views/sitemap/show.html.erb
+++ b/app/views/sitemap/show.html.erb
@@ -1,0 +1,14 @@
+<%= render Content::LandingHeroComponent.new(
+  title: "Sitemap",
+  colour: "pastel yellow-yellow",
+) %>
+
+<section class="container">
+  <div class="row inset">
+    <ul>
+      <% @sitemap_data.each do |page, metadata| %>
+        <li><%= link_to metadata[:title], page %></li>
+      <% end %>
+    </ul>
+  </div>
+</section>

--- a/app/views/sitemap/show.html.erb
+++ b/app/views/sitemap/show.html.erb
@@ -1,14 +1,29 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Sitemap",
+  title: "A to Z index",
   colour: "pastel yellow-yellow",
 ) %>
 
+<%= meta_tag(key: 'description', value: "Explore our comprehensive A to Z index of all the pages on Get Into Teaching") %>
+
 <section class="container">
   <div class="row inset">
-    <ul>
-      <% @sitemap_data.each do |page, metadata| %>
-        <li><%= link_to metadata[:title], page %></li>
+    <% ('A'..'Z').each do |letter| %>
+      <% if @a_z_sitemap_data.key?(letter) %>
+        <%= link_to letter, "##{letter}", class: "link" %>
+      <% else %>
+        <span><%= letter %></span>
       <% end %>
-    </ul>
+    <% end %>
+  </div>
+
+  <div class="row inset">
+    <% @a_z_sitemap_data.each do |letter, pages| %>
+      <h2 id="<%= letter %>"><%= letter.upcase %></h2>
+      <ul>
+        <% pages.each do |page, metadata| %>
+          <li><%= link_to metadata[:title], page %></li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get "/403", to: "errors#forbidden"
   get "/healthcheck.json", to: "healthchecks#show", as: :healthcheck
   get "/sitemap.xml", to: "sitemap#show", via: :all
+  get "/sitemap", to: "sitemap#show", via: :all
   get "/check", to: proc { [200, {}, %w[OK]] }
 
   YAML.load_file(Rails.root.join("config/redirects.yml")).fetch("redirects").tap do |redirect_rules|

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -13,7 +13,7 @@ end
 RSpec.feature "content pages check", :content, type: :feature do
   include Values
 
-  let(:other_paths) { %w[/ /feedback /search /teacher-training-adviser/sign_up/identity /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference /chat /routes-into-teaching] }
+  let(:other_paths) { %w[/ /feedback /search /teacher-training-adviser/sign_up/identity /mailinglist/signup /mailinglist/signup/name /cookies /cookie_preference /chat /routes-into-teaching /sitemap] }
   let(:ignored_path_patterns) { [%r{/assets/documents/}, %r{/event-categories}, %r{/test}] }
 
   before do

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -1,123 +1,149 @@
 require "rails_helper"
 
 RSpec.describe SitemapController, type: :request do
-  subject { Nokogiri::XML(response.body) }
+  let(:events) { build_list(:event_api, 3) }
 
   let(:content_pages) do
     {
       "/train-to-be-a-teacher" => {
-        name: "Train to be a teacher",
+        title: "Train to be a teacher",
         priority: 0.8,
         date: "2020-11-11",
       },
-      "/salaries-and-benfits" => {
-        name: "Salaries and benefits",
+      "/salaries-and-benefits" => {
+        title: "Salaries and benefits",
         priority: 0.7,
       },
       "/my-story-into-teaching/what-a-great-story" => {
-        name: "What a great story",
+        title: "What a great story",
         priority: 0.7,
         date: "2020-10-10",
       },
       "/test/a" => {
-        name: "A/B Test",
+        title: "A/B Test",
         noindex: true,
+      },
+      "/draft" => {
+        title: "Draft page",
+        draft: true,
       },
     }
   end
-  let(:event_pages) do
-    events.map { |e| event_path(e.readable_id) }.index_with({})
+
+  let(:other_paths) do
+    {
+      "/events" => { title: "Events" },
+      "/events/about-get-into-teaching-events" => { title: "About Get Into Teaching Events" },
+    }
   end
-  let(:all_sitemap_pages) { content_sitemap_pages.merge(event_pages) }
-  let(:content_sitemap_pages) { content_pages.except("/test/a") }
-  let(:events) { build_list(:event_api, 3) }
+
+  let(:valid_pages_with_data) do
+    content_pages.merge(other_paths).reject do |_path, data|
+      data[:noindex] || data[:draft]
+    end
+  end
 
   before do
     freeze_time
+    allow(Pages::Frontmatter).to receive(:list).and_return(content_pages)
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to \
       receive(:search_teaching_events).with(
         start_after: Time.zone.now,
         quantity: 100,
         type_ids: [Crm::EventType.get_into_teaching_event_id, Crm::EventType.online_event_id],
       ).and_return(events)
-    allow(Pages::Frontmatter).to receive(:list) { content_pages }
-    get("/sitemap.xml")
+    stub_const("SitemapController::OTHER_PATHS", other_paths)
   end
 
-  describe "#show" do
+  describe "GET /sitemap" do
+    let(:doc) { Nokogiri::HTML(response.body) }
+    let(:links) { doc.css("a[href^='/']").map { |a| a["href"] } }
+
+    before { get "/sitemap" }
+
+    it "renders the HTML sitemap" do
+      expect(response).to be_successful
+      expect(response.content_type).to include("text/html")
+    end
+
+    it "renders the correct pages" do
+      expect(links).to include("/train-to-be-a-teacher", "/salaries-and-benefits", "/my-story-into-teaching/what-a-great-story")
+
+      events.each do |event|
+        expect(links).to include(event_path(event.readable_id))
+      end
+
+      other_paths.each_key do |path|
+        expect(links).to include(path)
+      end
+    end
+
+    it "does not include noindex pages" do
+      expect(links).not_to include("/test/a")
+    end
+
+    it "does not include draft pages" do
+      expect(links).not_to include("/draft")
+    end
+  end
+
+  describe "GET /sitemap.xml" do
+    let(:doc) { Nokogiri::XML(response.body) }
     let(:sitemap_namespace) { "http://www.sitemaps.org/schemas/sitemap/0.9" }
+    let(:locs) { doc.xpath("//xmlns:url/xmlns:loc").map { |node| URI(node.text).path } }
 
-    specify "the document should have the correct namespace" do
-      expect(subject.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
+    before { get "/sitemap.xml" }
+
+    it "renders an XML sitemap" do
+      expect(response).to be_successful
+      expect(response.content_type).to include("application/xml")
     end
 
-    describe "sitemap pages" do
-      let(:expected) { SitemapController::OTHER_PATHS.count + all_sitemap_pages.count }
-      let(:paths) { all_sitemap_pages.keys.concat(SitemapController::OTHER_PATHS) }
-
-      specify "should have the right number of pages" do
-        expect(expected).to eql(subject.xpath("/xmlns:urlset/xmlns:url").size)
-      end
-
-      specify "the pages should have the correct paths" do
-        expect(
-          subject
-            .xpath("xmlns:urlset/xmlns:url/xmlns:loc")
-            .map { |node| URI(node.text).path },
-        ).to match_array(paths)
-      end
+    it "has the correct namespace" do
+      expect(doc.at_xpath("/xmlns:urlset").namespace.href).to eql(sitemap_namespace)
     end
 
-    describe "priority" do
-      specify "priority should be assinged from frontmatter" do
-        content_sitemap_pages.each do |path, data|
-          importance = subject.at_xpath(
-            %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:priority),
-          ).text
+    it "renders the correct pages" do
+      expect(locs).to include("/train-to-be-a-teacher", "/salaries-and-benefits", "/my-story-into-teaching/what-a-great-story")
 
-          expect(importance).to eql(data[:priority].to_s)
-        end
+      events.each do |event|
+        expect(locs).to include(event_path(event.readable_id))
+      end
+
+      other_paths.each_key do |path|
+        expect(locs).to include(path)
       end
     end
 
-    describe "lastmod" do
-      specify "last modified date should be assinged from frontmatter" do
-        content_sitemap_pages.each do |path, data|
-          last_modified = subject.at_xpath(
-            %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:lastmod),
-          ).text
+    it "does not include noindex pages" do
+      expect(locs).not_to include("/test/a")
+    end
 
-          expect(last_modified).to eql((data[:date] || SitemapController::DEFAULT_LASTMOD).to_s)
-        end
+    it "does not include draft pages" do
+      expect(locs).not_to include("/draft")
+    end
+
+    it "assigns priority level from frontmatter" do
+      valid_pages_with_data.each do |path, data|
+        next unless data[:priority]
+
+        priority = doc.at_xpath(
+          %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:priority),
+        ).text
+
+        expect(priority).to eql(data[:priority].to_s)
       end
     end
 
-    describe "noindex" do
-      specify "skips pages that have noindex in the frontmatter" do
-        expect(subject.to_s).not_to include("/test/a")
-      end
-    end
+    it "assigns lastmod date from frontmatter" do
+      valid_pages_with_data.each do |path, data|
+        next unless data[:lastmod]
 
-    context "when a page is set to draft" do
-      let(:content_pages) do
-        {
-          "/draft" => {
-            name: "Draft page",
-            draft: true,
-          },
-          "/published" => {
-            name: "Published page",
-            draft: false,
-          },
-        }
-      end
+        last_modified = subject.at_xpath(
+          %(/xmlns:urlset/xmlns:url[xmlns:loc = 'http://www.example.com#{path}']/xmlns:lastmod),
+        ).text
 
-      specify "draft pages aren't included in the sitemap" do
-        expect(subject).not_to match(/draft/)
-      end
-
-      specify "published pages are included in the sitemap" do
-        expect(subject).to match(/published/)
+        expect(last_modified).to eql((data[:date] || SitemapController::DEFAULT_LASTMOD).to_s)
       end
     end
   end


### PR DESCRIPTION
### Trello card

https://trello.com/c/Cd8ivlc2/7668-generate-user-friendly-sitemap-and-add-link-to-footer

### Context

We want to have an automated sitemap or A-Z index that is linked to in the footer

### Changes proposed in this pull request

- Refactor sitemap controller to present a hash of `path => metadata` that can be used by both the xml sitemap and the html sitemap
- Add html sitemap page
- Add sitemap link to footer

### Guidance to review

