### PR TITLE
Set deploy label for dependapot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,7 +375,12 @@ jobs:
   review:
     name: Review Deployment Process
     needs: [ build_release ]
-    if: github.ref != 'refs/heads/master'
+    if: |
+      github.ref != 'refs/heads/master' && 
+      (
+        github.actor != 'dependabot[bot]' || 
+        contains(github.event.pull_request.labels.*.name, 'deploy')
+      )
     runs-on: ubuntu-latest
     continue-on-error: true
     concurrency: Review_${{github.event.number}}


### PR DESCRIPTION
### Trello card

https://trello.com/c/7FORm75E/2451-git-dependabot-review-apps-on-deploy-label

  Context

  Dependabot PRs were automatically triggering review app deployments, which is unnecessary
  for most dependency updates and consumes resources. This change ensures review apps are
  only deployed for Dependabot PRs when explicitly needed.

  Changes proposed in this pull request

  - Modified the GitHub Actions workflow condition for review app deployments
  - Added logic to skip review app deployment for Dependabot PRs by default
  - Allows manual override by adding a "deploy" label to Dependabot PRs when review app
  testing is required

  Guidance to review

  - Verify the conditional logic correctly identifies Dependabot PRs (github.actor != 
  'dependabot[bot]')
  - Confirm the label check syntax is correct
  (contains(github.event.pull_request.labels.*.name, 'deploy'))
  - Test that regular PRs still trigger review app deployments as expected
  - Test that Dependabot PRs without the "deploy" label do not trigger deployments
  - Test that Dependabot PRs with the "deploy" label do trigger deployments