### PR TITLE
Add image build workflow

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout
 
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
       - name: Build without cache and push docker image
         id: build-image
         uses: DFE-Digital/github-actions/build-docker-image@master

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -32,6 +32,7 @@ jobs:
           reuse-cache: false
           snyk-token: ${{ secrets.SNYK_TOKEN }}
           max-cache: true
+          docker-repository: ${{ env.DOCKER_REPOSITORY }}
 
       - name: Notify slack on failure
         uses: rtCamp/action-slack-notify@master

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -5,97 +5,41 @@ on:
   schedule:
     - cron: '0 12 * * 0'
 
+  push:
+    branches:
+      - add_build_image_gh_wrkflws
+
 permissions:
   contents: write
   packages: write
   id-token: write
 
 jobs:
-  build:
-    name: Build
-    environment: review
+  build-no-cache:
+    outputs:
+      docker-image-tag: ${{ steps.build-image.outputs.tag }}
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        name: Checkout
 
-      - name: set-up-environment
-        uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - uses: Azure/login@v2
+      - name: Build without cache and push docker image
+        id: build-image
+        uses: DFE-Digital/github-actions/build-docker-image@master
         with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch secrets from key vault
-        uses: azure/CLI@v2
-        id: keyvault-yaml-secret
-        with:
-          inlineScript: |
-            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.KEY_VAULT_REVIEW }}" --query "value" -o tsv)
-            echo "::add-mask::$SLACK_WEBHOOK"
-            echo "SLACK_WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
-            SNYK_TOKEN=$(az keyvault secret show --name "SNYK-TOKEN" --vault-name "${{ secrets.KEY_VAULT_REVIEW }}" --query "value" -o tsv)
-            echo "::add-mask::$SNYK_TOKEN"
-            echo "SNYK_TOKEN=$SNYK_TOKEN" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
-
-      - name: Get Short SHA
-        id: sha
-        run: echo "short=$(echo $GITHUB_SHA | cut -c -7)" >> $GITHUB_OUTPUT
-
-      - name: Login to GitHub Container Repository
-        uses: docker/login-action@v3.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push base image
-        uses: docker/build-push-action@v6
-        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           context: .
-          tags: ${{ env.DOCKER_REPOSITORY }}:base-master
-          push: true
-          target: base
-          build-args: |
-            SHA=${{ steps.sha.outputs.short }}
-        env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
+          reuse-cache: false
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+          max-cache: true
 
-      - name: Build release image locally
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: ${{ env.DOCKER_REPOSITORY }}:master
-          push: false
-          load: true
-          build-args: |
-            SHA=${{ steps.sha.outputs.short }}
-        env:
-          DOCKER_BUILD_RECORD_UPLOAD: false
-
-      - name: Run Snyk to check Docker image for vulnerabilities
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK_TOKEN }}
-        with:
-          image: ${{ env.DOCKER_REPOSITORY }}:master
-          args: --severity-threshold=high --file=Dockerfile
-
-      - name: Push image to registry
-        if: success()
-        run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
-
-      - name: Slack Notification
-        if: failure() && github.ref == 'refs/heads/master'
+      - name: Notify slack on failure
         uses: rtCamp/action-slack-notify@master
-        env:
-           SLACK_COLOR: ${{ env.SLACK_ERROR }}
-           SLACK_MESSAGE: 'There has been a failure building the application'
-           SLACK_TITLE: 'Failure Building Application'
-           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+        if: ${{ failure() }}
+        with:
+          SLACK_USERNAME: CI Deployment
+          SLACK_COLOR: failure
+          SLACK_ICON_EMOJI: ":github-logo:"
+          SLACK_TITLE: "Build failure"
+          SLACK_MESSAGE: ":alert: Rebuild docker cache failure :sadparrot:"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context
Use a standard workflow for building container images without using image cache

### Changes proposed in this pull request
Add a new github actions workflow for building images without using image cache

### Guidance to review
Check the workflow - _TBD_

### Trello card 
https://trello.com/c/ktsJEPED/2326-use-build-docker-image-github-action


### Checklist
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

