### PR TITLE
Better table formatting at high zoom

### DIFF
--- a/app/webpacker/styles/table.scss
+++ b/app/webpacker/styles/table.scss
@@ -15,6 +15,7 @@ table {
       margin-bottom: $table-spacing;
       border-bottom: 1px solid $grey-light;
       word-break: normal;
+      white-space: nowrap;
 
       &:first-child {
         padding-left: 0;
@@ -24,10 +25,15 @@ table {
         padding-right: 0;
       }
     }
+
+    > th:nth-child(1) {
+      white-space: normal;
+    }
   }
 
   tbody td {
     @include font-size("xsmall");
+    white-space: normal;
   }
 
   &.first-column-headings {


### PR DESCRIPTION
### Trello card
[Reflow issue on bursaries page](https://trello.com/c/VPfsc5aM/7610-gds-accessibility-audit-21-reflow-issue-on-bursaries-page-level-aa)

### Context
The table of scholarships and bursaries on the bursaries page was pushing the page width out at high zoom (400% @ 1280px)

### Changes proposed in this pull request
Changes the word-wrap settings for table headings

### Guidance to review

Test at normal zoom and at high zoom. Also test the cookies page which is subtly changed by this PR.

