### PR TITLE
Adds degree status filter to the picklist presenter

### DIFF
--- a/app/models/events/steps/personalised_updates.rb
+++ b/app/models/events/steps/personalised_updates.rb
@@ -30,8 +30,7 @@ module Events
       end
 
       def degree_status_options
-        @degree_status_options ||=
-          GetIntoTeachingApiClient::PickListItemsApi.new.get_qualification_degree_status
+        @degree_status_options ||= PickListItemsApiPresenter.new.get_qualification_degree_status
       end
 
       def degree_status_option_ids

--- a/app/models/mailing_list/steps/degree_status.rb
+++ b/app/models/mailing_list/steps/degree_status.rb
@@ -20,7 +20,7 @@ module MailingList
     private
 
       def query_degree_status
-        GetIntoTeachingApiClient::PickListItemsApi.new.get_qualification_degree_status
+        PickListItemsApiPresenter.new.get_qualification_degree_status
       end
     end
   end

--- a/app/presenters/pick_list_items_api_presenter.rb
+++ b/app/presenters/pick_list_items_api_presenter.rb
@@ -17,4 +17,5 @@ class PickListItemsApiPresenter
   end
 
   delegate_and_filter(:get_candidate_journey_stages, [222_750_000, 222_750_003])
+  delegate_and_filter(:get_qualification_degree_status, [222_750_000, 222_750_001, 222_750_002, 222_750_003, 222_750_004, 222_750_005])
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/uqR0KCFq

### Context

Since we added a new option to the CRM, this has appeared in production as currently we don't filter down the picklist. We need to filter the picklist to just the options we want, fortunately, I made a presenter for just this occasion!

### Changes proposed in this pull request

- Adds degree status to picklist api presenter to filter down picklist options
- Adds this to the degree status steps of both the mailing list and events wizards

### Guidance to review

