### PR TITLE
Accessible page titles in TTA Funnel

### DIFF
--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -91,15 +91,19 @@ module TeacherTrainingAdviser
     end
 
     def set_step_page_title
-      @page_title = "Get a free adviser"
+      if @current_step.present? && @current_step.title
+        @page_title = @current_step.title
 
-      if @current_step&.title
-        @page_title += ", #{@current_step.title.downcase} step"
+        unless @current_step.respond_to?(:skip_title_suffix?) && @current_step.skip_title_suffix?
+          @page_title << " - Adviser sign up"
+        end
+      else
+        @page_title = "Adviser sign up"
       end
     end
 
     def set_completed_page_title
-      @page_title = "Get a free adviser, sign up completed"
+      @page_title = "You're signed up"
     end
   end
 end

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -94,9 +94,7 @@ module TeacherTrainingAdviser
       if @current_step.present? && @current_step.title
         @page_title = @current_step.title
 
-        unless @current_step.respond_to?(:skip_title_suffix?) && @current_step.skip_title_suffix?
-          @page_title << " - Adviser sign up"
-        end
+        @page_title << " - Adviser sign up" unless @current_step.try(:skip_title_suffix?)
       else
         @page_title = "Adviser sign up"
       end

--- a/app/controllers/teacher_training_adviser/steps_controller.rb
+++ b/app/controllers/teacher_training_adviser/steps_controller.rb
@@ -103,7 +103,7 @@ module TeacherTrainingAdviser
     end
 
     def set_completed_page_title
-      @page_title = "You're signed up"
+      @page_title = "You're signed up for an adviser"
     end
   end
 end

--- a/app/models/concerns/funnel_title.rb
+++ b/app/models/concerns/funnel_title.rb
@@ -5,8 +5,8 @@ module FunnelTitle
     return unless title_attribute
 
     title_scope = title_base_scopes
-                    .map{ |scope| scope << title_class_name_scope }
-                    .find{ |scope| I18n.exists?(title_attribute, scope: scope) }
+                    .map { |scope| scope << title_class_name_scope }
+                    .find { |scope| I18n.exists?(title_attribute, scope: scope) }
     if title_scope
       I18n.t title_attribute, scope: title_scope
     end
@@ -22,8 +22,8 @@ module FunnelTitle
 
   def title_base_scopes
     [
-      [:helpers, :legend],
-      [:helpers, :label]
+      %i[helpers legend],
+      %i[helpers label],
     ]
   end
 

--- a/app/models/concerns/funnel_title.rb
+++ b/app/models/concerns/funnel_title.rb
@@ -1,0 +1,33 @@
+module FunnelTitle
+  include I18n
+
+  def title
+    return unless title_attribute
+
+    title_scope = title_base_scopes
+                    .map{ |scope| scope << title_class_name_scope }
+                    .find{ |scope| I18n.exists?(title_attribute, scope: scope) }
+    if title_scope
+      I18n.t title_attribute, scope: title_scope
+    end
+  end
+
+  def title_attribute
+    attributes.keys.first
+  end
+
+  def title_class_name_scope
+    self.class.name.underscore.gsub("/", "_")
+  end
+
+  def title_base_scopes
+    [
+      [:helpers, :legend],
+      [:helpers, :label]
+    ]
+  end
+
+  def skip_title_suffix?
+    false
+  end
+end

--- a/app/models/concerns/funnel_title.rb
+++ b/app/models/concerns/funnel_title.rb
@@ -1,6 +1,5 @@
+require "i18n"
 module FunnelTitle
-  include I18n
-
   def title
     return unless title_attribute
 

--- a/app/models/teacher_training_adviser/steps/already_signed_up.rb
+++ b/app/models/teacher_training_adviser/steps/already_signed_up.rb
@@ -1,6 +1,5 @@
 module TeacherTrainingAdviser::Steps
   class AlreadySignedUp < GITWizard::Step
-
     include FunnelTitle
 
     def skipped?

--- a/app/models/teacher_training_adviser/steps/already_signed_up.rb
+++ b/app/models/teacher_training_adviser/steps/already_signed_up.rb
@@ -1,5 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class AlreadySignedUp < GITWizard::Step
+
+    include FunnelTitle
+
     def skipped?
       can_subscribe = @store["can_subscribe_to_teacher_training_adviser"]
       can_subscribe.nil? || can_subscribe
@@ -7,6 +10,10 @@ module TeacherTrainingAdviser::Steps
 
     def can_proceed?
       false
+    end
+
+    def title_attribute
+      :title
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/authenticate.rb
+++ b/app/models/teacher_training_adviser/steps/authenticate.rb
@@ -1,5 +1,5 @@
 module TeacherTrainingAdviser::Steps
-  class Authenticate <  GITWizard::Steps::Authenticate
+  class Authenticate < GITWizard::Steps::Authenticate
     include FunnelTitle
 
     def title_attribute

--- a/app/models/teacher_training_adviser/steps/authenticate.rb
+++ b/app/models/teacher_training_adviser/steps/authenticate.rb
@@ -1,0 +1,13 @@
+module TeacherTrainingAdviser::Steps
+  class Authenticate <  GITWizard::Steps::Authenticate
+    include FunnelTitle
+
+    def title_attribute
+      :title
+    end
+
+    def skip_title_suffix?
+      true
+    end
+  end
+end

--- a/app/models/teacher_training_adviser/steps/date_of_birth.rb
+++ b/app/models/teacher_training_adviser/steps/date_of_birth.rb
@@ -17,6 +17,8 @@ module TeacherTrainingAdviser::Steps
     }
     before_validation :date_of_birth, :add_invalid_error
 
