### PR TITLE
Use venue address for event map

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -52,8 +52,15 @@ module EventsHelper
     building = event.building
     return nil unless building
     return building.address_city if event.is_online
+    return event.venue_address.compact.join(",\n") if event.respond_to?(:venue_address)
 
-    event.venue_address.compact.join(",\n")
+    [
+      building.address_line1,
+      building.address_line2,
+      building.address_line3,
+      building.address_city,
+      building.address_postcode,
+    ].compact.join(",\n")
   end
 
   def event_location_map(event)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -52,9 +52,9 @@ module EventsHelper
     building = event.building
     return nil unless building
     return building.address_city if event.is_online
-    return event.venue_address.compact.join(",\n") if event.respond_to?(:venue_address)
 
     [
+      building.venue,
       building.address_line1,
       building.address_line2,
       building.address_line3,

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -53,13 +53,7 @@ module EventsHelper
     return nil unless building
     return building.address_city if event.is_online
 
-    [
-      building.address_line1,
-      building.address_line2,
-      building.address_line3,
-      building.address_city,
-      building.address_postcode,
-    ].compact.join(",\n")
+    event.venue_address.compact.join(",\n")
   end
 
   def event_location_map(event)

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -73,7 +73,7 @@ describe EventsHelper, type: "helper" do
       allow(Rails.application.config.x).to receive(:google_maps_key).and_return("12345")
     end
 
-    it { is_expected.to match(/data-map-description="Line 1,\nLine 2,\nManchester,\nMA1 1AM" /) }
+    it { is_expected.to match(/data-map-description="Albert Hall,\nLine 1,\nLine 2,\nManchester,\nMA1 1AM" /) }
     it { is_expected.to match(/zoom=10/) }
     it { is_expected.to match(/alt="Map showing #{event.name}"/) }
   end
@@ -136,12 +136,12 @@ describe EventsHelper, type: "helper" do
 
     it "returns the address, comma separated with line breaks between parts" do
       expect(event.building).not_to be_nil
-      expect(event_address(event)).to eq("Line 1,\nLine 2,\nManchester,\nMA1 1AM")
+      expect(event_address(event)).to eq("Albert Hall,\nLine 1,\nLine 2,\nManchester,\nMA1 1AM")
     end
 
     it "returns the address, when all fields have values" do
       event.building = building_fully_populated
-      expect(event_address(event)).to eq("Line 1,\nLine 2,\nLine 3,\nManchester,\nMA1 1AM")
+      expect(event_address(event)).to eq("Albert Hall,\nLine 1,\nLine 2,\nLine 3,\nManchester,\nMA1 1AM")
     end
   end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/ylR7Hrwf

### Context

We want to update the Open venue map in Google mapsto use venue name as well as event address

### Changes proposed in this pull request

- Use venue address instead of building address in events helper

### Guidance to review

