### PR TITLE
Use sonar.token property in sonar-scanner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,7 +364,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sonar-scanner
-           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
            -Dsonar.organization=dfe-digital
            -Dsonar.host.url=https://sonarcloud.io/
            -Dsonar.projectKey=DFE-Digital_get-into-teaching-app


### PR DESCRIPTION
Fix the SonarCloud authentication option in the GitHub Actions workflow by replacing -Dsonar.login with -Dsonar.token in .github/workflows/build.yml. This ensures the scanner uses the SONAR_TOKEN secret correctly and prevents authentication failures during analysis.

### Trello card

### Context

### Changes proposed in this pull request

### Guidance to review

