### PR TITLE
Revise IRP pilot details and eligibility criteria ahead of 30 June cl…

### DIFF
--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -23,17 +23,12 @@ inset_text:
       <p>The IRP pilot was a 2 year trial to support non-UK citizens who want to teach in England. It offered up to £10,000 to eligible non-UK teachers of languages or physics, to help cover some of the costs of moving to England. It started on 1 September 2023 and ended on 31 May 2025.</p> 
       <br>
       <p>Applications for the first $nonuk_internationalrelocationpayment_instalment$ of the IRP closed on 30 June 2025. Applications for the second instalment of the IRP closed on 30 June 2026.</p>
+      <p> If you have questions about the IRP, missed the application window, or believe you were eligible and have not been contacted, you can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.</p>
       <br>
-      <p> If you:
-      <p> * have questions about the IRP
-      <p> * believe you were eligible and have not been contacted
-      <p> * missed the application window
-      <br>
-      <p> You can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.</p> 
-      <br>
-      <p> [Find out more about teaching in England if you trained outside the UK](https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas).</p> 
 ---
 $applications-open$
+
+$teachinuk$
 
 ## Receiving the IRP
 

--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -26,7 +26,7 @@ inset_text:
       <br>
       <p> Applications for the first $nonuk_internationalrelocationpayment_instalment$ of the IRP closed on 30 June 2025. Applications for the second instalment of the IRP closed on 30 June 2026.</p>
       <br>
-      <p> If you have questions about the IRP, missed the application window, or believe you were eligible and have not been contacted, you can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.</p>
+      <p> If you have questions about the IRP, missed the application window, or believe you were eligible and have not been contacted, you can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your query.</p>
       <br>
 ---
 $applications-open$

--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -18,209 +18,36 @@ backlink: "../../"
 inset_text:
   applications-open:
     text: |-
-      <p><h2>End of the international relocation payment (IRP) pilot</h2></p>
+      <p><h2>What the international relocation payment (IRP) pilot was</h2></p>
       <br>
-      <p>The 2-year IRP pilot which ran from 1 September 2023 to 31 May 2025 has ended and is not being extended.</p> 
+      <p>The IRP pilot was a 2 year trial to support non-UK citizens who want to teach in England. It offered up to £10,000 to eligible non-UK teachers of languages or physics, to help cover some of the costs of moving to England. It started on 1 September 2023 and ended on 31 May 2025.</p> 
       <br>
-      <p>Teachers who have received their first $nonuk_internationalrelocationpayment_instalment$ IRP instalment for a qualifying role started between 1 March 2024 and 31 May 2025 are still able to apply for their second instalment from September 2025.</p>
+      <p>Applications for the first $nonuk_internationalrelocationpayment_instalment$ of the IRP closed on 30 June 2025. Applications for the second instalment of the IRP closed on 30 June 2026.</p>
       <br>
-      <p>Before you apply, you must read the guidance on this page to check you are eligible for the IRP.</p>
+      <p> If you:
+      <p> * have questions about the IRP
+      <p> * believe you were eligible and have not been contacted
+      <p> * missed the application window
       <br>
-      <p>Teachers who have received their first payment will be contacted by email when they become eligible after they have reached the anniversary of their original start date. This will provide details on how to apply for the second $nonuk_internationalrelocationpayment_instalment$ payment.</p>
+      <p> You can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.</p> 
+      <br>
+      <p> [Find out more about teaching in England if you trained outside the UK](https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas).</p> 
 ---
 $applications-open$
 
