### PR TITLE
changed code to get rid of current page breadcrumb

### DIFF
--- a/app/components/header/breadcrumb_component.html.erb
+++ b/app/components/header/breadcrumb_component.html.erb
@@ -1,13 +1,10 @@
 <section class="container breadcrumbs tab-after-nav-menu" tabindex="-1">
   <nav class="govuk-breadcrumbs" aria-label="breadcrumbs" role="navigation">
     <ol class="govuk-breadcrumbs__list">
-      <% helpers.breadcrumb_trail do |crumb| %>
+      <% helpers.breadcrumb_trail.each do |crumb| %>
+        <% next if crumb.current? %> <!-- Skip current page -->
         <li class="govuk-breadcrumbs__list-item">
-          <% if crumb.current? %>
-            <%= tag.span(crumb.name, class: "govuk-breadcrumbs__current") %>
-          <% else %>
-            <%= link_to(crumb.name, crumb.url, class: "govuk-breadcrumbs__link") %>
-          <% end %>
+          <%= link_to(crumb.name, crumb.url, class: "govuk-breadcrumbs__link") %>
         </li>
       <% end %>
     </ol>


### PR DESCRIPTION
### Trello card
https://trello.com/c/gR1ekbA8/8341-remove-the-current-page-from-all-breadcrumbs

### Context
editing header component code to get rid of breadcrumbs for current page 

### Guidance to review

