### PR TITLE
2340 rate limiting facebook agent

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -11,8 +11,27 @@
         ],
         "environment_short": "pd",
         "origin_hostname": "get-into-teaching-app-production.teacherservices.cloud",
-        "null_host_header": false,
-        "rate_limit": 400
+        "null_host_header": false
       }
+    },
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 400,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    },
+    {
+      "agent": "facebook",
+      "priority": 50,
+      "duration": 1,
+      "limit": 10,
+      "selector": "User-Agent",
+      "operator": "Contains",
+      "match_values": "facebookexternalhit"
     }
+  ]
   }

--- a/terraform/domains/environment_domains/config/test.tfvars.json
+++ b/terraform/domains/environment_domains/config/test.tfvars.json
@@ -1,16 +1,16 @@
 {
-    "hosted_zone": {
-      "getintoteaching.education.gov.uk": {
-        "front_door_name": "s189p01-git-dom-fd",
-        "resource_group_name": "s189p01-git-dom-rg",
-        "domains": [
-          "staging"
-        ],
-        "cached_paths": [
-          "/packs/*"
-        ],
-        "environment_short": "ts",
-        "origin_hostname": "get-into-teaching-app-test.test.teacherservices.cloud"
-      }
+  "hosted_zone": {
+    "getintoteaching.education.gov.uk": {
+      "front_door_name": "s189p01-git-dom-fd",
+      "resource_group_name": "s189p01-git-dom-rg",
+      "domains": [
+        "staging"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "ts",
+      "origin_hostname": "get-into-teaching-app-test.test.teacherservices.cloud"
     }
   }
+}

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -11,7 +11,7 @@ module "domains" {
   null_host_header    = try(each.value.null_host_header, false)
   cached_paths        = try(each.value.cached_paths, [])
   redirect_rules      = try(each.value.redirect_rules, [])
-  rate_limit          = try(each.value.rate_limit, null)
+  rate_limit          = try(var.rate_limit, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -2,3 +2,16 @@ variable "hosted_zone" {
   type    = map(any)
   default = {}
 }
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}


### PR DESCRIPTION
### Trello card

https://trello.com/c/F83a6xQe/2340-rate-limiting-facebook-agent

### Context

rate limit the facebook crawler

### Changes proposed in this pull request

Add rate limiting rules to terraform config

### Guidance to review
make test domains-plan (no change)
make production domains-plan

Has been previously applied manually to test domain, but now removed.


