### PR TITLE
9111 training provider events wizard build step 11b in person location details

### DIFF
--- a/app/controllers/provider_events/steps_controller.rb
+++ b/app/controllers/provider_events/steps_controller.rb
@@ -16,6 +16,12 @@ module ProviderEvents
       # override inherited index method
     end
 
+    def completed
+      super
+      @email_address = wizard_store["email"]
+      @reference_number = wizard_store[:reference_number]
+    end
+
   private
 
     def first_step_class
@@ -37,7 +43,7 @@ module ProviderEvents
     end
 
     def crm_store
-      session[:provider_events] ||= {}
+      session[:provider_events_crm] ||= {}
     end
 
     def set_page_title
@@ -55,7 +61,7 @@ module ProviderEvents
     end
 
     def set_completed_page_title
-      @page_title = "All done"
+      @page_title = "Application submitted"
     end
 
     def resolve_layout

--- a/app/models/concerns/normalise_postcode.rb
+++ b/app/models/concerns/normalise_postcode.rb
@@ -1,7 +1,0 @@
-module NormalisePostcode
-  def normalise_postcode(field_name)
-    value = send(field_name)
-
-    send("#{field_name}=".to_sym, value.to_s.strip.upcase.presence) unless value.nil?
-  end
-end

--- a/app/models/concerns/normalise_postcode.rb
+++ b/app/models/concerns/normalise_postcode.rb
@@ -1,0 +1,7 @@
+module NormalisePostcode
+  def normalise_postcode(field_name)
+    value = send(field_name)
+
+    send("#{field_name}=".to_sym, value.to_s.strip.upcase.presence) unless value.nil?
+  end
+end

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -1,13 +1,13 @@
 module MailingList
   module Steps
     class Postcode < ::GITWizard::Step
+      include NormalisePostcode
+
       attribute :address_postcode
 
       validates :address_postcode, postcode: true
 
-      before_validation if: :address_postcode do
-        self.address_postcode = address_postcode.to_s.strip.upcase.presence
-      end
+      before_validation -> { normalise_postcode :address_postcode }
 
       include FunnelTitle
 

--- a/app/models/mailing_list/steps/postcode.rb
+++ b/app/models/mailing_list/steps/postcode.rb
@@ -1,15 +1,15 @@
 module MailingList
   module Steps
     class Postcode < ::GITWizard::Step
-      include NormalisePostcode
+      include FunnelTitle
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :address_postcode
 
       validates :address_postcode, postcode: true
 
-      before_validation -> { normalise_postcode :address_postcode }
-
-      include FunnelTitle
+      normalizes :address_postcode, with: ->(field) { field.to_s.squish.upcase.presence }
 
       def optional?
         true

--- a/app/models/provider_events/steps/email.rb
+++ b/app/models/provider_events/steps/email.rb
@@ -4,7 +4,7 @@ module ProviderEvents
       include FunnelTitle
 
       attribute :email
-      validates :email, presence: true, email_format: true, length: { maximum: 100 } # NB: the CRm imposes a limit of 100 chars on this field
+      validates :email, presence: true, email_format: true, length: { maximum: 100 } # NB: the CRM imposes a limit of 100 chars on this field
     end
   end
 end

--- a/app/models/provider_events/steps/event_description.rb
+++ b/app/models/provider_events/steps/event_description.rb
@@ -5,9 +5,12 @@ module ProviderEvents
       MAX_CHARS = MAX_WORDS * 20
 
       include FunnelTitle
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :event_description
       validates :event_description, presence: true, length: { maximum: MAX_CHARS }, number_of_words: { less_than: MAX_WORDS }
+      normalizes :event_description, with: ->(field) { field.to_s.squish.presence }
     end
   end
 end

--- a/app/models/provider_events/steps/event_name.rb
+++ b/app/models/provider_events/steps/event_name.rb
@@ -2,9 +2,12 @@ module ProviderEvents
   module Steps
     class EventName < ::GITWizard::Step
       include FunnelTitle
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :event_name
       validates :event_name, presence: true, length: { maximum: 200 }
+      normalizes :event_name, with: ->(field) { field.to_s.squish.presence }
     end
   end
 end

--- a/app/models/provider_events/steps/event_times.rb
+++ b/app/models/provider_events/steps/event_times.rb
@@ -28,6 +28,10 @@ module ProviderEvents
         end
       end
 
+      def reviewable_answers
+        { "event_times" => start_time.present? && end_time.present? ? "#{start_time.strftime('%H:%M')} - #{end_time.strftime('%H:%M')}" : nil }
+      end
+
     private
 
       def event_date

--- a/app/models/provider_events/steps/event_type.rb
+++ b/app/models/provider_events/steps/event_type.rb
@@ -17,6 +17,10 @@ module ProviderEvents
         @event_types ||= EVENT_TYPES.map { |id| EventTypeData.new(id: id, value: id) }
       end
 
+      def reviewable_answers
+        { "event_type" => event_type ? I18n.t("helpers.answer.provider_events_steps.event_type.event_type.#{event_type}") : nil }
+      end
+
     private
 
       def event_type_inquiry = event_type.to_s.inquiry

--- a/app/models/provider_events/steps/in_person_location.rb
+++ b/app/models/provider_events/steps/in_person_location.rb
@@ -27,7 +27,17 @@ module ProviderEvents
         @buildings ||= GetIntoTeachingApiClient::TeachingEventBuildingsApi.new.get_teaching_event_buildings
       end
 
+      def reviewable_answers
+        if existing?
+          { "venue" => building_record.present? ? "#{building_record.venue} (#{building_record&.address_postcode})" : nil }
+        end
+      end
+
     private
+
+      def building_record
+        @building_record ||= buildings.find { |b| b.id == building } if building.present?
+      end
 
       def location_option_inquiry = location_option.to_s.inquiry
     end

--- a/app/models/provider_events/steps/new_venue.rb
+++ b/app/models/provider_events/steps/new_venue.rb
@@ -1,0 +1,24 @@
+module ProviderEvents
+  module Steps
+    class NewVenue < ::GITWizard::Step
+      include FunnelTitle
+      include NormalisePostcode
+
+      attribute :venue_name
+      attribute :address_line_1
+      attribute :address_line_2
+      attribute :address_line_3
+      attribute :address_city
+      attribute :address_postcode
+
+      validates :venue_name, presence: true
+      validates :address_postcode, presence: true, postcode: true, length: { maximum: 10 }
+
+      before_validation -> { normalise_postcode :address_postcode }
+
+      def skipped?
+        other_step(:in_person_location).existing?
+      end
+    end
+  end
+end

--- a/app/models/provider_events/steps/new_venue.rb
+++ b/app/models/provider_events/steps/new_venue.rb
@@ -2,7 +2,8 @@ module ProviderEvents
   module Steps
     class NewVenue < ::GITWizard::Step
       include FunnelTitle
-      include NormalisePostcode
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :venue_name
       attribute :address_line_1
@@ -14,10 +15,23 @@ module ProviderEvents
       validates :venue_name, presence: true
       validates :address_postcode, presence: true, postcode: true, length: { maximum: 10 }
 
-      before_validation -> { normalise_postcode :address_postcode }
+      normalizes :venue_name, :address_line_1, :address_line_2, :address_line_3, :address_city, with: ->(field) { field.to_s.squish.presence }
+      normalizes :address_postcode, with: ->(field) { field.to_s.squish.upcase.presence }
 
       def skipped?
         other_step(:in_person_location).skipped? || other_step(:in_person_location).existing?
