### PR TITLE
Add accessibility section to event detail pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "text"
 gem "indefinite_article"
 
 gem "connection_pool"
-gem "get_into_teaching_api_client_faraday", ">= 3.5.1", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
+gem "get_into_teaching_api_client_faraday", ">= 3.5.3", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client", branch: "add-accessibility-info-to-events"
 
 gem "redis"
 gem "redis-session-store", ">= 0.11.4"

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "text"
 gem "indefinite_article"
 
 gem "connection_pool"
-gem "get_into_teaching_api_client_faraday", ">= 3.5.3", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client", branch: "add-accessibility-info-to-events"
+gem "get_into_teaching_api_client_faraday", ">= 3.5.3", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
 gem "redis"
 gem "redis-session-store", ">= 0.11.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,8 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: a2e0c7f1230c552ba4825e73cc74a3c73866cd50
-  branch: add-accessibility-info-to-events
+  revision: d32fa2e663b6f496ab21c75ce019c67b90f64515
   specs:
     get_into_teaching_api_client (3.5.3)
       faraday (~> 1.0, >= 1.0.1)
@@ -165,7 +164,7 @@ GEM
     amazing_print (1.8.1)
     ast (2.4.3)
     base64 (0.3.0)
-    benchmark (0.4.0)
+    benchmark (0.4.1)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -215,7 +214,7 @@ GEM
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
       railties (>= 6.1)
-    drb (2.2.1)
+    drb (2.2.3)
     erb (5.0.1)
     erb_lint (0.9.0)
       activesupport
@@ -245,14 +244,14 @@ GEM
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
+    faraday-em_synchrony (1.0.1)
     faraday-encoding (0.0.6)
       faraday
     faraday-excon (1.1.0)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.0)
+    faraday-multipart (1.1.1)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
@@ -532,7 +531,7 @@ GEM
       psych (>= 4.0.0)
     redis (5.4.0)
       redis-client (>= 0.22.0)
-    redis-client (0.24.0)
+    redis-client (0.25.0)
       connection_pool
     redis-session-store (0.11.6)
       actionpack (>= 5.2.4.1, < 9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,11 +31,12 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 16d84f778f7b14a23ba52968ae1ed7d0b480806d
+  revision: a2e0c7f1230c552ba4825e73cc74a3c73866cd50
+  branch: add-accessibility-info-to-events
   specs:
-    get_into_teaching_api_client (3.5.1)
+    get_into_teaching_api_client (3.5.3)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (3.5.1)
+    get_into_teaching_api_client_faraday (3.5.3)
       activesupport
       faraday
       faraday-encoding
@@ -745,7 +746,7 @@ DEPENDENCIES
   foreman
   front_matter_parser!
   geometry!
-  get_into_teaching_api_client_faraday (>= 3.5.1)!
+  get_into_teaching_api_client_faraday (>= 3.5.3)!
   git_wizard!
   google-api-client (>= 0.53.0)
   govuk_design_system_formbuilder (>= 2.8.0)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -63,18 +63,6 @@ module EventsHelper
     ].compact.join(",\n")
   end
 
-  def event_location_map(event)
-    address = event_address(event)
-
-    ajax_map(
-      address,
-      zoom: 10,
-      mapsize: [732, 490],
-      title: event.name,
-      description: address,
-    )
-  end
-
   def event_type_color(type_id)
     case type_id
     when git_event_type_id

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -2,6 +2,8 @@ module TeachingEvents
   class EventPresenter
     attr_reader :event
 
+    include ApiOptions
+
     def initialize(event)
       @event = event
     end
@@ -26,6 +28,7 @@ module TeachingEvents
       :type_id,
       :status_id,
       :web_feed_id,
+      :accessibility_options,
       to: :event,
     )
 
@@ -46,6 +49,18 @@ module TeachingEvents
         event_building.address_city,
         event_building.address_postcode,
       ].compact
+    end
+
+    def accessibility_options_with_labels
+      return unless has_accessibility_options?
+
+      generate_api_options(
+        GetIntoTeachingApiClient::PickListItemsApi, :get_teaching_event_accessibilty, [], accessibility_options
+      ).keys
+    end
+
+    def has_accessibility_options?
+      accessibility_options.any?
     end
 
     def has_location?

--- a/app/presenters/teaching_events/event_presenter.rb
+++ b/app/presenters/teaching_events/event_presenter.rb
@@ -60,7 +60,7 @@ module TeachingEvents
     end
 
     def has_accessibility_options?
-      accessibility_options.any?
+      accessibility_options.present?
     end
 
     def has_location?

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -1,9 +1,9 @@
 <section class="teaching-event__venue-information">
-  <h2 class="heading-s">Venue information</h2>
+  <h2 class="heading-s">Venue address</h2>
 
