### PR TITLE
8997 Rebrand landing page headers

### DIFF
--- a/app/views/content/landing/advisers.md
+++ b/app/views/content/landing/advisers.md
@@ -6,7 +6,7 @@ content:
     - content/landing/advisers/adviser
 image: "static/images/content/campus-advisers/adviser.jpeg"
 layout: "layouts/minimal"
-colour: green-yellow
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/advisers/_header.html.erb
+++ b/app/views/content/landing/advisers/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get a free adviser",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/campus-advisers.md
+++ b/app/views/content/landing/campus-advisers.md
@@ -6,7 +6,7 @@ content:
     - content/landing/campus-advisers/adviser
 image: "static/images/content/campus-advisers/adviser.jpeg"
 layout: "layouts/minimal"
-colour: pink-yellow
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/campus-advisers/_header.html.erb
+++ b/app/views/content/landing/campus-advisers/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Sign up for an adviser",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/campus-mailing-list.md
+++ b/app/views/content/landing/campus-mailing-list.md
@@ -5,7 +5,7 @@ content:
     - content/landing/campus-mailing-list/header
     - content/landing/campus-mailing-list/mailing-list
 image: "static/images/content/hero-images/chemistry.jpg"
-colour: pink-yellow
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/campus-mailing-list/_header.html.erb
+++ b/app/views/content/landing/campus-mailing-list/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Sign up for emails",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/careers.md
+++ b/app/views/content/landing/careers.md
@@ -9,7 +9,7 @@ content:
     - content/shared/block-promos/mailing_routes_under18version
 image: "static/images/content/hero-images/0029.jpg"
 layout: "layouts/minimal"
-colour: pink-blue
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/careers/_header.html.erb
+++ b/app/views/content/landing/careers/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "You're more of a teacher than you think",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/food-for-thought.md
+++ b/app/views/content/landing/food-for-thought.md
@@ -7,7 +7,7 @@ content:
     - content/shared/block-promos/adviser_routes
 image: "static/images/content/hero-images/cake.png"
 layout: "layouts/minimal"
-colour: pink-yellow
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/food-for-thought/_header.html.erb
+++ b/app/views/content/landing/food-for-thought/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Food for thought",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/how-much-do-teachers-get-paid.md
+++ b/app/views/content/landing/how-much-do-teachers-get-paid.md
@@ -8,7 +8,7 @@ content:
     - content/landing/how-much-do-teachers-get-paid/content
     - content/shared/block-promos/mailing_adviser_routes
 image: "static/images/content/hero-images/science.jpg"
-colour: "pink-blue"
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/how-much-do-teachers-get-paid/_header.html.erb
+++ b/app/views/content/landing/how-much-do-teachers-get-paid/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "How much do teachers get paid?",
+  title: @front_matter["title"],
   colour:  @front_matter["colour"],
   image: @front_matter["image"]
 ) %>

--- a/app/views/content/landing/how-to-become-a-teacher.md
+++ b/app/views/content/landing/how-to-become-a-teacher.md
@@ -9,7 +9,7 @@ content:
     - content/shared/block-promos/mailing_adviser_routes
 image: "static/images/content/hero-images/0031.jpg"
 layout: "layouts/minimal"
-colour: pink-blue  
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/how-to-become-a-teacher/_header.html.erb
+++ b/app/views/content/landing/how-to-become-a-teacher/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "How to become a teacher",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/how-to-fund-your-teacher-training.md
+++ b/app/views/content/landing/how-to-fund-your-teacher-training.md
@@ -9,7 +9,7 @@ content:
     - content/shared/block-promos/mailing_adviser_routes
 image: "static/images/content/hero-images/chemistry.jpg"
 layout: "layouts/minimal"
-colour: pink-blue
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
+++ b/app/views/content/landing/how-to-fund-your-teacher-training/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Fund your teacher training",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/mailing-list-1.md
+++ b/app/views/content/landing/mailing-list-1.md
@@ -5,6 +5,7 @@ content:
     - content/landing/mailing-list-1/header
     - content/landing/mailing-list-1/mailing-list
 image: "static/images/content/hero-images/english.jpg"
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/mailing-list-1/_header.html.erb
+++ b/app/views/content/landing/mailing-list-1/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get personalised guidance",
-  colour: "pink-blue",
+  title: @front_matter["title"],
+  colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/mailing-list-2.md
+++ b/app/views/content/landing/mailing-list-2.md
@@ -4,7 +4,7 @@ description: Free advice and support on how to become a teacher. Get the latest 
 content:
     - content/landing/mailing-list-2/header
     - content/landing/mailing-list-2/mailing-list
