### PR TITLE
Added portrait orientation to youtube video component

### DIFF
--- a/app/components/content/youtube_video_component.html.erb
+++ b/app/components/content/youtube_video_component.html.erb
@@ -1,4 +1,4 @@
-<div class="youtube-video">
+<div class="youtube-video youtube-video--<%= orientation %>">
   <%= tag.iframe(
     title: title,
     loading: "lazy",

--- a/app/components/content/youtube_video_component.rb
+++ b/app/components/content/youtube_video_component.rb
@@ -27,6 +27,8 @@ module Content
         error_message = "#{required_attr} must be present"
         fail(ArgumentError, error_message) if send(required_attr).blank?
       end
+
+      fail(ArgumentError, "orientation is not valid") unless [:landscape, :portrait].include?(orientation)
     end
   end
 end

--- a/app/components/content/youtube_video_component.rb
+++ b/app/components/content/youtube_video_component.rb
@@ -28,7 +28,7 @@ module Content
         fail(ArgumentError, error_message) if send(required_attr).blank?
       end
 
-      fail(ArgumentError, "orientation is not valid") unless [:landscape, :portrait].include?(orientation)
+      fail(ArgumentError, "orientation is not valid") unless %i[landscape portrait].include?(orientation)
     end
   end
 end

--- a/app/components/content/youtube_video_component.rb
+++ b/app/components/content/youtube_video_component.rb
@@ -1,14 +1,15 @@
 module Content
   class YoutubeVideoComponent < ViewComponent::Base
-    attr_reader :id, :title
+    attr_reader :id, :title, :orientation
 
     include ContentHelper
 
-    def initialize(id:, title:)
+    def initialize(id:, title:, orientation: :landscape)
       super
 
       @id = id
       @title = substitute_values(title)
+      @orientation = orientation
     end
 
     def src

--- a/app/views/content/events/get-the-most-from-events/_content.html.erb
+++ b/app/views/content/events/get-the-most-from-events/_content.html.erb
@@ -115,7 +115,8 @@
     <div class="video">
       <%= render Content::YoutubeVideoComponent.new(
         id: "w3AVk-ByUaA",
-        title: "A video about What happens at a Get Into Teaching event"
+        title: "A video about What happens at a Get Into Teaching event",
+        orientation: :portrait
       ) %>
       <p><a href="/events/what-happens-at-events-transcript">Read the transcript for the 'What happens at a Get Into Teaching event' video</a>.</p>
     </div>

--- a/app/views/content/events/get-the-most-from-events/_content.html.erb
+++ b/app/views/content/events/get-the-most-from-events/_content.html.erb
@@ -115,8 +115,7 @@
     <div class="video">
       <%= render Content::YoutubeVideoComponent.new(
         id: "w3AVk-ByUaA",
-        title: "A video about What happens at a Get Into Teaching event",
-        orientation: :portrait
+        title: "A video about What happens at a Get Into Teaching event"
       ) %>
       <p><a href="/events/what-happens-at-events-transcript">Read the transcript for the 'What happens at a Get Into Teaching event' video</a>.</p>
     </div>

--- a/app/views/content/life-as-a-teacher/explore-subjects/maths/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/explore-subjects/maths/_article.html.erb
@@ -7,6 +7,20 @@
       <%= render 'content/shared/teaching/benefits' %>
       <%= render 'content/shared/teaching/why_teach' %>
   </section>
+</div>
+
+  <div class="row inset">
+    <div class="video">
+      <section class="col col-720">
+        <%= render Content::YoutubeVideoComponent.new(
+          id: "oJjoodXrvlU",
+          title: "A video about what a career in teaching taught maths teacher Juvayriyah",
+          orientation: :portrait
+        ) %>
+        <p><a href="/shared/transcripts/what-teaching-taught-me-juvayriyah">Read the transcript for the 'What teaching taught me - Juvayriyah' video</a>.</p>
+      </section>
+    </div>
+  </div>
 
   <section class="col col-720">
     <%= render 'content/shared/quotes/quote_maths_rotna' %>

--- a/app/views/content/life-as-a-teacher/explore-subjects/maths/_article.html.erb
+++ b/app/views/content/life-as-a-teacher/explore-subjects/maths/_article.html.erb
@@ -1,30 +1,16 @@
 <div class="row inset">
   <section class="col col-720 col-space-l-top">
     <h2 class="heading--box-blue">Why teach <%= @front_matter["subject"] %></h2>
-      <p> Maths is critical to science, technology and engineering as well as being fundamental for most jobs.</p>
-      <p>A good understanding of maths can help children develop life skills such as cooking, managing a budget and problem solving.</p>
-      <!-- Why teach: benefits -->
-      <%= render 'content/shared/teaching/benefits' %>
-      <%= render 'content/shared/teaching/why_teach' %>
+    <p> Maths is critical to science, technology and engineering as well as being fundamental for most jobs.</p>
+    <p>A good understanding of maths can help children develop life skills such as cooking, managing a budget and problem solving.</p>
+    <!-- Why teach: benefits -->
+    <%= render 'content/shared/teaching/benefits' %>
+    <%= render 'content/shared/teaching/why_teach' %>
   </section>
-</div>
-
-  <div class="row inset">
-    <div class="video">
-      <section class="col col-720">
-        <%= render Content::YoutubeVideoComponent.new(
-          id: "oJjoodXrvlU",
-          title: "A video about what a career in teaching taught maths teacher Juvayriyah",
-          orientation: :portrait
-        ) %>
-        <p><a href="/shared/transcripts/what-teaching-taught-me-juvayriyah">Read the transcript for the 'What teaching taught me - Juvayriyah' video</a>.</p>
-      </section>
-    </div>
-  </div>
 
   <section class="col col-720">
     <%= render 'content/shared/quotes/quote_maths_rotna' %>
-    </section>
+  </section>
 
   <section class="col col-720 col-space-l-top">
     <h2 class="heading--box-blue">Shape your pupils' futures</h2>
@@ -33,10 +19,10 @@
       <p>By solving challenging problems, your pupils could make significant contributions to these impactful areas.</p>
       <p>Your pupils will learn more from you than you might think. As their teacher, you’ll guide your pupils though the skills they need to show their understanding of maths. You'll teach them valuable life skills such as critical thinking, decision making and problem solving.</p>
     </div>
-   </section>
+  </section>
 
-    <section class="col col-720">
-   <%= render 'content/shared/quotes/quote_maths_dimitra' %>
+  <section class="col col-720">
+    <%= render 'content/shared/quotes/quote_maths_dimitra' %>
   </section>
 
   <section class="col col-720">

--- a/app/webpacker/styles/components/youtube-video.scss
+++ b/app/webpacker/styles/components/youtube-video.scss
@@ -7,6 +7,19 @@
     aspect-ratio: 16 / 9;
   }
 
