### PR TITLE
Update recruitment cycle dates for 2027

### DIFF
--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -22,7 +22,7 @@ expander:
     text: Check what you need to do before you travel and after you arrive <a href="https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine">if you are moving to the UK from Ukraine</a>.
 ---
 
-You can apply for postgraduate teacher training courses starting in $recruitmentcycle_academicyear$ $recruitmentcycle_openanddeadline$. 
+For postgraduate teacher training courses starting in the $recruitmentcycle_academicyear$, you can apply $recruitmentcycle_openanddeadline$. 
 
 $application-deadlines$
 

--- a/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
+++ b/app/views/content/how-to-apply-for-teacher-training/when-to-apply-for-teacher-training.md
@@ -22,7 +22,7 @@ expander:
     text: Check what you need to do before you travel and after you arrive <a href="https://www.gov.uk/guidance/move-to-the-uk-if-youre-from-ukraine">if you are moving to the UK from Ukraine</a>.
 ---
 
-You can apply for postgraduate teacher training courses starting in $recruitmentcycle_coursestart$ $recruitmentcycle_openanddeadline$. 
+You can apply for postgraduate teacher training courses starting in $recruitmentcycle_academicyear$ $recruitmentcycle_openanddeadline$. 
 
 $application-deadlines$
 

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,9 +1,9 @@
 recruitmentcycle:
-  coursestart: September 2026
-  openanddeadline: from 9am on 7 October 2025 to 6pm on 15 September 2026
-  openingdate: 7 October 2025
+  coursestart: September 2027
+  openanddeadline: from 9am on 6 October 2025 to 6pm on 21 September 2027
+  openingdate: 6 October 2027
   openingmonth: October
-  deadlinedate: 15 September 2026
+  deadlinedate: 21 September 2027
   deadlinetime: 6pm
-  providerdeadline: 23 September 2026
+  providerdeadline: 29 September 2027
   

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,7 +1,7 @@
 recruitmentcycle:
   coursestart: September 2027
   openanddeadline: from 9am on 6 October 2026 to 6pm on 21 September 2027
-  openingdate: 6 October 2027
+  openingdate: 6 October 2026
   openingmonth: October
   deadlinedate: 21 September 2027
   deadlinetime: 6pm

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -1,6 +1,6 @@
 recruitmentcycle:
   coursestart: September 2027
-  openanddeadline: from 9am on 6 October 2025 to 6pm on 21 September 2027
+  openanddeadline: from 9am on 6 October 2026 to 6pm on 21 September 2027
   openingdate: 6 October 2027
   openingmonth: October
   deadlinedate: 21 September 2027

--- a/config/values/recruitmentcycle.yml
+++ b/config/values/recruitmentcycle.yml
@@ -6,4 +6,4 @@ recruitmentcycle:
   deadlinedate: 21 September 2027
   deadlinetime: 6pm
   providerdeadline: 29 September 2027
-  
+  academicyear: 2027 to 2028 academic year


### PR DESCRIPTION
Copied dates from https://www.gov.uk/government/publications/recruiting-trainee-teachers-recruitment-cycle-dates/recruiting-postgraduate-trainee-teachers-recruitment-cycle-dates#to-2027-recruitment-cycle

### Trello card
https://trello.com/c/Vq6mZ2cU/4710-update-cycle-dates

### Context
We need to update the new recruitment cycle dates across the site.

### Changes proposed in this pull request

### Guidance to review

