### PR TITLE
Allow integration test to reflect real-world behaviour

### DIFF
--- a/spec/integration/teacher_training_adviser_spec.rb
+++ b/spec/integration/teacher_training_adviser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Teacher Training Adviser integration tests", :integration, :mech
   it "Full journey as a new candidate" do
     submit_personal_details(rand_first_name, rand_last_name, rand_email)
     complete_sign_up
-    expect(page).to have_text("we'll give you a call")
+    expect(page).to have_text(/(we'll give you a call)|(Please give us a call)/i)
   end
 
   it "Full journey as an existing candidate" do

--- a/spec/support/spec_helpers/contract.rb
+++ b/spec/support/spec_helpers/contract.rb
@@ -234,9 +234,17 @@ module SpecHelpers
 
     def submit_uk_callback_step(telephone, slot = nil)
       expect_current_step(:uk_callback)
+      expect(page).to have_content "We need to check that your degree from outside the UK meets the standards for teacher training in England."
 
-      fill_in "Your telephone number", with: telephone
-      select slot if slot.present?
+      # NB: Sometimes the staging CRM does not have any call-back quotas available
+      if page.has_field? "teacher_training_adviser_steps_uk_callback[callback_offered]", type: :hidden, with: "true"
+        fill_in "Your telephone number", with: telephone
+        select slot if slot.present?
+      else
+        # If there are no call-back quotas available, the user should be prompted
+        # to telephone the service
+        expect(page).to have_link "0800 389 2500", href: "tel://08003892500"
+      end
       click_on_continue
     end
 


### PR DESCRIPTION
If there are no booking quotas available, ask the user to call the service

### Trello card

### Context

An integration test was failing if there were no call-back booking quotas available on the staging system

### Changes proposed in this pull request

Update the test to better reflect this use case

### Guidance to review