+  &--portrait {
+    iframe {
+      display: block;
+      margin: auto;
+      width: 100%;
+      aspect-ratio: 9 / 16;
+
+      @include mq($from: tablet) {
+        width: 50%;
+      }
+    }
+  }
+
   // Simulates 16 / 9 aspect ratio.
   @supports not (aspect-ratio: 1) {
     position: relative;

--- a/docs/content.md
+++ b/docs/content.md
@@ -239,9 +239,21 @@ youtube_video:
 $return-to-teaching-advisers-video$
 ```
 
+To render vertical videos (9:16 aspect ratio), you can pass in the optional `orientation: :portrait` parameter.
+
+```yaml
+---
+youtube_video:
+  return-to-teaching-advisers-video:
+    id: 2NrLm_XId4k
+    title: A video about what Return to Teaching Advisers do
+    orientation: :portrait
+---
+```
+
 #### iframe
 
-When adding an iFrame elemet as part of Markdown content or a HTML page we should ensure it has an appropriate `title` attribute that explains the contents of the iFrame (in most of our cases we are showing a video). For example:
+When adding an iFrame element as part of Markdown content or a HTML page we should ensure it has an appropriate `title` attribute that explains the contents of the iFrame (in most of our cases we are showing a video). For example:
 
 ```
 <iframe

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -32,4 +32,16 @@ describe Content::YoutubeVideoComponent, type: :component do
       it { expect { render }.to raise_error(ArgumentError, "title must be present") }
     end
   end
+
+  describe "orientation" do
+    context "when not present" do
+      it { is_expected.to have_css(".youtube-video.youtube-video--landscape iframe") }
+    end
+
+    context "when portrait" do
+      let(:component) { described_class.new(id: id, title: title, orientation: :portrait) }
+
+      it { is_expected.to have_css(".youtube-video.youtube-video--portrait iframe") }
+    end
+  end
 end

--- a/spec/components/content/youtube_video_component_spec.rb
+++ b/spec/components/content/youtube_video_component_spec.rb
@@ -43,5 +43,11 @@ describe Content::YoutubeVideoComponent, type: :component do
 
       it { is_expected.to have_css(".youtube-video.youtube-video--portrait iframe") }
     end
+
+    context "when invalid" do
+      let(:component) { described_class.new(id: id, title: title, orientation: :wonky) }
+
+      it { expect { render }.to raise_error(ArgumentError, "orientation is not valid") }
+    end
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/jkP6kT1k/7800-add-portrait-attribute-to-youtube-embed?filter=member:spencerldixon

### Context

We have lots of YouTube shorts videos from the partnerships team that we want to add to the site
YouTube shorts are portrait format whereas our current embed functionality only allows for horizontal format

### Changes proposed in this pull request

- Add a utility class for portrait mode in youtube component css
- Default to landscape if no orientation given
- Added tests
- Updated content guidance

### Guidance to review