-  <%= tag.p(safe_join(@event.venue_address, tag.br)) %>
-
-  <section><%= event_location_map(@event) %></section>
+  <p>
+    <%= safe_join(@event.venue_address, tag.br) %>
+  </p>
 
   <ul>
     <li>
@@ -16,4 +16,12 @@
       <%= image_tag(@event.building.image_url, alt: @event.building.venue) %>
     </div>
   <% end %>
+
+  <% if @event.has_accessibility_options? %>
+    <h2 class="heading-s">Accessibility features</h2>
+    <ul>
+      <%= safe_join(@event.accessibility_options_with_labels.map{|i| tag.li(i)}) %>
+    </ul>
+  <% end %>
+
 </section>

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -5,7 +5,7 @@
     <%= safe_join(@event.venue_address, tag.br) %>
   </p>
 
-  <ul>
+  <ul class="map-link">
     <li>
       <%= link_to("Open venue map in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %>
     </li>
@@ -19,7 +19,7 @@
 
   <% if @event.has_accessibility_options? %>
     <h2 class="heading-s">Accessibility features</h2>
-    <ul>
+    <ul class="accessibility_options">
       <%= safe_join(@event.accessibility_options_with_labels.map { |i| tag.li(i) }) %>
     </ul>
   <% end %>

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -20,7 +20,7 @@
   <% if @event.has_accessibility_options? %>
     <h2 class="heading-s">Accessibility features</h2>
     <ul>
-      <%= safe_join(@event.accessibility_options_with_labels.map{|i| tag.li(i)}) %>
+      <%= safe_join(@event.accessibility_options_with_labels.map { |i| tag.li(i) }) %>
     </ul>
   <% end %>
 

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 
   <% if @event.has_accessibility_options? %>
-    <h2 class="heading-s">Accessibility features</h2>
+    <h2 class="heading-s">Venue accessibility features</h2>
     <ul class="accessibility_options">
       <%= safe_join(@event.accessibility_options_with_labels.map { |i| tag.li(i) }) %>
     </ul>

--- a/app/views/teaching_events/show/_venue-information.html.erb
+++ b/app/views/teaching_events/show/_venue-information.html.erb
@@ -1,5 +1,5 @@
 <section class="teaching-event__venue-information">
-  <h2 class="heading-s">Venue address</h2>
+  <h2 class="heading-s">Venue information</h2>
 
   <p>
     <%= safe_join(@event.venue_address, tag.br) %>
@@ -7,7 +7,7 @@
 
   <ul class="map-link">
     <li>
-      <%= link_to("Open venue map in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "blank") %>
+      <%= link_to("See venue in Google Maps", "https://maps.google.com/?q=#{event_address(@event)}", target: "_blank", rel: "noopener") %>
     </li>
   </ul>
 
@@ -24,4 +24,8 @@
     </ul>
   <% end %>
 
+  <p class="govuk-!-margin-top-6">
+    For more information about accessibility at the venue,
+    <%= link_to "contact our support team", "/help-and-support" %>.
+  </p>
 </section>

--- a/app/webpacker/styles/teaching-events.scss
+++ b/app/webpacker/styles/teaching-events.scss
@@ -518,9 +518,13 @@ $icon-size: 3rem;
       margin: unset;
     }
 
-    ul {
+    ul.map-link {
       list-style: none;
       padding-left: 0;
+    }
+
+    ul.accessibility_options {
+      list-style: disc;
     }
   }
 

--- a/spec/factories/api/accessibility_option_factory.rb
+++ b/spec/factories/api/accessibility_option_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :accessibility_option_api, class: "GetIntoTeachingApiClient::PickListItem" do
-    sequence (:id)
-    sequence(:value) { "Accessibility option #{_1}"}
+    sequence(:id)
+    sequence(:value) { "Accessibility option #{_1}" }
   end
 end

--- a/spec/factories/api/accessibility_option_factory.rb
+++ b/spec/factories/api/accessibility_option_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :accessibility_option_api, class: "GetIntoTeachingApiClient::PickListItem" do
+    sequence (:id)
+    sequence(:value) { "Accessibility option #{_1}"}
+  end
+end

--- a/spec/factories/api/event_api_factory.rb
+++ b/spec/factories/api/event_api_factory.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     is_virtual { false }
     building { build :event_building_api }
     region_id { Crm::EventRegion.all_ids.sample }
+    accessibility_options { [1, 2] }
 
     trait :closed do
       status_id { Crm::EventStatus.closed_id }
@@ -62,6 +63,10 @@ FactoryBot.define do
 
     trait :no_location do
       building { nil }
+    end
+
+    trait :no_accessibility_options do
+      accessibility_options { [] }
     end
 
     trait :pending do

--- a/spec/features/internal_spec.rb
+++ b/spec/features/internal_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "action_text/system_test_helper"
 
 RSpec.feature "Internal section", type: :feature do
+  include_context "with stubbed accessibility options api"
+
   let(:types) { Crm::EventType::ALL.values }
   let(:pending_provider_event) do
     build(:event_api,

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
       else
         # NB: online events do not have an address or accessibility information
         expect(page).not_to have_css("h2", text: "Venue address")
-        expect(page).not_to have_css("h2", text: "Accessibility features")
+        expect(page).not_to have_css("h2", text: "Venue accessibility features")
       end
     end
   end

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).to have_link("Register for this event", href: event_steps_path(event.readable_id), count: 2)
 
       expect(page).to have_css("h2", text: "Event information")
-      expect(page).to have_css("h2", text: "Venue address")
+      expect(page).to have_css("h2", text: "Venue information")
       expect(page).to have_css("h2", text: "Venue accessibility features")
 
       expect(page).not_to have_css("h2", text: "Provider information")
@@ -45,11 +45,11 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).to have_css("h2", text: "Provider information")
 
       if expect_venue
