### PR TITLE
Remove keywords from life as a teacher section

### DIFF
--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers.md
@@ -2,19 +2,6 @@
 title: "Become an early years teacher"
 image: false
 backlink: "../"
-keywords:
- - EYITT
- - Early
- - Years
- - Early Years
- - EYTS
- - Early Years Teacher Status
- - Under 5
- - EY
- - E.Y.
- - nursery
- - preschool
- - year one
 description: |-
   Find out how to become an early years teacher. Discover the qualifications you need, the different early years teacher training routes and the cost.
 expander:

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers.md
@@ -4,17 +4,6 @@ article_classes: ['longform']
 image: "static/images/content/hero-images/0031.jpg"
 description: |-
   Find out how to teach in further education in England. Explore which qualifications you need and how to find further education teacher training.
-keywords:
-  - Further
-  - Further education
-  - FE
-  - College
-  - Vocational
-  - Vocation
-  - F.E.
-  - NVQ
-  - BTEC
-  - HND
 ---
 
 

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/primary.md
@@ -10,10 +10,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/teacher-primary.jpg"
-keywords:
-- primary school
-- primary school teacher
-- primary school teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/age-groups-and-specialisms/primary/article"

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/secondary.md
@@ -10,10 +10,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/chemistry.jpg"
-keywords:
-  - secondary school teacher
-  - secondary school teacher training
-
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/age-groups-and-specialisms/secondary/article"

--- a/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
+++ b/app/views/content/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs.md
@@ -10,15 +10,6 @@ cta_arrow_link:
   find:
     link_target: "https://find-teacher-training-courses.service.gov.uk/results?send_courses=true&applications_open=true&order=course_name_ascending"
     link_text: "Find a teacher training course with a SEND specialism"
-keywords:
-  - SEND
-  - disabled
-  - disability  
-  - disabilities
-  - special educational needs
-  - teaching
-  - teacher
-  - special school
 quote:
   q-gloria:
     text: "I'm passionate about being there for my students, helping them see their potential and overcome their own challenges."

--- a/app/views/content/life-as-a-teacher/change-careers/becoming-a-parent-sparked-my-interest-in-teaching.md
+++ b/app/views/content/life-as-a-teacher/change-careers/becoming-a-parent-sparked-my-interest-in-teaching.md
@@ -6,13 +6,6 @@ description: |-
   Hear how bursaries helped physics teacher and mum Claire get into teaching, and why she changed careers to become a teacher.
 layout: "layouts/minimal" 
 colour: grey-pink
-keywords:
-  - teaching
-  - physics
-  - science
-  - career changer
-  - changing careers
-  - career
 content: 
   - "content/life-as-a-teacher/change-careers/becoming-a-parent-sparked-my-interest-in-teaching/header" 
   - "content/life-as-a-teacher/change-careers/becoming-a-parent-sparked-my-interest-in-teaching/article"

--- a/app/views/content/life-as-a-teacher/change-careers/benefits-of-changing-careers.md
+++ b/app/views/content/life-as-a-teacher/change-careers/benefits-of-changing-careers.md
@@ -4,11 +4,6 @@ description: |-
   Explore the benefits of changing careers, including teacher salaries, job security, and making a real difference in young people's lives.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - teaching
-  - career changer
-  - changing careers
-  - career
 content: 
   - "content/life-as-a-teacher/change-careers/benefits-of-changing-careers/header" 
   - "content/life-as-a-teacher/change-careers/benefits-of-changing-careers/article"

--- a/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher.md
+++ b/app/views/content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher.md
@@ -4,11 +4,6 @@ description: |-
   Find out about the different routes you could take to swap your current career for the classroom.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - teaching
-  - career changer
-  - changing careers
-  - career
 content: 
   - "content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/header" 
   - "content/life-as-a-teacher/change-careers/how-to-change-careers-to-become-a-teacher/article"

--- a/app/views/content/life-as-a-teacher/change-careers/making-a-career-change-to-teaching.md
+++ b/app/views/content/life-as-a-teacher/change-careers/making-a-career-change-to-teaching.md
@@ -6,11 +6,6 @@ description: |-
   Peter shares how he switched careers to teaching, after more than 25 years working in finance.
 layout: "layouts/minimal" 
 colour: grey-pink