+    include FunnelTitle
+
     # Rescue argument error thrown by
     # validates_timeliness/extensions/multiparameter_handler.rb
     # when the user enters a DOB like `-1, -1, -2`.

--- a/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_maths_english.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = Crm::BooleanType::ALL
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["has_gcse_maths_and_english_id"] = OPTIONS.key(has_gcse_maths_and_english_id).to_s.capitalize
@@ -14,10 +16,6 @@ module TeacherTrainingAdviser::Steps
 
     def skipped?
       other_step(:what_degree_class).skipped?
-    end
-
-    def title
-      "english and maths gcses"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/gcse_science.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = Crm::BooleanType::ALL
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["has_gcse_science_id"] = OPTIONS.key(has_gcse_science_id).to_s.capitalize

--- a/app/models/teacher_training_adviser/steps/has_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/has_teacher_id.rb
@@ -4,6 +4,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :has_id, inclusion: { in: [true, false] }
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["has_id"] = has_id ? "Yes" : "No"
@@ -15,10 +17,6 @@ module TeacherTrainingAdviser::Steps
       returning_teacher = other_step(:returning_teacher).returning_to_teaching
 
       !returning_teacher || teacher_id_prefilled
-    end
-
-    def title
-      "have teacher reference number"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/have_a_degree.rb
+++ b/app/models/teacher_training_adviser/steps/have_a_degree.rb
@@ -24,6 +24,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :degree_options, inclusion: { in: DEGREE_OPTIONS.values }
 
+    include FunnelTitle
+
     def degree_options=(value)
       super
       set_degree_status

--- a/app/models/teacher_training_adviser/steps/identity.rb
+++ b/app/models/teacher_training_adviser/steps/identity.rb
@@ -3,6 +3,8 @@ module TeacherTrainingAdviser::Steps
     attribute :channel_id, :integer
     attribute :sub_channel_id
 
+    include FunnelTitle
+
     def export
       super.without("sub_channel_id")
     end
@@ -21,8 +23,12 @@ module TeacherTrainingAdviser::Steps
       super
     end
 
-    def title
-      nil
+    def title_attribute
+      :title
+    end
+
+    def skip_title_suffix?
+      true
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -1,5 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class NoDegree < GITWizard::Step
+
+    include FunnelTitle
+
     def can_proceed?
       false
     end
@@ -9,6 +12,14 @@ module TeacherTrainingAdviser::Steps
       have_degree = have_a_degree_step.degree_options != HaveADegree::DEGREE_OPTIONS[:no]
 
       have_a_degree_step.skipped? || have_degree
+    end
+
+    def title_attribute
+      :title
+    end
+
+    def skip_title_suffix?
+      true
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/no_degree.rb
+++ b/app/models/teacher_training_adviser/steps/no_degree.rb
@@ -1,6 +1,5 @@
 module TeacherTrainingAdviser::Steps
   class NoDegree < GITWizard::Step
-
     include FunnelTitle
 
     def can_proceed?

--- a/app/models/teacher_training_adviser/steps/not_eligible.rb
+++ b/app/models/teacher_training_adviser/steps/not_eligible.rb
@@ -1,6 +1,5 @@
 module TeacherTrainingAdviser::Steps
   class NotEligible < GITWizard::Step
-
     include FunnelTitle
 
     def can_proceed?

--- a/app/models/teacher_training_adviser/steps/not_eligible.rb
+++ b/app/models/teacher_training_adviser/steps/not_eligible.rb
@@ -1,5 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class NotEligible < GITWizard::Step
+
+    include FunnelTitle
+
     def can_proceed?
       false
     end
@@ -10,6 +13,14 @@ module TeacherTrainingAdviser::Steps
       train_to_teach_in_uk = other_step(:train_to_teach_in_uk).train_to_teach_in_uk
 
       !returning_teacher || has_paid_experience_in_uk || train_to_teach_in_uk
+    end
+
+    def title_attribute
+      :title
+    end
+
+    def skip_title_suffix?
+      true
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_callback.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_callback.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :phone_call_scheduled_at, presence: true
 
