### PR TITLE
Update bin/dev to restore foreman

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,2 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env bash
+foreman start -f Procfile.dev


### PR DESCRIPTION
### Trello card
[Fix the bin/dev process when running in codespaces](https://trello.com/c/xX4ilya2/8077-fix-the-bin-dev-process-when-running-in-codespaces)

### Context
An upgrade to Rails 8 broke the binding of the bin/dev command to the IP address of the local server

### Changes proposed in this pull request
Restore the previous foreman process

### Guidance to review

