### PR TITLE
Fix opengraph tags

### DIFF
--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -4,7 +4,11 @@ module MetadataHelper
   def meta_tag(key:, value:, opengraph: false)
     return if value.blank?
 
-    tag.meta(name: prepend_opengraph(key, opengraph), content: value)
+    if opengraph
+      tag.meta(property: "og:#{key}", content: value)
+    else
+      tag.meta(name: key, content: value)
+    end
   end
 
   def image_meta_tags(image_path:, opengraph: true)
@@ -16,11 +20,5 @@ module MetadataHelper
       meta_tag(key: "image", value: image_url, opengraph: opengraph),
       meta_tag(key: "image:alt", value: Image.new.alt(image_path), opengraph: opengraph),
     ])
-  end
-
-private
-
-  def prepend_opengraph(key, opengraph)
-    opengraph ? %(og:#{key}) : key
   end
 end

--- a/app/views/content/trainees/got-into-teaching.md
+++ b/app/views/content/trainees/got-into-teaching.md
@@ -4,7 +4,7 @@ description: Celebrate accepting your teacher training place and starting your j
 content:
     - content/trainees/got-into-teaching/header
     - content/trainees/got-into-teaching/content
-image: "static/images/content/hero-images/celebration.jpg"
+image: "static/images/content/hero-images/chemistry.jpg"
 layout: "layouts/minimal"
 colour: yellow-green
 noindex: true

--- a/app/views/content/trainees/got-into-teaching.md
+++ b/app/views/content/trainees/got-into-teaching.md
@@ -4,7 +4,7 @@ description: Celebrate accepting your teacher training place and starting your j
 content:
     - content/trainees/got-into-teaching/header
     - content/trainees/got-into-teaching/content
-image: "static/images/content/hero-images/chemistry.jpg"
+image: "static/images/content/hero-images/celebration.jpg"
 layout: "layouts/minimal"
 colour: yellow-green
 noindex: true

--- a/app/views/sections/_head.html.erb
+++ b/app/views/sections/_head.html.erb
@@ -48,6 +48,7 @@
   <%= meta_tag(key: 'title', value: page_title(@page_title, @front_matter), opengraph: true) %>
   <%= meta_tag(key: 'site_name', value: "Get Into Teaching", opengraph: true) %>
   <%= meta_tag(key: 'locale', value: "en_GB", opengraph: true) %>
+  <%= meta_tag(key: 'url', value: request.original_url, opengraph: true) %>
   <%= meta_tag(key: "facebook-domain-verification", value: "h1r6sd9bvqql7fyzy5jmdoniuw1rtf") %>
   <%= image_meta_tags(
     image_path: @front_matter["image"] || @front_matter["meta_image"],

--- a/spec/helpers/metadata_helper_spec.rb
+++ b/spec/helpers/metadata_helper_spec.rb
@@ -14,9 +14,10 @@ describe MetadataHelper, type: "helper" do
 
       specify "renders a meta tag for the #{key}" do
         rendered = Nokogiri.parse(meta_tag(**item[:provided])).at_css("meta")
+        attribute = item.dig(:provided, :opengraph) ? "property" : "name" # Open graph tags should use property
 
         expect(rendered.name).to eql "meta"
-        expect(rendered.attributes["name"].value).to eql(key)
+        expect(rendered.attributes[attribute].value).to eql(key)
         expect(rendered.attributes["content"].value).to eql(value)
       end
     end
@@ -32,13 +33,13 @@ describe MetadataHelper, type: "helper" do
 
       expect(tags).to include(
         <<~HTML.chomp,
-          <meta name="og:image" content="http://test.host/packs-test/v1/static/images/content/hero-images/teacher2-e8f0d711e6d72e7ee752.jpg">
+          <meta property="og:image" content="http://test.host/packs-test/v1/static/images/content/hero-images/teacher2-e8f0d711e6d72e7ee752.jpg">
         HTML
       )
 
       expect(tags).to include(
         <<~HTML.chomp,
-          <meta name="og:image:alt" content="A teacher listening to a group of students">
+          <meta property="og:image:alt" content="A teacher listening to a group of students">
         HTML
       )
     end

--- a/spec/requests/fake_browser_time_spec.rb
+++ b/spec/requests/fake_browser_time_spec.rb
@@ -14,13 +14,13 @@ describe "Fake browser time", type: :request do
     context "when the path has fake_browser_time in the query string" do
       let(:path) { root_path(fake_browser_time: Time.zone.now.to_i) }
 
-      it { is_expected.to include("fake_browser_time") }
+      it { is_expected.to include("js/fake_browser_time") }
     end
 
     context "when the path does not have fake_browser_time in the query string" do
       let(:path) { root_path }
 
-      it { is_expected.not_to include("fake_browser_time") }
+      it { is_expected.not_to include("js/fake_browser_time") }
     end
   end
 
@@ -30,7 +30,11 @@ describe "Fake browser time", type: :request do
     context "when the path has fake_browser_time in the query string" do
       let(:path) { root_path(fake_browser_time: Time.zone.now.to_i) }
 
-      it { is_expected.not_to include("fake_browser_time") }
+      it "does" do
+        puts response.body
+      end
+
+      it { is_expected.not_to include("js/fake_browser_time") }
     end
   end
 end

--- a/spec/requests/fake_browser_time_spec.rb
+++ b/spec/requests/fake_browser_time_spec.rb
@@ -30,10 +30,6 @@ describe "Fake browser time", type: :request do
     context "when the path has fake_browser_time in the query string" do
       let(:path) { root_path(fake_browser_time: Time.zone.now.to_i) }
 
-      it "does" do
-        puts response.body
-      end
-
       it { is_expected.not_to include("js/fake_browser_time") }
     end
   end


### PR DESCRIPTION
### Trello card

### Context

Opengraph images were not working on the `/trainees/got-into-teaching` page

### Changes proposed in this pull request

- Changes our metatags helper to use `property` instead of `name` for opengraph tags as required by the spec
- Adds a `og:url` tag for the original url of the page as required on all pages by the spec

### Guidance to review