+    include FunnelTitle
+
     def reviewable_answers
       {
         "callback_date" => phone_call_scheduled_at&.to_date,
@@ -23,8 +25,8 @@ module TeacherTrainingAdviser::Steps
       callback_not_offered || overseas_country_skipped || have_a_degree_skipped || !equivalent_degree
     end
 
-    def title
-      "callback time"
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_country.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_country.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :country_id, lookup_items: { method: :get_countries }
 
+    include FunnelTitle
+
     OMIT_COUNTRY_IDS = [
       "76f5c2e6-74f9-e811-a97a-000d3a2760f2", # Unknown
       "72f5c2e6-74f9-e811-a97a-000d3a2760f2", # United Kingdom
@@ -32,10 +34,6 @@ module TeacherTrainingAdviser::Steps
       super.tap do |answers|
         answers["country_id"] = country_name
       end
-    end
-
-    def title
-      "country"
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/overseas_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_telephone.rb
@@ -8,6 +8,8 @@ module TeacherTrainingAdviser::Steps
       self.address_telephone = address_telephone.to_s.strip.presence
     end
 
+    include FunnelTitle
+
     def self.contains_personal_details?
       true
     end
@@ -30,8 +32,8 @@ module TeacherTrainingAdviser::Steps
       overseas_country_skippped || equivalent_degree
     end
 
-    def title
-      "international telephone"
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
+++ b/app/models/teacher_training_adviser/steps/overseas_time_zone.rb
@@ -13,6 +13,8 @@ module TeacherTrainingAdviser::Steps
       self.address_telephone = address_telephone.to_s.strip.presence
     end
 
+    include FunnelTitle
+
     def self.contains_personal_details?
       true
     end
@@ -45,8 +47,8 @@ module TeacherTrainingAdviser::Steps
       overseas_country_skipped || !equivalent_degree
     end
 
-    def title
-      "contact details and timezone"
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/paid_teaching_experience_in_uk.rb
+++ b/app/models/teacher_training_adviser/steps/paid_teaching_experience_in_uk.rb
@@ -3,6 +3,8 @@ module TeacherTrainingAdviser::Steps
     attribute :has_paid_experience_in_uk, :boolean
     validates :has_paid_experience_in_uk, inclusion: { in: [true, false] }
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["has_paid_experience_in_uk"] = has_paid_experience_in_uk ? "Yes" : "No"

--- a/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
+++ b/app/models/teacher_training_adviser/steps/previous_teacher_id.rb
@@ -2,6 +2,8 @@ module TeacherTrainingAdviser::Steps
   class PreviousTeacherId < GITWizard::Step
     attribute :teacher_id, :string
 
+    include FunnelTitle
+
     def optional?
       true
     end
@@ -16,8 +18,8 @@ module TeacherTrainingAdviser::Steps
       has_teacher_id_skipped || !has_id
     end
 
-    def title
-      "teacher reference number"
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -1,6 +1,5 @@
 module TeacherTrainingAdviser::Steps
   class QualificationRequired < GITWizard::Step
-
     include FunnelTitle
 
     def can_proceed?

--- a/app/models/teacher_training_adviser/steps/qualification_required.rb
+++ b/app/models/teacher_training_adviser/steps/qualification_required.rb
@@ -1,5 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class QualificationRequired < GITWizard::Step
+
+    include FunnelTitle
+
     def can_proceed?
       false
     end
@@ -18,8 +21,12 @@ module TeacherTrainingAdviser::Steps
         (retake_gcse_science_skipped || retaking_gcse_science)
     end
 
-    def title
-      "gcses required"
+    def title_attribute
+      :title
+    end
+
+    def skip_title_suffix?
+      true
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_maths_english.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = Crm::BooleanType::ALL
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["planning_to_retake_gcse_maths_and_english_id"] =
@@ -20,10 +22,6 @@ module TeacherTrainingAdviser::Steps
       has_gcse_maths_english = has_gcse_maths_and_english_id != GcseMathsEnglish::OPTIONS["No"]
 
       gcse_maths_english_skipped || has_gcse_maths_english
-    end
-
-    def title
-      "retake english and maths gcses"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
+++ b/app/models/teacher_training_adviser/steps/retake_gcse_science.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = Crm::BooleanType::ALL
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["planning_to_retake_gcse_science_id"] =

--- a/app/models/teacher_training_adviser/steps/returning_teacher.rb
+++ b/app/models/teacher_training_adviser/steps/returning_teacher.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :type_id, pick_list_items: { method: :get_candidate_types }
 
+    include FunnelTitle
+
     def returning_to_teaching
       type_id == OPTIONS[:returning_to_teaching]
     end

--- a/app/models/teacher_training_adviser/steps/review_answers.rb
+++ b/app/models/teacher_training_adviser/steps/review_answers.rb
@@ -1,6 +1,5 @@
 module TeacherTrainingAdviser::Steps
   class ReviewAnswers < GITWizard::Step
-
     include FunnelTitle
 
     def personal_detail_answers_by_step

--- a/app/models/teacher_training_adviser/steps/review_answers.rb
+++ b/app/models/teacher_training_adviser/steps/review_answers.rb
@@ -1,5 +1,8 @@
 module TeacherTrainingAdviser::Steps
   class ReviewAnswers < GITWizard::Step
+
+    include FunnelTitle
+
     def personal_detail_answers_by_step
       answers_by_step.select { |k| k.contains_personal_details? } # rubocop:disable Style/SymbolProc
     end
@@ -11,6 +14,10 @@ module TeacherTrainingAdviser::Steps
     def seen?
       # ensure this step is always shown to the candidate
       false
+    end
+
+    def title_attribute
+      :title
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/stage_interested_teaching.rb
@@ -8,6 +8,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["preferred_education_phase_id"] = OPTIONS.key(preferred_education_phase_id).to_s.capitalize
@@ -20,10 +22,6 @@ module TeacherTrainingAdviser::Steps
 
     def returning_teacher?
       other_step(:returning_teacher).returning_to_teaching
-    end
-
-    def title
-      "stage interested in teaching"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_of_degree.rb
+++ b/app/models/teacher_training_adviser/steps/stage_of_degree.rb
@@ -16,6 +16,8 @@ module TeacherTrainingAdviser::Steps
 
     NOT_FINAL_YEAR = DEGREE_STATUS.except(:final_year)
 
+    include FunnelTitle
+
     def skipped?
       have_a_degree_step = other_step(:have_a_degree)
       studying = have_a_degree_step.degree_options == HaveADegree::DEGREE_OPTIONS[:studying]
@@ -36,10 +38,6 @@ module TeacherTrainingAdviser::Steps
 
     def self.options
       generate_api_options(GetIntoTeachingApiClient::PickListItemsApi, :get_qualification_degree_status, nil, DEGREE_STATUS.values)
-    end
-
-    def title
-      "degree stage"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/stage_taught.rb
+++ b/app/models/teacher_training_adviser/steps/stage_taught.rb
@@ -8,6 +8,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["stage_taught_id"] = OPTIONS.key(stage_taught_id).to_s.capitalize

--- a/app/models/teacher_training_adviser/steps/stage_trained.rb
+++ b/app/models/teacher_training_adviser/steps/stage_trained.rb
@@ -10,6 +10,8 @@ module TeacherTrainingAdviser::Steps
 
     OPTIONS = { primary: 222_750_000, secondary: 222_750_001 }.freeze
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["stage_taught_id"] = OPTIONS.key(stage_taught_id).to_s.capitalize
@@ -30,10 +32,6 @@ module TeacherTrainingAdviser::Steps
 
     def stage_taught_primary?
       stage_taught_id == OPTIONS[:primary]
-    end
-
-    def title
-      "stage trained to teach"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     NOT_SURE_ID = 12_917
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["initial_teacher_training_year_id"] = years.find { |y| y.id == initial_teacher_training_year_id }&.value
@@ -43,10 +45,6 @@ module TeacherTrainingAdviser::Steps
                       end
 
       itt_years.find { |item| item.value == inferred_year.to_s }&.id
-    end
-
-    def title
-      "teacher training year"
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
+++ b/app/models/teacher_training_adviser/steps/subject_interested_teaching.rb
@@ -4,6 +4,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_teaching_subject_id, lookup_items: { method: :get_teaching_subjects }
 
+    include FunnelTitle
+
     def self.options
       Crm::TeachingSubject.all_without_primary
     end
@@ -20,10 +22,6 @@ module TeacherTrainingAdviser::Steps
       phase_is_not_secondary = preferred_education_phase_id != StageInterestedTeaching::OPTIONS[:secondary]
 
       have_a_degree_skipped || phase_is_not_secondary
-    end
-
-    def title
-      "subject interested in teaching"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
+++ b/app/models/teacher_training_adviser/steps/subject_like_to_teach.rb
@@ -4,6 +4,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :preferred_teaching_subject_id, lookup_items: { method: :get_teaching_subjects }
 
+    include FunnelTitle
+
     def self.options
       Crm::TeachingSubject.all_without_primary
     end
@@ -17,10 +19,6 @@ module TeacherTrainingAdviser::Steps
       super.tap do |answers|
         answers["preferred_teaching_subject_id"] = Crm::TeachingSubject.lookup_by_uuid(preferred_teaching_subject_id)
       end
-    end
-
-    def title
-      "subject you want to teach"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/subject_taught.rb
+++ b/app/models/teacher_training_adviser/steps/subject_taught.rb
@@ -4,6 +4,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :subject_taught_id, lookup_items: { method: :get_teaching_subjects }
 
+    include FunnelTitle
+
     def self.options
       Crm::TeachingSubject.all_without_primary
     end

--- a/app/models/teacher_training_adviser/steps/subject_trained.rb
+++ b/app/models/teacher_training_adviser/steps/subject_trained.rb
@@ -7,6 +7,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :subject_taught_id, lookup_items: { method: :get_teaching_subjects }
 
+    include FunnelTitle
+
     def self.options
       Crm::TeachingSubject.all_without_primary
     end
@@ -24,10 +26,6 @@ module TeacherTrainingAdviser::Steps
       super.tap do |answers|
         answers["subject_taught_id"] = Crm::TeachingSubject.lookup_by_uuid(subject_taught_id)
       end
-    end
-
-    def title
-      "subject trained to teach"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/train_to_teach_in_uk.rb
+++ b/app/models/teacher_training_adviser/steps/train_to_teach_in_uk.rb
@@ -3,6 +3,8 @@ module TeacherTrainingAdviser::Steps
     attribute :train_to_teach_in_uk, :boolean
     validates :train_to_teach_in_uk, inclusion: { in: [true, false] }
 
+    include FunnelTitle
+
     def reviewable_answers
       super.tap do |answers|
         answers["train_to_teach_in_uk"] = train_to_teach_in_uk ? "Yes" : "No"

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -6,16 +6,14 @@ module TeacherTrainingAdviser::Steps
 
     before_validation :sanitize_input
 
+    include FunnelTitle
+
     def self.contains_personal_details?
       true
     end
 
     def skipped?
       other_step(:uk_or_overseas).uk_or_overseas != UkOrOverseas::OPTIONS[:uk]
-    end
-
-    def title
-      "postcode"
     end
 
   private

--- a/app/models/teacher_training_adviser/steps/uk_callback.rb
+++ b/app/models/teacher_training_adviser/steps/uk_callback.rb
@@ -13,6 +13,8 @@ module TeacherTrainingAdviser::Steps
       self.address_telephone = address_telephone.to_s.strip.presence
     end
 
+    include FunnelTitle
+
     def self.contains_personal_details?
       true
     end
@@ -38,6 +40,10 @@ module TeacherTrainingAdviser::Steps
       equivalent_degree = have_a_degree_step.degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       uk_address_skipped || have_a_degree_skipped || !equivalent_degree
+    end
+
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
+++ b/app/models/teacher_training_adviser/steps/uk_or_overseas.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :uk_or_overseas, inclusion: { in: OPTIONS.values }
 
+    include FunnelTitle
+
     def uk?
       uk_or_overseas == OPTIONS[:uk]
     end
@@ -14,10 +16,6 @@ module TeacherTrainingAdviser::Steps
       {
         "uk_or_overseas" => uk_or_overseas,
       }
-    end
-
-    def title
-      "location"
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_telephone.rb
+++ b/app/models/teacher_training_adviser/steps/uk_telephone.rb
@@ -8,6 +8,8 @@ module TeacherTrainingAdviser::Steps
       self.address_telephone = address_telephone.to_s.strip.presence
     end
 
+    include FunnelTitle
+
     def self.contains_personal_details?
       true
     end
@@ -24,6 +26,10 @@ module TeacherTrainingAdviser::Steps
       equivalent_degree = degree_options == HaveADegree::DEGREE_OPTIONS[:equivalent]
 
       uk_address_skipped || equivalent_degree
+    end
+
+    def title_attribute
+      :fieldset
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -38,9 +38,9 @@ module TeacherTrainingAdviser::Steps
 
     def title_attribute
       if studying?
-        'uk_degree_grade_id.studying'
+        "uk_degree_grade_id.studying"
       else
-        'uk_degree_grade_id.graduated'
+        "uk_degree_grade_id.graduated"
       end
     end
   end

--- a/app/models/teacher_training_adviser/steps/what_degree_class.rb
+++ b/app/models/teacher_training_adviser/steps/what_degree_class.rb
@@ -9,6 +9,8 @@ module TeacherTrainingAdviser::Steps
 
     attribute :uk_degree_grade_id, :integer
 
+    include FunnelTitle
+
     def self.options
       generate_api_options(GetIntoTeachingApiClient::PickListItemsApi, :get_qualification_uk_degree_grades, OMIT_GRADE_IDS)
     end
@@ -34,8 +36,12 @@ module TeacherTrainingAdviser::Steps
       end
     end
 
-    def title
-      "degree class"
+    def title_attribute
+      if studying?
+        'uk_degree_grade_id.studying'
+      else
+        'uk_degree_grade_id.graduated'
+      end
     end
   end
 end

--- a/app/models/teacher_training_adviser/steps/what_subject_degree.rb
+++ b/app/models/teacher_training_adviser/steps/what_subject_degree.rb
@@ -6,6 +6,8 @@ module TeacherTrainingAdviser::Steps
 
     validates :degree_subject, presence: true
 
+    include FunnelTitle
+
     def initialize(wizard, store, attributes = {}, *args)
       super
       assign_attributes({ degree_subject_nojs: degree_subject })
@@ -25,10 +27,6 @@ module TeacherTrainingAdviser::Steps
       ].none?(degree_options)
 
       have_a_degree_skipped || not_studying_or_have_a_degree
-    end
-
-    def title
-      "degree subject"
     end
   end
 end

--- a/app/models/teacher_training_adviser/wizard.rb
+++ b/app/models/teacher_training_adviser/wizard.rb
@@ -14,7 +14,7 @@ module TeacherTrainingAdviser
 
     self.steps = [
       Steps::Identity,
-      GITWizard::Steps::Authenticate,
+      Steps::Authenticate,
       Steps::AlreadySignedUp,
       Steps::ReturningTeacher,
       Steps::HasTeacherId,

--- a/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
+++ b/app/views/teacher_training_adviser/steps/_already_signed_up.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <h1>You've already signed up</h1>
+  <%= tag.h1 t("helpers.label.teacher_training_adviser_steps_already_signed_up.title") %>
 
   <p>The email address <%= mail_to(session["sign_up"]["email"], nil) %> has already been used to sign up for an adviser.</p>
 

--- a/app/views/teacher_training_adviser/steps/_authenticate.html.erb
+++ b/app/views/teacher_training_adviser/steps/_authenticate.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_fieldset legend: { text: "You're already registered with us", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t('helpers.label.teacher_training_adviser_steps_authenticate.title'), tag: "h1" } do %>
   <%= render "wizard/steps/authenticate", f: f, resend_verification_path: resend_verification_teacher_training_adviser_steps_path %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_has_teacher_id.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_radio_buttons_fieldset(:has_id, inline: true, legend: { tag: "h1", text: "Do you have a teacher reference number (TRN)?" }) do %>
+<%= f.govuk_radio_buttons_fieldset(:has_id, inline: true, legend: { tag: "h1" }) do %>
   <%= f.govuk_radio_button :has_id, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :has_id, false, label: { text: 'No' }, link_errors: true %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_identity.html.erb
+++ b/app/views/teacher_training_adviser/steps/_identity.html.erb
@@ -2,7 +2,7 @@
 <% content_for(:right_image) { "images/content/tta-sign-up/right.jpg" } %>
 <% content_for(:mobile_image) { "images/content/tta-sign-up/mobile.jpg" } %>
 
-<h1>Get a free adviser</h1>
+<%= tag.h1 t("helpers.label.teacher_training_adviser_steps_identity.title") %>
 
 <p>
   If you're thinking about teaching in England, an adviser can provide free, one-to-one support by phone,

--- a/app/views/teacher_training_adviser/steps/_no_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_no_degree.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-form-group">
-  <h1>We're sorry, but you need a degree to sign up for an adviser</h1>
+  <%=tag.h1 t("helpers.label.teacher_training_adviser_steps_no_degree.title") %>
 
-    <p>You need a bachelor’s degree to train to teach in primary, secondary and special schools in England.</p>
-    <p>If you do not already have one, you can <%= link_to("train to be a qualified teacher as part of your bachelor’s degree", "/train-to-be-a-teacher/if-you-dont-have-a-degree") %>.</p>
-    <p>You can also <%= link_to("teach in further education", "https://www.teachinfurthereducation.education.gov.uk/") %> without a degree.</p>
-    <p><%= link_to("Find out more about the qualifications you need to teach", "/train-to-be-a-teacher/qualifications-you-need-to-teach") %>.</p>
+  <p>You need a bachelor’s degree to train to teach in primary, secondary and special schools in England.</p>
+  <p>If you do not already have one, you can <%= link_to("train to be a qualified teacher as part of your bachelor’s degree", "/train-to-be-a-teacher/if-you-dont-have-a-degree") %>.</p>
+  <p>You can also <%= link_to("teach in further education", "https://www.teachinfurthereducation.education.gov.uk/") %> without a degree.</p>
+  <p><%= link_to("Find out more about the qualifications you need to teach", "/train-to-be-a-teacher/qualifications-you-need-to-teach") %>.</p>
 </div>

--- a/app/views/teacher_training_adviser/steps/_no_degree.html.erb
+++ b/app/views/teacher_training_adviser/steps/_no_degree.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <%=tag.h1 t("helpers.label.teacher_training_adviser_steps_no_degree.title") %>
+  <%= tag.h1 t("helpers.label.teacher_training_adviser_steps_no_degree.title") %>
 
   <p>You need a bachelor’s degree to train to teach in primary, secondary and special schools in England.</p>
   <p>If you do not already have one, you can <%= link_to("train to be a qualified teacher as part of your bachelor’s degree", "/train-to-be-a-teacher/if-you-dont-have-a-degree") %>.</p>

--- a/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
+++ b/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <%=tag.h1 t("helpers.label.teacher_training_adviser_steps_not_eligible.title") %>
+  <%= tag.h1 t("helpers.label.teacher_training_adviser_steps_not_eligible.title") %>
 
   <p>To get a return to teaching adviser, you need to have either:</p>
   <ul>

--- a/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
+++ b/app/views/teacher_training_adviser/steps/_not_eligible.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <h1>Sorry, you are not eligible for this service</h1>
+  <%=tag.h1 t("helpers.label.teacher_training_adviser_steps_not_eligible.title") %>
 
   <p>To get a return to teaching adviser, you need to have either:</p>
   <ul>

--- a/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_callback.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_fieldset legend: { text: "Choose a time", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t("helpers.legend.teacher_training_adviser_steps_overseas_callback.fieldset"), tag: "h1" } do %>
 <%= f.govuk_select :phone_call_scheduled_at, callback_options(f.object.class.callback_booking_quotas) %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_telephone.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t('helpers.legend.teacher_training_adviser_steps_overseas_telephone.fieldset'), tag: "h1" } do %>
   <%= f.govuk_phone_field :address_telephone, width: 20, prefix_text: "+", value: f.object.address_telephone_value, autocomplete: "tel-national" %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_overseas_time_zone.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_fieldset legend: { text: "You told us you have an equivalent degree and live overseas", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t("helpers.legend.teacher_training_adviser_steps_overseas_time_zone.fieldset"), tag: "h1" } do %>
 
 <% if f.object.class.callback_booking_quotas.any? %>
   <p>We need to call you to check your degree. When we call, our adviser will ask for more details about the qualification you have.</p>

--- a/app/views/teacher_training_adviser/steps/_paid_teaching_experience_in_uk.html.erb
+++ b/app/views/teacher_training_adviser/steps/_paid_teaching_experience_in_uk.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_radio_buttons_fieldset(:has_paid_experience_in_uk, inline: true, legend: { tag: "h1", text: "Do you have paid teaching experience in the UK of at least one term?" }) do %>
+<%= f.govuk_radio_buttons_fieldset(:has_paid_experience_in_uk, inline: true, legend: { tag: "h1" }) do %>
   <%= f.govuk_radio_button :has_paid_experience_in_uk, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :has_paid_experience_in_uk, false, label: { text: 'No' }, link_errors: true %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
+++ b/app/views/teacher_training_adviser/steps/_previous_teacher_id.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_fieldset legend: { text: "What is your teacher reference number (TRN)?", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t("helpers.legend.teacher_training_adviser_steps_previous_teacher_id.fieldset"), tag: "h1" } do %>
   <%= f.govuk_text_field :teacher_id, width: 20 %>
 <% end %>
 <details class="govuk-details">

--- a/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
+++ b/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
@@ -1,4 +1,4 @@
-<h1>We're sorry, but you need the right GCSEs to sign up for an adviser</h1>
+<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_qualification_required.title')  %>
 <div class="govuk-form-group">
     <p>To train to be a teacher, teacher training providers ask you to show your ability through GCSEs. You'll need the following GCSEs (or an equivalent):</p>
 

--- a/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
+++ b/app/views/teacher_training_adviser/steps/_qualification_required.html.erb
@@ -1,4 +1,4 @@
-<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_qualification_required.title')  %>
+<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_qualification_required.title') %>
 <div class="govuk-form-group">
     <p>To train to be a teacher, teacher training providers ask you to show your ability through GCSEs. You'll need the following GCSEs (or an equivalent):</p>
 

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,4 +1,4 @@
-<h1>Check your answers before you continue</h1>
+<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_review_answers.title')  %>
 
 <h2 class="govuk-heading-m">Personal details</h2>
 

--- a/app/views/teacher_training_adviser/steps/_review_answers.html.erb
+++ b/app/views/teacher_training_adviser/steps/_review_answers.html.erb
@@ -1,4 +1,4 @@
-<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_review_answers.title')  %>
+<%= tag.h1 t('helpers.label.teacher_training_adviser_steps_review_answers.title') %>
 
 <h2 class="govuk-heading-m">Personal details</h2>
 

--- a/app/views/teacher_training_adviser/steps/_train_to_teach_in_uk.html.erb
+++ b/app/views/teacher_training_adviser/steps/_train_to_teach_in_uk.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_radio_buttons_fieldset(:train_to_teach_in_uk, inline: true, legend: { tag: "h1", text: "Did you train to teach in the UK?" }) do %>
+<%= f.govuk_radio_buttons_fieldset(:train_to_teach_in_uk, inline: true, legend: { tag: "h1" }) do %>
   <%= f.govuk_radio_button :train_to_teach_in_uk, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :train_to_teach_in_uk, false, label: { text: 'No' }, link_errors: true %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_address.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_address.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", width: 20, label: { text: "What is your postcode?", size: "m", tag: "h1" } do %>
+<%= f.govuk_text_field :address_postcode, autocomplete: "postal-code", width: 20, label: { size: "m", tag: "h1" } do %>
   <p>We try and match you with an adviser providing support in your region.</p>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_callback.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_fieldset legend: { text: "You told us you have an equivalent degree and live in the United Kingdom", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t("helpers.legend.teacher_training_adviser_steps_uk_callback.fieldset"), tag: "h1" } do %>
 
 <% if f.object.class.callback_booking_quotas.any? %>
   <p>You need to book a callback with us to check your degree. We will contact you once your call is booked.</p>

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_fieldset legend: { text: "What is your telephone number?", tag: "h1" } do %>
+<%= f.govuk_fieldset legend: {  text: t('helpers.legend.teacher_training_adviser_steps_uk_telephone.fieldset'), tag: "h1" } do %>
   <%= f.govuk_phone_field :address_telephone, autocomplete: "tel", width: 20 %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
+++ b/app/views/teacher_training_adviser/steps/_uk_telephone.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_fieldset legend: {  text: t('helpers.legend.teacher_training_adviser_steps_uk_telephone.fieldset'), tag: "h1" } do %>
+<%= f.govuk_fieldset legend: { text: t('helpers.legend.teacher_training_adviser_steps_uk_telephone.fieldset'), tag: "h1" } do %>
   <%= f.govuk_phone_field :address_telephone, autocomplete: "tel", width: 20 %>
 <% end %>

--- a/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
+++ b/app/views/teacher_training_adviser/steps/_what_degree_class.html.erb
@@ -1,8 +1,8 @@
 <%
 text = if f.object.studying?
-         "What degree class are you predicted to get?"
+         t('helpers.label.teacher_training_adviser_steps_what_degree_class.uk_degree_grade_id.studying')
        else
-         "Which class is your degree?"
+         t('helpers.label.teacher_training_adviser_steps_what_degree_class.uk_degree_grade_id.graduated')
        end
 %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -710,6 +710,7 @@ en:
         timed_one_time_password: "Enter your verification code:"
 
       teacher_training_adviser_steps_identity:
+        title: "Get a free adviser"
         first_name: "First name"
         last_name: "Last name"
         email: "Email address"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -725,6 +725,11 @@ en:
       teacher_training_adviser_steps_what_subject_degree:
         degree_subject: "What subject is your degree?"
         degree_subject_nojs: "What subject is your degree?"
+      teacher_training_adviser_steps_what_degree_class:
+        uk_degree_grade_id:
+          graduated: "Which class is your degree?"
+          studying: "What degree class are you predicted to get?"
+
       teacher_training_adviser_steps_subject_like_to_teach:
         preferred_teaching_subject_id: "Which subject would you like to teach if you return to teaching?"
       teacher_training_adviser_steps_subject_taught:
@@ -740,6 +745,8 @@ en:
       teacher_training_adviser_steps_uk_callback:
         address_telephone: "Contact telephone number"
         phone_call_scheduled_at: "Select your preferred day and time for a callback"
+      teacher_training_adviser_steps_uk_address:
+        address_postcode: "What is your postcode?"
       teacher_training_adviser_steps_overseas_country:
         country_id: "Which country do you live in?"
       teacher_training_adviser_steps_uk_or_overseas:
@@ -784,6 +791,18 @@ en:
           equivalent: "I am not a UK citizen and have, or am studying for, an equivalent qualification"
           "no": "No"
           studying: "I'm studying for a degree"
+      teacher_training_adviser_steps_qualification_required:
+        title: "We're sorry, but you need the right GCSEs to sign up for an adviser"
+      teacher_training_adviser_steps_review_answers:
+        title: "Check your answers before you continue"
+      teacher_training_adviser_steps_authenticate:
+        title: "You're already registered with us"
+      teacher_training_adviser_steps_already_signed_up:
+        title: "You've already signed up"
+      teacher_training_adviser_steps_no_degree:
+        title: "We're sorry, but you need a degree to sign up for an adviser"
+      teacher_training_adviser_steps_not_eligible:
+        title: "Sorry, you are not eligible for this service"
 
       teacher_training_adviser_feedback:
         unsuccessful_visit_explanation: "Give details"
@@ -908,9 +927,27 @@ en:
       teacher_training_adviser_steps_returning_teacher:
         type_id: "Are you qualified to teach?"
       teacher_training_adviser_steps_has_teacher_id:
-        has_id: "Do you have your previous teacher reference number?"
+        has_id: "Do you have a teacher reference number (TRN)?"
+      teacher_training_adviser_steps_paid_teaching_experience_in_uk:
+        has_paid_experience_in_uk: "Do you have paid teaching experience in the UK of at least one term?"
       teacher_training_adviser_steps_have_a_degree:
         degree_options: "Do you have a degree?"
+      teacher_training_adviser_steps_train_to_teach_in_uk:
+        train_to_teach_in_uk: "Did you train to teach in the UK?"
+      teacher_training_adviser_steps_uk_telephone:
+        fieldset: "What is your telephone number?"
+      teacher_training_adviser_steps_overseas_telephone:
+        fieldset: "What is your telephone number?"
+      teacher_training_adviser_steps_overseas_callback:
+        fieldset: "Choose a time"
+      teacher_training_adviser_steps_overseas_time_zone:
+        fieldset: "You told us you have an equivalent degree and live overseas"
+      teacher_training_adviser_steps_previous_teacher_id:
+        fieldset: "What is your teacher reference number (TRN)?"
+      teacher_training_adviser_steps_uk_callback:
+        fieldset: "You told us you have an equivalent degree and live in the United Kingdom"
+
+
 
   internal:
     status:

--- a/spec/features/teacher_training_adviser/sign_up_spec.rb
+++ b/spec/features/teacher_training_adviser/sign_up_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       # check page title remains correct for non completed steps
       expect(page).to have_css "h1", text: "Where do you live?"
       click_on "Next step"
-      expect(page).to have_title("Get a free adviser, location step | Get Into Teaching GOV.UK")
+      expect(page).to have_title("Error: Where do you live? - Adviser sign up | Get Into Teaching GOV.UK")
       choose "UK"
       click_on "Next step"
 
@@ -1078,11 +1078,11 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Send another code to verify my details"
 
       expect(page).to have_text "We've sent you another email"
-      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field", with: invalid_code
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field", with: invalid_code
       click_on "Next step"
 
       expect(page).to have_text "Please enter the latest verification code sent to your email address"
-      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field-error", with: valid_code
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field-error", with: valid_code
       click_on "Next step"
 
       expect(page).to have_css "h1", text: "Are you qualified to teach?"
@@ -1157,7 +1157,7 @@ RSpec.feature "Sign up for a teacher training adviser", type: :feature do
       click_on "Next step"
 
       expect(page).to have_css "h1", text: "You're already registered with us"
-      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field", with: valid_code
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field", with: valid_code
       click_on "Next step"
 
       expect(page).to have_css "h1", text: "Are you qualified to teach?"

--- a/spec/models/concerns/funnel_title_spec.rb
+++ b/spec/models/concerns/funnel_title_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe FunnelTitle do
+  let(:testing_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include FunnelTitle
+
+      attribute :attrib1, :integer
+
+      def self.name
+        "Namespace::ExampleClass"
+      end
+    end
+  end
+
+  let(:instance) { testing_class.new }
+
+  describe "#title_attribute" do
+    subject { instance.title_attribute }
+
+    it { is_expected.to eql("attrib1") }
+  end
+
+  describe "#title_class_name_scope" do
+    subject { instance.title_class_name_scope }
+
+    it { is_expected.to eql("namespace_example_class") }
+  end
+
+  describe "#title_base_scopes" do
+    subject { instance.title_base_scopes }
+
+    it { is_expected.to contain_exactly(%i[helpers legend], %i[helpers label]) }
+  end
+
+  describe "#title" do
+    before do
+      instance.title_base_scopes.each do |s|
+        scope = s + %w[namespace_example_class]
+        allow(I18n).to receive(:exists?).with("attrib1", scope: scope) { translation_exists }
+        allow(I18n).to receive(:t).with("attrib1", scope: scope).and_return("Hello World")
+      end
+    end
+
+    subject { instance.title }
+
+    context "when translation is present" do
+      let(:translation_exists) { true }
+
+      it { is_expected.to eql("Hello World") }
+    end
+
+    context "when translation is missing" do
+      let(:translation_exists) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/teacher_training_adviser/wizard_spec.rb
+++ b/spec/models/teacher_training_adviser/wizard_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TeacherTrainingAdviser::Wizard do
     it do
       expect(subject).to eql [
         TeacherTrainingAdviser::Steps::Identity,
-        GITWizard::Steps::Authenticate,
+        TeacherTrainingAdviser::Steps::Authenticate,
         TeacherTrainingAdviser::Steps::AlreadySignedUp,
         TeacherTrainingAdviser::Steps::ReturningTeacher,
         TeacherTrainingAdviser::Steps::HasTeacherId,

--- a/spec/support/spec_helpers/contract.rb
+++ b/spec/support/spec_helpers/contract.rb
@@ -254,7 +254,7 @@ module SpecHelpers
     end
 
     def submit_verification_code(candidate_identity)
-      fill_in "git-wizard-steps-authenticate-timed-one-time-password-field", with: "123456"
+      fill_in "teacher-training-adviser-steps-authenticate-timed-one-time-password-field", with: "123456"
       mock_exchange_code_for_candidate(candidate_identity)
       click_on_continue
     end


### PR DESCRIPTION
### Trello card
[Insufficiently descriptive page titles in TTA funnel](https://trello.com/c/JGTkTYCw/8052-gds-accessibility-audit-26-insufficiently-descriptive-page-titles-in-adviser-funnel)

### Context
The page titles in the Teaching Training Adviser (TTA) funnel  did not match the `<h1>` headings, which leads to poor accessibility

### Changes proposed in this pull request
Refactor code in TTA to ensure page titles are populated from locales config and used in both page titles and in `<h1>`s

### Guidance to review
Test multiple paths of the funnel

NB: as specified in the requirements, the following pages will have non-matching titles:

* start page (`/identity`)
* `/authenticate`
* `/no_degree`
* `/qualification_required`
* `/completed`

