### PR TITLE
9112 training provider events wizard build step 12 registration details

### DIFF
--- a/app/models/provider_events/steps/email.rb
+++ b/app/models/provider_events/steps/email.rb
@@ -4,7 +4,7 @@ module ProviderEvents
       include FunnelTitle
 
       attribute :email
-      validates :email, presence: true, email_format: true, length: { maximum: 100 } # NB: the CRm imposes a limit of 100 chars on this field
+      validates :email, presence: true, email_format: true, length: { maximum: 100 } # NB: the CRM imposes a limit of 100 chars on this field
     end
   end
 end

--- a/app/models/provider_events/steps/registration_details.rb
+++ b/app/models/provider_events/steps/registration_details.rb
@@ -1,0 +1,25 @@
+module ProviderEvents
+  module Steps
+    class RegistrationDetails < ::GITWizard::Step
+      include FunnelTitle
+      REGISTRATION_OPTIONS = [WEBSITE = "website".freeze, EMAIL = "email".freeze].freeze
+
+      attribute :registration_option
+      attribute :registration_email
+      attribute :registration_website
+
+      validates :registration_option, presence: true, inclusion: REGISTRATION_OPTIONS
+
+      validates :registration_email, presence: true, email_format: true, length: { maximum: 100 }, if: -> { email_registration? } # NB: the CRM imposes a limit of 100 chars on this field
+      validates :registration_website, presence: true, length: { maximum: 300 }, url: { no_local: true }, if: -> { website_registration? }
+
+      def website_registration?
+        registration_option == WEBSITE
+      end
+
+      def email_registration?
+        registration_option == EMAIL
+      end
+    end
+  end
+end

--- a/app/models/provider_events/wizard.rb
+++ b/app/models/provider_events/wizard.rb
@@ -15,6 +15,7 @@ module ProviderEvents
       Steps::OnlinePostcode,
       Steps::InPersonLocation,
       Steps::NewVenue,
+      Steps::RegistrationDetails,
     ]
   end
 end

--- a/app/views/provider_events/steps/_registration_details.html.erb
+++ b/app/views/provider_events/steps/_registration_details.html.erb
@@ -1,0 +1,8 @@
+<%= f.govuk_radio_buttons_fieldset(:registration_option, legend: { tag: 'h1', text: t("helpers.label.provider_events_steps_registration_details.registration_option") }) do %>
+  <%= f.govuk_radio_button :registration_option, ProviderEvents::Steps::RegistrationDetails::EMAIL, label: { text: t("helpers.answer.provider_events_steps.registration_details.registration_option.email")} do %>
+    <%= f.govuk_email_field :registration_email %>
+  <% end %>
+  <%= f.govuk_radio_button :registration_option, ProviderEvents::Steps::RegistrationDetails::WEBSITE, label: { text: t("helpers.answer.provider_events_steps.registration_details.registration_option.website")} do %>
+    <%= f.govuk_url_field :registration_website %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -755,6 +755,14 @@ en:
           attributes:
             registration_option:
               blank: "Select if people will register through email or a website"
+            registration_email:
+              blank: "Enter email"
+              invalid: "Enter an email address in the correct format, like name@example.com"
+              too_long: "Email must be 100 characters or less"
+            registration_website:
+              blank: "Enter website URL"
+              too_long: "Website URL must be 300 characters or less"
+              url: "Website URL must be valid and start with https:// or http://"
 
   helpers:
     answer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,10 @@ en:
             address_postcode:
               blank: "Enter postcode"
               invalid: "Enter a full UK postcode"
+        provider_events/steps/registration_details:
+          attributes:
+            registration_option:
+              blank: "Select if people will register through email or a website"
 
   helpers:
     answer:
@@ -853,6 +857,10 @@ en:
           location_option:
             existing: "Search existing venues"
             new: "Add a new venue"
+        registration_details:
+          registration_option:
+            email: "By email"
+            website: "Through a website"
 
     label:
       wizard_steps_authenticate:
@@ -1045,6 +1053,10 @@ en:
         address_line_3: "Address line 3"
         address_city: "Town or city"
         address_postcode: "Postcode"
+      provider_events_steps_registration_details:
+        registration_option: "How will people register for your event?"
+        registration_email: "Email address"
+        registration_website: "Website URL"
 
     hint:
       events_steps_accessibility_support:
@@ -1153,6 +1165,9 @@ en:
         online_postcode_extra: "This helps people in your target area find your event, even when it's online."
       provider_events_steps_in_person_location:
         location_option: "This information will help people find your event."
+      provider_events_steps_registration_details:
+        registration_email: "Enter the email address you want people to use to sign up."
+        registration_website: "Enter the website address you want people to use to sign up."
 
     legend:
       teacher_training_adviser_feedback:

--- a/spec/features/provider_events/register_new_provider_event_spec.rb
+++ b/spec/features/provider_events/register_new_provider_event_spec.rb
@@ -58,6 +58,13 @@ RSpec.feature "Register a provider event", type: :feature do
       expect(page).to have_field("Provide a postcode for your event")
       fill_in "Provide a postcode for your event", with: "Te57 1nG"
       click_on "Next step"
+
+      expect(page).to have_content("How will people register for your event?")
+      within_fieldset("How will people register for your event?") do
+        choose "Through a website"
+        fill_in "Website URL", with: "https://www.example.com/"
+      end
+      click_on "Next step"
     end
 
     describe "Registering an in-person event" do