+      end
+
+      def reviewable_answers
+        if other_step(:in_person_location).new?
+          { "venue" => address.presence }
+        end
+      end
+
+    private
+
+      def address
+        [venue_name, address_line_1, address_line_2, address_line_3, address_city, address_postcode].compact.join(", ")
       end
     end
   end

--- a/app/models/provider_events/steps/new_venue.rb
+++ b/app/models/provider_events/steps/new_venue.rb
@@ -17,7 +17,7 @@ module ProviderEvents
       before_validation -> { normalise_postcode :address_postcode }
 
       def skipped?
-        other_step(:in_person_location).existing?
+        other_step(:in_person_location).skipped? || other_step(:in_person_location).existing?
       end
     end
   end

--- a/app/models/provider_events/steps/online_postcode.rb
+++ b/app/models/provider_events/steps/online_postcode.rb
@@ -2,15 +2,19 @@ module ProviderEvents
   module Steps
     class OnlinePostcode < ::GITWizard::Step
       include FunnelTitle
-      include NormalisePostcode
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :online_postcode
       validates :online_postcode, presence: true, postcode: true, length: { maximum: 10 }
-
-      before_validation -> { normalise_postcode :online_postcode }
+      normalizes :online_postcode, with: ->(field) { field.to_s.squish.upcase.presence }
 
       def skipped?
         other_step(:event_type).in_person?
+      end
+
+      def reviewable_answers
+        super if other_step(:event_type).online?
       end
     end
   end

--- a/app/models/provider_events/steps/online_postcode.rb
+++ b/app/models/provider_events/steps/online_postcode.rb
@@ -2,20 +2,15 @@ module ProviderEvents
   module Steps
     class OnlinePostcode < ::GITWizard::Step
       include FunnelTitle
+      include NormalisePostcode
 
       attribute :online_postcode
       validates :online_postcode, presence: true, postcode: true, length: { maximum: 10 }
 
-      before_validation :normalise_postcode
+      before_validation -> { normalise_postcode :online_postcode }
 
       def skipped?
         other_step(:event_type).in_person?
-      end
-
-    private
-
-      def normalise_postcode
-        self.online_postcode = online_postcode.strip.upcase.presence if online_postcode.present?
       end
     end
   end

--- a/app/models/provider_events/steps/organisation_name.rb
+++ b/app/models/provider_events/steps/organisation_name.rb
@@ -2,9 +2,12 @@ module ProviderEvents
   module Steps
     class OrganisationName < ::GITWizard::Step
       include FunnelTitle
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :organisation_name
       validates :organisation_name, presence: true, length: { maximum: 200 }
+      normalizes :organisation_name, with: ->(field) { field.to_s.squish.presence }
     end
   end
 end

--- a/app/models/provider_events/steps/registration_details.rb
+++ b/app/models/provider_events/steps/registration_details.rb
@@ -10,16 +10,22 @@ module ProviderEvents
 
       validates :registration_option, presence: true, inclusion: REGISTRATION_OPTIONS
 
-      validates :registration_email, presence: true, email_format: true, length: { maximum: 100 }, if: -> { email_registration? } # NB: the CRM imposes a limit of 100 chars on this field
-      validates :registration_website, presence: true, length: { maximum: 300 }, url: { no_local: true }, if: -> { website_registration? }
+      validates :registration_email, presence: true, email_format: true, length: { maximum: 100 }, if: -> { email? } # NB: the CRM imposes a limit of 100 chars on this field
+      validates :registration_website, presence: true, length: { maximum: 300 }, url: { no_local: true }, if: -> { website? }
 
-      def website_registration?
-        registration_option == WEBSITE
+      delegate :website?, :email?, to: :registration_option_inquiry
+
+      def reviewable_answers
+        { "registration_details": if website?
+                                    registration_website
+                                  elsif email?
+                                    registration_email
+                                  end }
       end
 
-      def email_registration?
-        registration_option == EMAIL
-      end
+    private
+
+      def registration_option_inquiry = registration_option.to_s.inquiry
     end
   end
 end

--- a/app/models/provider_events/steps/registration_details.rb
+++ b/app/models/provider_events/steps/registration_details.rb
@@ -1,0 +1,25 @@
+module ProviderEvents
+  module Steps
+    class RegistrationDetails < ::GITWizard::Step
+      include FunnelTitle
+      REGISTRATION_OPTIONS = [WEBSITE = "website".freeze, EMAIL = "email".freeze].freeze
+
+      attribute :registration_option
+      attribute :registration_email
+      attribute :registration_website
+
+      validates :registration_option, presence: true, inclusion: REGISTRATION_OPTIONS
+
+      validates :registration_email, presence: true, email_format: true, length: { maximum: 100 }, if: -> { email_registration? } # NB: the CRM imposes a limit of 100 chars on this field
+      validates :registration_website, presence: true, length: { maximum: 300 }, url: { no_local: true }, if: -> { website_registration? }
+
+      def website_registration?
+        registration_option == WEBSITE
+      end
+
+      def email_registration?
+        registration_option == EMAIL
+      end
+    end
+  end
+end

--- a/app/models/provider_events/steps/review_answers.rb
+++ b/app/models/provider_events/steps/review_answers.rb
@@ -1,0 +1,49 @@
+module ProviderEvents
+  module Steps
+    class ReviewAnswers < ::GITWizard::Step
+      include FunnelTitle
+
+      EVENT_DETAILS = [Steps::Email,
+                       Steps::EventName,
+                       Steps::EventDescription,
+                       Steps::OrganisationName,
+                       Steps::EventWebsite,
+                       Steps::TargetAudience,
+                       Steps::EventDate,
+                       Steps::EventTimes].freeze
+
+      VENUE_DETAILS = [Steps::EventType,
+                       Steps::OnlinePostcode,
+                       Steps::InPersonLocation,
+                       Steps::NewVenue].freeze
+
+      REGISTRATION_DETAILS = [Steps::RegistrationDetails].freeze
+
+      def event_details_answers_by_step
+        filtered_answers_by_step(EVENT_DETAILS)
+      end
+
+      def venue_details_answers_by_step
+        filtered_answers_by_step(VENUE_DETAILS)
+      end
+
+      def registration_details_answers_by_step
+        filtered_answers_by_step(REGISTRATION_DETAILS)
+      end
+
+      def seen?
+        false # ensure this step is always shown
+      end
+
+    private
+
+      def filtered_answers_by_step(filter)
+        answers_by_step.select { |k| filter.include?(k) }
+      end
+
+      def answers_by_step
+        @answers_by_step ||= @wizard.reviewable_answers_by_step
+      end
+    end
+  end
+end

--- a/app/models/provider_events/steps/target_audience.rb
+++ b/app/models/provider_events/steps/target_audience.rb
@@ -2,9 +2,12 @@ module ProviderEvents
   module Steps
     class TargetAudience < ::GITWizard::Step
       include FunnelTitle
+      include ActiveRecord::Normalization
+      include ActiveModel::Dirty
 
       attribute :target_audience
       validates :target_audience, presence: true, length: { maximum: 500 }
+      normalizes :target_audience, with: ->(field) { field.to_s.squish.presence }
     end
   end
 end

--- a/app/models/provider_events/wizard.rb
+++ b/app/models/provider_events/wizard.rb
@@ -2,6 +2,8 @@ module ProviderEvents
   class Wizard < ::GITWizard::Base
     DEFAULT_ERROR_MESSAGE = "Choose an option from the list".freeze
 
