### PR TITLE
Remove callback from the mailing list completion page

### DIFF
--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -41,8 +41,6 @@
         <% if studying? %>
           <%= render "mailing_list/steps/completed/shared/steps_to_become_a_teacher" %>
         <% end %>
-
-        <%= render(partial: "mailing_list/steps/completed/shared/book_a_callback") %>
       </div>
     </section>
   </section>

--- a/app/views/mailing_list/steps/completed/shared/_book_a_callback.html.erb
+++ b/app/views/mailing_list/steps/completed/shared/_book_a_callback.html.erb
@@ -1,9 +1,0 @@
-<h3 class="heading-s">Have a question?</h3>
-
-<p>
-  Our helpful team of experts can answer any teacher training questions, including what teaching is like, qualifications, routes into teaching or your application.
-</p>
-
-<p>
-  <a href="tel:08003892500">Call us on 0800 389 2500</a> Monday to Friday between 8:30am and 5:30pm, (except on <a href="https://www.gov.uk/bank-holidays">bank holidays</a>) or <%= link_to("choose a time for us to give you a call", callbacks_steps_path,) %>.
-</p>

--- a/docs/sign-up-journeys.md
+++ b/docs/sign-up-journeys.md
@@ -20,12 +20,7 @@ graph TD;
 
   subject --> postcode["What's your UK postcode? (optional)"]
   
-  postcode --> offer_callback{Offer callback?}
-  
-  offer_callback -- Slots Available --> completed_with_callback["You've signed up with Book a Callback link"]
-  offer_callback -- No Slots Available --> completed[You've signed up] 
-
-  completed_with_callback --> book_a_callback[Book a Callback]
+  postcode --> completed[You've signed up] 
 ```
 
 ## Event sign up flow

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_title("Free personalised teacher training guidance, sign up completed | Get Into Teaching")
-    expect(page).to have_text "Test, you're signed up")
+    expect(page).to have_text "Test, you're signed up"
   end
 
   scenario "Full journey as an on-campus candidate" do

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -45,8 +45,7 @@ RSpec.feature "Mailing list wizard", type: :feature do
     click_on "Complete sign up"
 
     expect(page).to have_title("Free personalised teacher training guidance, sign up completed | Get Into Teaching")
-    expect(page).to have_text "Test, you're signed up"
-    expect(page).to have_link("choose a time for us to give you a call")
+    expect(page).to have_text "Test, you're signed up")
   end
 
   scenario "Full journey as an on-campus candidate" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/R7y8IJyP/8055-remove-callback-funnel-link-from-mailing-list-completion-page
### Context

### Changes proposed in this pull request
Remove the callback signposting from the mailing list completion page
### Guidance to review