@@ -121,6 +128,13 @@ RSpec.feature "Register a provider event", type: :feature do
         within_fieldset("Where will your event be?") do
           choose "Search existing venues"
           select "test, M1 7AX", from: "Search for existing buildings"
+        end
+        click_on "Next step"
+
+        expect(page).to have_content("How will people register for your event?")
+        within_fieldset("How will people register for your event?") do
+          choose "Through a website"
+          fill_in "Website URL", with: "https://www.example.com/"
         end
         click_on "Next step"
       end
@@ -194,7 +208,14 @@ RSpec.feature "Register a provider event", type: :feature do
           fill_in "Address line 2", with: "Wimbledon"
           fill_in "Address line 3", with: "Merton"
           fill_in "Town or city", with: "London"
-          fill_in "Postcode", with: "TE57 ING"
+          fill_in "Postcode", with: "TE57 1NG"
+          click_on "Next step"
+
+          expect(page).to have_content("How will people register for your event?")
+          within_fieldset("How will people register for your event?") do
+            choose "Through a website"
+            fill_in "Website URL", with: "https://www.example.com/"
+          end
           click_on "Next step"
         end
       end

--- a/spec/models/provider_events/steps/event_website_spec.rb
+++ b/spec/models/provider_events/steps/event_website_spec.rb
@@ -14,16 +14,5 @@ RSpec.describe ProviderEvents::Steps::EventWebsite do
 
   it { is_expected.not_to be_skipped }
 
-  describe "event_website" do
-    context "when it is invalid" do
-      it { is_expected.not_to allow_value("http://localhost/foo/bar").for :event_website }
-      it { is_expected.not_to allow_value("ftp://foo.bar/").for :event_website }
-      it { is_expected.not_to allow_value("https://foo/bar").for :event_website }
-    end
-
-    context "when it is valid" do
-      it { is_expected.to allow_value("http://foo.bar/foo/bar").for :event_website }
-      it { is_expected.to allow_value("https://foo.bar/foo/bar").for :event_website }
-    end
-  end
+  it_behaves_like "a validated url", :event_website
 end

--- a/spec/models/provider_events/steps/registration_details_spec.rb
+++ b/spec/models/provider_events/steps/registration_details_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ProviderEvents::Steps::RegistrationDetails do
+  include_context "with wizard step"
+
+  it_behaves_like "a with wizard step"
+
+  it { is_expected.to respond_to :registration_option }
+  it { is_expected.to respond_to :registration_email }
+  it { is_expected.to respond_to :registration_website }
+
+  it { is_expected.to respond_to :website_registration? }
+  it { is_expected.to respond_to :email_registration? }
+
+  it { is_expected.to validate_presence_of :registration_option }
+  it { is_expected.to validate_inclusion_of(:registration_option).in_array(%w[website email]) }
+
+  it { is_expected.not_to be_skipped }
+
+  context "when email registration" do
+    before { subject.registration_option = "email" }
+
+    it { expect(subject.email_registration?).to be true }
+    it { expect(subject.website_registration?).to be false }
+
+    it { is_expected.to validate_presence_of(:registration_email) }
+    it { is_expected.to validate_length_of(:registration_email).is_at_most(100) }
+
+    it { is_expected.not_to validate_presence_of(:registration_website) }
+  end
+
+  context "when website registration" do
+    before { subject.registration_option = "website" }
+
+    it { expect(subject.email_registration?).to be false }
+    it { expect(subject.website_registration?).to be true }
+
+    it { is_expected.to validate_presence_of(:registration_website) }
+    it { is_expected.to validate_length_of(:registration_website).is_at_most(300) }
+
+    it { is_expected.not_to validate_presence_of(:registration_email) }
+
+    it_behaves_like "a validated url", :registration_website
+  end
+end

--- a/spec/models/provider_events/wizard_spec.rb
+++ b/spec/models/provider_events/wizard_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ProviderEvents::Wizard do
         ProviderEvents::Steps::OnlinePostcode,
         ProviderEvents::Steps::InPersonLocation,
         ProviderEvents::Steps::NewVenue,
+        ProviderEvents::Steps::RegistrationDetails,
       ]
     }
   end

--- a/spec/support/wizard_support.rb
+++ b/spec/support/wizard_support.rb
@@ -208,3 +208,16 @@ shared_examples "a normalised and validated postcode" do |postcode_field, invali
     end
   end
 end
+
+shared_examples "a validated url" do |url_field|
+  context "when it is invalid" do
+    it { is_expected.not_to allow_value("http://localhost/foo/bar").for url_field }
+    it { is_expected.not_to allow_value("ftp://foo.bar/").for url_field }
+    it { is_expected.not_to allow_value("https://foo/bar").for url_field }
+  end
+
+  context "when it is valid" do
+    it { is_expected.to allow_value("http://foo.bar/foo/bar").for url_field }
+    it { is_expected.to allow_value("https://foo.bar/foo/bar").for url_field }
+  end
+end


### PR DESCRIPTION
### Trello card
[Training Provider Events step 12 - registration details](https://trello.com/c/KuXLUmjj/9112-training-provider-events-wizard-build-step-12-registration-details)

### Context

### Changes proposed in this pull request
Adds step 12 to collect registration details for the provider event

### Guidance to review
NB: this merges into feature branch https://github.com/DFE-Digital/get-into-teaching-app/pull/5153