+    ATTRIBUTES_TO_LEAVE = %w[email reference_number].freeze
+
     self.steps = [
       Steps::Email,
       Steps::EventName,
@@ -16,6 +18,16 @@ module ProviderEvents
       Steps::InPersonLocation,
       Steps::NewVenue,
       Steps::RegistrationDetails,
+      Steps::ReviewAnswers,
     ]
+
+    def complete!
+      super.tap do |result|
+        break unless result
+
+        @store[:reference_number] = "COMING-SOON"
+        @store.prune!(leave: ATTRIBUTES_TO_LEAVE)
+      end
+    end
   end
 end

--- a/app/models/provider_events/wizard.rb
+++ b/app/models/provider_events/wizard.rb
@@ -14,10 +14,7 @@ module ProviderEvents
       Steps::EventType,
       Steps::OnlinePostcode,
       Steps::InPersonLocation,
-
-      # Steps::EventFormat,
-      # Steps::EventRegion,
-      # Steps::EventRegistration,
+      Steps::NewVenue,
     ]
   end
 end

--- a/app/models/provider_events/wizard.rb
+++ b/app/models/provider_events/wizard.rb
@@ -15,6 +15,7 @@ module ProviderEvents
       Steps::OnlinePostcode,
       Steps::InPersonLocation,
       Steps::NewVenue,
+      Steps::RegistrationDetails,
     ]
   end
 end

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -1,13 +1,14 @@
 module TeacherTrainingAdviser::Steps
   class UkAddress < GITWizard::Step
-    include NormalisePostcode
-    attribute :address_postcode, :string
+    include FunnelTitle
+    include ActiveRecord::Normalization
+    include ActiveModel::Dirty
+
+    attribute :address_postcode
 
     validates :address_postcode, format: { with: /^([A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$/i, multiline: true }
 
-    before_validation -> { normalise_postcode :address_postcode }
-
-    include FunnelTitle
+    normalizes :address_postcode, with: ->(field) { field.to_s.squish.upcase.presence }
 
     def self.contains_personal_details?
       true

--- a/app/models/teacher_training_adviser/steps/uk_address.rb
+++ b/app/models/teacher_training_adviser/steps/uk_address.rb
@@ -1,10 +1,11 @@
 module TeacherTrainingAdviser::Steps
   class UkAddress < GITWizard::Step
+    include NormalisePostcode
     attribute :address_postcode, :string
 
     validates :address_postcode, format: { with: /^([A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}|GIR ?0A{2})$/i, multiline: true }
 
-    before_validation :sanitize_input
+    before_validation -> { normalise_postcode :address_postcode }
 
     include FunnelTitle
 
@@ -14,12 +15,6 @@ module TeacherTrainingAdviser::Steps
 
     def skipped?
       other_step(:location).overseas? || other_step(:degree_country).another_country?
-    end
-
-  private
-
-    def sanitize_input
-      self.address_postcode = address_postcode.to_s.strip.presence if address_postcode
     end
   end
 end

--- a/app/views/provider_events/steps/_new_venue.html.erb
+++ b/app/views/provider_events/steps/_new_venue.html.erb
@@ -1,0 +1,43 @@
+<%= tag.h1 t("helpers.label.provider_events_steps_new_venue.title") %>
+
+<%= f.govuk_text_field(
+      :venue_name,
+      width: 'two-thirds',
+      label: { tag: "h4" },
+    )
+%>
+
+<%= f.govuk_text_field(
+      :address_line_1,
+      width: 'two-thirds',
+      label: { tag: "h4" },
+      )
+%>
+
+<%= f.govuk_text_field(
+      :address_line_2,
+      width: 'two-thirds',
+      label: { tag: "h4" },
+      )
+%>
+
+<%= f.govuk_text_field(
+      :address_line_3,
+      width: 'two-thirds',
+      label: { tag: "h4" },
+      )
+%>
+
+<%= f.govuk_text_field(
+      :address_city,
+      width: 'two-thirds',
+      label: { tag: "h4" },
+      )
+%>
+
+<%= f.govuk_text_field(
+      :address_postcode,
+      width: 'one-third',
+      label: { tag: "h4" },
+      )
+%>

--- a/app/views/provider_events/steps/_new_venue.html.erb
+++ b/app/views/provider_events/steps/_new_venue.html.erb
@@ -11,33 +11,33 @@
       :address_line_1,
       width: 'two-thirds',
       label: { tag: "h4" },
-      )
+    )
 %>
 
 <%= f.govuk_text_field(
       :address_line_2,
       width: 'two-thirds',
       label: { tag: "h4" },
-      )
+    )
 %>
 
 <%= f.govuk_text_field(
       :address_line_3,
       width: 'two-thirds',
       label: { tag: "h4" },
-      )
+    )
 %>
 
 <%= f.govuk_text_field(
       :address_city,
       width: 'two-thirds',
       label: { tag: "h4" },
-      )
+    )
 %>
 
 <%= f.govuk_text_field(
       :address_postcode,
       width: 'one-third',
       label: { tag: "h4" },
-      )
+    )
 %>

--- a/app/views/provider_events/steps/_registration_details.html.erb
+++ b/app/views/provider_events/steps/_registration_details.html.erb
@@ -1,0 +1,8 @@
+<%= f.govuk_radio_buttons_fieldset(:registration_option, legend: { tag: 'h1', text: t("helpers.label.provider_events_steps_registration_details.registration_option") }) do %>
+  <%= f.govuk_radio_button :registration_option, ProviderEvents::Steps::RegistrationDetails::EMAIL, label: { text: t("helpers.answer.provider_events_steps.registration_details.registration_option.email")} do %>
+    <%= f.govuk_email_field :registration_email %>
+  <% end %>
+  <%= f.govuk_radio_button :registration_option, ProviderEvents::Steps::RegistrationDetails::WEBSITE, label: { text: t("helpers.answer.provider_events_steps.registration_details.registration_option.website")} do %>
+    <%= f.govuk_url_field :registration_website %>
+  <% end %>
+<% end %>

--- a/app/views/provider_events/steps/_review_answers.html.erb
+++ b/app/views/provider_events/steps/_review_answers.html.erb
@@ -1,0 +1,23 @@
+<%= tag.h1 t('helpers.label.provider_events_steps_review_answers.title') %>
+
+<%= tag.h3 t('helpers.label.provider_events_steps_review_answers.event_details') %>
+
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% f.object.event_details_answers_by_step.each do |step, answers| %>
+    <%= render partial: "provider_events/steps/review_answers/answer", collection: answers, locals: { step: step } %>
+  <% end %>
+</dl>
+
+<%= tag.h3 t('helpers.label.provider_events_steps_review_answers.venue_details') %>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% f.object.venue_details_answers_by_step.each do |step, answers| %>
+    <%= render partial: "provider_events/steps/review_answers/answer", collection: answers, locals: { step: step } %>
+  <% end %>
+</dl>
+
+<%= tag.h3 t('helpers.label.provider_events_steps_review_answers.registration_process') %>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% f.object.registration_details_answers_by_step.each do |step, answers| %>
+    <%= render partial: "provider_events/steps/review_answers/answer", collection: answers, locals: { step: step } %>
+  <% end %>
+</dl>