-keywords:
-  - teaching
-  - career changer
-  - changing careers
-  - career
 content: 
   - "content/life-as-a-teacher/change-careers/making-a-career-change-to-teaching/header" 
   - "content/life-as-a-teacher/change-careers/making-a-career-change-to-teaching/article"

--- a/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers.md
+++ b/app/views/content/life-as-a-teacher/change-careers/support-with-changing-careers.md
@@ -4,11 +4,6 @@ description: |-
   Discover the support and resources available to help you transition smoothly into a rewarding teaching career.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - teaching
-  - career changer
-  - changing careers
-  - career
 content: 
   - "content/life-as-a-teacher/change-careers/support-with-changing-careers/header" 
   - "content/life-as-a-teacher/change-careers/support-with-changing-careers/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/art-and-design.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/art-and-design.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/art-easels.jpg"
-keywords:
-  - art and design
-  - teaching art and design
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/art-and-design/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/biology.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/biology.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0030.jpg"
-keywords:
-  - biology
-  - teaching biology
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/biology/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/business.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/business.md
@@ -9,10 +9,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/teacher2.jpg"
-keywords:
-  - business studies 
-  - teaching business 
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/business/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/chemistry.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/chemistry.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/chemistry.jpg"
-keywords:
-  - chemistry
-  - teaching chemistry
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/chemistry/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/computing.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/computing.md
@@ -14,10 +14,6 @@ backlink: "../../"
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0036.jpg"
-keywords:
-  - computing
-  - teaching computing
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/computing/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/design-and-technology.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/design-and-technology.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0037.jpg"
-keywords:
-  - design and technology
-  - teaching design and techology
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/design-and-technology/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/drama.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/drama.md
@@ -9,10 +9,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0034.jpg"
-keywords:
-  - drama
-  - teaching drama
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/drama/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/engineers-teach-physics.md
@@ -11,13 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/physics.jpg"
-keywords:
-  - engineers
-  - material scientists
-  - physics
-  - teaching physics
-  - career change
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/engineers-teach-physics/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/english.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/english.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0032.jpg"
-keywords:
-  - english
-  - teaching english
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/english/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/geography.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/geography.md
@@ -11,10 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/geography.jpg"
-keywords:
-  - geography
-  - teaching geography
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/geography/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/history.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/history.md
@@ -8,10 +8,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/teacher2.jpg"
-keywords:
-  - history
-  - teaching history
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/history/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/languages.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/languages.md
@@ -11,16 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/languages.jpg"
-keywords:
-  - French
-  - German
-  - Spanish
-  - languages
-  - ancient languages
-  - modern languages
-  - teaching languages
-  - teaching modern languages
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/languages/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/maths.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/maths.md
@@ -13,10 +13,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/maths-pythagoras.jpg"
-keywords:
-  - maths
-  - teaching maths
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/maths/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/music.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/music.md
@@ -10,10 +10,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/music-ukuleles.jpg"
-keywords:
-  - music
-  - teaching music
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/music/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/physical-education.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/physical-education.md
@@ -10,12 +10,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0031.jpg"
-keywords:
-  - physical education
-  - teaching PE
-  - PE
-  - subjects
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/physical-education/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/physics.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/physics.md
@@ -11,11 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/physics-van-de-graaff.jpg"
-keywords:
-  - physics
-  - teaching physics
-  - subjects
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/physics/article"

--- a/app/views/content/life-as-a-teacher/explore-subjects/religious-education.md
+++ b/app/views/content/life-as-a-teacher/explore-subjects/religious-education.md
@@ -11,11 +11,6 @@ description: |-
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
 image: "static/images/content/hero-images/0011.jpg"
-keywords:
-  - physics
-  - teaching physics
-  - subjects
-  - teacher training
 content:
   - "content/shared/subject-pages/header"
   - "content/life-as-a-teacher/explore-subjects/religious-education/article"

