### PR TITLE
Add padding to links on A-to-Z sitemap

### DIFF
--- a/app/views/sitemap/show.html.erb
+++ b/app/views/sitemap/show.html.erb
@@ -7,9 +7,9 @@
   <div class="row inset">
     <% ('A'..'Z').each do |letter| %>
       <% if @a_z_sitemap_data.key?(letter) %>
-        <%= link_to letter, "##{letter}", class: "link" %>
+        <%= link_to letter, "##{letter}", class: "link link--padding" %>
       <% else %>
-        <span><%= letter %></span>
+        <span class="link--padding"><%= letter %></span>
       <% end %>
     <% end %>
   </div>

--- a/app/webpacker/styles/links-and-buttons.scss
+++ b/app/webpacker/styles/links-and-buttons.scss
@@ -71,6 +71,16 @@
   }
 }
 
+.link--padding {
+  @include mq($from: mobile) {
+    padding: 0.3rem;
+  }
+  @include mq($until: mobile) {
+    margin: 0.6rem;
+    line-height: 2;
+  }
+}
+
 ol.primary > li {
   &:focus {
     border: dotted red 1px;


### PR DESCRIPTION
### Trello card
[Add padding to links on A-to-Z](https://trello.com/c/9zj6uWzL/7987-add-padding-to-links-at-top-of-a-z-index-page)

### Context
Some padding is required on the links to ensure the sitemap is accessible

### Changes proposed in this pull request
Adds padding to links

### Guidance to review
Test using the [target size](https://accessibility.education.gov.uk/knowledge-hub/tools-testing/bookmarklets/target-size) booklet