--- a/app/views/provider_events/steps/completed.html.erb
+++ b/app/views/provider_events/steps/completed.html.erb
@@ -1,9 +1,31 @@
-<section class="container">
-  <div class="row">
-    <div class="col">
-      <h1>Thanks for your provider event</h1>
+<section class="container main-section">
+  <div class="row inset">
+    <div class="col col-720">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+          Application submitted
+        </h1>
+        <h3>Your reference number<br>
+          <b><%= @reference_number %></b>
+        </h3>
+      </div>
+
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        We have sent a confirmation email to <b><%= @email_address %></b>. We will also send
+        you an email to let you know when your event has been published.
+      </p>
+
+      <p>
+        <%= link_to "Submit another event", provider_events_steps_path %>
+      </p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>
+        We aim to add your event within 10 working days. This may take longer during busier periods.
+      </p>
+      <p>
+        We may contact you to ask for more information. If you need to contact us about your event,
+        email <a href="mailto:ITT-provider.EVENTS@education.gov.uk?subject=Teaching%20Provider%20Event">ITT-provider.EVENTS@education.gov.uk</a>
       </p>
     </div>
   </div>

--- a/app/views/provider_events/steps/review_answers/_answer.html.erb
+++ b/app/views/provider_events/steps/review_answers/_answer.html.erb
@@ -1,0 +1,13 @@
+<dl class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%= t("answers.provider_events.#{step.key}.#{answer.first}.title", **Value.data) %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= format_answer(answer.last) %>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to(provider_events_step_path(step.key)) do %>
+      <%= safe_html_format("Change <span class='visually-hidden'> #{t("answers.#{step.key}.#{answer.first}.change")}</span>") %>
+    <% end %>
+  </dd>
+</dl>

--- a/app/views/provider_events/steps/show.html.erb
+++ b/app/views/provider_events/steps/show.html.erb
@@ -1,1 +1,1 @@
-<%= render "form/sign_up", current_step: @current_step, wizard: @wizard, section_class: "provider-events", complete_button_text: "Next step" %>
+<%= render "form/sign_up", current_step: @current_step, wizard: @wizard, section_class: "provider-events" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -744,6 +744,13 @@ en:
               blank: "Search for an existing venue or add a new venue"
             building:
               blank: "Search for an existing building"
+        provider_events/steps/new_venue:
+          attributes:
+            venue_name:
+              blank: "Enter venue name"
+            address_postcode:
+              blank: "Enter postcode"
+              invalid: "Enter a full UK postcode"
 
   helpers:
     answer:
@@ -1030,6 +1037,14 @@ en:
       provider_events_steps_in_person_location:
         location_option: "Where will your event be?"
         building: "Search for existing buildings"
+      provider_events_steps_new_venue:
+        title: "Venue details"
+        venue_name: "Venue name"
+        address_line_1: "Address line 1"
+        address_line_2: "Address line 2"
+        address_line_3: "Address line 3"
+        address_city: "Town or city"
+        address_postcode: "Postcode"
 
     hint:
       events_steps_accessibility_support:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,18 @@ en:
             address_postcode:
               blank: "Enter postcode"
               invalid: "Enter a full UK postcode"
+        provider_events/steps/registration_details:
+          attributes:
+            registration_option:
+              blank: "Select if people will register through email or a website"
+            registration_email:
+              blank: "Enter email"
+              invalid: "Enter an email address in the correct format, like name@example.com"
+              too_long: "Email must be 100 characters or less"
+            registration_website:
+              blank: "Enter website URL"
+              too_long: "Website URL must be 300 characters or less"
+              url: "Website URL must be valid and start with https:// or http://"
 
   helpers:
     answer:
@@ -853,6 +865,10 @@ en:
           location_option:
             existing: "Search existing venues"
             new: "Add a new venue"
+        registration_details:
+          registration_option:
+            email: "By email"
+            website: "Through a website"
 
     label:
       wizard_steps_authenticate:
@@ -1045,6 +1061,10 @@ en:
         address_line_3: "Address line 3"
         address_city: "Town or city"
         address_postcode: "Postcode"
+      provider_events_steps_registration_details:
+        registration_option: "How will people register for your event?"
+        registration_email: "Email address"
+        registration_website: "Website URL"
 
     hint:
       events_steps_accessibility_support:
@@ -1153,6 +1173,9 @@ en:
         online_postcode_extra: "This helps people in your target area find your event, even when it's online."
       provider_events_steps_in_person_location:
         location_option: "This information will help people find your event."
+      provider_events_steps_registration_details:
+        registration_email: "Enter the email address you want people to use to sign up."
+        registration_website: "Enter the website address you want people to use to sign up."
 
     legend:
       teacher_training_adviser_feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,6 +367,49 @@ en:
         title: "How would you describe your current situation?"
         change: "your current situation"
 
+    provider_events:
+      email:
+        email:
+          title: "What is your email address?"
+          change: "your email"
+      event_name:
+        event_name:
+          title: "What is the name of your event?"
+      event_description:
+        event_description:
+          title: "Describe your event"
+      organisation_name:
+        organisation_name:
+          title: "What is the name of your organisation?"
+      event_website:
+        event_website:
+          title: "Provide your website URL"
+      target_audience:
+        target_audience:
+          title: "Who is this event for?"
+      event_date:
+        event_date:
+          title: "What day is your event?"
+      event_times:
+        event_times:
+          title: "What time does your event start and end?"
+      event_type:
+        event_type:
+          title: "What type of event is this?"
+      online_postcode:
+        online_postcode:
+          title: "Provide a postcode for your event"
+      in_person_location:
+        venue:
+          title: "Where will your event be?"
+      new_venue:
+        venue:
+          title: "Where will your event be?"
+      registration_details:
+        registration_details:
+          title: "How will people register for your event?"
+
+
   activerecord:
     errors:
       models:
@@ -1065,6 +1108,11 @@ en:
         registration_option: "How will people register for your event?"
         registration_email: "Email address"
         registration_website: "Website URL"
+      provider_events_steps_review_answers:
+        title: "Check your answers before you submit your event details"
+        event_details: "Event details"
+        venue_details: "Venue details"
+        registration_process: "Registration process"
 
     hint:
       events_steps_accessibility_support:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,9 @@ Rails.application.routes.draw do
     resources :steps,
               path: "/",
               only: %i[index show update] do
+      collection do
+        get :completed, to: "steps#completed"
+      end
     end
   end
 

--- a/spec/features/provider_events/register_new_provider_event_spec.rb
+++ b/spec/features/provider_events/register_new_provider_event_spec.rb
@@ -58,6 +58,13 @@ RSpec.feature "Register a provider event", type: :feature do
       expect(page).to have_field("Provide a postcode for your event")
       fill_in "Provide a postcode for your event", with: "Te57 1nG"
       click_on "Next step"
+
+      expect(page).to have_content("How will people register for your event?")
+      within_fieldset("How will people register for your event?") do
+        choose "Through a website"
+        fill_in "Website URL", with: "https://www.example.com/"
+      end
+      click_on "Next step"
     end
 
     describe "Registering an in-person event" do
@@ -121,6 +128,13 @@ RSpec.feature "Register a provider event", type: :feature do
         within_fieldset("Where will your event be?") do
           choose "Search existing venues"
           select "test, M1 7AX", from: "Search for existing buildings"
+        end
+        click_on "Next step"
+
+        expect(page).to have_content("How will people register for your event?")
+        within_fieldset("How will people register for your event?") do
+          choose "Through a website"
+          fill_in "Website URL", with: "https://www.example.com/"
         end
         click_on "Next step"
       end
@@ -194,7 +208,14 @@ RSpec.feature "Register a provider event", type: :feature do
           fill_in "Address line 2", with: "Wimbledon"
           fill_in "Address line 3", with: "Merton"
           fill_in "Town or city", with: "London"
-          fill_in "Postcode", with: "TE57 ING"
+          fill_in "Postcode", with: "TE57 1NG"
+          click_on "Next step"
+
+          expect(page).to have_content("How will people register for your event?")
+          within_fieldset("How will people register for your event?") do
+            choose "Through a website"
+            fill_in "Website URL", with: "https://www.example.com/"
+          end
           click_on "Next step"
         end
       end

--- a/spec/features/provider_events/register_new_provider_event_spec.rb
+++ b/spec/features/provider_events/register_new_provider_event_spec.rb
@@ -124,6 +124,80 @@ RSpec.feature "Register a provider event", type: :feature do
         end
         click_on "Next step"
       end
+
+      describe "Registering an in-person event at a new venue" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::TeachingEventBuildingsApi).to receive(:get_teaching_event_buildings).and_return(buildings)
+          visit provider_events_steps_path
+        end
+
+        let(:buildings) { build_list(:event_building, 1) }
+
+        it "navigates the steps" do
+          expect(page).to have_link(href: provider_events_step_path(ProviderEvents::Steps::Email.key))
+          click_on "Start now"
+
+          expect(page).to have_field("What is your email address?")
+          fill_in "What is your email address?", with: "test@test.test"
+          click_on "Next step"
+
+          expect(page).to have_field("What is the name of your event?")
+          fill_in "What is the name of your event?", with: "Super-duper Event"
+          click_on "Next step"
+
+          expect(page).to have_field("Describe your event")
+          fill_in "Describe your event", with: "Lorem ipsum dolor sit amet"
+          click_on "Next step"
+
+          expect(page).to have_field("What is the name of your organisation?")
+          fill_in "What is the name of your organisation?", with: "Training Organisation"
+          click_on "Next step"
+
+          expect(page).to have_field("Provide your website URL")
+          fill_in "Provide your website URL", with: "https://www.example.com"
+          click_on "Next step"
+
+          expect(page).to have_field("Who is this event for?")
+          fill_in "Who is this event for?", with: "Lorem ipsum dolor sit amet"
+          click_on "Next step"
+
+          expect(page).to have_field("What day is your event?")
+          fill_in "What day is your event", with: "30/12/3000"
+          click_on "Next step"
+
+          expect(page).to have_content("What time does your event start and end?")
+          within_fieldset("Start at") do
+            fill_in "Hour", with: 13
+            fill_in "Minute", with: 0o0
+          end
+          within_fieldset("End at") do
+            fill_in "Hour", with: 17
+            fill_in "Minute", with: 30
+          end
+          click_on "Next step"
+
+          expect(page).to have_content("What type of event is this?")
+          within_fieldset("What type of event is this?") do
+            choose "In-person"
+          end
+          click_on "Next step"
+
+          expect(page).to have_content("Where will your event be?")
+          within_fieldset("Where will your event be?") do
+            choose "Add a new venue"
+          end
+          click_on "Next step"
+
+          expect(page).to have_content("Venue details")
+          fill_in "Venue name", with: "Womble HQ"
+          fill_in "Address line 1", with: "Wimbledon Common"
+          fill_in "Address line 2", with: "Wimbledon"
+          fill_in "Address line 3", with: "Merton"
+          fill_in "Town or city", with: "London"
+          fill_in "Postcode", with: "TE57 ING"
+          click_on "Next step"
+        end
+      end
     end
   end
 end

