### PR TITLE
2937 - Review app to Postgres v17

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 3000:3000
   postgres:
-    image: postgres:15-alpine
+    image: postgres:17-alpine
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
     needs: [ build_base ]
     services:
       postgres:
-        image: postgres:13.10
+        image: postgres:17.10
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -592,7 +592,7 @@ jobs:
        name: test
     services:
       postgres:
-        image: postgres:13.10
+        image: postgres:17.10
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/terraform/aks/config/review.tfvars.json
+++ b/terraform/aks/config/review.tfvars.json
@@ -8,5 +8,6 @@
     "sidekiq_replicas" : 1,
     "sidekiq_memory_max" : "1Gi",
     "enable_dfe_analytics_federated_auth": true,
-    "dataset_name": "git_website_events_review"
+    "dataset_name": "git_website_events_review",
+    "postgres_version": 17
 }


### PR DESCRIPTION
### Context

We want to upgrade Postgres to version 17 

### Changes proposed in this pull request

- Set the review app to use Postgres v17

### Guidance to review

This PR will deploy a review app. Check the deployments create a Postgres image using v17,

<img width="717" height="289" alt="image" src="https://github.com/user-attachments/assets/77206b3a-702f-4600-934b-054fb90109cd" />

"https://get-into-teaching-app-review-5189.test.teacherservices.cloud/"

### Link to Trello card

https://trello.com/c/c8kHaR8B/2937-upgrade-git-postgres-version

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
