### PR TITLE
2937 - Upgrade Postgres to v17 in prod

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -21,5 +21,6 @@
     "sidekiq_replicas" : 1,
     "sidekiq_memory_max" : "1Gi",
     "enable_dfe_analytics_federated_auth": true,
-    "dataset_name": "git_website_events_production"
+    "dataset_name": "git_website_events_production",
+    "postgres_version": 17
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -107,7 +107,7 @@ variable "sidekiq_replicas" {
   default = 1
 }
 
-variable "postgres_version" { default = 16 }
+variable "postgres_version" { default = 17 }
 
 variable "deploy_redis_cache" {
   default     = false


### PR DESCRIPTION
### Context

We want to upgrade Postgres to version 17 

### Changes proposed in this pull request

- Set the production environment to use Postgres v17
- Set the default Postgres version to 17

### Guidance to review

- This PR must only be merged **AFTER** the manual upgrade has been completed.
- Make sure the PostgreSQL version is 17 in the overview of s189p01-git-pd-pg in the Azure portal.

https://get-into-teaching-app-review-5194.test.teacherservices.cloud/

### Link to Trello card

https://trello.com/c/c8kHaR8B/2937-upgrade-git-postgres-version

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
