### PR TITLE
Add block promo to how to become a teacher page

### DIFF
--- a/app/views/layouts/steps.html.erb
+++ b/app/views/layouts/steps.html.erb
@@ -18,9 +18,7 @@
 
         <section class="row">
           <div class="col col-full-content">
-            <%= render CallsToAction::AdviserComponent.new(
-              text: "An adviser with years of teaching experience can help you with your teacher training application. Chat by phone, text or email, as little or as often as you need.",
-            ) %>
+            <%= render 'content/shared/block-promos/mailing_adviser_routes' %>
           </div>
         </section>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/bsddUprS/7675

### Context
We have iterated our promo designs to make it easier to add more than one promo per page 

### Changes proposed in this pull request
Implement new promo blocks on the How to become a teacher page

### Guidance to review


