### PR TITLE
Implement rate limiting for the prod website

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -11,7 +11,8 @@
         ],
         "environment_short": "pd",
         "origin_hostname": "get-into-teaching-app-production.teacherservices.cloud",
-        "null_host_header": false
+        "null_host_header": false,
+        "rate_limit": 500
       }
     }
   }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -11,6 +11,7 @@ module "domains" {
   null_host_header    = try(each.value.null_host_header, false)
   cached_paths        = try(each.value.cached_paths, [])
   redirect_rules      = try(each.value.redirect_rules, [])
+  rate_limit          = try(each.value.rate_limit, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.


### PR DESCRIPTION
### Trello card

https://trello.com/c/lMG5Q82M/2313-rate-limiting-for-git

### Context

We've seen an increase in website scanning which can cause failures for normal users.
This PR implements rate limiting at the front door ingress, using the rate_limiting option that was previously tested and added to the domains terraform module. 
It sets max requests per 5 minute period for a single IP address.
Looking at previous stats I don't see any real usage of more than 200-300 requests, but we will start by limiting to 500 requests per 5 minute intervals and can tune further.

### Changes proposed in this pull request

Update terraform configuration

### Guidance to review

make production domains-plan (adds new resources)
make test domains-plan (no change)

