### PR TITLE
Update training drop-off date to 6pm on 15th september

### DIFF
--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -81,8 +81,8 @@ module TeacherTrainingAdviser::Steps
     end
 
     def before_current_year_threshold?
-      # After 15th September you can no longer start teacher training for that year.
-      Time.zone.today < date_to_drop_current_year
+      # After 6pm on 15th September you can no longer start teacher training for that year.
+      Time.zone.now < datetime_to_drop_current_year
     end
 
     def before_academic_year_end?
@@ -91,15 +91,15 @@ module TeacherTrainingAdviser::Steps
     end
 
     def number_of_years
-      Time.zone.today.between?(date_to_add_additional_year, date_to_drop_current_year - 1.day) ? 3 : 2
+      Time.zone.today.between?(date_to_add_additional_year, datetime_to_drop_current_year.to_date - 1.day) ? 3 : 2
     end
 
     def date_to_add_additional_year
       Date.new(current_year, 6, 24)
     end
 
-    def date_to_drop_current_year
-      Date.new(current_year, 9, 16)
+    def datetime_to_drop_current_year
+      Time.zone.local(current_year, 9, 15, 18, 0) # 6pm on 15th September
     end
 
     def academic_year_cutoff

--- a/app/models/teacher_training_adviser/steps/start_teacher_training.rb
+++ b/app/models/teacher_training_adviser/steps/start_teacher_training.rb
@@ -81,7 +81,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def before_current_year_threshold?
-      # After 16th September you can no longer start teacher training for that year.
+      # After 15th September you can no longer start teacher training for that year.
       Time.zone.today < date_to_drop_current_year
     end
 
@@ -99,7 +99,7 @@ module TeacherTrainingAdviser::Steps
     end
 
     def date_to_drop_current_year
-      Date.new(current_year, 9, 17)
+      Date.new(current_year, 9, 16)
     end
 
     def academic_year_cutoff

--- a/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
+++ b/spec/models/teacher_training_adviser/steps/start_teacher_training_spec.rb
@@ -82,9 +82,24 @@ RSpec.describe TeacherTrainingAdviser::Steps::StartTeacherTraining do
       end
     end
 
-    context "when its after 17th September of the current year (2022)" do
+    context "when its 5:59pm on 15th September of the current year (2022)" do
       around do |example|
-        travel_to(Date.new(2022, 9, 17)) { example.run }
+        travel_to(Time.zone.local(2022, 9, 15, 17, 59)) { example.run }
+      end
+
+      it "returns 'Not sure', and the next 3 years" do
+        expect(years.map(&:value)).to contain_exactly(
+          "Not sure",
+          "2022 - start your training this September",
+          "2023",
+          "2024",
+        )
+      end
+    end
+
+    context "when its after 6:01pm on 15th September of the current year (2022)" do
+      around do |example|
+        travel_to(Time.zone.local(2022, 9, 15, 18, 1)) { example.run }
       end
 
       it "returns 'Not sure', and the next 3 years" do


### PR DESCRIPTION
### Trello card
[Remove old training year from adviser funnel](https://trello.com/c/b26XpKeY/9259-remove-old-training-year-from-advisor-funnel)

### Context

### Changes proposed in this pull request
Ensure the current year option disappears at 6pm on Tuesday 15th September

### Guidance to review

