### PR TITLE
Add Lifelong Learning Entitlement section

### DIFF
--- a/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
+++ b/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
@@ -93,9 +93,9 @@ $student-finance-calculator$
 
 ## Lifelong learning entitlement (LLE)
 
-If you already have a degree, or have used all of your tuition fee loan entitlement, you may still be able to get a tuition fee loan to train to teach through the lifelong learning entitlement (LLE).
+If you already have a degree, or have used all of your tuition fee loan entitlement, you may still be able to get a tuition fee loan to train to teach through the lifelong learning entitlement (LLE). 
 
-This funding is called priority additional entitlement. It's available for certain priority courses, including initial teacher training (ITT).
+This funding is called priority additional entitlement. It is available to eligible students in England studying priority courses, including initial teacher training (ITT).
 
 $lifelong-learning-entitlement$
 

--- a/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
+++ b/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
@@ -27,6 +27,9 @@ cta_arrow_link:
   veterans-support:
     link_target: "/funding-and-support/if-youre-a-veteran"
     link_text: "Find out more about financial support if you’re a veteran"
+  lifelong-learning-entitlement:
+    link_target: "https://www.gov.uk/government/publications/lifelong-learning-entitlement-lle-overview"
+    link_text: "Find out more about the LLE"  
 navigation: 20.12
 navigation_description: Find out which loans you could get to help pay your fees and living expenses while you train.
 expander:
@@ -94,7 +97,7 @@ If you already have a degree, or have used all of your tuition fee loan entitlem
 
 This funding is called priority additional entitlement. It's available for certain priority courses, including initial teacher training (ITT).
 
-[Find out more about the LLE](https://www.gov.uk/government/publications/lifelong-learning-entitlement-lle-overview).
+$lifelong-learning-entitlement$
 
 ## Check your eligibility for a bursary or scholarship
 

--- a/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
+++ b/app/views/content/funding-and-support/tuition-fee-and-maintenance-loans.md
@@ -88,6 +88,14 @@ The maximum amount you may be eligible to borrow is:
 
 $student-finance-calculator$
 
+## Lifelong learning entitlement (LLE)
+
+If you already have a degree, or have used all of your tuition fee loan entitlement, you may still be able to get a tuition fee loan to train to teach through the lifelong learning entitlement (LLE).
+
+This funding is called priority additional entitlement. It's available for certain priority courses, including initial teacher training (ITT).
+
+[Find out more about the LLE](https://www.gov.uk/government/publications/lifelong-learning-entitlement-lle-overview).
+
 ## Check your eligibility for a bursary or scholarship
 
 You may also be eligible for a tax-free bursary or scholarship, depending on the subject you're training to teach.


### PR DESCRIPTION
Added section on Lifelong Learning Entitlement (LLE) for tuition fee loans.

### Trello card
https://trello.com/c/pq93pRsQ/9223-content-update-for-new-lifelong-learning-entitlement-funding

### Context
https://www.gov.uk/government/publications/lifelong-learning-entitlement-lle-overview/lifelong-learning-entitlement-overview

We need to make changes to the student finance for teacher training page to include the above information relevant to our audience.

### Changes proposed in this pull request
Added a section to talk about the LLE

### Guidance to review