--- a/spec/features/provider_events/register_new_provider_event_spec.rb
+++ b/spec/features/provider_events/register_new_provider_event_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Register a provider event", type: :feature do
       click_on "Next step"
 
       expect(page).to have_field("Who is this event for?")
-      fill_in "Who is this event for?", with: "Lorem ipsum dolor sit amet"
+      fill_in "Who is this event for?", with: "Trainee teachers"
       click_on "Next step"
 
       expect(page).to have_field("What day is your event?")
@@ -41,7 +41,7 @@ RSpec.feature "Register a provider event", type: :feature do
       expect(page).to have_content("What time does your event start and end?")
       within_fieldset("Start at") do
         fill_in "Hour", with: 13
-        fill_in "Minute", with: 0o0
+        fill_in "Minute", with: 0
       end
       within_fieldset("End at") do
         fill_in "Hour", with: 17
@@ -62,9 +62,37 @@ RSpec.feature "Register a provider event", type: :feature do
       expect(page).to have_content("How will people register for your event?")
       within_fieldset("How will people register for your event?") do
         choose "Through a website"
-        fill_in "Website URL", with: "https://www.example.com/"
+        fill_in "Website URL", with: "https://www.example.com/register"
       end
       click_on "Next step"
+
+      expect(page).to have_content("Check your answers before you submit your event details")
+      expect(page).to have_content("What is your email address?")
+      expect(page).to have_content("test@test.test")
+      expect(page).to have_content("What is the name of your event?")
+      expect(page).to have_content("Super-duper Event")
+      expect(page).to have_content("Describe your event")
+      expect(page).to have_content("Lorem ipsum dolor sit amet")
+      expect(page).to have_content("What is the name of your organisation?")
+      expect(page).to have_content("Training Organisation")
+      expect(page).to have_content("Provide your website URL")
+      expect(page).to have_content("https://www.example.com")
+      expect(page).to have_content("Who is this event for?")
+      expect(page).to have_content("Trainee teachers")
+      expect(page).to have_content("What day is your event?")
+      expect(page).to have_content("30 December 3000")
+      expect(page).to have_content("What time does your event start and end?")
+      expect(page).to have_content("13:00 - 17:30")
+      expect(page).to have_content("What type of event is this?")
+      expect(page).to have_content("Online")
+      expect(page).to have_content("Provide a postcode for your event")
+      expect(page).to have_content("TE57 1NG")
+      expect(page).to have_content("How will people register for your event?")
+      expect(page).to have_content("https://www.example.com/register")
+      click_on "Complete sign up"
+
+      expect(page).to have_content("Application submitted")
+      expect(page).to have_content("test@test.test")
     end
 
     describe "Registering an in-person event" do
@@ -110,7 +138,7 @@ RSpec.feature "Register a provider event", type: :feature do
         expect(page).to have_content("What time does your event start and end?")
         within_fieldset("Start at") do
           fill_in "Hour", with: 13
-          fill_in "Minute", with: 0o0
+          fill_in "Minute", with: 0
         end
         within_fieldset("End at") do
           fill_in "Hour", with: 17
@@ -137,6 +165,16 @@ RSpec.feature "Register a provider event", type: :feature do
           fill_in "Website URL", with: "https://www.example.com/"
         end
         click_on "Next step"
+
+        expect(page).to have_content("Check your answers before you submit your event details")
+        expect(page).to have_content("What type of event is this?")
+        expect(page).to have_content("In-person")
+        expect(page).to have_content("Where will your event be?")
+        expect(page).to have_content("test (M1 7AX)")
+        click_on "Complete sign up"
+
+        expect(page).to have_content("Application submitted")
+        expect(page).to have_content("test@test.test")
       end
 
       describe "Registering an in-person event at a new venue" do
@@ -182,7 +220,7 @@ RSpec.feature "Register a provider event", type: :feature do
           expect(page).to have_content("What time does your event start and end?")
           within_fieldset("Start at") do
             fill_in "Hour", with: 13
-            fill_in "Minute", with: 0o0
+            fill_in "Minute", with: 0
           end
           within_fieldset("End at") do
             fill_in "Hour", with: 17
@@ -217,6 +255,16 @@ RSpec.feature "Register a provider event", type: :feature do
             fill_in "Website URL", with: "https://www.example.com/"
           end
           click_on "Next step"