-## What the IRP is for
-
-The IRP is a 2-year trial to support non-UK citizens who want to teach in England. It offers up to $nonuk_internationalrelocationpayment_value$ to eligible non-UK teachers of languages or physics, to help cover some of the costs of moving to England. 
-
-2024 to 2025 is the second and final year of the trial. 
-
-The IRP is paid in 2 instalments of $nonuk_internationalrelocationpayment_instalment$, spread over 2 years. The application window for applying for the first instalment has now closed. However, teachers who have already received their first instalment are able to apply for their second instalment from September 2025. 
-
-If you received the IRP payment for the 2023 to 2024 academic year you cannot receive the IRP again. The IRP is available whether you teach full-time or part-time.
-
-$teachinuk$
-
-## Check your eligibility
-
-To be eligible for the maximum IRP of $nonuk_internationalrelocationpayment_value$, you must meet all the eligibility requirements when you apply for both the first and second instalments.
-
-You will not be able to use eligibility for the IRP in your visa application as proof that you have enough money to support yourself.
-
-Trainees who train to teach in the 2024 to 2025 academic year are no longer eligible for the IRP. This applies to all trainees who started courses from 1 July 2024 onwards. Trainees in languages or physics may still be eligible to <a href="/funding-and-support/scholarships-and-bursaries">get a bursary or apply for a scholarship</a> worth up to $scholarships_nonuk_max$.
-
-### Eligibility requirements for IRP instalment 1 ($nonuk_internationalrelocationpayment_instalment$)
-
-Applications for IRP instalment 1 have closed. DfE may not be able to process late applications if you do not apply during the correct application window. If you missed the correct application window, then contact international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility. 
-
-If you have already received your first instalment, you may still be eligible to apply for your second instalment. 
-
-### Eligibility requirements for IRP instalment 2 ($nonuk_internationalrelocationpayment_instalment$)
-
-To be eligible for the second instalment of the IRP, you must:
-
-* meet all the eligibility requirements set out in this section
-
-* have successfully applied for and received the first instalment of the IRP
-
-#### Teaching subject and school
-
-To be eligible for the second instalment of the IRP, your teaching subject and school must continue to meet the eligibility criteria. You must:
-
-* have worked as a teacher in a qualifying school and role for the previous year (3 consecutive terms)
-
-* be contracted to work as a teacher for at least another year
-
-* be teaching in a subject and school which meets the requirements detailed on this page
- 
-Your term time employment must be continuous, unless [you take time off work for statutory leave](https://www.gov.uk/browse/employing-people/time-off), such as parental leave or sick leave. The Department for Education (DfE) will review time taken off for any other reason on a case-by-case basis.
-
-You can move between eligible schools and remain eligible for the second instalment (see example 1).
-
-You can start midway through the academic year and as long as you complete 3 full terms, you will remain eligible for the second instalment (see example 2).
-
-Any term time employment gaps will make you ineligible for the second instalment (see example 3).
-
-In your role in a state secondary school in England, you must be working as one of the following:
-
-* a physics teacher
-
-* a general or combined science teacher – you must teach the physics element of these subjects
-
-* a language teacher – any language taught in an English state school is eligible, except English
-
-If you are employed to teach more than one subject, then physics, general or combined science or a language or languages must make up at least 50% of your time in the classroom. Your school can tell you how much of your time is allocated to teaching eligible subjects. 
-
-You will not be eligible if you are teaching English, unless it is combined with an eligible subject.
-
-Examples of eligible teaching jobs include:
-
-* 50% modern foreign languages (for example, French, Spanish or German) and 50% another subject (for example, history)
-
-* 50% modern foreign languages (for example, French, Spanish or German) and 50% English language
-
-* 50% physics and 50% maths
-
-* 50% general or combined science (must include the physics element) and 50% maths
-
-Examples of eligible languages commonly taught in English state secondary schools include:
-
-* Ancient languages (such as Latin)
-* French
-* German
-* Italian
-* Japanese
-* Mandarin
-* Russian
-* Spanish
-
-Teaching English is not classed as an eligible subject for the IRP.
-
-You will not be eligible if you are:
-
-* employed by a recruitment agency – an agency can find you a job in a school, but your contract must be with the school and your salary must be paid directly to you by the school, not by the recruitment agency
-
-* teaching in Wales, Scotland or Northern Ireland
-
-* a UK citizen, including citizens of Wales, Scotland and Northern Ireland
-
-* an Irish citizen
-
-##### Example 1
-You start your first eligible teaching job in England in September 2024 and successfully apply for the first instalment of the IRP.  You work a full academic year of 3 terms, leaving the school in July 2025. 
-
-You successfully apply for a new IRP eligible teaching job on a one-year contract starting in September 2025. You visit family outside the UK for the summer holidays and return to England to take up your teaching job and apply for the second instalment of the IRP. 
-
-You are eligible for the second instalment of the IRP because you have been continuously employed as a teacher in eligible schools. 
-
-##### Example 2
-You start your first teaching job in England in January 2025 and successfully apply for the first instalment of the IRP, working for the rest of that academic year of 2 terms. 
-
-You decide to stay on at the school and return after the summer holidays in September 2025. Your contract is extended for a further year, and you apply for the second instalment of the IRP after the end of your third term of employment in January 2025. 
-
-You are eligible for the second instalment of the IRP because you have been continuously employed as a teacher and have a contract for further 12 months.
-
-##### Example 3
-You start a teaching job in England in January 2025 and successfully apply for the first instalment of the IRP in your first term. 
-
-You continue to work at the school for a total of 3 terms, leaving in December 2025. However, you do not find a new teaching job until March 2026. Because there is a gap (December 2025 to March 2026) between your 2 jobs that is not covered by any statutory leave, you will not be eligible for the second instalment of the IRP because you have not been in continuous employment as a teacher. 
-
-#### Type of visa
-
-To be eligible for the second instalment of the IRP, you must remain on an eligible visa throughout your employment in England.  Most teachers will need a Skilled Worker visa. Eligible visas are:
-
-* [Skilled Worker visa](https://www.gov.uk/skilled-worker-visa)
-
-* [Youth Mobility Scheme](https://www.gov.uk/youth-mobility)
-
-* [India Young Professionals Scheme visa](https://www.gov.uk/india-young-professionals-scheme-visa)
-
-* [Family visa](https://www.gov.uk/uk-family-visa)
-
-* [UK Ancestry visa](https://www.gov.uk/ancestry-visa)
-
-* [British National (Overseas) visa](https://www.gov.uk/british-national-overseas-bno-visa)
-
-* [High Potential Individual visa](https://www.gov.uk/high-potential-individual-visa)
-
-For the following Ukrainian and Afghan visas, you can apply for your visa from within or from outside the UK:
-
-* [Afghan citizens resettlement scheme](https://www.gov.uk/guidance/afghan-citizens-resettlement-scheme)
-
-* [Afghan Relocations and Assistance Policy](https://www.gov.uk/government/publications/afghan-relocations-and-assistance-policy/afghan-relocations-and-assistance-policy-information-and-guidance)
-
-* [Ukraine Family Scheme visa](https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa)
-
-* [Ukraine Sponsorship Scheme](https://www.gov.uk/guidance/apply-for-a-visa-under-the-ukraine-sponsorship-scheme)
-
-You can change your visa, as long as any new visa appears on the list of eligible visas on this page (example 1). You will not need to apply for any new visa from outside the UK.
-
-If your new visa is not listed on this page, you will not be eligible for the second instalment (see example 2).
-
-The Department for Education will validate your application with [UK Visas and Immigration](https://www.gov.uk/government/organisations/uk-visas-and-immigration) and the school or schools where you have worked since applying for the first instalment of the IRP. If you meet the eligibility requirements for the second instalment set out on this page, you should receive the second instalment of $nonuk_internationalrelocationpayment_instalment$ following successful completion of our eligibility checks.
-
-##### Example 1
-You arrive in the UK in September 2024 on a Youth Mobility Scheme visa. You are employed as a teacher on a contract lasting 1 academic year, and successfully apply for the first instalment of the IRP. 
-
-At the end of the academic year, your school offers to make your contract permanent and sponsor you for a Skilled Worker visa for 3 years. As your Youth Mobility Scheme visa is only valid for 2 years, and you are planning to work as a teacher in England for longer than this, you agree to switch your visa. 
-
-You apply for the second instalment of the IRP in September 2025. You remain eligible because the Youth Mobility Scheme visa and the Skilled Worker visa are on the list of eligible visas on this page. 
-
-##### Example 2
-You arrive in the UK in September 2024 on a Youth Mobility Scheme visa. You are employed as a teacher on a contract lasting 2 academic years and successfully apply for the first instalment of the IRP. 
-
-Early in 2025, your partner moves to the UK on a Skilled Worker visa lasting 3 years. You visit family outside the UK during the summer holidays. As your Youth Mobility Scheme visa is limited to 2 years, you decide to apply to join your partner as a dependant on their visa instead. You return to the UK to continue your employment in September 2025 on a dependant visa.
-
-You are not eligible for the second instalment of the IRP as the dependant visa does not appear on the list of eligible visas on this page.
-
-## How to apply for the IRP
-
-Applications for the first $nonuk_internationalrelocationpayment_instalment$ instalment of the IRP closed on 30 June 2025.
-
-Teachers who have already received their first instalment are able to apply for their second instalment from September 2025 to end of June 2026. Before you apply, you’ll need to check you meet the eligibility requirements. If you are eligible, you should receive the money following successful completion of our eligibility checks.
-
-You can apply for the second IRP instalment once you have completed 3 consecutive terms of employment as a teacher in a qualifying role which will be from September 2025 at the earliest.
-
-Teachers who have received their first payment of $nonuk_internationalrelocationpayment_instalment$ will be contacted by email when they become eligible after they have reached the anniversary of their original start date. This will provide details on how to apply for the second $nonuk_internationalrelocationpayment_instalment$ payment.
-
-If you have questions about this or believe you are eligible and have not been contacted or you miss the application window, email international.relocationpayment@education.gov.uk.
-
-DfE may not be able to process late applications if you do not apply during the correct application window. If you miss the correct application window, then contact international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.
-
-## Receiving the IRP payments
+## Receiving the IRP
 
 You’ll be paid the second instalment of the IRP after your eligibility checks are completed. We cannot guarantee an exact payment date.
 
 To be paid the IRP, you must have a UK bank account (this can be digital). The IRP cannot be paid into a building society account.
 
-You must also have a [UK National Insurance number](https://www.gov.uk/apply-national-insurance-number). You can apply for this once you arrive in England, as long as your visa gives you the right to work and you have a confirmed job.
+You must also have a [UK National Insurance number](https://www.gov.uk/apply-national-insurance-number). You can apply for this once you arrive in England, if your visa gives you the right to work and you have a confirmed job.
 
 You will not have to provide any evidence of the relocation costs you have incurred.
 
-If your details, such as your address, change after you have applied, let us know as soon as possible to avoid any delay to your payment.
+If your details (such as your address) change after you have applied, let us know as soon as possible to avoid any delay to your payment.
 
-DfE can withhold instalments of the IRP if you no longer meet eligibility requirements or we discover an error. 
+The Department for Education (DfE) can withhold instalments of the IRP if you no longer meet eligibility requirements or we discover an error. 
 
 DfE can take back any IRP payments that have been made to an ineligible applicant.
 
@@ -228,12 +55,11 @@ You cannot reapply for the IRP in following years if you leave the UK and then r
 
 ### Tax and the IRP
 
-DfE will pay the UK tax owed on the IRP to ensure you receive the full $nonuk_internationalrelocationpayment_value$, as long as your overall earnings do not exceed $nonuk_internationalrelocationpayment_thresholdfortaxonpayments$ in the year you receive the IRP. You may have to [pay higher rate of UK Income Tax](https://www.gov.uk/browse/tax/income-tax) on any earnings which take you over $nonuk_internationalrelocationpayment_thresholdfortaxonpayments$.
+DfE will pay the UK tax owed on the IRP to ensure you receive the full $nonuk_internationalrelocationpayment_value$, if your overall earnings do not exceed $nonuk_internationalrelocationpayment_thresholdfortaxonpayments$ in the year you receive the IRP. You may have to [pay higher rate of UK Income Tax](https://www.gov.uk/browse/tax/income-tax) on any earnings which take you over $nonuk_internationalrelocationpayment_thresholdfortaxonpayments$.
 
 ### Protect yourself from fraud
 
 You do not need to pay an agent or any other third party to complete your application. Any agency or person contacting you offering to apply for the international relocation payment on your behalf is likely to be fraudulent. [Avoid and report internet scams and phishing](https://www.gov.uk/report-suspicious-emails-websites-phishing).
-
 
 ### Other types of financial support from the UK government
 

--- a/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
+++ b/app/views/content/non-uk-teachers/get-an-international-relocation-payment.md
@@ -1,16 +1,16 @@
 ---
-title: "Get an international relocation payment (IRP)"
+title: "International relocation payment (IRP)"
 subcategory: If you're already a teacher
 description: |-
-  Non-UK teachers in physics and languages could be eligible for financial help in the form of an international relocation payment from the UK government.
+  The international relocation payment (IRP) was a 2 year pilot offering up to $nonuk_internationalrelocationpayment_value$ for eligible non-UK teachers of languages or physics.
 promo_content:
 cta_arrow_link:
   teachinuk:
     link_target: "/non-uk-teachers/teach-in-england-if-you-trained-overseas"
     link_text: "Find out more about teaching in England if you trained outside the UK"
 navigation: 20.60
-navigation_title: Get an international relocation payment (IRP)
-navigation_description: Teachers of languages or physics could be eligible for financial help from the UK government worth $nonuk_internationalrelocationpayment_value$.
+navigation_title: The international relocation payment (IRP)
+navigation_description: The international relocation payment (IRP) offered eligible teachers of languages or physics financial help from the UK government worth $nonuk_internationalrelocationpayment_value$.
 navigation_visible: false
 noindex: true
 image: "static/images/content/hero-images/geography.jpg"
@@ -20,15 +20,16 @@ inset_text:
     text: |-
       <p><h2>What the international relocation payment (IRP) pilot was</h2></p>
       <br>
-      <p>The IRP pilot was a 2 year trial to support non-UK citizens who want to teach in England. It offered up to £10,000 to eligible non-UK teachers of languages or physics, to help cover some of the costs of moving to England. It started on 1 September 2023 and ended on 31 May 2025.</p> 
+      <p> The IRP pilot was a 2 year trial to support non-UK citizens who want to teach in England. It offered up to $nonuk_internationalrelocationpayment_value$ to eligible non-UK teachers of languages or physics, to help cover some of the costs of moving to England.<p> 
       <br>
-      <p>Applications for the first $nonuk_internationalrelocationpayment_instalment$ of the IRP closed on 30 June 2025. Applications for the second instalment of the IRP closed on 30 June 2026.</p>
+      <p> It started on 1 September 2023 and ended on 31 May 2025.</p> 
+      <br>
+      <p> Applications for the first $nonuk_internationalrelocationpayment_instalment$ of the IRP closed on 30 June 2025. Applications for the second instalment of the IRP closed on 30 June 2026.</p>
+      <br>
       <p> If you have questions about the IRP, missed the application window, or believe you were eligible and have not been contacted, you can email international.relocationpayment@education.gov.uk explaining your circumstances and we will review your eligibility.</p>
       <br>
 ---
 $applications-open$
-
-$teachinuk$
 
 ## Receiving the IRP
 

--- a/config/values/scholarships.yml
+++ b/config/values/scholarships.yml
@@ -3,8 +3,6 @@ scholarships:
   computing: £31,000
   languagesfrenchgermanspanish: £22,000
   physics: £31,000
-  nonuk:
-    max: £31,000
   generic:
     maxshortened: £31k
     max: £31,000


### PR DESCRIPTION
…osure

Updated the content regarding the international relocation payment (IRP) pilot, including changes to eligibility and application details.

### Trello card
https://trello.com/c/FJvPiC6v/9130-irp-international-relocation-payment-adjust-copy-to-state-initiative-closed

### Context
The second IRP deadline is 30 June 2026 - team have requested it is revised before shut down later this year.

### Changes proposed in this pull request
See above.

### Guidance to review

