### PR TITLE
Cache chat availability and add client refresh jitter

### DIFF
--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -32,8 +32,11 @@ private
 
     @availability ||=
       begin
-        response = Faraday.get(availability_api_uri)
-        JSON.parse(response.body) if response.success?
+        # Cache the response for a few seconds to reduce upstream server traffic
+        Rails.cache.fetch("chat_availability_api", expires_in: 10.seconds) do
+          response = Faraday.get(availability_api_uri)
+          JSON.parse(response.body) if response.success?
+        end
       rescue Faraday::ConnectionFailed
         nil
       end

--- a/app/webpacker/controllers/chat_controller.js
+++ b/app/webpacker/controllers/chat_controller.js
@@ -66,10 +66,14 @@ export default class extends Controller {
     }
   }
 
+  // add a couple of seconds of random jitter to the refresh cycle to smooth out traffic
   startRefreshing() {
-    this.refreshTimer = setInterval(() => {
-      this.setChatState();
-    }, this.refreshIntervalValue);
+    this.refreshTimer = setInterval(
+      () => {
+        this.setChatState();
+      },
+      this.refreshIntervalValue + Math.floor(Math.random() * 3000),
+    );
   }
 
   stopRefreshing() {


### PR DESCRIPTION
### Trello card
[Investigate and resolve chat outage](https://trello.com/c/COyW7RQK/9249-investigate-and-resolve-chat-outage-on-the-help-and-support-page)

### Context

### Changes proposed in this pull request
Cache the chat availability API response in Rails.cache (key: "chat_availability_api") for 10 seconds to reduce upstream load and keep the existing Faraday::ConnectionFailed handling. Add a small random jitter (0–3000ms) to the client-side polling interval in the chat controller to smooth out synchronised refresh spikes.

### Guidance to review