-        expect(page).to have_css("h2", text: "Venue address")
+        expect(page).to have_css("h2", text: "Venue information")
         expect(page).to have_css("h2", text: "Venue accessibility features")
       else
         # NB: online events do not have an address or accessibility information
-        expect(page).not_to have_css("h2", text: "Venue address")
+        expect(page).not_to have_css("h2", text: "Venue information")
         expect(page).not_to have_css("h2", text: "Venue accessibility features")
       end
     end

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       expect(page).to have_css("h2", text: "Event information")
       expect(page).to have_css("h2", text: "Venue address")
-      expect(page).to have_css("h2", text: "Accessibility features")
+      expect(page).to have_css("h2", text: "Venue accessibility features")
 
       expect(page).not_to have_css("h2", text: "Provider information")
     end

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Searching for teaching events", type: :feature do
+  include_context "with stubbed accessibility options api"
+
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi).to receive(:get_teaching_event).and_return(event)
   end
@@ -20,7 +22,8 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).to have_link("Register for this event", href: event_steps_path(event.readable_id), count: 2)
 
       expect(page).to have_css("h2", text: "Event information")
-      expect(page).to have_css("h2", text: "Venue information")
+      expect(page).to have_css("h2", text: "Venue address")
+      expect(page).to have_css("h2", text: "Accessibility features")
 
       expect(page).not_to have_css("h2", text: "Provider information")
     end
@@ -42,9 +45,12 @@ RSpec.feature "Searching for teaching events", type: :feature do
       expect(page).to have_css("h2", text: "Provider information")
 
       if expect_venue
-        expect(page).to have_css("h2", text: "Venue information")
+        expect(page).to have_css("h2", text: "Venue address")
+        expect(page).to have_css("h2", text: "Accessibility features")
       else
-        expect(page).not_to have_css("h2", text: "Venue information")
+        # NB: online events do not have an address or accessibility information
+        expect(page).not_to have_css("h2", text: "Venue address")
+        expect(page).not_to have_css("h2", text: "Accessibility features")
       end
     end
   end
@@ -56,7 +62,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
   end
 
   describe "viewing a online event" do
-    let(:event) { build(:event_api, :online_event, :with_provider_info) }
+    let(:event) { build(:event_api, :online_event, :with_provider_info, :no_accessibility_options) }
 
     include_examples "regular teaching event", false
   end

--- a/spec/features/teaching_events/viewing_spec.rb
+++ b/spec/features/teaching_events/viewing_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Searching for teaching events", type: :feature do
 
       if expect_venue
         expect(page).to have_css("h2", text: "Venue address")
-        expect(page).to have_css("h2", text: "Accessibility features")
+        expect(page).to have_css("h2", text: "Venue accessibility features")
       else
         # NB: online events do not have an address or accessibility information
         expect(page).not_to have_css("h2", text: "Venue address")

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -66,18 +66,6 @@ describe EventsHelper, type: "helper" do
     end
   end
 
-  describe "#event_location_map" do
-    subject { event_location_map(event) }
-
-    before do
-      allow(Rails.application.config.x).to receive(:google_maps_key).and_return("12345")
-    end
-
-    it { is_expected.to match(/data-map-description="Albert Hall,\nLine 1,\nLine 2,\nManchester,\nMA1 1AM" /) }
-    it { is_expected.to match(/zoom=10/) }
-    it { is_expected.to match(/alt="Map showing #{event.name}"/) }
-  end
-
   describe "#can_sign_up_online?" do
     subject { can_sign_up_online?(event) }
 