+
+          expect(page).to have_content("Check your answers before you submit your event details")
+          expect(page).to have_content("What type of event is this?")
+          expect(page).to have_content("In-person")
+          expect(page).to have_content("Where will your event be?")
+          expect(page).to have_content("Womble HQ, Wimbledon Common, Wimbledon, Merton, London, TE57 1NG")
+          click_on "Complete sign up"
+
+          expect(page).to have_content("Application submitted")
+          expect(page).to have_content("test@test.test")
         end
       end
     end

--- a/spec/models/mailing_list/steps/postcode_spec.rb
+++ b/spec/models/mailing_list/steps/postcode_spec.rb
@@ -5,29 +5,12 @@ describe MailingList::Steps::Postcode do
   let(:msg) { "Enter a valid UK postcode" }
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a normalised and validated postcode", :address_postcode, "Enter a valid UK postcode"
 
   it { expect(subject).to be_optional }
-  it { is_expected.to respond_to :address_postcode }
 
-  describe "validations for address_postcode" do
-    it { is_expected.to allow_value("TE57 1NG").for :address_postcode }
-    it { is_expected.to allow_value("  TE571NG  ").for :address_postcode }
-    it { is_expected.to allow_value(nil).for :address_postcode }
-    it { is_expected.to allow_value("").for :address_postcode }
-    it { is_expected.not_to allow_value("random").for(:address_postcode).with_message(msg) }
-    it { is_expected.not_to allow_value("TE57 ING").for(:address_postcode).with_message(msg) }
-  end
-
-  describe "data cleaning for the postcode" do
-    it "normalises the postcode" do
-      subject.address_postcode = "  te57 1ng "
-      subject.valid?
-      expect(subject.address_postcode).to eq("TE57 1NG")
-      subject.address_postcode = "  "
-      subject.valid?
-      expect(subject.address_postcode).to be_nil
-    end
-  end
+  it { is_expected.to allow_value(nil).for :address_postcode }
+  it { is_expected.to allow_value("").for :address_postcode }
 
   describe "skipped?" do
     before do

--- a/spec/models/provider_events/steps/event_description_spec.rb
+++ b/spec/models/provider_events/steps/event_description_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderEvents::Steps::EventDescription do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a sanitised field", :event_description
 
   it { is_expected.to respond_to :event_description }
 

--- a/spec/models/provider_events/steps/event_name_spec.rb
+++ b/spec/models/provider_events/steps/event_name_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderEvents::Steps::EventName do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a sanitised field", :event_name
 
   it { is_expected.to respond_to :event_name }
 

--- a/spec/models/provider_events/steps/event_website_spec.rb
+++ b/spec/models/provider_events/steps/event_website_spec.rb
@@ -14,16 +14,5 @@ RSpec.describe ProviderEvents::Steps::EventWebsite do
 
   it { is_expected.not_to be_skipped }
 
-  describe "event_website" do
-    context "when it is invalid" do
-      it { is_expected.not_to allow_value("http://localhost/foo/bar").for :event_website }
-      it { is_expected.not_to allow_value("ftp://foo.bar/").for :event_website }
-      it { is_expected.not_to allow_value("https://foo/bar").for :event_website }
-    end
-
-    context "when it is valid" do
-      it { is_expected.to allow_value("http://foo.bar/foo/bar").for :event_website }
-      it { is_expected.to allow_value("https://foo.bar/foo/bar").for :event_website }
-    end
-  end
+  it_behaves_like "a validated url", :event_website
 end

--- a/spec/models/provider_events/steps/new_venue_spec.rb
+++ b/spec/models/provider_events/steps/new_venue_spec.rb
@@ -19,19 +19,29 @@ RSpec.describe ProviderEvents::Steps::NewVenue do
 
   describe "skipped?" do
     before do
-      allow(instance).to receive(:other_step).with(:in_person_location) { instance_double(ProviderEvents::Steps::InPersonLocation, existing?: existing) }
+      allow(instance).to receive(:other_step).with(:in_person_location) { instance_double(ProviderEvents::Steps::InPersonLocation, existing?: existing, skipped?: skipped) }
     end
 
-    context "when existing location" do
-      let(:existing) { true }
+    context "when in_person_location is skipped" do
+      let(:skipped) { true }
 
       it { is_expected.to be_skipped }
     end
 
-    context "when a new location" do
-      let(:existing) { false }
+    context "when in_person_location is not skipped" do
+      let(:skipped) { false }
 
-      it { is_expected.not_to be_skipped }
+      context "when existing location" do
+        let(:existing) { true }
+
+        it { is_expected.to be_skipped }
+      end
+
+      context "when a new location" do
+        let(:existing) { false }
+
+        it { is_expected.not_to be_skipped }
+      end
     end
   end
 end

--- a/spec/models/provider_events/steps/new_venue_spec.rb
+++ b/spec/models/provider_events/steps/new_venue_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe ProviderEvents::Steps::NewVenue do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a sanitised field", :venue_name
+  it_behaves_like "a sanitised field", :address_line_1
+  it_behaves_like "a sanitised field", :address_line_2
+  it_behaves_like "a sanitised field", :address_line_3
+  it_behaves_like "a sanitised field", :address_city
   it_behaves_like "a normalised and validated postcode", :address_postcode, "Enter a full UK postcode"
 
   it { is_expected.to respond_to :venue_name }

--- a/spec/models/provider_events/steps/new_venue_spec.rb
+++ b/spec/models/provider_events/steps/new_venue_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe ProviderEvents::Steps::NewVenue do
+  include_context "with wizard step"
+
+  it_behaves_like "a with wizard step"
+  it_behaves_like "a normalised and validated postcode", :address_postcode, "Enter a full UK postcode"
+
+  it { is_expected.to respond_to :venue_name }
+  it { is_expected.to respond_to :address_line_1 }
+  it { is_expected.to respond_to :address_line_2 }
+  it { is_expected.to respond_to :address_line_3 }
+  it { is_expected.to respond_to :address_city }
+  it { is_expected.to respond_to :address_postcode }
+
+  it { is_expected.to validate_presence_of :venue_name }
+  it { is_expected.to validate_presence_of :address_postcode }
+  it { is_expected.to validate_length_of(:address_postcode).is_at_most(10) }
+
+  describe "skipped?" do
+    before do
+      allow(instance).to receive(:other_step).with(:in_person_location) { instance_double(ProviderEvents::Steps::InPersonLocation, existing?: existing) }
+    end
+
+    context "when existing location" do
+      let(:existing) { true }
+
+      it { is_expected.to be_skipped }
+    end
+
+    context "when a new location" do
+      let(:existing) { false }
+
+      it { is_expected.not_to be_skipped }
+    end
+  end
+end

--- a/spec/models/provider_events/steps/online_postcode_spec.rb
+++ b/spec/models/provider_events/steps/online_postcode_spec.rb
@@ -4,41 +4,10 @@ RSpec.describe ProviderEvents::Steps::OnlinePostcode do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
-
-  it { is_expected.to respond_to :online_postcode }
+  it_behaves_like "a normalised and validated postcode", :online_postcode, "Enter a full UK postcode"
 
   it { is_expected.to validate_presence_of :online_postcode }
-
   it { is_expected.to validate_length_of(:online_postcode).is_at_most(10) }
