### PR TITLE
Replace landing page hero image, tweak bullet spacing

### DIFF
--- a/app/views/content/landing/how-much-do-teachers-get-paid.md
+++ b/app/views/content/landing/how-much-do-teachers-get-paid.md
@@ -7,7 +7,7 @@ content:
     - content/landing/how-much-do-teachers-get-paid/mailing_list
     - content/landing/how-much-do-teachers-get-paid/content
     - content/shared/block-promos/mailing_adviser_routes
-image: "static/images/content/hero-images/science.jpg"
+image: "static/images/content/hero-images/maths-1-1-2.jpg"
 colour: "gitpurple-gitpurple white-text"
 layout: "layouts/minimal"
 noindex: true

--- a/app/webpacker/styles/components/checklist-collage.scss
+++ b/app/webpacker/styles/components/checklist-collage.scss
@@ -18,7 +18,7 @@
 
   .checklist-grid {
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: 4rem auto;
     column-gap: 1.5rem;
     row-gap: 2rem;
     align-self: center;


### PR DESCRIPTION
### Trello card
[Replace image that is due to expire](https://trello.com/c/35MmHWQG/9129-replace-image-that-is-due-to-expire-19-july-2026)

### Context

### Changes proposed in this pull request
Replace hero image on landing page; tweak bullet spacing on landing page

### Guidance to review