--- a/spec/models/mailing_list/wizard_spec.rb
+++ b/spec/models/mailing_list/wizard_spec.rb
@@ -110,12 +110,12 @@ describe MailingList::Wizard do
       subject.complete!
 
       filtered_json = {
+        "degreeStatusId" => request.degree_status_id,
         "candidateId" => nil,
         "qualificationId" => nil,
         "preferredTeachingSubjectId" => request.preferred_teaching_subject_id,
         "acceptedPolicyId" => request.accepted_policy_id,
         "considerationJourneyStageId" => request.consideration_journey_stage_id,
-        "degreeStatusId" => request.degree_status_id,
         "channelId" => nil,
         "email" => "[FILTERED]",
         "firstName" => "[FILTERED]",

--- a/spec/requests/gtm_spec.rb
+++ b/spec/requests/gtm_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "Google Tag Manager", type: :request do
   include_context "with wizard data"
+  include_context "with stubbed accessibility options api"
 
   let(:event) { build(:event_api) }
   let(:layout_paths) do

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -139,6 +139,8 @@ describe Internal::EventsController, type: :request do
   end
 
   describe "#show" do
+    include_context "with stubbed accessibility options api"
+
     let(:event_to_get_readable_id) { "1" }
 
     context "when any user type" do
@@ -314,7 +316,8 @@ describe Internal::EventsController, type: :request do
                 video_url: nil,
                 message: nil,
                 region_id: nil,
-                web_feed_id: nil)
+                web_feed_id: nil,
+                accessibility_options: [1,2])
         end
 
         context "when \"select a venue\" is selected" do
@@ -331,9 +334,13 @@ describe Internal::EventsController, type: :request do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
               .to receive(:upsert_teaching_event).with(expected_request_body)
 
+            # TODO: fixme - maybe add accessibility_options to the internal event model?
+
             post internal_events_path,
                  headers: basic_auth_headers("author", "password2"),
                  params: { internal_event: params }
+
+
 
             expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "provider"))
             expect(Rails.logger).to have_received(:info).with(%r{author - create/update - .*#{expected_request_body.id}.*})

--- a/spec/requests/internal/events_controller_spec.rb
+++ b/spec/requests/internal/events_controller_spec.rb
@@ -317,7 +317,7 @@ describe Internal::EventsController, type: :request do
                 message: nil,
                 region_id: nil,
                 web_feed_id: nil,
-                accessibility_options: [1,2])
+                accessibility_options: nil)
         end
 
         context "when \"select a venue\" is selected" do
@@ -334,13 +334,9 @@ describe Internal::EventsController, type: :request do
             expect_any_instance_of(GetIntoTeachingApiClient::TeachingEventsApi)
               .to receive(:upsert_teaching_event).with(expected_request_body)
 
-            # TODO: fixme - maybe add accessibility_options to the internal event model?
-
             post internal_events_path,
                  headers: basic_auth_headers("author", "password2"),
                  params: { internal_event: params }
-
-
 
             expect(response).to redirect_to(internal_events_path(status: :pending, readable_id: "Test", event_type: "provider"))
             expect(Rails.logger).to have_received(:info).with(%r{author - create/update - .*#{expected_request_body.id}.*})
@@ -429,7 +425,8 @@ describe Internal::EventsController, type: :request do
                 video_url: nil,
                 message: nil,
                 region_id: nil,
-                web_feed_id: nil)
+                web_feed_id: nil,
+                accessibility_options: nil)
         end
 
         it "posts event" do

--- a/spec/requests/structured_data_spec.rb
+++ b/spec/requests/structured_data_spec.rb
@@ -14,6 +14,8 @@ describe "Google Structured Data", type: :request do
   end
 
   context "when viewing an event page" do
+    include_context "with stubbed accessibility options api"
+
     let(:event) { build(:event_api) }
     let(:path) { event_path(id: event.readable_id) }
 

--- a/spec/requests/teaching_events_spec.rb
+++ b/spec/requests/teaching_events_spec.rb
@@ -28,6 +28,8 @@ describe "teaching events", type: :request do
   end
 
   describe "#show" do
+    include_context "with stubbed accessibility options api"
+
     let(:event) { build(:event_api) }
     let(:readable_id) { event.readable_id }
 

--- a/spec/support/api_support.rb
+++ b/spec/support/api_support.rb
@@ -42,3 +42,14 @@ shared_context "with stubbed callback quotas api" do
       .to receive(:get_callback_booking_quotas) { quotas }
   end
 end
+
+shared_context "with stubbed accessibility options api" do
+  let(:accessibilty_options) do
+    build_list(:accessibility_option_api, 3)
+  end
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PickListItemsApi).to \
+      receive(:get_teaching_event_accessibilty).and_return(accessibilty_options)
+  end
+end


### PR DESCRIPTION
### Trello card
[Add accessibility section to event details page](https://trello.com/c/d64FEZKb/7961-f13-add-accessibility-section-to-event-detail-pages)

### Context

### Changes proposed in this pull request
* Show's accessibility options on events pages
* Removes the inline Google map from events pages

### Guidance to review