--- a/app/views/content/life-as-a-teacher/pay-and-benefits/teacher-pay.md
+++ b/app/views/content/life-as-a-teacher/pay-and-benefits/teacher-pay.md
@@ -16,39 +16,6 @@ cta_arrow_link:
   steps:
     link_target: "/steps-to-become-a-teacher"
     link_text: "Find out how to become a teacher"
-keywords:
-  - Salary
-  - Salaries
-  - Band
-  - Pay
-  - Pay scale
-  - Scale
-  - Teacher Salary
-  - Teacher Salaries
-  - Leading Practitioner
-  - Headteacher
-  - Progression
-  - Unqualified Teacher
-  - Teaching and learning responsibility
-  - TLR
-  - Holiday
-  - Annual Leave
-  - Pension
-  - Additional
-  - Responsibility
-  - Responsibilities
-  - Career
-  - Benefits
-  - Earnings
-  - Leadership
-  - Early Career Framework
-  - Support
-  - Training
-  - ECF
-  - Teaching
-  - Teacher training
-  - How to become a teacher
-  - Teacher training courses
 ---
 If you’re a primary or secondary teacher in England, your salary will depend on the type of school you work in, where the school is, and the pay range you’re on.
 

--- a/app/views/content/life-as-a-teacher/pay-and-benefits/teachers-pension-scheme.md
+++ b/app/views/content/life-as-a-teacher/pay-and-benefits/teachers-pension-scheme.md
@@ -6,11 +6,6 @@ description: |-
 image: false
 promo_content:
   - "content/shared/block-promos/mailing_adviser_routes"
-keywords:
-  - Teachers pension
-  - Pension
-  - Benefits
-  - Earnings
 ---
 One of the great benefits of a teaching career is a secure pension that will help you save for your future. 
 

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/abigails-career-progression-story.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/abigails-career-progression-story.md
@@ -6,10 +6,6 @@ description: |-
   Hear from Abigail about her journey to becoming head of maths, only 6 years into her teaching career.
 layout: "layouts/minimal"
 colour: grey-pink
-keywords:
-  - teaching
-  - maths
-  - career progression
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/abigails-career-progression-story/header" 
   - "content/life-as-a-teacher/teaching-as-a-career/abigails-career-progression-story/article"

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/career-progression.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/career-progression.md
@@ -4,42 +4,6 @@ description: |-
   Find out about the opportunities for progression as a teacher, including salary progression, professional qualifications, and mentorship.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - Professional Development
-  - Teacher Promotion
-  - Career Development
-  - Progression
-  - Career Progression
-  - Development
-  - Scale
-  - Teacher Salary
-  - Teacher Salaries
-  - Leading Practitioner
-  - Headteacher
-  - Progression
-  - Promotion
-  - Teaching and learning responsibility
-  - Teaching and learning responsibility payment
-  - TLR
-  - Teaching Roles
-  - Promoted
-  - Teaching Responsibilities
-  - Additional
-  - Payments
-  - Responsibility
-  - Responsibilities
-  - Career
-  - Career Prospects
-  - Earnings
-  - Leadership
-  - NQT
-  - National professional qualification
-  - Support
-  - Training
-  - Salary increase
-  - Salary review
-  - Pastoral care
-  - ECF
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/career-progression/header" 
   - "content/life-as-a-teacher/teaching-as-a-career/career-progression/article"

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/from-qualified-teacher-to-head-of-biology.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/from-qualified-teacher-to-head-of-biology.md
@@ -6,10 +6,6 @@ description: |-
   Sarah shares her story of how she became a department head in a subject she loves. 
 layout: "layouts/minimal"
 colour: grey-pink
-keywords:
-  - teaching
-  - biology
-  - career progression
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/from-qualified-teacher-to-head-of-biology/header" 
   - "content/life-as-a-teacher/teaching-as-a-career/from-qualified-teacher-to-head-of-biology/article"

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/from-teaching-internship-to-leadership-roles.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/from-teaching-internship-to-leadership-roles.md
@@ -6,11 +6,6 @@ description: |-
   In Ben’s second year of teaching, he took on the role of head of physics. He then moved departments and became assistant head of maths.
 layout: "layouts/minimal"
 colour: grey-pink
