### PR TITLE
Fix completion page (next steps) logic on mailing list

### DIFF
--- a/app/helpers/mailing_list_helper.rb
+++ b/app/helpers/mailing_list_helper.rb
@@ -1,29 +1,29 @@
 module MailingListHelper
-  def high_commitment?(consideration_journey_stage: consideration_journey_stage_id)
+  def ml_high_commitment?(consideration_journey_stage: ml_consideration_journey_stage_id)
     consideration_journey_stage == Crm::OptionSet.lookup_by_key(:consideration_journey_stage, :i_m_very_sure_and_think_i_ll_apply)
   end
 
-  def low_commitment?(consideration_journey_stage: consideration_journey_stage_id)
+  def ml_low_commitment?(consideration_journey_stage: ml_consideration_journey_stage_id)
     consideration_journey_stage == Crm::OptionSet.lookup_by_key(:consideration_journey_stage, :it_s_just_an_idea)
   end
 
-  def graduate?(degree_status: degree_status_id)
+  def ml_graduate?(degree_status: ml_degree_status_id)
     degree_status == Crm::OptionSet.lookup_by_key(:degree_status, :graduate_or_postgraduate)
   end
 
-  def studying?(degree_status: degree_status_id)
+  def ml_studying?(degree_status: ml_degree_status_id)
     degree_status == Crm::OptionSet.lookup_by_key(:degree_status, :not_yet_i_m_studying_for_one)
   end
 
-  def no_degree?(degree_status: degree_status_id)
+  def ml_no_degree?(degree_status: ml_degree_status_id)
     degree_status == Crm::OptionSet.lookup_by_key(:degree_status, :i_don_t_have_a_degree_and_am_not_studying_for_one)
   end
 
-  def degree_status_id
+  def ml_degree_status_id
     session.dig("mailinglist", "degree_status_id")
   end
 
-  def consideration_journey_stage_id
+  def ml_consideration_journey_stage_id
     session.dig("mailinglist", "consideration_journey_stage_id")
   end
 end

--- a/app/views/mailing_list/steps/completed.html.erb
+++ b/app/views/mailing_list/steps/completed.html.erb
@@ -18,27 +18,27 @@
 
         <h2 class="heading-m">Your next steps</h2>
 
-        <% if graduate? && high_commitment? %>
+        <% if ml_graduate? && ml_high_commitment? %>
           <%= render "mailing_list/steps/completed/shared/get_an_adviser_high_commitment" %>
         <% end %>
 
-        <% if (graduate? && low_commitment?) || studying? %>
+        <% if (ml_graduate? && ml_low_commitment?) || ml_studying? %>
           <%= render "mailing_list/steps/completed/shared/get_an_adviser_low_commitment" %>
         <% end %>
 
-        <% if graduate? || (studying? && high_commitment?) %>
+        <% if ml_graduate? || (ml_studying? && ml_high_commitment?) %>
           <%= render "mailing_list/steps/completed/shared/find_a_teacher_training_course" %>
         <% end %>
 
-        <% if low_commitment? && (studying? || no_degree?) %>
+        <% if ml_low_commitment? && (ml_studying? || ml_no_degree?) %>
           <%= render "mailing_list/steps/completed/shared/is_teaching_right_for_me" %>
         <% end %>
 
-        <% if no_degree? %>
+        <% if ml_no_degree? %>
           <%= render(partial: "mailing_list/steps/completed/shared/train_to_teach_no_degree") %>
         <% end %>
 
-        <% if studying? %>
+        <% if ml_studying? %>
           <%= render "mailing_list/steps/completed/shared/steps_to_become_a_teacher" %>
         <% end %>
 

--- a/spec/features/mailing_list_wizard_spec.rb
+++ b/spec/features/mailing_list_wizard_spec.rb
@@ -165,6 +165,45 @@ RSpec.feature "Mailing list wizard", type: :feature do
     expect(page).to have_text "Test, you're signed up"
   end
 