-colour: pink-blue
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/mailing-list-2/_header.html.erb
+++ b/app/views/content/landing/mailing-list-2/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get personalised guidance",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/mailing-list-3.md
+++ b/app/views/content/landing/mailing-list-3.md
@@ -5,6 +5,7 @@ content:
     - content/landing/mailing-list-3/header
     - content/landing/mailing-list-3/mailing-list
 image: "static/images/content/hero-images/english.jpg"
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/mailing-list-3/_header.html.erb
+++ b/app/views/content/landing/mailing-list-3/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get personalised guidance",
-  colour: "pink-blue",
+  title: @front_matter["title"],
+  colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/mailing-list.md
+++ b/app/views/content/landing/mailing-list.md
@@ -5,6 +5,7 @@ content:
     - content/landing/mailing-list/header
     - content/landing/mailing-list/mailing-list
 image: "static/images/content/hero-images/english.jpg"
+colour: "white-text gitpurple-gitpurple"
 layout: "layouts/minimal"
 noindex: true
 breadcrumbs: false

--- a/app/views/content/landing/mailing-list/_header.html.erb
+++ b/app/views/content/landing/mailing-list/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get personalised guidance",
-  colour: "pink-blue",
+  title: @front_matter["title"],
+  colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/return-to-teaching-advisers.md
+++ b/app/views/content/landing/return-to-teaching-advisers.md
@@ -6,7 +6,7 @@ content:
    - content/landing/return-to-teaching-advisers/adviser
 image: "static/images/content/campus-advisers/adviser.jpeg"
 layout: "layouts/minimal"
-colour: green-yellow
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_adviser.html.erb
@@ -9,24 +9,25 @@
       ) do %>
           <p>If you're thinking about returning to teaching in England, an adviser can help you:</p>
           <ul>
-          <li>get classroom experience</li>
-          <li>search for teaching jobs</li>
-          <li>support you with the application process</li>
+            <li>get classroom experience</li>
+            <li>search for teaching jobs</li>
+            <li>support you with the application process</li>
           </ul>
-        <p>You can talk to an adviser as little or as often as you need.</p>
-        <p>To be eligible for an adviser, you'll need to have:</p>
-        <ul>
-        <li>English qualified teacher status (QTS)</li>
-        <li>previously taught in the UK or have trained to teach in the UK</li>
-        <li>an interest in teaching in an English state school</li>
-            </ul>
+          <p>You can talk to an adviser as little or as often as you need.</p>
+          <p>To be eligible for an adviser, you'll need to have:</p>
+          <ul>
+            <li>English qualified teacher status (QTS)</li>
+            <li>previously taught in the UK or have trained to teach in the UK</li>
+            <li>an interest in teaching in an English state school</li>
+          </ul>
 
-    <section class="inset-text purple">
+        <section class="inset-text gitpink">
           <h2 role="text">
-          <span class="header">Non-UK citizens:</span>
+            <span class="header">Non-UK citizens:</span>
           </h2>
           <p>If you qualified as a teacher outside the UK and want to teach in England, find out about <a href="/non-uk-teachers">teaching as a non-UK citizen</a>.</p>
+        </section>
+      <% end %>
     </section>
-    <% end %>
   </div>
 </div>

--- a/app/views/content/landing/return-to-teaching-advisers/_header.html.erb
+++ b/app/views/content/landing/return-to-teaching-advisers/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "Get a return to teaching adviser",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree.md
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree.md
@@ -9,7 +9,7 @@ content:
     - content/shared/block-promos/mailing_adviser_routes
 image: "static/images/content/hero-images/0030.jpg"
 layout: "layouts/minimal"
-colour: pink-blue
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/train-to-teach-if-you-have-a-degree/_header.html.erb
+++ b/app/views/content/landing/train-to-teach-if-you-have-a-degree/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "How to start teacher training",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>

--- a/app/views/content/landing/train-to-teach.md
+++ b/app/views/content/landing/train-to-teach.md
@@ -9,7 +9,7 @@ content:
     - content/shared/block-promos/mailing_adviser_routes
 image: "static/images/content/hero-images/0029.jpg"
 layout: "layouts/minimal"
-colour: pink-blue
+colour: "white-text gitpurple-gitpurple"
 noindex: true
 breadcrumbs: false
 ---

--- a/app/views/content/landing/train-to-teach/_header.html.erb
+++ b/app/views/content/landing/train-to-teach/_header.html.erb
@@ -1,5 +1,5 @@
 <%= render Content::LandingHeroComponent.new(
-  title: "How can I train to teach?",
+  title: @front_matter["title"],
   colour: @front_matter["colour"],
   image: @front_matter["image"],
 ) %>


### PR DESCRIPTION
### Trello card
[Rebrand landing page banners](https://trello.com/c/BciAm4oB/8997-rebrand-landing-page-banners)

### Context

### Changes proposed in this pull request
Rebrands all landing pages using new colours

### Guidance to review

NB: merges into 8950 https://github.com/DFE-Digital/get-into-teaching-app/pull/5115
