### PR TITLE
8954 Rebrand set h1 h2 font to Montserrat

### DIFF
--- a/app/webpacker/styles/headings.scss
+++ b/app/webpacker/styles/headings.scss
@@ -187,10 +187,12 @@
 
 h1 {
   @extend .heading-xxl;
+  font-family: Montserrat, sans-serif;
 }
 
 h2 {
   @extend .heading-xl;
+  font-family: Montserrat, sans-serif;
 
   > i.icon {
     margin-right: .3em;

--- a/app/webpacker/styles/sections/hero.scss
+++ b/app/webpacker/styles/sections/hero.scss
@@ -435,7 +435,6 @@ $mobile-cutoff: 800px;
 .hero.rebrand {
   &.content-wide {
     .hero__title {
-      font-family: Montserrat, sans-serif;
       font-weight: 700;
 
       @include mq($until: tablet) {


### PR DESCRIPTION
### Trello card
[Rebrand h1 h2 font](https://trello.com/c/ilQAZ8sr/8954-rebrand-h1-h2-font)

### Context

### Changes proposed in this pull request
Add Montserrat as the font-family on h1 and h2 in headings.scss and remove the redundant font-family declaration from .hero.rebrand .content-wide .hero__title. This centralizes heading typography, reduces duplication, and ensures consistent font use across headings while preserving existing weight and icon styles.

### Guidance to review

NB: Merges into https://github.com/DFE-Digital/get-into-teaching-app/tree/8955-rebrand-headings-colour-inspirationcardcomponent
