### PR TITLE
removing early career payment from non-UK teacher page

### DIFF
--- a/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
+++ b/app/views/content/non-uk-teachers/fees-and-funding-for-non-uk-trainees.md
@@ -167,7 +167,7 @@ If you need to apply for another visa, for example, a Skilled Worker visa, you w
 ## Get help
 
 
-Contact the [UK Council for International Student Affairs website](https://www.ukcisa.org.uk/About-UKCISA) for advice on what financial support may be available.
+Contact the [UK Council for International Student Affairs website](https://www.ukcisa.org.uk) for advice on what financial support may be available.
 
 You may be eligible for personalised support from a teacher training adviser. They can help with your teacher training application.
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -211,7 +211,7 @@ You may be eligible for:
 
 * a [levelling up premium payment](https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers) if you teach chemistry, computing, maths or physics 
 
-* the [international relocation payment (IRP)](#get-an-international-relocation-payment-irp-worth-up-to-10000) if you teach languages or physics
+* the [international relocation payment (IRP)](/non-uk-teachers/get-an-international-relocation-payment) if you teach languages or physics
 
 ## Plan your move to England
 

--- a/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
+++ b/app/views/content/non-uk-teachers/teach-in-england-if-you-trained-overseas.md
@@ -207,9 +207,11 @@ You'll also be able to develop your career through the [national professional qu
 
 ### Financial help
 
-You may be eligible for the [levelling up premium payment](https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers) or the [early career payment](https://www.gov.uk/guidance/early-career-payments-guidance-for-teachers-and-schools). 
+You may be eligible for:
 
-You can only receive the [international relocation payment (IRP)](#get-an-international-relocation-payment-irp-worth-up-to-10000) once, and you cannot receive both the levelling up premium payment and the early career payment in the same year.
+* a [levelling up premium payment](https://www.gov.uk/guidance/levelling-up-premium-payments-for-teachers) if you teach chemistry, computing, mathematics or physics 
+
+* the [international relocation payment (IRP)](#get-an-international-relocation-payment-irp-worth-up-to-10000) if you teach languages or physics
 
 ## Plan your move to England
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/Yt4NKnjz/7794-remove-reference-to-early-career-payment-from-the-teach-in-england-if-you-trained-outside-the-uk-page

### Context

### Changes proposed in this pull request

### Guidance to review