+  scenario "Full journey as a new candidate without a degree and not studying for one shows next steps" do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token).and_raise(GetIntoTeachingApiClient::ApiError)
+
+    visit mailing_list_steps_path
+
+    expect(page).to have_title(mailing_list_page_title)
+
+    expect(page).to have_text "Free personalised teacher training guidance"
+    fill_in_name_step
+    click_on "Next step"
+
+    expect(page).not_to have_text "Tell us more about you so that you only get emails relevant to your circumstances."
+
+    expect(page).to have_text "Are you already qualified to teach?"
+    choose "No"
+    click_on "Next step"
+
+    expect(page).to have_text "Do you have a degree?"
+    choose "No"
+    click_on "Next step"
+
+    expect(page).to have_text "How interested are you in applying"
+    choose "I think I'll apply"
+    click_on "Next step"
+
+    expect(page).to have_text "Select the subject you're most interested in teaching"
+    select "French"
+    click_on "Next step"
+
+    expect(page).to have_text "We'll only use this to send you information about events happening near you"
+    click_on "Complete sign up"
+
+    expect(page).to have_text "Test, you're signed up"
+    expect(page).to have_text "Your next steps"
+    expect(page).to have_link("train to be a teacher if you don't have a degree")
+    expect(page).to have_link("teaching in further education")
+  end
+
   scenario "Full journey as an existing candidate" do
     first_name = "Joey"
 

--- a/spec/helpers/mailing_list_helper_spec.rb
+++ b/spec/helpers/mailing_list_helper_spec.rb
@@ -18,60 +18,60 @@ RSpec.describe MailingListHelper, type: :helper do
     end
   end
 
-  describe "#high_commitment?" do
+  describe "#ml_high_commitment?" do
     it "returns true for consideration_journey_stage 222750003" do
-      expect(high_commitment?(consideration_journey_stage: 222_750_003)).to be true
+      expect(ml_high_commitment?(consideration_journey_stage: 222_750_003)).to be true
     end
 
     it "returns false for other consideration_journey_stage values" do
-      expect(high_commitment?(consideration_journey_stage: 123_456_789)).to be false
+      expect(ml_high_commitment?(consideration_journey_stage: 123_456_789)).to be false
     end
   end
 
-  describe "#low_commitment?" do
+  describe "#ml_low_commitment?" do
     it "returns true for consideration_journey_stage 222750000" do
-      expect(low_commitment?(consideration_journey_stage: 222_750_000)).to be true
+      expect(ml_low_commitment?(consideration_journey_stage: 222_750_000)).to be true
     end
 
     it "returns false for other consideration_journey_stage values" do
-      expect(low_commitment?(consideration_journey_stage: 123_456_789)).to be false
+      expect(ml_low_commitment?(consideration_journey_stage: 123_456_789)).to be false
     end
   end
 
-  describe "#graduate?" do
+  describe "#ml_graduate?" do
     it "returns true for degree_status 222750000" do
-      expect(graduate?(degree_status: 222_750_000)).to be true
+      expect(ml_graduate?(degree_status: 222_750_000)).to be true
     end
 
     it "returns false for other degree_status values" do
-      expect(graduate?(degree_status: 123_456_789)).to be false
+      expect(ml_graduate?(degree_status: 123_456_789)).to be false
     end
   end
 
-  describe "#studying?" do
+  describe "#ml_studying?" do
     it "returns true for degree_status 222750006" do
-      expect(studying?(degree_status: 222_750_006)).to be true
+      expect(ml_studying?(degree_status: 222_750_006)).to be true
     end
 
     it "returns false for other degree_status values" do
-      expect(studying?(degree_status: 123_456_789)).to be false
+      expect(ml_studying?(degree_status: 123_456_789)).to be false
     end
   end
 
-  describe "#no_degree?" do
+  describe "#ml_no_degree?" do
     it "returns true for degree_status 222750004" do
-      expect(no_degree?(degree_status: 222_750_004)).to be true
+      expect(ml_no_degree?(degree_status: 222_750_004)).to be true
     end
 
     it "returns false for other degree_status values" do
-      expect(no_degree?(degree_status: 123_456_789)).to be false
+      expect(ml_no_degree?(degree_status: 123_456_789)).to be false
     end
   end
 
-  describe "#consideration_journey_stage_id" do
+  describe "#ml_consideration_journey_stage_id" do
     before do
       allow(session).to receive(:dig).with("mailinglist", "consideration_journey_stage_id").and_return(nil)
-      consideration_journey_stage_id
+      ml_consideration_journey_stage_id
     end
 
     specify "checks the welcome guide and mailing list session values" do


### PR DESCRIPTION
### Trello card
[Resolve mailing list completion page logic](https://trello.com/c/Upckt5Bu/8089-resolve-mailing-list-completion-page-content)

### Context
A bug was introduced which prevented the Next Steps logic from resolving correctly on the mailing list

### Changes proposed in this pull request
the bug was caused by helper methods being redefined in different helpers - resolved by unique naming

### Guidance to review
check the mailing list completion page logic is now correct