-
-  describe "validations for online_postcode" do
-    it { is_expected.to allow_value("TE57 1NG").for :online_postcode }
-    it { is_expected.to allow_value("  TE571NG  ").for :online_postcode }
-    it { is_expected.to allow_value("  Te571nG  ").for :online_postcode }
-    it { is_expected.not_to allow_value(nil).for(:online_postcode).with_message("Enter postcode") }
-    it { is_expected.not_to allow_value("").for(:online_postcode).with_message("Enter postcode") }
-    it { is_expected.not_to allow_value("random").for(:online_postcode).with_message("Enter a full UK postcode") }
-    it { is_expected.not_to allow_value("TE57 ING").for(:online_postcode).with_message("Enter a full UK postcode") }
-  end
-
-  describe "normalise_postcode" do
-    before do
-      subject.online_postcode = postcode
-      subject.valid?
-    end
-
-    context "when the postcode is in lowercase" do
-      let(:postcode) { "wc1n 1ab" }
-
-      it { expect(subject.online_postcode).to eq("WC1N 1AB") }
-    end
-
-    context "when the postcode has whitespace" do
-      let(:postcode) { " wc1n 1ab " }
-
-      it { expect(subject.online_postcode).to eq("WC1N 1AB") }
-    end
-  end
 
   describe "skipped?" do
     before do

--- a/spec/models/provider_events/steps/organisation_name_spec.rb
+++ b/spec/models/provider_events/steps/organisation_name_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderEvents::Steps::OrganisationName do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a sanitised field", :organisation_name
 
   it { is_expected.to respond_to :organisation_name }
 

--- a/spec/models/provider_events/steps/registration_details_spec.rb
+++ b/spec/models/provider_events/steps/registration_details_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ProviderEvents::Steps::RegistrationDetails do
   it { is_expected.to respond_to :registration_email }
   it { is_expected.to respond_to :registration_website }
 
-  it { is_expected.to respond_to :website_registration? }
-  it { is_expected.to respond_to :email_registration? }
+  it { is_expected.to respond_to :website? }
+  it { is_expected.to respond_to :email? }
 
   it { is_expected.to validate_presence_of :registration_option }
   it { is_expected.to validate_inclusion_of(:registration_option).in_array(%w[website email]) }
@@ -20,8 +20,8 @@ RSpec.describe ProviderEvents::Steps::RegistrationDetails do
   context "when email registration" do
     before { subject.registration_option = "email" }
 
-    it { expect(subject.email_registration?).to be true }
-    it { expect(subject.website_registration?).to be false }
+    it { expect(subject.email?).to be true }
+    it { expect(subject.website?).to be false }
 
     it { is_expected.to validate_presence_of(:registration_email) }
     it { is_expected.to validate_length_of(:registration_email).is_at_most(100) }
@@ -32,8 +32,8 @@ RSpec.describe ProviderEvents::Steps::RegistrationDetails do
   context "when website registration" do
     before { subject.registration_option = "website" }
 
-    it { expect(subject.email_registration?).to be false }
-    it { expect(subject.website_registration?).to be true }
+    it { expect(subject.email?).to be false }
+    it { expect(subject.website?).to be true }
 
     it { is_expected.to validate_presence_of(:registration_website) }
     it { is_expected.to validate_length_of(:registration_website).is_at_most(300) }

--- a/spec/models/provider_events/steps/registration_details_spec.rb
+++ b/spec/models/provider_events/steps/registration_details_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ProviderEvents::Steps::RegistrationDetails do
+  include_context "with wizard step"
+
+  it_behaves_like "a with wizard step"
+
+  it { is_expected.to respond_to :registration_option }
+  it { is_expected.to respond_to :registration_email }
+  it { is_expected.to respond_to :registration_website }
+
+  it { is_expected.to respond_to :website_registration? }
+  it { is_expected.to respond_to :email_registration? }
+
+  it { is_expected.to validate_presence_of :registration_option }
+  it { is_expected.to validate_inclusion_of(:registration_option).in_array(%w[website email]) }
+
+  it { is_expected.not_to be_skipped }
+
+  context "when email registration" do
+    before { subject.registration_option = "email" }
+
+    it { expect(subject.email_registration?).to be true }
+    it { expect(subject.website_registration?).to be false }
+
+    it { is_expected.to validate_presence_of(:registration_email) }
+    it { is_expected.to validate_length_of(:registration_email).is_at_most(100) }
+
+    it { is_expected.not_to validate_presence_of(:registration_website) }
+  end
+
+  context "when website registration" do
+    before { subject.registration_option = "website" }
+
+    it { expect(subject.email_registration?).to be false }
+    it { expect(subject.website_registration?).to be true }
+
+    it { is_expected.to validate_presence_of(:registration_website) }
+    it { is_expected.to validate_length_of(:registration_website).is_at_most(300) }
+
+    it { is_expected.not_to validate_presence_of(:registration_email) }
+
+    it_behaves_like "a validated url", :registration_website
+  end
+end

--- a/spec/models/provider_events/steps/review_answers_spec.rb
+++ b/spec/models/provider_events/steps/review_answers_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe ProviderEvents::Steps::ReviewAnswers do
+  include_context "with wizard step"
+
+  let(:answers_by_step) do
+    {
+      ProviderEvents::Steps::Email => { email: "test@test.test" },
+      ProviderEvents::Steps::EventName => { event_name: "Event Name" },
+      ProviderEvents::Steps::EventDescription => { event_description: "Event Description" },
+      ProviderEvents::Steps::OrganisationName => { organisation_name: "Organisation Name" },
+      ProviderEvents::Steps::EventWebsite => { event_website: "https://www.example.com" },
+      ProviderEvents::Steps::TargetAudience => { target_audience: "Target Audience" },
+      ProviderEvents::Steps::EventDate => { event_date: "01/01/2999" },
+      ProviderEvents::Steps::EventTimes => { start_time: "09:00", end_time: "17:30" },
+      ProviderEvents::Steps::EventType => { event_type: "in_person" },
+      ProviderEvents::Steps::OnlinePostcode => {},
+      ProviderEvents::Steps::InPersonLocation => { location_option: "new" },
+      ProviderEvents::Steps::NewVenue => { venue_name: "Venue Name", address_line_1: "Address Line 1", address_city: "Londontown", address_postcode: "WC1A 1AA" },
+      ProviderEvents::Steps::RegistrationDetails => { registration_option: "website", registration_website: "https://www.example.com/register" },
+    }
+  end
+
+  it_behaves_like "a with wizard step"
+
+  describe "#seen?" do
+    it { is_expected.not_to be_seen }
+  end
+
+  describe "#event_details_answers_by_step" do
+    subject { instance.event_details_answers_by_step }
+
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:answers_by_step).and_return answers_by_step
+    end
+
+    it {
+      expect(subject).to eq(answers_by_step.slice(
+                              ProviderEvents::Steps::Email,
+                              ProviderEvents::Steps::EventName,
+                              ProviderEvents::Steps::EventDescription,
+                              ProviderEvents::Steps::OrganisationName,
+                              ProviderEvents::Steps::EventWebsite,
+                              ProviderEvents::Steps::TargetAudience,
+                              ProviderEvents::Steps::EventDate,
+                              ProviderEvents::Steps::EventTimes,
+                            ))
+    }
+  end
+
+  describe "#venue_details_answers_by_step" do
+    subject { instance.venue_details_answers_by_step }
+
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:answers_by_step).and_return answers_by_step
+    end
+
+    it {
+      expect(subject).to eq(answers_by_step.slice(
+                              ProviderEvents::Steps::EventType,
+                              ProviderEvents::Steps::OnlinePostcode,
+                              ProviderEvents::Steps::InPersonLocation,
+                              ProviderEvents::Steps::NewVenue,
+                            ))
+    }
+  end
+
+  describe "#registration_details_answers_by_step" do
+    subject { instance.registration_details_answers_by_step }
+
+    before do
+      allow_any_instance_of(described_class).to \
+        receive(:answers_by_step).and_return answers_by_step
+    end
+
+    it {
+      expect(subject).to eq(answers_by_step.slice(
+                              ProviderEvents::Steps::RegistrationDetails,
+                            ))
+    }
+  end
+end

