### PR TITLE
Remove keywords from funding and apply sections

### DIFF
--- a/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
+++ b/app/views/content/funding-and-support/if-youre-a-parent-or-carer.md
@@ -22,14 +22,6 @@ cta_arrow_link:
 navigation: 20.30
 navigation_title: Funding and support if you're a parent or carer
 navigation_description: Find out what extra grants and schemes are available if you have children or other caring responsibilities.
-keywords:
-    - Bursaries
-    - Bursary
-    - Scholarship
-    - Scholarships
-    - Grant
-    - Parents
-    - Carers
 expander:
   international-content:
     title: funding and support if you're a parent or carer

--- a/app/views/content/funding-and-support/if-youre-a-veteran.md
+++ b/app/views/content/funding-and-support/if-youre-a-veteran.md
@@ -13,11 +13,6 @@ cta_arrow_link:
     link_text: "Find out more about postgraduate scholarships and bursaries"
 navigation_title: Funding and support if you're a veteran
 navigation_description: Find out how to get support training to teach if you're a veteran transitioning from or you've already left the armed forces.
-keywords:
-    - veterans
-    - service leavers
-    - army
-    - military
 ---
 
 If you’re transitioning from the armed forces or your service has already ended, you could be eligible for support to train to teach.

--- a/app/views/content/funding-and-support/if-youre-disabled.md
+++ b/app/views/content/funding-and-support/if-youre-disabled.md
@@ -9,13 +9,6 @@ navigation_title: Funding and support if you have a learning difficulty, health 
 navigation_description: Find out about the support you can get while training to teach if you're neurodivergent, have a long-term physical or mental health condition, or have any other accessibility need.
 promo_content:
   - "content/shared/block-promos/adviser_mailing_routes"
-keywords:
-    - Disability
-    - Disabilities
-    - DSA
-    - Financial Support
-    - Disabled students
-    - Disabled Students’ Allowances
 expander:
   international-content:
     title: funding and support if you have a health condition or disability

--- a/app/views/content/funding-and-support/salaried-teacher-training.md
+++ b/app/views/content/funding-and-support/salaried-teacher-training.md
@@ -11,16 +11,6 @@ cta_arrow_link:
   find-courses:
     link_target: "https://find-teacher-training-courses.service.gov.uk/results?funding%5B%5D=salary&funding%5B%5D=apprenticeship&applications_open=true&order=course_name_ascending"
     link_text: "Find a salaried teacher training course"
-keywords:
-    - Teach First
-    - School Direct
-    - School Direct (salaried)
-    - Postgraduate teaching apprenticeship
-    - PGTA
-    - Salaried courses
-    - Salaried teacher training
-    - Salaried teacher training course
-    - Paid teacher training
 expander:
   salaried-teacher-training:
     title: salaried teacher training

--- a/app/views/content/funding-and-support/scholarships-and-bursaries.md
+++ b/app/views/content/funding-and-support/scholarships-and-bursaries.md
@@ -18,16 +18,6 @@ navigation_title: Bursaries and scholarships
 navigation_description: Find out if you're eligible for extra funding depending on the subject you're training to teach.
 before-content:
     - content/funding-and-support/scholarships-and-bursaries/funding-widget
-keywords:
-    - Bursaries
-    - Bursary
-    - Scholarship
-    - Scholarships
-    - Grant
-    - Grants
-    - Financial Support
-    - Undergraduate
-    - Postgraduate
 ---
 
 ## Eligibility for bursaries

--- a/app/views/content/funding-and-support/tuition-fees.md
+++ b/app/views/content/funding-and-support/tuition-fees.md
@@ -8,13 +8,6 @@ promo_content:
   - "content/shared/block-promos/adviser_findfees"
 navigation: 20.10
 navigation_description: Find out the cost of postgraduate teacher training courses with tuition fees.
-keywords:
-    - Tuition Fees
-    - Teacher Training Course Fees
-    - How Much Cost Train As Teacher
-    - Teacher Training Tuition Fees
-    - Student Finance
-    - Financial Support
 expander:
   postgraduate-fees:
     title: postgraduate fees

--- a/app/views/content/how-to-apply-for-teacher-training/if-your-application-is-unsuccessful.md
+++ b/app/views/content/how-to-apply-for-teacher-training/if-your-application-is-unsuccessful.md
@@ -5,18 +5,6 @@ description: |-
 navigation: 30.30
 navigation_title: If your application is unsuccessful
 navigation_description: Find out what to do if your teacher training application is unsuccessful.
-keywords:
-  - adviser
-  - advisor
-  - ITT
-  - Initial Teacher Training
-  - QTS
-  - Qualified Teacher Status
-  - Teacher Training Adviser
-  - application
-  - apply
-  - how to apply
-  - applying for teacher training
 promo_content:
   - "content/shared/block-promos/adviser_events"
 expander:

--- a/app/views/content/how-to-apply-for-teacher-training/subject-knowledge-enhancement.md
+++ b/app/views/content/how-to-apply-for-teacher-training/subject-knowledge-enhancement.md
@@ -11,11 +11,6 @@ youtube_video:
 navigation: 30.25
 navigation_title: Subject knowledge enhancement (SKE)
 navigation_description: Find out how to improve your subject knowledge with a subject knowledge enhancement course.
-keywords:
-  - Subject knowledge
-  - Subject knowledge enhancement
-  - SKE
-  - enhance
 expander:
   SKE-bursaries:
     title: SKE bursaries

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-personal-statement.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-personal-statement.md
@@ -6,27 +6,6 @@ description: |-
 navigation: 30.10
 navigation_title: Teacher training personal statement
 navigation_description: Find out what to include in your teacher training personal statement.
-keywords:
-  - teacher training personal statement
-  - adviser
-  - advisor
-  - ITT
-  - Initial Teacher Training
-  - QTS
-  - Qualified Teacher Status
-  - Teacher Training Adviser
-  - application
-  - apply
-  - how to apply
-  - applying for teacher training
-  - referees
-  - references
-  - process
-  - personal statement
-  - when to apply
-  - interviews
-  - offers
-  - teacher training application
 promo_content:
   - "content/shared/block-promos/adviser_apply"
 quote:

--- a/app/views/content/how-to-apply-for-teacher-training/teacher-training-references.md
+++ b/app/views/content/how-to-apply-for-teacher-training/teacher-training-references.md
@@ -6,27 +6,6 @@ description: |-
 navigation: 30.15
 navigation_title: Teacher training references
 navigation_description: Find out which teacher training references you need to provide and what they should include.
-keywords:
-  - teacher training references
-  - adviser
-  - advisor
-  - ITT
-  - Initial Teacher Training
-  - QTS
-  - Qualified Teacher Status
-  - Teacher Training Adviser
-  - application
-  - apply
-  - how to apply
-  - applying for teacher training
-  - referees
-  - references
-  - process
-  - personal statement
-  - when to apply
-  - interviews
-  - offers
-  - teacher training application
 promo_content:
   - "content/shared/block-promos/adviser_apply"
 ---

--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -5,8 +5,6 @@ description: |-
 navigation: 30.16
 navigation_title: When to apply for teacher training
 navigation_description:  Find out when you can apply for postgraduate teacher training courses.
-keywords:
-  - teacher training applications
 promo_content:
   - "content/shared/block-promos/adviser_apply"
 quote:


### PR DESCRIPTION
### Trello card
https://trello.com/c/ZZYxHTxS/7831
### Context
We've removed the search from the website, so we do not need to have keywords in the frontmatter.

### Changes proposed in this pull request
Remove keyword frontmatter from pages in the funding and apply sections. 

### Guidance to review