-keywords:
-  - teaching
-  - maths
-  - physics
-  - career progression
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/from-teaching-internship-to-leadership-roles/header" 
   - "content/life-as-a-teacher/teaching-as-a-career/from-teaching-internship-to-leadership-roles/article"

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/skills-to-teach.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/skills-to-teach.md
@@ -4,9 +4,6 @@ description: |-
   Find out about the the skills needed for teaching, including subject knowledge, pedagogy, and soft skills.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - skills
-  - skills to become a teacher
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/skills-to-teach/header"
   - "content/life-as-a-teacher/teaching-as-a-career/skills-to-teach/article"

--- a/app/views/content/life-as-a-teacher/teaching-as-a-career/turning-a-tough-lesson-into-a-success.md
+++ b/app/views/content/life-as-a-teacher/teaching-as-a-career/turning-a-tough-lesson-into-a-success.md
@@ -6,10 +6,6 @@ description: |-
   Physical education (PE) teacher Danny shares how he tackles challenging behaviour in lessons.
 layout: "layouts/minimal"
 colour: grey-pink
-keywords:
-  - teaching
-  - maths
-  - career progression
 content: 
   - "content/life-as-a-teacher/teaching-as-a-career/turning-a-tough-lesson-into-a-success/header" 
   - "content/life-as-a-teacher/teaching-as-a-career/turning-a-tough-lesson-into-a-success/article"

--- a/app/views/content/life-as-a-teacher/why-teach/abigails-favourite-things-about-teaching.md
+++ b/app/views/content/life-as-a-teacher/why-teach/abigails-favourite-things-about-teaching.md
@@ -6,11 +6,7 @@ description: |-
   Hear what Abigail enjoys most about teaching, and the impact she has through her job.
 layout: "layouts/minimal" 
 colour: grey-pink 
-image: "static/images/content/case-studies/abigail.jpg" 
-keywords:
-  - teaching
-  - maths
-  - science
+image: "static/images/content/case-studies/abigail.jpg"
 content: 
   - "content/life-as-a-teacher/why-teach/abigails-favourite-things-about-teaching/header" 
   - "content/life-as-a-teacher/why-teach/abigails-favourite-things-about-teaching/article"

--- a/app/views/content/life-as-a-teacher/why-teach/bens-favourite-things-about-teaching.md
+++ b/app/views/content/life-as-a-teacher/why-teach/bens-favourite-things-about-teaching.md
@@ -6,11 +6,7 @@ description: |-
   Hear from Ben about his favourite things about teaching.
 layout: "layouts/minimal" 
 colour: grey-pink 
-image: "static/images/content/case-studies/ben.jpg" 
-keywords:
-  - teaching
-  - maths
-  - science
+image: "static/images/content/case-studies/ben.jpg"
 content: 
   - "content/life-as-a-teacher/why-teach/bens-favourite-things-about-teaching/header" 
   - "content/life-as-a-teacher/why-teach/bens-favourite-things-about-teaching/article"

--- a/app/views/content/life-as-a-teacher/why-teach/why-become-a-teacher.md
+++ b/app/views/content/life-as-a-teacher/why-teach/why-become-a-teacher.md
@@ -4,9 +4,6 @@ description: |-
   Explore the many reasons why you should become a teacher in England. From making a difference from day one, to exploring your creativity and benefiting from a competitive salary and generous holidays.
 layout: "layouts/minimal"
 colour: pastel yellow-yellow
-keywords:
-  - why become a teacher
-  - why should I teach
 content: 
   - "content/life-as-a-teacher/why-teach/why-become-a-teacher/header" 
   - "content/life-as-a-teacher/why-teach/why-become-a-teacher/article"


### PR DESCRIPTION
### Trello card
https://trello.com/c/ZZYxHTxS/7831-remove-keywords-from-front-matter

### Context
We've removed the search from the website, so we do not need to have keywords in the frontmatter.

### Changes proposed in this pull request
Remove keyword frontmatter from pages in the life as a teacher section. 

### Guidance to review

