### PR TITLE
Allow analytics.tiktok.com in CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -40,7 +40,7 @@ SecureHeaders::Configuration.default do |config|
   reddit      = %w[www.redditstatic.com alb.reddit.com conversions-config.reddit.com]
   clarity     = %w[www.clarity.ms *.clarity.ms *.bing.com]
   vwo         = %w[app.vwo.com *.visualwebsiteoptimizer.com]
-  tiktok      = %w[*.analytics.tiktok.com]
+  tiktok      = %w[analytics.tiktok.com *.analytics.tiktok.com]
 
   quoted_unsafe_inline = ["'unsafe-inline'"]
   quoted_unsafe_eval   = ["'unsafe-eval'"]


### PR DESCRIPTION
Update secure_headers CSP config to include the explicit analytics.tiktok.com host alongside the existing wildcard (*.analytics.tiktok.com). This ensures both the root analytics domain and its subdomains are allowed, preventing TikTok analytics requests from being blocked.

### Trello card
[TikTok CSP](https://trello.com/c/7OxL3QAl/9080-connecting-social-assets-with-wpp650-for-paid-social)

### Context

### Changes proposed in this pull request

### Guidance to review