--- a/spec/models/provider_events/steps/target_audience_spec.rb
+++ b/spec/models/provider_events/steps/target_audience_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderEvents::Steps::TargetAudience do
   include_context "with wizard step"
 
   it_behaves_like "a with wizard step"
+  it_behaves_like "a sanitised field", :target_audience
 
   it { is_expected.to respond_to :target_audience }
 

--- a/spec/models/provider_events/wizard_spec.rb
+++ b/spec/models/provider_events/wizard_spec.rb
@@ -19,7 +19,49 @@ RSpec.describe ProviderEvents::Wizard do
         ProviderEvents::Steps::InPersonLocation,
         ProviderEvents::Steps::NewVenue,
         ProviderEvents::Steps::RegistrationDetails,
+        ProviderEvents::Steps::ReviewAnswers,
       ]
     }
+  end
+
+  describe "#complete!" do
+    subject { described_class.new(wizardstore, current_step) }
+
+    let(:wizardstore) { GITWizard::Store.new store[uuid], {} }
+    let(:uuid) { SecureRandom.uuid }
+    let(:store) do
+      { uuid => {
+        "email" => "email@address.com",
+        "event_description" => "Event Description",
+        "organisation_name" => "Organisation Name",
+      } }
+    end
+    let(:current_step) { "review_answers" }
+
+    before do
+      allow(subject).to receive(:valid?).and_return(true)
+    end
+
+    context "with prune! spy" do
+      before { allow(wizardstore).to receive(:prune!) }
+
+      it "prunes the store, retaining certain attributes" do
+        subject.complete!
+        expect(wizardstore).to have_received(:prune!).with({ leave: %w[email reference_number] }).once
+      end
+    end
+
+    it "checks the wizard is valid" do
+      subject.complete!
+      is_expected.to have_received(:valid?)
+    end
+
+    it "prunes the store, retaining certain attributes" do
+      subject.complete!
+      expect(store[uuid]).to eql({
+        "email" => "email@address.com",
+        "reference_number" => "COMING-SOON",
+      })
+    end
   end
 end

--- a/spec/models/provider_events/wizard_spec.rb
+++ b/spec/models/provider_events/wizard_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ProviderEvents::Wizard do
         ProviderEvents::Steps::EventType,
         ProviderEvents::Steps::OnlinePostcode,
         ProviderEvents::Steps::InPersonLocation,
+        ProviderEvents::Steps::NewVenue,
       ]
     }
   end

--- a/spec/models/provider_events/wizard_spec.rb
+++ b/spec/models/provider_events/wizard_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ProviderEvents::Wizard do
         ProviderEvents::Steps::OnlinePostcode,
         ProviderEvents::Steps::InPersonLocation,
         ProviderEvents::Steps::NewVenue,
+        ProviderEvents::Steps::RegistrationDetails,
       ]
     }
   end

--- a/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/uk_address_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe TeacherTrainingAdviser::Steps::UkAddress do
   include_context "with a TTA wizard step"
   it_behaves_like "a with wizard step"
-  include_context "sanitize fields", %i[address_postcode]
+  it_behaves_like "a normalised and validated postcode", :address_postcode, "Enter a real postcode"
 
   it { is_expected.to be_contains_personal_details }
 

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -158,3 +158,53 @@ shared_examples "with a wizard step that exposes API lookup items as options" do
     end
   end
 end
+
+shared_examples "a normalised and validated postcode" do |postcode_field, invalid_message|
+  describe "validations for #{postcode_field}" do
+    it { is_expected.to respond_to postcode_field }
+    it { is_expected.to allow_value("TE57 1NG").for postcode_field }
+    it { is_expected.to allow_value("  TE571NG  ").for postcode_field }
+    it { is_expected.to allow_value("  Te571nG  ").for postcode_field }
+    it { is_expected.not_to allow_value("random").for(postcode_field).with_message(invalid_message) }
+    it { is_expected.not_to allow_value("TE57 ING").for(postcode_field).with_message(invalid_message) }
+  end
+
+  describe "normalised postcode" do
+    before do
+      instance.send("#{postcode_field}=".to_sym, test_value)
+      instance.valid?
+    end
+
+    subject { instance.send(postcode_field) }
+
+    context "when the postcode is in lowercase" do
+      let(:test_value) { "wc1n 1ab" }
+
+      it { is_expected.to eq("WC1N 1AB") }
+    end
+
+    context "when the postcode is a mixture of lowercase and uppercase" do
+      let(:test_value) { "wc1n 1AB" }
+
+      it { is_expected.to eq("WC1N 1AB") }
+    end
+
+    context "when the postcode has whitespace" do
+      let(:test_value) { "  wc1n 1ab  " }
+
+      it { is_expected.to eq("WC1N 1AB") }
+    end
+
+    context "when the postcode is blank" do
+      let(:test_value) { "  " }
+
+      it { is_expected.to be nil }
+    end
+
+    context "when the postcode is nil" do
+      let(:test_value) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -209,6 +209,45 @@ shared_examples "a normalised and validated postcode" do |postcode_field, invali
   end
 end
 
+shared_examples "a sanitised field" do |sanitised_field|
+  before do
+    instance.send("#{sanitised_field}=".to_sym, test_value)
+    instance.valid?
+  end
+
+  subject { instance.send(sanitised_field) }
+
+  context "when the field has whitespace" do
+    let(:test_value) { "     Hello        World     " }
+
+    it { is_expected.to eq("Hello World") }
+  end
+
+  context "when the field is whitespace" do
+    let(:test_value) { "    " }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the field is blank" do
+    let(:test_value) { "" }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the field is nil" do
+    let(:test_value) { nil }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the field is OK" do
+    let(:test_value) { "Hello World" }
+
+    it { is_expected.to eql("Hello World") }
+  end
+end
+
 shared_examples "a validated url" do |url_field|
   context "when it is invalid" do
     it { is_expected.not_to allow_value("http://localhost/foo/bar").for url_field }

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -208,3 +208,16 @@ shared_examples "a normalised and validated postcode" do |postcode_field, invali
     end
   end
 end
+
+shared_examples "a validated url" do |url_field|
+  context "when it is invalid" do
+    it { is_expected.not_to allow_value("http://localhost/foo/bar").for url_field }
+    it { is_expected.not_to allow_value("ftp://foo.bar/").for url_field }
+    it { is_expected.not_to allow_value("https://foo/bar").for url_field }
+  end
+
+  context "when it is valid" do
+    it { is_expected.to allow_value("http://foo.bar/foo/bar").for url_field }
+    it { is_expected.to allow_value("https://foo.bar/foo/bar").for url_field }
+  end
+end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -198,13 +198,13 @@ shared_examples "a normalised and validated postcode" do |postcode_field, invali
     context "when the postcode is blank" do
       let(:test_value) { "  " }
 
-      it { is_expected.to be nil }
+      it { is_expected.to be_nil }
     end
 
     context "when the postcode is nil" do
       let(:test_value) { nil }
 
-      it { is_expected.to be nil }
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
### Trello card
[Training Provider Events step 11(b) - in person location details](https://trello.com/c/o7bh5OoZ/9111-training-provider-events-wizard-build-step-11b-in-person-location-details)

### Context

### Changes proposed in this pull request
Adds a new step to capture the details of the new location
Also re-factors postcode normalisation as this is used in multiple steps

### Guidance to review
NB: this merges into feature branch https://github.com/DFE-Digital/get-into-teaching-app/pull/5153


